### PR TITLE
Implements world.address & friends, adds remaining opendream_unimplemented world vars/procs

### DIFF
--- a/DMCompiler/DMStandard/Defines.dm
+++ b/DMCompiler/DMStandard/Defines.dm
@@ -197,6 +197,11 @@
 #define SIDE_MAP 2
 #define TILED_ICON_MAP 32768
 
+//world.movement_mode
+#define LEGACY_MOVEMENT_MODE 0
+#define TILE_MOVEMENT_MODE 1
+#define PIXEL_MOVEMENT_MODE 2
+
 //generator() distributions
 #define UNIFORM_RAND 0
 #define NORMAL_RAND 1

--- a/DMCompiler/DMStandard/Types/World.dm
+++ b/DMCompiler/DMStandard/Types/World.dm
@@ -29,8 +29,8 @@
 	var/version = 0 as opendream_unimplemented
 
 	var/address
-	var/port
-	var/internet_address = "127.0.0.1" as opendream_unimplemented
+	var/port = 0
+	var/internet_address = "127.0.0.1"
 	var/url
 	var/status as opendream_unimplemented
 	var/list/params = list() as opendream_unimplemented

--- a/DMCompiler/DMStandard/Types/World.dm
+++ b/DMCompiler/DMStandard/Types/World.dm
@@ -31,9 +31,9 @@
 	var/version = 0 as opendream_unimplemented
 
 	var/address
-	var/port = 0
-	var/internet_address = "127.0.0.1"
-	var/url
+	var/port = 0 as opendream_compiletimereadonly
+	var/internet_address = "127.0.0.1" as opendream_unimplemented
+	var/url as opendream_unimplemented
 	var/visibility = 0 as opendream_unimplemented
 	var/status as opendream_unimplemented
 	var/list/params = list() as opendream_unimplemented

--- a/DMCompiler/DMStandard/Types/World.dm
+++ b/DMCompiler/DMStandard/Types/World.dm
@@ -16,12 +16,14 @@
 	var/cpu = 0 as opendream_unimplemented
 	var/fps = null
 	var/tick_usage
+	var/loop_checks = 0 as opendream_unimplemented
 
 	var/maxx = 0
 	var/maxy = 0
 	var/maxz = 0
 	var/icon_size = 32
 	var/view = 5
+	var/movement_mode = LEGACY_MOVEMENT_MODE as opendream_unimplemented
 
 	var/byond_version = DM_VERSION
 	var/byond_build = DM_BUILD
@@ -32,6 +34,7 @@
 	var/port = 0
 	var/internet_address = "127.0.0.1"
 	var/url
+	var/visibility = 0 as opendream_unimplemented
 	var/status as opendream_unimplemented
 	var/list/params = list() as opendream_unimplemented
 
@@ -59,6 +62,9 @@
 		set opendream_unimplemented = TRUE
 	proc/IsSubscribed(player, type)
 		set opendream_unimplemented = TRUE
+	proc/IsBanned(key,address,computer_id,type)
+		set opendream_unimplemented = TRUE
+		return FALSE;
 
 	proc/Reboot()
 		set opendream_unimplemented = TRUE
@@ -67,6 +73,8 @@
 		set opendream_unimplemented = TRUE
 
 	proc/Export(Addr, File, Persist, Clients)
+	proc/Import()
+		set opendream_unimplemented = TRUE
 
 	proc/SetScores()
 		set opendream_unimplemented = TRUE

--- a/OpenDreamRuntime/DreamManager.Connections.cs
+++ b/OpenDreamRuntime/DreamManager.Connections.cs
@@ -5,6 +5,8 @@ using OpenDreamShared.Network.Messages;
 using Robust.Server.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Network;
+using System.Net;
+using System.Net.Sockets;
 
 namespace OpenDreamRuntime
 {

--- a/OpenDreamRuntime/IDreamManager.cs
+++ b/OpenDreamRuntime/IDreamManager.cs
@@ -1,6 +1,3 @@
-using System.Linq;
-using System.Threading.Tasks;
-using System.Net;
 using OpenDreamRuntime.Objects;
 using Robust.Server.Player;
 

--- a/OpenDreamRuntime/IDreamManager.cs
+++ b/OpenDreamRuntime/IDreamManager.cs
@@ -1,4 +1,7 @@
-﻿using OpenDreamRuntime.Objects;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net;
+using OpenDreamRuntime.Objects;
 using Robust.Server.Player;
 
 namespace OpenDreamRuntime {

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectWorld.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectWorld.cs
@@ -49,12 +49,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         {
             get
             {
-                NetManager? net = (NetManager?)_netManager;
-                if(net == null) // This may be the case if we're on IntegrationNetManager instead of NetManager.
-                { // If so, I don't really know how to force RT to fess up about what our IP is, since it's all hidden behind privates at time of writing.
-                    return null;
-                }
-                return net.ServerChannel?.RemoteEndPoint.Address;
+                return null; //TODO: Implement this!
             }
         }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/185520298-7a0a294b-6fcf-4aa1-82a4-7e38941d894c.png)

## Summary
world.address and world.port are implemented, after a regression during RobustToolbox porting last year caused them to become commented out.

Makes #735 at least compile by setting up the associated `opendream_unimplemented`. Also went ahead and added every other one I could find in the ref; yell if I missed any.

Fixes #804.

## Changelog
- world.address and world.port have been added back in.
- Several world vars and procs now exist as unimplemented.