### PR TITLE
Improves the grammar, functionality, and code quality of set declarations

### DIFF
--- a/Content.Tests/DMProject/Tests/Statements/Control Flow/empty_blocks.dm
+++ b/Content.Tests/DMProject/Tests/Statements/Control Flow/empty_blocks.dm
@@ -1,0 +1,7 @@
+//COMPILE ERROR
+//Test that our pragma for this is working.
+#pragma EmptyBlock error
+/proc/RunTest()
+	var/thing = 2
+	if(TRUE)
+	var/other_thing = 3

--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -148,21 +148,11 @@ namespace DMCompiler.Compiler.DM {
         public DMASTProcStatement(Location location)
             : base(location)
         {}
-        /// <summary>
-        /// Gets whether this statement is or contains some <see cref="DMASTProcStatementSet"/>s.<br/>
-        /// This is <see langword="fucked"/> but having the helper in general is actually quite convenient.
-        /// </summary>
-        public bool IsSetStatement {
-            get {
-                switch (this) {
-                    case (DMASTProcStatementSet):
-                        return true;
-                    case (DMASTAggregate<DMASTProcStatementSet>):
-                        return true;
-                    default:
-                        return false;
-                }
-            }
+        /// <returns>
+        /// Returns true if this statement is either T or an aggregation of T (stored by an <see cref="DMASTAggregate{T}"/> instance). False otherwise.
+        /// </returns>
+        public bool IsAggregateOr<T>() where T : DMASTProcStatement {
+            return (this is T or DMASTAggregate<T>);
         }
     }
 
@@ -231,7 +221,7 @@ namespace DMCompiler.Compiler.DM {
         /// <summary> Initializes a block with only one statement (which may be a <see cref="DMASTProcStatementSet"/> :o) </summary>
         public DMASTProcBlockInner(Location location, DMASTProcStatement statement) : base(location)
         {
-            if (statement.IsSetStatement) {
+            if (statement.IsAggregateOr<DMASTProcStatementSet>()) { // If this is a Set statement or a set of Set statements
                 Statements = Array.Empty<DMASTProcStatement>();
                 SetStatements = new DMASTProcStatement[] { statement };
             } else {
@@ -239,14 +229,14 @@ namespace DMCompiler.Compiler.DM {
                 SetStatements = Array.Empty<DMASTProcStatement>();
             }
         }
-        public DMASTProcBlockInner(Location location, DMASTProcStatement[] statements, DMASTProcStatement[] set_statements)
+        public DMASTProcBlockInner(Location location, DMASTProcStatement[] statements, DMASTProcStatement[] setStatements)
             : base(location)
         {
             Statements = statements;
-            if (set_statements == null)
+            if (setStatements is null)
                 SetStatements = Array.Empty<DMASTProcStatement>();
             else
-                SetStatements = set_statements;
+                SetStatements = setStatements;
         }
 
         public override void Visit(DMASTVisitor visitor) {

--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -496,8 +496,7 @@ namespace DMCompiler.Compiler.DM {
         public DMASTExpression Value;
         public bool WasInKeyword; // Marks whether this was a "set x in y" expression, or a "set x = y" one
 
-        public DMASTProcStatementSet(Location location, string attribute, DMASTExpression value, bool wasInKeyword) : base(location)
-        {
+        public DMASTProcStatementSet(Location location, string attribute, DMASTExpression value, bool wasInKeyword) : base(location) {
             Attribute = attribute;
             Value = value;
             WasInKeyword = wasInKeyword;

--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -152,12 +152,9 @@ namespace DMCompiler.Compiler.DM {
         /// Gets whether this statement is or contains some <see cref="DMASTProcStatementSet"/>s.<br/>
         /// This is <see langword="fucked"/> but having the helper in general is actually quite convenient.
         /// </summary>
-        public bool IsSetStatement
-        {
-            get
-            {
-                switch (this)
-                {
+        public bool IsSetStatement {
+            get {
+                switch (this) {
                     case (DMASTProcStatementSet):
                         return true;
                     case (DMASTAggregate<DMASTProcStatementSet>):

--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -202,6 +202,16 @@ namespace DMCompiler.Compiler.DM {
         public DMASTProcStatement[] Statements;
 
         public DMASTProcBlockInner(Location location, DMASTProcStatement[] statements)
+        /// <summary> Initializes an empty block. </summary>
+        public DMASTProcBlockInner(Location location) : base(location)
+        {
+            Statements = Array.Empty<DMASTProcStatement>();
+        }
+        public DMASTProcBlockInner(Location location, DMASTProcStatement statement) : base(location)
+        {
+                Statements = new DMASTProcStatement[] { statement };
+                SetStatements = Array.Empty<DMASTProcStatement>();
+        }
             : base(location)
         {
             Statements = statements;

--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -234,13 +234,10 @@ namespace DMCompiler.Compiler.DM {
         /// <summary> Initializes a block with only one statement (which may be a <see cref="DMASTProcStatementSet"/> :o) </summary>
         public DMASTProcBlockInner(Location location, DMASTProcStatement statement) : base(location)
         {
-            if(statement.IsSetStatement)
-            {
+            if (statement.IsSetStatement) {
                 Statements = Array.Empty<DMASTProcStatement>();
                 SetStatements = new DMASTProcStatement[] { statement };
-            }
-            else
-            {
+            } else {
                 Statements = new DMASTProcStatement[] { statement };
                 SetStatements = Array.Empty<DMASTProcStatement>();
             }

--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -16,7 +16,6 @@ namespace DMCompiler.Compiler.DM {
         public void VisitObjectVarOverride(DMASTObjectVarOverride objectVarOverride) { throw new NotImplementedException(); }
         public void VisitProcStatementExpression(DMASTProcStatementExpression statementExpression) { throw new NotImplementedException(); }
         public void VisitProcStatementVarDeclaration(DMASTProcStatementVarDeclaration varDeclaration) { throw new NotImplementedException(); }
-        public void VisitProcStatementMultipleVarDeclarations(DMASTProcStatementMultipleVarDeclarations multipleVarDeclarations) { throw new NotImplementedException(); }
         public void VisitProcStatementReturn(DMASTProcStatementReturn statementReturn) { throw new NotImplementedException(); }
         public void VisitProcStatementBreak(DMASTProcStatementBreak statementBreak) { throw new NotImplementedException(); }
         public void VisitProcStatementContinue(DMASTProcStatementContinue statementContinue) { throw new NotImplementedException(); }
@@ -366,15 +365,22 @@ namespace DMCompiler.Compiler.DM {
         }
     }
 
-    public class DMASTProcStatementMultipleVarDeclarations : DMASTProcStatement {
-        public DMASTProcStatementVarDeclaration[] VarDeclarations;
+    /// <summary>
+    /// A kinda-abstract class that represents several statements that were created in unison by one "super-statement" <br/>
+    /// Such as, a var declaration that actually declares several vars at once (which in our parser must become "one" statement, hence this thing)
+    /// </summary>
+    /// <typeparam name="T">The DMASTProcStatement-derived class that this AST node holds.</typeparam>
 
-        public DMASTProcStatementMultipleVarDeclarations(Location location, DMASTProcStatementVarDeclaration[] varDeclarations) : base(location) {
-            VarDeclarations = varDeclarations;
+    public class DMASTAggregate<T> : DMASTProcStatement where T : DMASTProcStatement { // Gotta be honest? I like this "where" syntax better than C++20 concepts
+        public T[] Statements { get; }
+
+        public DMASTAggregate(Location location, T[] statements) : base(location) {
+            Statements = statements;
         }
 
         public override void Visit(DMASTVisitor visitor) {
-            visitor.VisitProcStatementMultipleVarDeclarations(this);
+            foreach (DMASTProcStatement statement in Statements)
+                statement.Visit(visitor);
         }
     }
 

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -821,19 +821,16 @@ namespace DMCompiler.Compiler.DM {
         {
             var loc = Current().Location;
 
-            if (allowMultiple)
-            {
+            if (allowMultiple) {
                 DMASTProcStatementSet[] block = ProcSetBlock();
                 if (block != null) return block;
             }
 
             List<DMASTProcStatementSet> setDeclarations = new(); // It's a list even in the non-block case because we could be comma-separated right mcfricking now
-            while (true) // x [in|=] y{, a [in|=] b} or something. I'm a comment, not a formal BNF expression.
-            {
+            while (true) { // x [in|=] y{, a [in|=] b} or something. I'm a comment, not a formal BNF expression.
                 Whitespace();
                 Token attributeToken = Current();
-                if(!Check(TokenType.DM_Identifier))
-                {
+                if(!Check(TokenType.DM_Identifier)) {
                     Error("Expected an identifier for set declaration");
                     return setDeclarations.ToArray();
                 }
@@ -1006,10 +1003,8 @@ namespace DMCompiler.Compiler.DM {
                     body = ProcBlock();
                 }
 
-                if (body == null)
-                {
+                if (body is null)
                     body = new DMASTProcBlockInner(loc);
-                }
                 Token afterIfBody = Current();
                 bool newLineAfterIf = Delimiter();
                 if (newLineAfterIf) Whitespace();

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -811,8 +811,7 @@ namespace DMCompiler.Compiler.DM {
 
         /// <param name="allowMultiple">This may look like a derelict of ProcVarEnd but it's not;<br/>
         /// Set does not allow path-based nesting of declarations the way var does, so we only allow nesting once, deactivating it thereafter.</param>
-        private DMASTProcStatementSet[] ProcSetEnd(bool allowMultiple)
-        {
+        private DMASTProcStatementSet[] ProcSetEnd(bool allowMultiple) {
             var loc = Current().Location;
 
             if (allowMultiple) {
@@ -921,8 +920,7 @@ namespace DMCompiler.Compiler.DM {
 
                 DMASTProcStatementSet[] sets = ProcSetEnd(true);
                 Token setBlockToken = Current();
-                if (sets is null || sets.Length == 0)
-                {
+                if (sets is null || sets.Length == 0) {
                     Error("Expected set declaration");
                     return null;
                 }
@@ -1160,14 +1158,13 @@ namespace DMCompiler.Compiler.DM {
                     DMASTProcStatement statement = ProcStatement();
 
                     //Loops without a body are valid DM
-                    if (statement is null)
-                    {
+                    if (statement is null) {
                         Error(WarningCode.EmptyBlock, "Empty while-block detected");
                         statement = new DMASTProcStatementContinue(loc);
                     } else if (statement.IsAggregateOr<DMASTProcStatementSet>()) { // set statements don't count as real, imo
                         Error(WarningCode.EmptyBlock, "Empty while-block detected");
                     }
-                    
+
                     body = new DMASTProcBlockInner(loc, statement);
                 }
                 if(conditional is DMASTConstantInteger){

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -631,15 +631,13 @@ namespace DMCompiler.Compiler.DM {
             if (Check(TokenType.DM_Var)) {
                 if (wasSlash) Error("Unsupported root variable declaration");
 
-                Whitespace();
+                Whitespace(); // NOTE: This might be a redundant whitespace check? Not... sure?
                 DMASTProcStatementVarDeclaration[] vars = ProcVarEnd(allowMultiple);
                 if (vars == null) Error("Expected a var declaration");
+                if (vars.Length > 1)
+                    return new DMASTAggregate<DMASTProcStatementVarDeclaration>(firstToken.Location, vars);
+                return vars[0];
 
-                if (vars.Length > 1) {
-                    return new DMASTProcStatementMultipleVarDeclarations(firstToken.Location, vars);
-                } else {
-                    return vars[0];
-                }
             } else if (wasSlash) {
                 ReuseToken(firstToken);
             }

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -200,7 +200,7 @@ namespace DMCompiler.Compiler.DM {
                             DMASTProcStatement procStatement = ProcStatement();
 
                             if (procStatement != null) {
-                                procBlock = new DMASTProcBlockInner(loc, new DMASTProcStatement[] { procStatement });
+                                procBlock = new DMASTProcBlockInner(loc, procStatement);
                             }
                         }
 
@@ -848,7 +848,7 @@ namespace DMCompiler.Compiler.DM {
                     DMASTProcStatement statement = ProcStatement();
 
                     if (statement == null) Error("Expected body or statement");
-                    body = new DMASTProcBlockInner(loc, new DMASTProcStatement[] { statement });
+                    body = new DMASTProcBlockInner(loc, statement);
                 }
 
                 return new DMASTProcStatementSpawn(loc, delay ?? new DMASTConstantInteger(loc, 0), body);
@@ -876,12 +876,17 @@ namespace DMCompiler.Compiler.DM {
                 DMASTProcBlockInner elseBody = null;
 
                 if (procStatement != null) {
-                    body = new DMASTProcBlockInner(loc, new DMASTProcStatement[] { procStatement });
+                    //if (procStatement.IsSetStatement)
+                        //Warning("Empty if block detected", ifbody);
+                    body = new DMASTProcBlockInner(loc, procStatement);
                 } else {
                     body = ProcBlock();
                 }
 
-                if (body == null) body = new DMASTProcBlockInner(loc, new DMASTProcStatement[0]);
+                if (body == null)
+                {
+                    body = new DMASTProcBlockInner(loc);
+                }
                 Token afterIfBody = Current();
                 bool newLineAfterIf = Delimiter();
                 if (newLineAfterIf) Whitespace();
@@ -892,12 +897,12 @@ namespace DMCompiler.Compiler.DM {
                     procStatement = ProcStatement();
 
                     if (procStatement != null) {
-                        elseBody = new DMASTProcBlockInner(loc, new DMASTProcStatement[] { procStatement });
+                        elseBody = new DMASTProcBlockInner(loc, procStatement);
                     } else {
                         elseBody = ProcBlock();
                     }
 
-                    if (elseBody == null) elseBody = new DMASTProcBlockInner(loc, new DMASTProcStatement[0]);
+                    if (elseBody == null) elseBody = new DMASTProcBlockInner(loc);
                 } else if (newLineAfterIf) {
                     ReuseToken(afterIfBody);
                 }
@@ -1011,7 +1016,7 @@ namespace DMCompiler.Compiler.DM {
                         statement = ProcStatement();
                         if (statement == null) Error("Expected body or statement");
                     }
-                    body = new DMASTProcBlockInner(loc, new DMASTProcStatement[] { statement });
+                    body = new DMASTProcBlockInner(loc, statement);
                 }
 
                 return body;
@@ -1035,9 +1040,13 @@ namespace DMCompiler.Compiler.DM {
                     DMASTProcStatement statement = ProcStatement();
 
                     //Loops without a body are valid DM
-                    if (statement == null) statement = new DMASTProcStatementContinue(loc);
-
-                    body = new DMASTProcBlockInner(loc, new DMASTProcStatement[] { statement });
+                    if (statement == null)
+                    {
+                        //Warning("Empty while block detected", statement_token);
+                        statement = new DMASTProcStatementContinue(loc);
+                    }
+                    
+                    body = new DMASTProcBlockInner(loc, statement);
                 }
                 if(conditional is DMASTConstantInteger){
                     if(((DMASTConstantInteger)conditional).Value != 0){
@@ -1201,9 +1210,9 @@ namespace DMCompiler.Compiler.DM {
                     var loc = Current().Location;
 
                     if (statement != null) {
-                        body = new DMASTProcBlockInner(loc, new DMASTProcStatement[] { statement });
+                        body = new DMASTProcBlockInner(loc,statement);
                     } else {
-                        body = new DMASTProcBlockInner(loc, new DMASTProcStatement[0]);
+                        body = new DMASTProcBlockInner(loc);
                     }
                 }
 
@@ -1221,9 +1230,9 @@ namespace DMCompiler.Compiler.DM {
                     DMASTProcStatement statement = ProcStatement();
 
                     if (statement != null) {
-                        body = new DMASTProcBlockInner(loc, new DMASTProcStatement[] { statement });
+                        body = new DMASTProcBlockInner(loc, statement);
                     } else {
-                        body = new DMASTProcBlockInner(loc, new DMASTProcStatement[0]);
+                        body = new DMASTProcBlockInner(loc);
                     }
                 }
 
@@ -1243,7 +1252,7 @@ namespace DMCompiler.Compiler.DM {
                     DMASTProcStatement statement = ProcStatement();
 
                     if (statement == null) Error("Expected body or statement");
-                    tryBody = new DMASTProcBlockInner(loc, new DMASTProcStatement[] { statement });
+                    tryBody = new DMASTProcBlockInner(loc,statement);
                 }
 
                 if (_unimplementedWarnings)
@@ -1270,7 +1279,7 @@ namespace DMCompiler.Compiler.DM {
                 if (catchBody == null) {
                     DMASTProcStatement statement = ProcStatement();
 
-                    if (statement != null) catchBody = new DMASTProcBlockInner(loc, new DMASTProcStatement[] { statement });
+                    if (statement != null) catchBody = new DMASTProcBlockInner(loc, statement);
                 }
 
                 return new DMASTProcStatementTryCatch(loc, tryBody, catchBody, parameter);
@@ -1306,7 +1315,7 @@ namespace DMCompiler.Compiler.DM {
                 var loc = Current().Location;
                 DMASTProcStatement statement = ProcStatement();
 
-                if (statement != null) body = new DMASTProcBlockInner(loc, new DMASTProcStatement[] { statement });
+                if (statement != null) body = new DMASTProcBlockInner(loc, statement);
             }
             return new DMASTProcStatementLabel(expression.Location, expression.Identifier, body);
         }

--- a/DMCompiler/DM/Visitors/DMASTSimplifier.cs
+++ b/DMCompiler/DM/Visitors/DMASTSimplifier.cs
@@ -164,12 +164,6 @@ namespace DMCompiler.DM.Visitors {
             SimplifyExpression(ref varDeclaration.Value);
         }
 
-        public void VisitProcStatementMultipleVarDeclarations(DMASTProcStatementMultipleVarDeclarations multipleVarDeclarations) {
-            foreach (DMASTProcStatementVarDeclaration varDeclaration in multipleVarDeclarations.VarDeclarations) {
-                varDeclaration.Visit(this);
-            }
-        }
-
         public void VisitProcStatementTryCatch(DMASTProcStatementTryCatch tryCatch) {
             tryCatch.TryBody.Visit(this);
             tryCatch.CatchBody?.Visit(this);

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -116,14 +116,13 @@ namespace DMCompiler.DM.Visitors {
                 case DMASTProcStatementVarDeclaration varDeclaration: ProcessStatementVarDeclaration(varDeclaration); break;
                 case DMASTProcStatementTryCatch tryCatch: ProcessStatementTryCatch(tryCatch); break;
                 case DMASTProcStatementThrow dmThrow: ProcessStatementThrow(dmThrow); break;
-                case DMASTProcStatementMultipleVarDeclarations multipleVarDeclarations: {
-                    foreach (DMASTProcStatementVarDeclaration varDeclaration in multipleVarDeclarations.VarDeclarations) {
-                        ProcessStatementVarDeclaration(varDeclaration);
-                    }
-
+                //FIXME: Is there a more generic way of doing this, where Aggregate doesn't need every possible type state specified here?
+                case DMASTAggregate<DMASTProcStatementVarDeclaration> polyvar:
+                    foreach (var declare in polyvar.Statements)
+                        ProcessStatementVarDeclaration(declare);
                     break;
-                }
                 default: throw new CompileAbortException(statement.Location, "Invalid proc statement");
+                }
             }
         }
 

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -172,8 +172,7 @@ namespace DMCompiler.DM.Visitors {
         {
             var attribute = statementSet.Attribute.ToLower();
             // TODO deal with "src"
-            if(attribute == "src")
-            {
+            if(attribute == "src") {
                 DMCompiler.UnimplementedWarning(statementSet.Location, "'set src' is unimplemented");
                 return;
             }
@@ -188,8 +187,7 @@ namespace DMCompiler.DM.Visitors {
             } else {
                 previousSetStatementValue = constant;
             }
-            if (statementSet.WasInKeyword)  // check if it was 'set x in y' or whatever
-            {                               // (which is illegal for everything except setting src to something)
+            if (statementSet.WasInKeyword) { // check if it was 'set x in y' or whatever                               // (which is illegal for everything except setting src to something)
                 DMCompiler.Emit(WarningCode.BadToken, statementSet.Location, "Use of 'in' keyword is illegal here. Did you mean '='?");
                 //fallthrough into normal behaviour because this error is kinda pedantic
             }
@@ -201,58 +199,38 @@ namespace DMCompiler.DM.Visitors {
                 }
                 case "opendream_unimplemented": {
                     if (constant.IsTruthy())
-                    {
                         _proc.Attributes |= ProcAttributes.Unimplemented;
-                    }
                     else
-                    {
                         _proc.Attributes &= ~ProcAttributes.Unimplemented;
-                    }
                     break;
                 }
                 case "hidden":
                     if (constant.IsTruthy())
-                    {
                         _proc.Attributes |= ProcAttributes.Hidden;
-                    }
                     else
-                    {
                         _proc.Attributes &= ~ProcAttributes.Hidden;
-                    }
                     break;
                 case "popup_menu":
                     if (constant.IsTruthy()) // The default is to show it so we flag it if it's hidden
-                    {
                         _proc.Attributes &= ~ProcAttributes.HidePopupMenu;
-                    }
                     else
-                    {
                         _proc.Attributes |= ProcAttributes.HidePopupMenu;
-                    }
 
                     DMCompiler.UnimplementedWarning(statementSet.Location, "set popup_menu is not implemented");
                     break;
                 case "instant":
                     if (constant.IsTruthy())
-                    {
                         _proc.Attributes |= ProcAttributes.Instant;
-                    }
                     else
-                    {
                         _proc.Attributes &= ~ProcAttributes.Instant;
-                    }
 
                     DMCompiler.UnimplementedWarning(statementSet.Location, "set instant is not implemented");
                     break;
                 case "background":
                     if (constant.IsTruthy())
-                    {
                         _proc.Attributes |= ProcAttributes.Background;
-                    }
                     else
-                    {
                         _proc.Attributes &= ~ProcAttributes.Background;
-                    }
                     break;
                 case "name":
                     if (constant is not Expressions.String nameStr) {

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -190,9 +190,11 @@ namespace DMCompiler {
         }
 
         /// <summary> Emits the given warning, according to its ErrorLevel as set in our config. </summary>
-        public static void Emit(WarningCode code, Location loc, string message) {
+        /// <returns> True if the warning was an error, false if not.</returns>
+        public static bool Emit(WarningCode code, Location loc, string message) {
             ErrorLevel level = Config.errorConfig[code];
             Emit(new CompilerEmission(level, code, loc, message));
+            return level == ErrorLevel.Error;
         }
 
         /// <summary>

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -19,3 +19,4 @@
 #pragma PointlessBuiltinCall warning
 #pragma MalformedRange warning
 #pragma InvalidRange error
+#pragma InvalidSetStatement error

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -20,3 +20,6 @@
 #pragma MalformedRange warning
 #pragma InvalidRange error
 #pragma InvalidSetStatement error
+
+//3000-3999
+#pragma EmptyBlock warning

--- a/OpenDreamShared/Compiler/CompilerError.cs
+++ b/OpenDreamShared/Compiler/CompilerError.cs
@@ -46,6 +46,7 @@ namespace OpenDreamShared.Compiler {
         InvalidRange = 2301,
         InvalidSetStatement = 2302,
         // 3000 - 3999 are reserved for stylistic configuration.
+        EmptyBlock = 3100,
 
         // 4000 - 4999 are reserved for runtime configuration. (TODO: Runtime doesn't know about configs yet!)
     }

--- a/OpenDreamShared/Compiler/CompilerError.cs
+++ b/OpenDreamShared/Compiler/CompilerError.cs
@@ -44,6 +44,7 @@ namespace OpenDreamShared.Compiler {
         PointlessBuiltinCall = 2206, // For pointless calls to issaved() or initial()
         MalformedRange = 2300,
         InvalidRange = 2301,
+        InvalidSetStatement = 2302,
         // 3000 - 3999 are reserved for stylistic configuration.
 
         // 4000 - 4999 are reserved for runtime configuration. (TODO: Runtime doesn't know about configs yet!)

--- a/OpenDreamShared/Compiler/Parser.cs
+++ b/OpenDreamShared/Compiler/Parser.cs
@@ -20,6 +20,9 @@ namespace OpenDreamShared.Compiler {
             Advance();
         }
 
+        /// <summary>
+        /// Does not consume; this is simply a friendly getter.
+        /// </summary>
         protected Token Current() {
             return _currentToken;
         }
@@ -80,12 +83,14 @@ namespace OpenDreamShared.Compiler {
             }
         }
 
-        protected void Consume(TokenType[] types, string errorMessage) {
+        /// <returns>The <see cref="TokenType"/> that was found.</returns>
+        protected TokenType Consume(TokenType[] types, string errorMessage) {
             foreach (TokenType type in types) {
-                if (Check(type)) return;
+                if (Check(type)) return type;
             }
 
             Error(errorMessage);
+            return TokenType.Unknown;
         }
 
         /// <summary>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/186030699-dee6f165-8903-4776-8ae0-398f46ca6160.png)
## Summary

Fixes #751 by doing a *bunch* of facelifting of how set statements are constructed.

In fixing this, I ended up shotgun-debugging a lot of things surrounding how `set` statements are constructed. This PR also include some additional documentation added to various things, as I looked at them or touched them during development of this.

## Changelog
* Fixes `set` declarations not respecting commas, indented blocks, nor bracing.
* Blocks now very consistently evaluate their `set` statements first and foremost, before anything else, in a way that makes sense
* Use of the `in` keyword is now properly prohibited for all set use cases except 'src'
* `set src` now properly gives an unimplemented warning
* Slightly optimizes `DMASTProcBlockInner` by reducing empty array allocations.
* Removes `DMASTProcStatementMultipleVarDeclarations`, and replaces it with `DMASTAggregate<>`.
* Makes `Consume` array overload return the `TokenType` if found
* OD can now correctly mimic the cursed behaviour BYOND has when a set statement's right-hand side is non-constant. This feature must be manually enabled through a #pragma directive. 