### PR TITLE
Fixes not accepting colon spam with goto labels, adds support for paren-less sleep calls

### DIFF
--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -1713,6 +1713,13 @@ namespace DMCompiler.Compiler.DM {
             Parameters = parameters;
         }
 
+        /// <summary>Helper constructor that converts the expression argument into a positional call parameter.</summary>
+        public DMASTProcCall(Location location, DMASTCallable callable, DMASTExpression paramExp) : base(location)
+        {
+            Callable = callable;
+            Parameters = new DMASTCallParameter[] { new DMASTCallParameter(paramExp.Location,paramExp)};
+        }
+
         public override void Visit(DMASTVisitor visitor) {
             visitor.VisitProcCall(this);
         }

--- a/OpenDreamShared/Compiler/Parser.cs
+++ b/OpenDreamShared/Compiler/Parser.cs
@@ -48,6 +48,10 @@ namespace OpenDreamShared.Compiler {
             _currentToken = token;
         }
 
+        /// <summary>
+        /// Does an optional consume on the Current() token. If Current() is not of this type, it is not Advance()'d.
+        /// </summary>
+        /// <returns>true if Current() was of the given type.</returns>
         protected bool Check(TokenType type) {
             if (Current().Type == type) {
                 Advance();
@@ -69,6 +73,20 @@ namespace OpenDreamShared.Compiler {
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Does an optional consume on as many of this type as it can. Returns the amount consumed. Advance() is not called if it fails to consume any.
+        /// </summary>
+        protected int CheckMany(TokenType type)
+        {
+            int ret = 0;
+            while(Current().Type == type)
+            {
+                ++ret;
+                Advance();
+            }
+            return ret;
         }
 
         protected void Consume(TokenType type, string errorMessage) {

--- a/OpenDreamShared/Misc.cs
+++ b/OpenDreamShared/Misc.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenDreamShared
+{
+    /// <summary>
+    /// TODO: Try to think of a better name for this (dummy) class.
+    /// </summary>
+    public static class Misc
+    {
+        /// <summary>
+        /// Defers calling the given action until the block is completed. <br/>
+        /// To use this properly, you must cast a magic spell against the GC, in this specific way: <br/>
+        /// <see langword="using"/> <see langword="var"/> _ = Defer(b =&gt; bluh(b), maybe_captured_parameter); <br/>
+        /// If everything goes well (!!), this MUST be called before the block that invokes it returns.
+        /// </summary>
+        public static DeferDisposable<T> Defer<T>(Action<T> action, T param1) => new DeferDisposable<T>(action, param1);
+
+        /// <inheritdoc cref="Defer{T}(Action{T}, T)"/>
+        public static DeferDisposableVoid Defer(Action action) => new DeferDisposableVoid(action);
+
+        public readonly struct DeferDisposable<T1> : IDisposable
+        {
+            readonly Action<T1> _action;
+            readonly T1 _param1;
+            public DeferDisposable(Action<T1> action, T1 param1)
+            {
+                _action = action;
+                _param1 = param1;
+            }
+            public void Dispose() => _action.Invoke(_param1);
+        }
+        public readonly struct DeferDisposableVoid: IDisposable
+        {
+            readonly Action _action;
+            public DeferDisposableVoid(Action action)
+            {
+                _action = action;
+            }
+            public void Dispose() => _action.Invoke();
+        }
+    }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/188250269-f945c02c-7b54-49bb-b3ac-c193a518005e.png)

Fixes #518.

## Summary
In this PR is also a little new tool for the codebase: A defer pattern I found for C#. Here, it is used to consume whitespace regardless of which control flow in `ProcStatementFromExpression` does the returning. I figure it will be useful in many other places in the codebase later on.

## Changelog
- Goto labels with an exaggerated amount of colons, `::::LIKE_THIS::::`, are now parsed correctly.
- Calling sleep without any parentheses (as in `sleep 40`) is now properly implemented.
- Attempting to make a label called `sleep` now compiletimes, as per parity.