### PR TITLE
Fold constant AST expressions into strings instead of interpolating them

### DIFF
--- a/DMCompiler/Compiler/DM/DMParserHelper.cs
+++ b/DMCompiler/Compiler/DM/DMParserHelper.cs
@@ -143,6 +143,31 @@ namespace DMCompiler.Compiler.DM {
 
                                     if (expressionParser.Errors.Count > 0) Errors.AddRange(expressionParser.Errors);
                                     if (expressionParser.Warnings.Count > 0) Warnings.AddRange(expressionParser.Warnings);
+
+                                    if (expression is DMASTExpressionConstant)
+                                    {
+                                        switch (expression) {
+                                            case DMASTConstantString constantString:
+                                                stringBuilder.Append(constantString.Value);
+                                                break;
+                                            case DMASTConstantInteger constantInteger:
+                                                stringBuilder.Append(constantInteger.Value);
+                                                break;
+                                            case DMASTConstantFloat constantFloat:
+                                                stringBuilder.Append(constantFloat.Value);
+                                                break;
+                                            case DMASTConstantPath constantPath:
+                                                stringBuilder.Append(constantPath.Value);
+                                                break;
+                                            case DMASTConstantResource constantResource:
+                                                stringBuilder.Append(constantResource.Path);
+                                                break;
+                                        }
+                                        currentInterpolationType = StringFormatEncoder.InterpolationDefault;
+                                        insideBrackets.Clear();
+                                        break;
+                                    }
+
                                     interpolationValues.Add(expression);
                                 }
                                 else
@@ -359,7 +384,7 @@ namespace DMCompiler.Compiler.DM {
             if (bracketNesting > 0) Error("Expected ']'");
 
             string stringValue = stringBuilder.ToString();
-            if (interpolationValues is null)
+            if (interpolationValues is null || !interpolationValues.Any())
             {
                 if (usedPrefixMacro != null) // FIXME: \the should not compiletime here, instead becoming a tab character followed by "he", when in parity mode
                     Error($"Macro \"\\{usedPrefixMacro}\" requires interpolated expression");


### PR DESCRIPTION
This is technically not something BYOND is great at doing.
It means things like `set name = "FOO ([STRING_DEFINE])"` will no longer error, which is good; they work fine in BYOND, I'm pretty sure.
However, it also means that `var/const/foo = "FOO ([STRING_DEFINE])"` will work, which technically breaks parity with BYOND, but only in that it's _more_ permissive.