### PR TITLE
Fixes `typesof()` for non-paths

### DIFF
--- a/Content.Tests/DMProject/Tests/Procs/typesof_invalid.dm
+++ b/Content.Tests/DMProject/Tests/Procs/typesof_invalid.dm
@@ -1,0 +1,9 @@
+
+/proc/RunTest()
+	var/list/L1 = typesof(null)
+	ASSERT(islist(L1))
+	ASSERT(L1.len == 0)
+
+	var/list/L2 = typesof(5)
+    ASSERT(islist(L2))
+    ASSERT(L2.len == 0)

--- a/Content.Tests/DMProject/Tests/Procs/typesof_invalid.dm
+++ b/Content.Tests/DMProject/Tests/Procs/typesof_invalid.dm
@@ -5,5 +5,5 @@
 	ASSERT(L1.len == 0)
 
 	var/list/L2 = typesof(5)
-    ASSERT(islist(L2))
-    ASSERT(L2.len == 0)
+	ASSERT(islist(L2))
+	ASSERT(L2.len == 0)

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1854,7 +1854,9 @@ namespace OpenDreamRuntime.Procs.Native {
             DreamList list = DreamList.Create();
 
             foreach (DreamValue type in arguments.GetAllArguments()) {
-                DreamPath typePath = type.GetValueAsPath();
+                if (!type.TryGetValueAsPath(out var typePath)) {
+                    continue;
+                }
 
                 if (typePath.LastElement == "proc") {
                     DreamPath objectTypePath = typePath.AddToPath("..");

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1858,11 +1858,17 @@ namespace OpenDreamRuntime.Procs.Native {
                     if (!type.TryGetValueAsDreamObject(out var typeObj) || typeObj?.ObjectDefinition is null || typeObj is DreamList) {
                         if (type.TryGetValueAsString(out var typeString)) {
                             var stringToPath = new DreamPath(typeString);
-                            if (DreamManager.ObjectTree.HasTreeEntry(stringToPath)) {
-                                typePath = stringToPath;
-                            } else {
+                            if (stringToPath.LastElement == "proc") {
+                                DreamPath objectPath = stringToPath.AddToPath("..");
+                                if (!DreamManager.ObjectTree.HasTreeEntry(objectPath))
+                                {
+                                    continue;
+                                }
+                            }
+                            else if (!DreamManager.ObjectTree.HasTreeEntry(stringToPath)) {
                                 continue;
                             }
+                            typePath = stringToPath;
                         } else {
                             continue;
                         }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1856,10 +1856,19 @@ namespace OpenDreamRuntime.Procs.Native {
             foreach (DreamValue type in arguments.GetAllArguments()) {
                 if (!type.TryGetValueAsPath(out var typePath)) {
                     if (!type.TryGetValueAsDreamObject(out var typeObj) || typeObj?.ObjectDefinition is null) {
-                        continue;
+                        if (type.TryGetValueAsString(out var typeString)) {
+                            var stringToPath = new DreamPath(typeString);
+                            if (DreamManager.ObjectTree.HasTreeEntry(stringToPath)) {
+                                typePath = stringToPath;
+                            } else {
+                                continue;
+                            }
+                        } else {
+                            continue;
+                        }
+                    } else {
+                        typePath = typeObj.ObjectDefinition.Type;
                     }
-
-                    typePath = typeObj.ObjectDefinition.Type;
                 }
 
                 if (typePath.LastElement == "proc") {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1855,7 +1855,11 @@ namespace OpenDreamRuntime.Procs.Native {
 
             foreach (DreamValue type in arguments.GetAllArguments()) {
                 if (!type.TryGetValueAsPath(out var typePath)) {
-                    continue;
+                    if (!type.TryGetValueAsDreamObject(out var typeObj) || typeObj?.ObjectDefinition is null) {
+                        continue;
+                    }
+
+                    typePath = typeObj.ObjectDefinition.Type;
                 }
 
                 if (typePath.LastElement == "proc") {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1855,7 +1855,7 @@ namespace OpenDreamRuntime.Procs.Native {
 
             foreach (DreamValue type in arguments.GetAllArguments()) {
                 if (!type.TryGetValueAsPath(out var typePath)) {
-                    if (!type.TryGetValueAsDreamObject(out var typeObj) || typeObj?.ObjectDefinition is null) {
+                    if (!type.TryGetValueAsDreamObject(out var typeObj) || typeObj?.ObjectDefinition is null || typeObj is DreamList) {
                         if (type.TryGetValueAsString(out var typeString)) {
                             var stringToPath = new DreamPath(typeString);
                             if (DreamManager.ObjectTree.HasTreeEntry(stringToPath)) {


### PR DESCRIPTION
Replicates BYOND behavior