### PR TITLE
Support const-eval for `==` and `!=`

### DIFF
--- a/DMCompiler/DM/Expressions/Binary.cs
+++ b/DMCompiler/DM/Expressions/Binary.cs
@@ -1,6 +1,7 @@
 using OpenDreamShared.Compiler;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Dream.Procs;
+using Robust.Shared.Maths;
 
 namespace DMCompiler.DM.Expressions {
     abstract class BinaryOp : DMExpression {
@@ -295,7 +296,9 @@ namespace DMCompiler.DM.Expressions {
                 return false;
             }
 
-            constant = lhs.NotEquals(rhs);
+            constant = lhs.Equals(rhs);
+            // We're always going 0 -> 1 or 1 -> 0 so we can do this to avoid branching
+            constant.Value = Math.Abs(constant.Value - 1);
             return true;
         }
     }

--- a/DMCompiler/DM/Expressions/Binary.cs
+++ b/DMCompiler/DM/Expressions/Binary.cs
@@ -261,6 +261,16 @@ namespace DMCompiler.DM.Expressions {
         public Equal(Location location, DMExpression lhs, DMExpression rhs)
             : base(location, lhs, rhs) { }
 
+        public override bool TryAsConstant(out Constant constant) {
+            if (!LHS.TryAsConstant(out var lhs) || !RHS.TryAsConstant(out var rhs)) {
+                constant = null;
+                return false;
+            }
+
+            constant = lhs.Equals(rhs);
+            return true;
+        }
+
         public override void EmitPushValue(DMObject dmObject, DMProc proc) {
             LHS.EmitPushValue(dmObject, proc);
             RHS.EmitPushValue(dmObject, proc);
@@ -277,6 +287,16 @@ namespace DMCompiler.DM.Expressions {
             LHS.EmitPushValue(dmObject, proc);
             RHS.EmitPushValue(dmObject, proc);
             proc.NotEqual();
+        }
+
+        public override bool TryAsConstant(out Constant constant) {
+            if (!LHS.TryAsConstant(out var lhs) || !RHS.TryAsConstant(out var rhs)) {
+                constant = null;
+                return false;
+            }
+
+            constant = lhs.NotEquals(rhs);
+            return true;
         }
     }
 

--- a/DMCompiler/DM/Expressions/Constant.cs
+++ b/DMCompiler/DM/Expressions/Constant.cs
@@ -250,7 +250,7 @@ namespace DMCompiler.DM.Expressions {
         }
 
         public override Constant Equals(Constant rhs) {
-            if (rhs is not Number rhsNum || MathHelper.CloseTo(rhsNum.Value, Value)) {
+            if (rhs is not Number rhsNum || !MathHelper.CloseTo(rhsNum.Value, Value)) {
                 return new Number(Location, 0); // false
             }
 
@@ -258,7 +258,7 @@ namespace DMCompiler.DM.Expressions {
         }
 
         public override Constant NotEquals(Constant rhs) {
-            if (rhs is not Number rhsNum || !MathHelper.CloseTo(rhsNum.Value, Value)) {
+            if (rhs is not Number rhsNum || MathHelper.CloseTo(rhsNum.Value, Value)) {
                 return new Number(Location, 1); // true
             }
 

--- a/DMCompiler/DM/Expressions/Constant.cs
+++ b/DMCompiler/DM/Expressions/Constant.cs
@@ -4,6 +4,7 @@ using OpenDreamShared.Json;
 using System;
 using System.Collections.Generic;
 using Robust.Shared.Localization;
+using Robust.Shared.Maths;
 
 namespace DMCompiler.DM.Expressions {
     abstract class Constant : DMExpression {
@@ -250,7 +251,7 @@ namespace DMCompiler.DM.Expressions {
         }
 
         public override Constant Equals(Constant rhs) {
-            if (rhs is not Number rhsNum || rhsNum.Value != Value) {
+            if (rhs is not Number rhsNum || MathHelper.CloseTo(rhsNum.Value, Value)) {
                 return new Number(Location, 0); // false
             }
 
@@ -258,7 +259,7 @@ namespace DMCompiler.DM.Expressions {
         }
 
         public override Constant NotEquals(Constant rhs) {
-            if (rhs is not Number rhsNum || rhsNum.Value != Value) {
+            if (rhs is not Number rhsNum || !MathHelper.CloseTo(rhsNum.Value, Value)) {
                 return new Number(Location, 1); // true
             }
 

--- a/DMCompiler/DM/Expressions/Constant.cs
+++ b/DMCompiler/DM/Expressions/Constant.cs
@@ -88,10 +88,6 @@ namespace DMCompiler.DM.Expressions {
         public virtual Constant Equals(Constant rhs) {
             throw new CompileErrorException(Location, $"const operation \"{this} == {rhs}\" is invalid");
         }
-
-        public virtual Constant NotEquals(Constant rhs) {
-            throw new CompileErrorException(Location, $"const operation \"{this} != {rhs}\" is invalid");
-        }
         #endregion
     }
 
@@ -116,14 +112,6 @@ namespace DMCompiler.DM.Expressions {
             }
 
             return new Number(Location, 1); // true
-        }
-
-        public override Constant NotEquals(Constant rhs) {
-            if (rhs is not Null) {
-                return new Number(Location, 1); // true
-            }
-
-            return new Number(Location, 0); // false
         }
     }
 
@@ -256,14 +244,6 @@ namespace DMCompiler.DM.Expressions {
 
             return new Number(Location, 1); // true
         }
-
-        public override Constant NotEquals(Constant rhs) {
-            if (rhs is not Number rhsNum || MathHelper.CloseTo(rhsNum.Value, Value)) {
-                return new Number(Location, 1); // true
-            }
-
-            return new Number(Location, 0); // false
-        }
     }
 
     // "abc"
@@ -300,14 +280,6 @@ namespace DMCompiler.DM.Expressions {
 
             return new Number(Location, 1); // true
         }
-
-        public override Constant NotEquals(Constant rhs) {
-            if (rhs is not String rhsString || rhsString.Value != Value) {
-                return new Number(Location, 1); // true
-            }
-
-            return new Number(Location, 0); // false
-        }
     }
 
     // 'abc'
@@ -339,14 +311,6 @@ namespace DMCompiler.DM.Expressions {
             }
 
             return new Number(Location, 1); // true
-        }
-
-        public override Constant NotEquals(Constant rhs) {
-            if (rhs is not Resource rhsResource || rhsResource.Value != Value) {
-                return new Number(Location, 1); // true
-            }
-
-            return new Number(Location, 0); // false
         }
     }
 
@@ -387,14 +351,6 @@ namespace DMCompiler.DM.Expressions {
             }
 
             return new Number(Location, 1); // true
-        }
-
-        public override Constant NotEquals(Constant rhs) {
-            if (rhs is not Path rhsPath || rhsPath.Value != Value) {
-                return new Number(Location, 1); // true
-            }
-
-            return new Number(Location, 0); // false
         }
     }
 }

--- a/DMCompiler/DM/Expressions/Constant.cs
+++ b/DMCompiler/DM/Expressions/Constant.cs
@@ -3,6 +3,7 @@ using OpenDreamShared.Dream;
 using OpenDreamShared.Json;
 using System;
 using System.Collections.Generic;
+using Robust.Shared.Localization;
 
 namespace DMCompiler.DM.Expressions {
     abstract class Constant : DMExpression {
@@ -83,6 +84,14 @@ namespace DMCompiler.DM.Expressions {
         public virtual Constant BinaryOr(Constant rhs) {
             throw new CompileErrorException(Location, $"const operation \"{this} | {rhs}\" is invalid");
         }
+
+        public virtual Constant Equals(Constant rhs) {
+            throw new CompileErrorException(Location, $"const operation \"{this} == {rhs}\" is invalid");
+        }
+
+        public virtual Constant NotEquals(Constant rhs) {
+            throw new CompileErrorException(Location, $"const operation \"{this} != {rhs}\" is invalid");
+        }
         #endregion
     }
 
@@ -99,6 +108,22 @@ namespace DMCompiler.DM.Expressions {
         public override bool TryAsJsonRepresentation(out object json) {
             json = null;
             return true;
+        }
+
+        public override Constant Equals(Constant rhs) {
+            if (rhs is not Null) {
+                return new Number(Location, 0); // false
+            }
+
+            return new Number(Location, 1); // true
+        }
+
+        public override Constant NotEquals(Constant rhs) {
+            if (rhs is not Null) {
+                return new Number(Location, 1); // true
+            }
+
+            return new Number(Location, 0); // false
         }
     }
 
@@ -223,6 +248,22 @@ namespace DMCompiler.DM.Expressions {
 
             return new Number(Location, ((int)Value) | ((int)rhsNum.Value));
         }
+
+        public override Constant Equals(Constant rhs) {
+            if (rhs is not Number rhsNum || rhsNum.Value != Value) {
+                return new Number(Location, 0); // false
+            }
+
+            return new Number(Location, 1); // true
+        }
+
+        public override Constant NotEquals(Constant rhs) {
+            if (rhs is not Number rhsNum || rhsNum.Value != Value) {
+                return new Number(Location, 1); // true
+            }
+
+            return new Number(Location, 0); // false
+        }
     }
 
     // "abc"
@@ -251,6 +292,22 @@ namespace DMCompiler.DM.Expressions {
 
             return new String(Location, Value + rhsString.Value);
         }
+
+        public override Constant Equals(Constant rhs) {
+            if (rhs is not String rhsString || rhsString.Value != Value) {
+                return new Number(Location, 0); // false
+            }
+
+            return new Number(Location, 1); // true
+        }
+
+        public override Constant NotEquals(Constant rhs) {
+            if (rhs is not String rhsString || rhsString.Value != Value) {
+                return new Number(Location, 1); // true
+            }
+
+            return new Number(Location, 0); // false
+        }
     }
 
     // 'abc'
@@ -274,6 +331,22 @@ namespace DMCompiler.DM.Expressions {
             };
 
             return true;
+        }
+
+        public override Constant Equals(Constant rhs) {
+            if (rhs is not Resource rhsResource || rhsResource.Value != Value) {
+                return new Number(Location, 0); // false
+            }
+
+            return new Number(Location, 1); // true
+        }
+
+        public override Constant NotEquals(Constant rhs) {
+            if (rhs is not Resource rhsResource || rhsResource.Value != Value) {
+                return new Number(Location, 1); // true
+            }
+
+            return new Number(Location, 0); // false
         }
     }
 
@@ -306,6 +379,22 @@ namespace DMCompiler.DM.Expressions {
             };
 
             return true;
+        }
+
+        public override Constant Equals(Constant rhs) {
+            if (rhs is not Path rhsPath || rhsPath.Value != Value) {
+                return new Number(Location, 0); // false
+            }
+
+            return new Number(Location, 1); // true
+        }
+
+        public override Constant NotEquals(Constant rhs) {
+            if (rhs is not Path rhsPath || rhsPath.Value != Value) {
+                return new Number(Location, 1); // true
+            }
+
+            return new Number(Location, 0); // false
         }
     }
 }


### PR DESCRIPTION
I haven't tested every single comparison but basic testing shows that it works. This PR is required for one of the preproc tests to pass in https://github.com/wixoaGit/OpenDream/pull/827