### PR TITLE
Fix issues with max(null, ...)

### DIFF
--- a/Content.Tests/DMProject/Tests/Builtins/Max.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Max.dm
@@ -1,0 +1,24 @@
+﻿/proc/RunTest()
+	// Single arg returns that arg
+	ASSERT(max(1) == 1)
+
+	// Multiple numbers returns the largest number, no matter order
+	ASSERT(max(1, 2, 3, 4) == 4)
+	ASSERT(max(4, 3, 2, 1) == 4)
+	ASSERT(max(1, 3, 4, 2) == 4)
+
+	// Strings compare alphabetically
+	ASSERT(max("a", "c", "b") == "c")
+
+	// Various comparisons between null and other values
+	ASSERT(max(null, null, null) == null)
+	ASSERT(max(null, "") == "")
+	ASSERT(max("", null) == "")
+	ASSERT(max("", "str", null) == "str")
+	ASSERT(max("", "str", "", null) == "str")
+	ASSERT(max(5, null) == 5)
+	ASSERT(max(-3, null) == null) // null > -3
+
+	// null and 0 are equal here so the last one is returned
+	ASSERT(max(0, null) == null)
+	ASSERT(max(null, 0) == 0)

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1006,19 +1006,27 @@ namespace OpenDreamRuntime.Procs.Native {
                 values = arguments.GetAllArguments();
             }
 
+            if (values.Count == 0)
+                return DreamValue.Null;
+
             DreamValue max = values[0];
 
             for (int i = 1; i < values.Count; i++) {
                 DreamValue value = values[i];
 
-                if (max == DreamValue.Null) {
-                    max = value;
+                if (value.TryGetValueAsFloat(out var lFloat)) {
+                    if (max == DreamValue.Null && lFloat >= 0)
+                        max = value;
+                    else if (max.TryGetValueAsFloat(out var rFloat) && lFloat > rFloat)
+                        max = value;
                 } else if (value == DreamValue.Null) {
-                    continue;
-                } else if (value.TryGetValueAsFloat(out var lFloat) && max.TryGetValueAsFloat(out float rFloat)) {
-                    if (lFloat > rFloat) max = value;
-                } else if (value.TryGetValueAsString(out var lString) && max.TryGetValueAsString(out var rString)) {
-                    if (string.Compare(lString, rString, StringComparison.Ordinal) > 0) max = value;
+                    if (max.TryGetValueAsFloat(out var maxFloat) && maxFloat <= 0)
+                        max = value;
+                } else if (value.TryGetValueAsString(out var lString)) {
+                    if (max == DreamValue.Null)
+                        max = value;
+                    else if (max.TryGetValueAsString(out var rString) && string.Compare(lString, rString, StringComparison.Ordinal) > 0)
+                        max = value;
                 } else {
                     throw new Exception($"Cannot compare {max} and {value}");
                 }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1011,8 +1011,10 @@ namespace OpenDreamRuntime.Procs.Native {
             for (int i = 1; i < values.Count; i++) {
                 DreamValue value = values[i];
 
-                if (value == DreamValue.Null) {
+                if (max == DreamValue.Null) {
                     max = value;
+                } else if (value == DreamValue.Null) {
+                    continue;
                 } else if (value.TryGetValueAsFloat(out var lFloat) && max.TryGetValueAsFloat(out float rFloat)) {
                     if (lFloat > rFloat) max = value;
                 } else if (value.TryGetValueAsString(out var lString) && max.TryGetValueAsString(out var rString)) {


### PR DESCRIPTION
`max(null, ...)` would error because of attempts to compare null with numeric values. This now special-cases null `value` and null `max` properly.

Unit tests coming soon.