### PR TITLE
Adds operator~= and proper json_encode()ing for /matrix

### DIFF
--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixAdd.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixAdd.dm
@@ -1,4 +1,3 @@
-﻿#include "Shared/MatrixEquals.dm"
 
 /proc/RunTest()
 	var/matrix/M = matrix(1, 2, 3, 4, 5, 6)
@@ -6,5 +5,5 @@
 
 	M.Add(N)
 
-	if(!M.Equals(matrix(8, 10, 12, 14, 16, 18)))
+	if(M ~! matrix(8, 10, 12, 14, 16, 18))
 		CRASH("Unexpected matrix/Add result: [json_encode(M)]")

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixAdd.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixAdd.dm
@@ -7,4 +7,4 @@
 	M.Add(N)
 
 	if(!M.Equals(matrix(8, 10, 12, 14, 16, 18)))
-		CRASH("Unexpected matrix/Add result")
+		CRASH("Unexpected matrix/Add result: [json_encode(M)]")

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixInvert.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixInvert.dm
@@ -1,17 +1,16 @@
-﻿// IGNORE
+// IGNORE
 // Invert currently fails because OpenDream doesn't handle floats the way BYOND does.
 // Un-ignore when that's changed.
-#include "Shared/MatrixEquals.dm"
 
 /proc/RunTest()
 	var/matrix/M = matrix(1, 2, 3, 4, 5, 6)
 
 	M.Invert()
 
-	if(!M.Equals(matrix(-1.6666667, 0.6666667, 1, 1.3333334, -0.33333334, -2)))
+	if(M ~! matrix(-1.6666667, 0.6666667, 1, 1.3333334, -0.33333334, -2))
 		CRASH("Unexpected matrix/Invert result: [json_encode(M)]")
 
 	M.Invert()
 
-	if(!M.Equals(matrix(1, 2, 3, 4, 5, 6)))
+	if(M ~! matrix(1, 2, 3, 4, 5, 6))
 		CRASH("Unexpected matrix/Invert result2: [json_encode(M)]")

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixInvert.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixInvert.dm
@@ -9,9 +9,9 @@
 	M.Invert()
 
 	if(!M.Equals(matrix(-1.6666667, 0.6666667, 1, 1.3333334, -0.33333334, -2)))
-		CRASH("Unexpected matrix/Invert result [M.a] [M.b] [M.c] [M.d] [M.e] [M.f]")
+		CRASH("Unexpected matrix/Invert result: [json_encode(M)]")
 
 	M.Invert()
 
 	if(!M.Equals(matrix(1, 2, 3, 4, 5, 6)))
-		CRASH("Unexpected matrix/Invert result2 [M.a] [M.b] [M.c] [M.d] [M.e] [M.f]")
+		CRASH("Unexpected matrix/Invert result2: [json_encode(M)]")

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixMultiply.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixMultiply.dm
@@ -1,4 +1,3 @@
-﻿#include "Shared/MatrixEquals.dm"
 
 /proc/RunTest()
 	var/matrix/M = matrix(1, 2, 3, 4, 5, 6)
@@ -6,5 +5,5 @@
 
 	M.Multiply(N)
 
-	if(!M.Equals(matrix(39, 54, 78, 54, 75, 108)))
+	if(M ~! matrix(39, 54, 78, 54, 75, 108))
 		CRASH("Unexpected matrix/Multiply result")

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixScale.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixScale.dm
@@ -6,4 +6,4 @@
 	M.Scale(2)
 
 	if(!M.Equals(matrix(2, 4, 6, 8, 10, 12)))
-		CRASH("Unexpected matrix/Scale result")
+		CRASH("Unexpected matrix/Scale result: [json_encode(M)]")

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixScale.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixScale.dm
@@ -1,9 +1,8 @@
-﻿#include "Shared/MatrixEquals.dm"
 
 /proc/RunTest()
 	var/matrix/M = matrix(1, 2, 3, 4, 5, 6)
 
 	M.Scale(2)
 
-	if(!M.Equals(matrix(2, 4, 6, 8, 10, 12)))
+	if(M ~! matrix(2, 4, 6, 8, 10, 12))
 		CRASH("Unexpected matrix/Scale result: [json_encode(M)]")

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixSubtract.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixSubtract.dm
@@ -1,4 +1,3 @@
-﻿#include "Shared/MatrixEquals.dm"
 
 /proc/RunTest()
 	var/matrix/M = matrix(1, 2, 3, 4, 5, 6)
@@ -6,5 +5,5 @@
 
 	M.Subtract(N)
 
-	if(!M.Equals(matrix(-6, -6, -6, -6, -6, -6)))
+	if(M ~! matrix(-6, -6, -6, -6, -6, -6))
 		CRASH("Unexpected matrix/Subtract result: [json_encode(M)]")

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixSubtract.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixSubtract.dm
@@ -7,4 +7,4 @@
 	M.Subtract(N)
 
 	if(!M.Equals(matrix(-6, -6, -6, -6, -6, -6)))
-		CRASH("Unexpected matrix/Subtract result")
+		CRASH("Unexpected matrix/Subtract result: [json_encode(M)]")

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixTranslate.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixTranslate.dm
@@ -6,4 +6,4 @@
 	M.Translate(2)
 
 	if(!M.Equals(matrix(1, 2, 5, 4, 5, 8)))
-		CRASH("Unexpected matrix/Translate result")
+		CRASH("Unexpected matrix/Translate result: [json_encode(M)]")

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixTranslate.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixTranslate.dm
@@ -1,9 +1,8 @@
-﻿#include "Shared/MatrixEquals.dm"
 
 /proc/RunTest()
 	var/matrix/M = matrix(1, 2, 3, 4, 5, 6)
 
 	M.Translate(2)
 
-	if(!M.Equals(matrix(1, 2, 5, 4, 5, 8)))
+	if(M ~! matrix(1, 2, 5, 4, 5, 8))
 		CRASH("Unexpected matrix/Translate result: [json_encode(M)]")

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixTurn.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixTurn.dm
@@ -1,9 +1,8 @@
-﻿#include "Shared/MatrixEquals.dm"
 
 /proc/RunTest()
 	var/matrix/M = matrix(1, 2, 3, 4, 5, 6)
 
 	M.Turn(90)
 
-	if(!M.Equals(matrix(4, 5, 6, -1, -2, -3)))
+	if(M ~! matrix(4, 5, 6, -1, -2, -3))
 		CRASH("Unexpected matrix/Turn result: [json_encode(M)]")

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixTurn.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixTurn.dm
@@ -6,4 +6,4 @@
 	M.Turn(90)
 
 	if(!M.Equals(matrix(4, 5, 6, -1, -2, -3)))
-		CRASH("Unexpected matrix/Turn result")
+		CRASH("Unexpected matrix/Turn result: [json_encode(M)]")

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/Shared/MatrixEquals.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/Shared/MatrixEquals.dm
@@ -1,4 +1,0 @@
-﻿// IGNORE
-
-/matrix/proc/Equals(matrix/mat)
-	return src.a == mat.a && src.b == mat.b && src.c == mat.c && src.d == mat.d && src.e == mat.e && src.f == mat.f

--- a/Content.Tests/DMProject/Tests/Operators/equivalence.dm
+++ b/Content.Tests/DMProject/Tests/Operators/equivalence.dm
@@ -29,7 +29,14 @@
 	ASSERT((m3 ~= m2) == FALSE)
 	ASSERT((m3 ~= m3) == TRUE)
 
+	var/matrix/m4 = matrix(1,2,3,4,5,6)
+	ASSERT((m1 ~= m4) == TRUE)
+	ASSERT((m2 ~= m4) == FALSE)
+	ASSERT((m3 ~= m4) == FALSE)
+	ASSERT((m4 ~= m4) == TRUE)
+
 	ASSERT(("apple" ~= m1) == FALSE)
 	ASSERT(("apple" ~! m1))
+	ASSERT(m1 ~! "apple")
 	ASSERT(m1 ~! m2)
 	ASSERT(1 ~= 1)

--- a/Content.Tests/DMProject/Tests/Operators/equivalence.dm
+++ b/Content.Tests/DMProject/Tests/Operators/equivalence.dm
@@ -14,3 +14,22 @@
 	ASSERT((l1 ~! l2) == TRUE)
 	ASSERT((l1 ~! l3) == TRUE)
 	ASSERT((l1 ~! l4) == TRUE)
+
+	var/matrix/m1 = matrix(1,2,3,4,5,6)
+	var/matrix/m2 = matrix(-1,-2,-3,-4,-5,6)
+	var/matrix/m3 = matrix(1,2,3,4,5,6)
+	m3.a = "poop"
+	ASSERT((m1 ~= m1) == TRUE)
+	ASSERT((m1 ~= m2) == FALSE)
+	ASSERT((m1 ~= m3) == FALSE)
+	ASSERT((m2 ~= m1) == FALSE)
+	ASSERT((m2 ~= m2) == TRUE)
+	ASSERT((m2 ~= m3) == FALSE)
+	ASSERT((m3 ~= m1) == FALSE)
+	ASSERT((m3 ~= m2) == FALSE)
+	ASSERT((m3 ~= m3) == TRUE)
+
+	ASSERT(("apple" ~= m1) == FALSE)
+	ASSERT(("apple" ~! m1))
+	ASSERT(m1 ~! m2)
+	ASSERT(1 ~= 1)

--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -22,6 +22,8 @@ namespace OpenDreamRuntime {
         }
 
         public static readonly DreamValue Null = new DreamValue((DreamObject?)null);
+        public static DreamValue True { get => new DreamValue(1f); }
+        public static DreamValue False { get => new DreamValue(0f); }
 
         public DreamValueType Type { get; private set; }
         public object Value { get; private set; }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -110,7 +110,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 {
                     _atomManager.UpdateAppearance(dreamObject, appearance => {
                         float[] matrixArray = value.TryGetValueAsDreamObjectOfType(DreamPath.Matrix, out var matrix)
-                            ? DreamMetaObjectMatrix.MatrixToFloatArray(matrix)
+                            ? DreamMetaObjectMatrix.MatrixToTransformFloatArray(matrix)
                             : DreamMetaObjectMatrix.IdentityMatrixArray;
 
                         appearance.Transform = matrixArray;

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectList.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectList.cs
@@ -156,7 +156,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
                 return DreamValue.True;
             }
-            return a.Equals(b) ? DreamValue.True : DreamValue.False;
+            return DreamValue.False; // This will never be true, because reaching this line means b is not a list, while a will always be.
         }
 
         public DreamValue OperatorCombine(DreamValue a, DreamValue b) {

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectList.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectList.cs
@@ -145,6 +145,20 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             return new DreamValue(list);
         }
 
+        public DreamValue OperatorEquivalent(DreamValue a, DreamValue b) {
+            if (a.TryGetValueAsDreamList(out var firstList) && b.TryGetValueAsDreamList(out var secondList)) {
+                if (firstList.GetLength() != secondList.GetLength()) return DreamValue.False;
+                var firstValues = firstList.GetValues();
+                var secondValues = secondList.GetValues();
+                for (var i = 0; i < firstValues.Count; i++) {
+                    if (!firstValues[i].Equals(secondValues[i])) return DreamValue.False;
+                }
+
+                return DreamValue.True;
+            }
+            return a.Equals(b) ? DreamValue.True : DreamValue.False;
+        }
+
         public DreamValue OperatorCombine(DreamValue a, DreamValue b) {
             DreamList list = a.GetValueAsDreamList();
 

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMatrix.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMatrix.cs
@@ -95,5 +95,19 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
             return ParentType.OperatorMultiply(a, b);
         }
+
+        public DreamValue OperatorEquivalent(DreamValue a, DreamValue b) {
+            if (a.TryGetValueAsDreamObjectOfType(DreamPath.Matrix, out DreamObject? left) && b.TryGetValueAsDreamObjectOfType(DreamPath.Matrix, out DreamObject? right)) {
+                string elements = "abcdef";
+                for (int i = 0; i < elements.Length; i++) {
+                    left.GetVariable(elements[i].ToString()).TryGetValueAsFloat(out var leftValue); // sets leftValue to 0 if this isn't a float
+                    right.GetVariable(elements[i].ToString()).TryGetValueAsFloat(out var rightValue); // ditto
+                    if (leftValue != rightValue)
+                        return DreamValue.False;
+                }
+                return DreamValue.True;
+            }
+            return a.Equals(b) ? DreamValue.True : DreamValue.False;
+        }
     }
 }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMatrix.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMatrix.cs
@@ -98,7 +98,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
         public DreamValue OperatorEquivalent(DreamValue a, DreamValue b) {
             if (a.TryGetValueAsDreamObjectOfType(DreamPath.Matrix, out DreamObject? left) && b.TryGetValueAsDreamObjectOfType(DreamPath.Matrix, out DreamObject? right)) {
-                string elements = "abcdef";
+                const string elements = "abcdef";
                 for (int i = 0; i < elements.Length; i++) {
                     left.GetVariable(elements[i].ToString()).TryGetValueAsFloat(out var leftValue); // sets leftValue to 0 if this isn't a float
                     right.GetVariable(elements[i].ToString()).TryGetValueAsFloat(out var rightValue); // ditto
@@ -107,7 +107,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 }
                 return DreamValue.True;
             }
-            return a.Equals(b) ? DreamValue.True : DreamValue.False;
+            return DreamValue.False; // This will never be true, because reaching this line means b is not a matrix, while a will always be.
         }
     }
 }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMatrix.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMatrix.cs
@@ -9,7 +9,10 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
         private readonly IDreamManager _dreamManager = IoCManager.Resolve<IDreamManager>();
 
-        public static float[] MatrixToFloatArray(DreamObject matrix) {
+        /// <summary> Used to create a float array understandable by <see cref="IconAppearance.Transform"/> to be a transform. </summary>
+        /// <returns>The matrix's values in an array, in [a,d,b,e,c,f] order.</returns>
+        /// <exception cref="ArgumentException">Thrown when matrix is invalid.</exception>
+        public static float[] MatrixToTransformFloatArray(DreamObject matrix) {
             if (!matrix.IsSubtypeOf(DreamPath.Matrix))
                 throw new ArgumentException($"Invalid matrix {matrix}");
 
@@ -21,6 +24,30 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             matrix.GetVariable("c").TryGetValueAsFloat(out array[4]);
             matrix.GetVariable("f").TryGetValueAsFloat(out array[5]);
             return array;
+        }
+
+        /// <summary>
+        /// Used when printing this matrix to enumerate its values in order.
+        /// </summary>
+        /// <returns>The matrix's values in [a,b,c,d,e,f] order.</returns>
+        /// <exception cref="ArgumentException">Thrown when matrix is invalid.</exception>
+        public static IEnumerable<float> EnumerateMatrix(DreamObject matrix) {
+            if (!matrix.IsSubtypeOf(DreamPath.Matrix))
+                throw new ArgumentException($"Invalid matrix {matrix}");
+
+            float ret = 0f;
+            matrix.GetVariable("a").TryGetValueAsFloat(out ret);
+            yield return ret;
+            matrix.GetVariable("b").TryGetValueAsFloat(out ret);
+            yield return ret;
+            matrix.GetVariable("c").TryGetValueAsFloat(out ret);
+            yield return ret;
+            matrix.GetVariable("d").TryGetValueAsFloat(out ret);
+            yield return ret;
+            matrix.GetVariable("e").TryGetValueAsFloat(out ret);
+            yield return ret;
+            matrix.GetVariable("f").TryGetValueAsFloat(out ret);
+            yield return ret;
         }
 
         public DreamValue OperatorMultiply(DreamValue a, DreamValue b) {

--- a/OpenDreamRuntime/Objects/MetaObjects/IDreamMetaObject.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/IDreamMetaObject.cs
@@ -66,6 +66,13 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             return ParentType.OperatorOr(a, b);
         }
 
+        public DreamValue OperatorEquivalent(DreamValue a, DreamValue b) {
+            if (ParentType == null)
+                return a.Equals(b) ? new DreamValue(1f) : new DreamValue(0f);
+
+            return ParentType.OperatorEquivalent(a, b);
+        }
+
         public DreamValue OperatorCombine(DreamValue a, DreamValue b) {
             if (ParentType == null)
                 throw new InvalidOperationException($"Cannot combine {a} and {b}");

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1899,21 +1899,13 @@ namespace OpenDreamRuntime.Procs {
         }
 
         private static bool IsEquivalent(DreamValue first, DreamValue second) {
-            if (first.TryGetValueAsDreamList(out var firstList) && second.TryGetValueAsDreamList(out var secondList))
-            {
-                if (firstList.GetLength() != secondList.GetLength()) return false;
-                var firstValues = firstList.GetValues();
-                var secondValues = secondList.GetValues();
-                for(var i = 0; i < firstValues.Count; i++)
-                {
-                    if (!firstValues[i].Equals(secondValues[i])) return false;
+            if(first.TryGetValueAsDreamObject(out var firstObject)) {
+                if(firstObject!.ObjectDefinition?.MetaObject is not null) {
+                    return firstObject.ObjectDefinition.MetaObject.OperatorEquivalent(first, second).IsTruthy();
                 }
-
-                return true;
             }
-
-
-            throw new NotImplementedException("Equivalence comparison for " + first + " and " + second + " is not implemented");
+            // Behaviour is otherwise equivalent (pun intended) to ==
+            return IsEqual(first, second);
         }
 
         private static bool IsGreaterThan(DreamValue first, DreamValue second) {

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1900,7 +1900,7 @@ namespace OpenDreamRuntime.Procs {
 
         private static bool IsEquivalent(DreamValue first, DreamValue second) {
             if(first.TryGetValueAsDreamObject(out var firstObject)) {
-                if(firstObject!.ObjectDefinition?.MetaObject is not null) {
+                if(firstObject?.ObjectDefinition?.MetaObject is not null) {
                     return firstObject.ObjectDefinition.MetaObject.OperatorEquivalent(first, second).IsTruthy();
                 }
             }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -13,6 +13,7 @@ using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Resources;
 using DreamValueType = OpenDreamRuntime.DreamValue.DreamValueType;
+using OpenDreamRuntime.Objects.MetaObjects;
 
 namespace OpenDreamRuntime.Procs.Native {
     static class DreamProcNativeRoot {
@@ -876,6 +877,15 @@ namespace OpenDreamRuntime.Procs.Native {
             }
             if (value.Type == DreamValueType.DreamObject) {
                 if (value.Value == null) return null;
+                if(value.TryGetValueAsDreamObjectOfType(DreamPath.Matrix,out var matrix)) { // Special behaviour for /matrix values
+                    StringBuilder builder = new(13); // 13 is the minimum character count this could have: "[1,2,3,4,5,6]"
+                    builder.Append('[');
+                    builder.AppendJoin(',',DreamMetaObjectMatrix.EnumerateMatrix(matrix));
+                    builder.Append(']');
+                    return builder.ToString();
+                    // This doesn't have any corresponding snowflaking in CreateValueFromJsonElement()
+                    // because BYOND actually just forgets that this was a matrix after doing json encoding.
+                }
                 return value.Stringify();
             }
             if(value.Type == DreamValueType.DreamResource) {

--- a/OpenDreamShared/Dream/IconAppearance.cs
+++ b/OpenDreamShared/Dream/IconAppearance.cs
@@ -17,9 +17,10 @@ namespace OpenDreamShared.Dream {
         [ViewVariables] public MouseOpacity MouseOpacity = MouseOpacity.PixelOpaque;
         [ViewVariables] public List<uint> Overlays = new();
         [ViewVariables] public List<uint> Underlays = new();
-        [ViewVariables] public float[] Transform = new float[6] {   1, 0,
-                                                                    0, 1,
-                                                                    0, 0 };
+        /// <summary> The Transform property of this appearance, in [a,d,b,e,c,f] order</summary>
+        [ViewVariables] public float[] Transform = new float[6] {   1, 0,   // a d
+                                                                    0, 1,   // b e
+                                                                    0, 0 }; // c f
 
         public IconAppearance() { }
 


### PR DESCRIPTION
## Summary

Here, `operator~=` was implemented by rewriting things a little so that equivalence is handled within MetaObjects rather than relying on snowflake behaviour hard-wired into the operator itself. This should allow for easier support for operator overriding whenever we get that implemented.

I also went ahead and added correct `json_encode()`ing for /matrix.

Adding this new operator means I could also toss out a weird helper proc lying in our test suite, since this operator acts equivalently (heh) to it.

## Changelog 
- Added support for the ~= operator for `/matrix`s.
- Using ~= instead of == on values that lack any special behaviour for that operator no longer causes an unimplemented exception.
- Fixed json_encode() not encoding /matrix values correctly.
- Added more unit testing for ~= and ~! operators.
- Modified the unit tests for /matrix so it uses ~= instead of a weird helper function hidden in the test suite.