### PR TITLE
Implement \s and \th macros

### DIFF
--- a/Content.Tests/DMProject/Tests/Text/StringInterpolation6.dm
+++ b/Content.Tests/DMProject/Tests/Text/StringInterpolation6.dm
@@ -1,0 +1,15 @@
+
+
+/proc/RunTest()
+	var/text = "["1"]\s"
+	ASSERT(text == "1s")
+	text = "[0]\s"
+	ASSERT(text == "0s")
+	text = "[null]\s"
+	ASSERT(text == "s")
+	text = "[1]\s"
+	ASSERT(text == "1")
+	text = "[1.00000001]\s"
+	ASSERT(text == "1")
+	text = "[1.0001]\s"
+	ASSERT(text == "1.0001s")

--- a/Content.Tests/DMProject/Tests/Text/StringInterpolation7.dm
+++ b/Content.Tests/DMProject/Tests/Text/StringInterpolation7.dm
@@ -1,0 +1,19 @@
+
+
+/proc/RunTest()
+	var/text = "[0]\th"
+	ASSERT(text == "0th")
+	text = "[1]\th"
+	ASSERT(text == "1st")
+	text = "[2]\th"
+	ASSERT(text == "2nd")
+	text = "[3]\th"
+	ASSERT(text == "3rd")
+	text = "[4]\th"
+	ASSERT(text == "4th")
+	text = "[-1]\th"
+	ASSERT(text == "-1th")
+	// TODO: this should assert/eval to 0th
+	text = "[null]\th"
+	ASSERT(findtextEx(text,"th") != 0)
+

--- a/DMCompiler/Compiler/DM/DMParserHelper.cs
+++ b/DMCompiler/Compiler/DM/DMParserHelper.cs
@@ -176,7 +176,6 @@ namespace DMCompiler.Compiler.DM {
                                 }
                                 i--;
 
-                                bool unimplemented = false;
                                 bool skipSpaces = false;
                                 bool consumeSpaceCharacter = false;
                                 switch (escapeSequence)
@@ -310,10 +309,6 @@ namespace DMCompiler.Compiler.DM {
                                         break;
                                 }
 
-                                if (unimplemented)
-                                {
-                                    DMCompiler.UnimplementedWarning(constantToken.Location, $"Unimplemented escape sequence \"{escapeSequence}\"");
-                                }
                                 if (skipSpaces)
                                 {
                                     // Note that some macros in BYOND require a single/zero space between them and the []

--- a/DMCompiler/Compiler/DM/DMParserHelper.cs
+++ b/DMCompiler/Compiler/DM/DMParserHelper.cs
@@ -283,13 +283,12 @@ namespace DMCompiler.Compiler.DM {
                                     //Plurals, ordinals, etc
                                     //(things that hug, as a suffix, the [] that they reference)
                                     case "s":
-                                        unimplemented = true;
                                         if (CheckInterpolation(hasSeenNonRefInterpolation, interpolationValues, "s")) break;
                                         stringBuilder.Append(StringFormatEncoder.Encode(StringFormatEncoder.FormatSuffix.PluralSuffix));
                                         break;
                                     case "th":
-                                        unimplemented = true;
                                         if (CheckInterpolation(hasSeenNonRefInterpolation, interpolationValues, "th")) break;
+                                        // TODO: this should error if not DIRECTLY after an expression ([]\s vs []AA\s)
                                         stringBuilder.Append(StringFormatEncoder.Encode(StringFormatEncoder.FormatSuffix.OrdinalIndicator));
                                         break;
                                     default:

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -335,6 +335,34 @@ namespace OpenDreamRuntime.Procs {
                     case StringFormatEncoder.FormatSuffix.LowerPossessivePronoun:
                         HandleSuffixPronoun(ref formattedString, interps, prevInterpIndex, new string[] { "his", "hers", "theirs", "its" });
                         break;
+                    case StringFormatEncoder.FormatSuffix.PluralSuffix:
+                        if (interps[prevInterpIndex].TryGetValueAsFloat(out var pluralNumber) && pluralNumber == 1)
+                        {
+                            continue;
+                        }
+                        formattedString.Append("s");
+                        continue;
+                    case StringFormatEncoder.FormatSuffix.OrdinalIndicator:
+                        // TODO: if the preceding expression value is not a float, it should be replaced with 0 (0th)
+                        if (interps[prevInterpIndex].TryGetValueAsFloat(out var ordinalNumber)) {
+                            switch (ordinalNumber) {
+                                case 1:
+                                    formattedString.Append("st");
+                                    break;
+                                case 2:
+                                    formattedString.Append("nd");
+                                    break;
+                                case 3:
+                                    formattedString.Append("rd");
+                                    break;
+                                default:
+                                    formattedString.Append("th");
+                                    break;
+                            }
+                        } else {
+                            formattedString.Append("th");
+                        }
+                        continue;
                     default:
                         if (Enum.IsDefined(typeof(StringFormatEncoder.FormatSuffix), formatType)) {
                             //Likely an unimplemented text macro, ignore it


### PR DESCRIPTION
Implements the \s and \th macros, with the only difference being that \th does not confirm it is directly after an expression and not replacing non-floats with 0.