### PR TITLE
Fixes statics not allowing calls to late-defined procs

### DIFF
--- a/Content.Tests/DMProject/Tests/Procs/late_proc_define.dm
+++ b/Content.Tests/DMProject/Tests/Procs/late_proc_define.dm
@@ -1,0 +1,11 @@
+
+// issue OD#869
+// https://github.com/OpenDreamProject/OpenDream/issues/869
+
+var/static/earlybird = proc_that_has_value()
+
+/proc/proc_that_has_value()
+    return 7
+
+/proc/RunTest()
+    ASSERT(earlybird == 7)

--- a/DMCompiler/DM/DMObject.cs
+++ b/DMCompiler/DM/DMObject.cs
@@ -8,6 +8,11 @@ using OpenDreamShared.Compiler;
 using OpenDreamShared.Dream.Procs;
 
 namespace DMCompiler.DM {
+    /// <remarks>
+    /// This doesn't represent a particular, specific instance of an object, <br/>
+    /// but rather stores the compiletime information necessary to describe a certain object definition, <br/>
+    /// including its procs, vars, path, parent, etc.
+    /// </remarks>
     class DMObject {
         public int Id;
         public DreamPath Path;

--- a/DMCompiler/DM/DMObjectTree.cs
+++ b/DMCompiler/DM/DMObjectTree.cs
@@ -29,18 +29,25 @@ namespace DMCompiler.DM {
 
         static DMObjectTree() {
             Reset();
-            GlobalInitProc = new(-1, GetDMObject(DreamPath.Root), null);
         }
 
+        /// <summary>
+        /// A thousand curses upon you if you add a new member to this thing without deleting it here.
+        /// </summary>
         public static void Reset() {
             AllObjects.Clear();
             AllProcs.Clear();
+
             Globals.Clear();
             GlobalProcs.Clear();
+            StringTable.Clear();
+            StringToStringID.Clear();
+
+            _globalInitAssigns.Clear();
             _pathToTypeId.Clear();
             _dmObjectIdCounter = 0;
             _dmProcIdCounter = 0;
-            GetDMObject(DreamPath.Root);
+            GlobalInitProc = new(-1, GetDMObject(DreamPath.Root), null);
         }
 
         public static DMProc CreateDMProc(DMObject dmObject, [CanBeNull] DMASTProcDefinition astDefinition)


### PR DESCRIPTION
Fixes #869.

## Summary

At first I thought that this would be arduous to set up, with the need for events or whatever, but it turns out that all that was needed was some short-circuiting during Object variable instantiation. :)

To elaborate a little, the superduper proc that instantiates all statics at runtime boot is only generated at the very end of DMObjectBuilder, after even DMProcBuilder has done its own work. So there was no real need to change any ordering, since by that point, all static declarations are already scanned.

This means that we can just, defer evaluating the static declaration's righthand-side until that point, no biggie. This is really just like, a five-line change; there's more diff than that here because I added a test, more comments, and did some minor code reorganization, in my usual style :^)

## Changelog
- Fixed statics not permitting assignment via a proc whose definition has yet to be found.