### PR TITLE
Replace some GetValueAs with TryGetValueAs

### DIFF
--- a/OpenDreamRuntime/DreamManager.Connections.cs
+++ b/OpenDreamRuntime/DreamManager.Connections.cs
@@ -114,7 +114,7 @@ namespace OpenDreamRuntime
         {
             foreach (DreamObject client in _clientToConnection.Keys)
             {
-                if (client.GetVariable("mob").GetValueAsDreamObject() == mob)
+                if (client.GetVariable("mob").TryGetValueAsDreamObject(out var mobD) && mobD == mob)
                     return client;
             }
 

--- a/OpenDreamRuntime/DreamMapManager.cs
+++ b/OpenDreamRuntime/DreamMapManager.cs
@@ -28,8 +28,8 @@ namespace OpenDreamRuntime {
             }
 
             public void SetArea(Vector2i pos, DreamObject area) {
-                if (area.GetVariable("x").GetValueAsInteger() > pos.X) area.SetVariable("x", new DreamValue(pos.X));
-                if (area.GetVariable("y").GetValueAsInteger() > pos.Y) area.SetVariable("y", new DreamValue(pos.Y));
+                if (area.GetVariable("x").TryGetValueAsInteger(out var xD) && xD > pos.X) area.SetVariable("x", new DreamValue(pos.X));
+                if (area.GetVariable("y").TryGetValueAsInteger(out var xY) && xY > pos.Y) area.SetVariable("y", new DreamValue(pos.Y));
 
                 Cells[pos.X - 1, pos.Y - 1].Area = area;
             }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -26,8 +26,8 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             _atomManager.DeleteMovableEntity(dreamObject);
             _dreamManager.WorldContentsList.RemoveValue(new DreamValue(dreamObject));
 
-            _atomManager.OverlaysListToAtom.Remove(dreamObject.GetVariable("overlays").GetValueAsDreamList());
-            _atomManager.UnderlaysListToAtom.Remove(dreamObject.GetVariable("underlays").GetValueAsDreamList());
+            if (dreamObject.GetVariable("overlays").TryGetValueAsDreamList(out var overlay)) _atomManager.OverlaysListToAtom.Remove(overlay);
+            if (dreamObject.GetVariable("underlays").TryGetValueAsDreamList(out var underlay))  _atomManager.UnderlaysListToAtom.Remove(underlay);
 
             ParentType?.OnObjectDeleted(dreamObject);
         }
@@ -221,7 +221,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     ? colorString
                     : "#FFFFFF"; // Defaults to white
                 appearance.SetColor(color);
-                appearance.Direction = (AtomDirection)image.GetVariable("dir").GetValueAsInteger();
+                appearance.Direction = (image.GetVariable("dir").TryGetValueAsInteger(out var dir) ? (AtomDirection) dir : AtomDirection.None);
                 image.GetVariable("layer").TryGetValueAsFloat(out appearance.Layer);
                 image.GetVariable("pixel_x").TryGetValueAsInteger(out appearance.PixelOffset.X);
                 image.GetVariable("pixel_y").TryGetValueAsInteger(out appearance.PixelOffset.Y);

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
@@ -18,9 +18,8 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
             _dreamManager.Clients.Add(dreamObject);
 
-            ClientPerspective perspective = (ClientPerspective)dreamObject.GetVariable("perspective").GetValueAsInteger();
-            if (perspective != ClientPerspective.Mob) {
-                //Runtime.StateManager.AddClientPerspectiveDelta(connection.CKey, perspective);
+            if (dreamObject.GetVariable("perspective").TryGetValueAsInteger(out var perspective) && (ClientPerspective) perspective != ClientPerspective.Mob) {
+                //Runtime.StateManager.AddClientPerspectiveDelta(connection.CKey, (ClientPerspective) perspective);
             }
         }
 
@@ -34,22 +33,22 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
             switch (varName) {
                 case "eye": {
-                    string ckey = dreamObject.GetVariable("ckey").GetValueAsString();
-                    DreamObject eye = value.GetValueAsDreamObject();
-
-                    //Runtime.StateManager.AddClientEyeIDDelta(ckey, eyeID);
+                    /*if(dreamObject.GetVariable("ckey").TryGetValueAsString(out var ckey) && variableValue.TryGetValueAsDreamObject(out var eye)) {
+                        Runtime.StateManager.AddClientEyeIDDelta(ckey, eyeID);
+                    }*/
                     break;
                 }
                 case "perspective": {
-                    string ckey = dreamObject.GetVariable("ckey").GetValueAsString();
-
-                    //Runtime.StateManager.AddClientPerspectiveDelta(ckey, (ClientPerspective)variableValue.GetValueAsInteger());
+                    /*if(dreamObject.GetVariable("ckey").TryGetValueAsString(out var ckey) && variableValue.TryGetValueAsInteger(out var perspective)) {
+                        Runtime.StateManager.AddClientPerspectiveDelta(ckey, (ClientPerspective) perspective);
+                    }*/
                     break;
                 }
                 case "mob": {
-                    DreamConnection connection = _dreamManager.GetConnectionFromClient(dreamObject);
-
-                    connection.MobDreamObject = value.GetValueAsDreamObject();
+                    DreamConnection? connection = _dreamManager.GetConnectionFromClient(dreamObject);
+                    if (connection != null && value.TryGetValueAsDreamObject(out var valueDreamObject) && valueDreamObject != null) {
+                        connection.MobDreamObject = valueDreamObject;
+                    }
                     break;
                 }
                 case "screen": {
@@ -86,9 +85,10 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     break;
                 }
                 case "statpanel": {
-                    //DreamConnection connection = Runtime.Server.GetConnectionFromClient(dreamObject);
-
-                    //connection.SelectedStatPanel = variableValue.GetValueAsString();
+                    /*DreamConnection connection = Runtime.Server.GetConnectionFromClient(dreamObject);
+                    if(variableValue.TryGetValueAsString(out var variableValueD)) {
+                        connection.SelectedStatPanel = variableValueD;
+                    }*/
                     break;
                 }
             }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMob.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMob.cs
@@ -28,7 +28,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             ParentType?.OnVariableSet(dreamObject, varName, value, oldValue);
 
             if (varName == "key" || varName == "ckey") {
-                if (_playerManager.TryGetSessionByUsername(value.GetValueAsString(), out var session)) {
+                if (value.TryGetValueAsString(out var username) && _playerManager.TryGetSessionByUsername(username, out var session)) {
                     var connection = _dreamManager.GetConnectionBySession(session);
 
                     connection.MobDreamObject = dreamObject;
@@ -36,8 +36,10 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             } else if (varName == "see_invisible") {
                //TODO
             } else if (varName == "client" && value != oldValue) {
-                var newClient = value.GetValueAsDreamObject();
-                var oldClient = oldValue.GetValueAsDreamObject();
+                if(!value.TryGetValueAsDreamObject(out var newClient)) {
+                    Logger.Warning("mob's client set to invalid value");
+                }
+                DreamObject oldClient = oldValue.GetValueAsDreamObject();
 
                 if (newClient != null) {
                     _dreamManager.GetConnectionFromClient(newClient).MobDreamObject = dreamObject;

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectWorld.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectWorld.cs
@@ -27,7 +27,16 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
             ParentType?.OnObjectCreated(dreamObject, creationArguments);
 
-            _dreamManager.WorldContentsList = dreamObject.GetVariable("contents").GetValueAsDreamList();
+            if (!dreamObject.GetVariable("contents").TryGetValueAsDreamList(out var contentsList)) {
+                Logger.Warning("world.contents did not contain a valid value. A default of list() is being used.");
+                contentsList = DreamList.Create();
+            }
+            _dreamManager.WorldContentsList = contentsList;
+
+            if (dreamObject.ObjectDefinition == null) {
+                Logger.Error("world's definition was null somehow.");
+                return;
+            }
 
             DreamValue log = dreamObject.ObjectDefinition.Variables["log"];
             dreamObject.SetVariable("log", log);
@@ -38,7 +47,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             }
 
             DreamValue view = dreamObject.ObjectDefinition.Variables["view"];
-            if (view.TryGetValueAsString(out string viewString)) {
+            if (view.TryGetValueAsString(out var viewString) && viewString != null) {
                 _viewRange = new ViewRange(viewString);
             } else {
                 if (!view.TryGetValueAsInteger(out var viewInt)) {


### PR DESCRIPTION
This replaces some calls that could be optional. There needs to be a `MustGetValueAs` for cases where it is guaranteed and should error otherwise, but this handles some cases where it could fail. The problem is figuring out what is supposed to happen in these cases is not very easy.