### PR TITLE
Fixes \th interpolation

### DIFF
--- a/Content.Tests/DMProject/Tests/Text/StringInterpolation7.dm
+++ b/Content.Tests/DMProject/Tests/Text/StringInterpolation7.dm
@@ -17,6 +17,8 @@
 	ASSERT(text == "4th")
 	text = "the fitness [1.7]\th is a"
 	ASSERT(text == "the fitness 1st is a")
+	text = "the fitness [99999999]\th is a"
+	ASSERT(text == "the fitness 100000000th is a")
 	// TODO: this should assert/eval to 0th
 	text = "[null]\th"
 	ASSERT(findtextEx(text,"th") != 0)

--- a/Content.Tests/DMProject/Tests/Text/StringInterpolation7.dm
+++ b/Content.Tests/DMProject/Tests/Text/StringInterpolation7.dm
@@ -13,6 +13,10 @@
 	ASSERT(text == "4th")
 	text = "[-1]\th"
 	ASSERT(text == "-1th")
+	text = "[4.52]\th"
+	ASSERT(text == "4th")
+	text = "the fitness [1.7]\th is a"
+	ASSERT(text == "the fitness 1st is a")
 	// TODO: this should assert/eval to 0th
 	text = "[null]\th"
 	ASSERT(findtextEx(text,"th") != 0)

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -349,7 +349,7 @@ namespace OpenDreamRuntime.Procs {
                             /// For some mystical reason byond converts \th to integers
                             interps[prevInterpIndex].TryGetValueAsFloat(out var temp);
                             /// This is slightly hacky but the only reliable way I know how to replace the number
-                            formattedString.Remove(formattedString.Length - temp.ToString().Length, temp.ToString().Length);
+                            formattedString.Length -= temp.ToString().Length;
                             formattedString.Append(ordinalNumber);
                             switch (ordinalNumber) {
                                 case 1:

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -346,10 +346,10 @@ namespace OpenDreamRuntime.Procs {
                         // TODO: if the preceding expression value is not a float, it should be replaced with 0 (0th)
                         if (interps[prevInterpIndex].TryGetValueAsInteger(out var ordinalNumber)) {
 
-                            /// For some mystical reason byond converts \th to integers
-                            interps[prevInterpIndex].TryGetValueAsFloat(out var temp);
-                            /// This is slightly hacky but the only reliable way I know how to replace the number
-                            formattedString.Length -= temp.ToString().Length;
+                            // For some mystical reason byond converts \th to integers
+                            // This is slightly hacky but the only reliable way I know how to replace the number
+                            // Need to call stringy to make sure its the right length to cut
+                            formattedString.Length -= interps[prevInterpIndex].Stringify().Length;
                             formattedString.Append(ordinalNumber);
                             switch (ordinalNumber) {
                                 case 1:

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -344,7 +344,13 @@ namespace OpenDreamRuntime.Procs {
                         continue;
                     case StringFormatEncoder.FormatSuffix.OrdinalIndicator:
                         // TODO: if the preceding expression value is not a float, it should be replaced with 0 (0th)
-                        if (interps[prevInterpIndex].TryGetValueAsFloat(out var ordinalNumber)) {
+                        if (interps[prevInterpIndex].TryGetValueAsInteger(out var ordinalNumber)) {
+
+                            /// For some mystical reason byond converts \th to integers
+                            interps[prevInterpIndex].TryGetValueAsFloat(out var temp);
+                            /// This is slightly hacky but the only reliable way I know how to replace the number
+                            formattedString.Remove(formattedString.Length - temp.ToString().Length, temp.ToString().Length);
+                            formattedString.Append(ordinalNumber);
                             switch (ordinalNumber) {
                                 case 1:
                                     formattedString.Append("st");


### PR DESCRIPTION
For some mystical byond comprehension reason byond will convert 4.52 to 4. should fix that without creating any extra bugs.