### PR TITLE
Ignore whitespace before a preprocessor concat token

### DIFF
--- a/DMCompiler/Compiler/DMPreprocessor/DMMacro.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMMacro.cs
@@ -5,10 +5,10 @@ using OpenDreamShared.Compiler;
 
 namespace DMCompiler.Compiler.DMPreprocessor {
     class DMMacro {
-        private List<string> _parameters;
-        private List<Token> _tokens;
-        private string _overflowParameter = null;
-        private int _overflowParameterIndex;
+        private readonly List<string> _parameters;
+        private readonly List<Token> _tokens;
+        private readonly string _overflowParameter;
+        private readonly int _overflowParameterIndex;
 
         public DMMacro(List<string> parameters, List<Token> tokens) {
             _parameters = parameters;
@@ -26,60 +26,87 @@ namespace DMCompiler.Compiler.DMPreprocessor {
                     }
                 }
             }
+
+            if (_tokens != null) {
+                // Concat tokens cause any whitespace directly before them to be ignored
+                for (int i = 1; i < _tokens.Count; i++) {
+                    Token token = _tokens[i];
+                    Token lastToken = _tokens[i - 1];
+
+                    if (token.Type == TokenType.DM_Preproc_TokenConcat &&
+                        lastToken.Type == TokenType.DM_Preproc_Whitespace) {
+                        _tokens.RemoveAt(--i);
+                    }
+                }
+            }
         }
 
         public bool HasParameters() {
             return _parameters != null;
         }
 
+        /// <summary>
+        /// Takes given parameters and creates a list of tokens representing the expanded macro
+        /// </summary>
+        /// <param name="replacing">The identifier being replaced with this macro</param>
+        /// <param name="parameters">Parameters for macro expansion. Null if none given.</param>
+        /// <returns>A list of tokens replacing the identifier</returns>
+        /// <exception cref="ArgumentException">Thrown if no parameters were given but are required</exception>
+        // TODO: Convert this to an IEnumerator<Token>? Could cut down on allocations.
         public virtual List<Token> Expand(Token replacing, List<List<Token>> parameters) {
-            if (parameters == null && HasParameters()) throw new ArgumentException("This macro requires parameters");
+            // If this macro has no parameters then we can just return our list of tokens
+            if (!HasParameters())
+                return _tokens;
 
-            List<Token> expandedTokens = new();
+            // If we have parameters but weren't given any, throw an exception
+            if (parameters == null)
+                throw new ArgumentException("This macro requires parameters");
+
+            List<Token> expandedTokens = new(_tokens.Count);
             foreach (Token token in _tokens) {
-                if (HasParameters()) {
-                    string parameterName = (token.Type == TokenType.DM_Preproc_TokenConcat || token.Type == TokenType.DM_Preproc_ParameterStringify) ? (string)token.Value : token.Text;
-                    int parameterIndex = _parameters.IndexOf(parameterName);
+                string parameterName =
+                    token.Type is TokenType.DM_Preproc_TokenConcat or TokenType.DM_Preproc_ParameterStringify
+                        ? (string) token.Value
+                        : token.Text;
+                int parameterIndex = _parameters.IndexOf(parameterName);
 
-                    if (parameterIndex != -1 && parameters.Count > parameterIndex) {
-                        List<Token> parameter = parameters[parameterIndex];
+                if (parameterIndex != -1 && parameters.Count > parameterIndex) {
+                    List<Token> parameter = parameters[parameterIndex];
 
-                        if (token.Type == TokenType.DM_Preproc_ParameterStringify) {
-                            StringBuilder tokenTextBuilder = new StringBuilder();
+                    if (token.Type == TokenType.DM_Preproc_ParameterStringify) {
+                        StringBuilder tokenTextBuilder = new StringBuilder();
 
-                            // Use a raw string. Use '#' because that can't appear in an expression.
-                            tokenTextBuilder.Append("@#");
-                            foreach (Token parameterToken in parameter) {
-                                tokenTextBuilder.Append(parameterToken.Text);
-                            }
-                            tokenTextBuilder.Append('#');
-
-                            string tokenText = tokenTextBuilder.ToString();
-                            expandedTokens.Add(new Token(TokenType.DM_Preproc_ConstantString, tokenText, Location.Unknown, tokenText.Substring(2, tokenText.Length - 3)));
-                        } else {
-                            foreach (Token parameterToken in parameter) {
-                                expandedTokens.Add(parameterToken);
-                            }
+                        // Use a raw string. Use '#' because that can't appear in an expression.
+                        // this does mean, however, that a '#' inside the string will make the preprocessor dump produce invalid code
+                        tokenTextBuilder.Append("@#");
+                        foreach (Token parameterToken in parameter) {
+                            tokenTextBuilder.Append(parameterToken.Text);
                         }
-                    } else if (_overflowParameter != null && parameterName == _overflowParameter) {
-                        for (int i = _overflowParameterIndex; i < parameters.Count; i++) {
-                            foreach (Token parameterToken in parameters[i]) {
-                                expandedTokens.Add(parameterToken);
-                            }
 
-                            expandedTokens.Add(new Token(TokenType.DM_Preproc_Punctuator_Comma, ",", Location.Unknown, null));
-                        }
+                        tokenTextBuilder.Append('#');
+
+                        string tokenText = tokenTextBuilder.ToString();
+                        expandedTokens.Add(new Token(TokenType.DM_Preproc_ConstantString, tokenText,
+                            Location.Unknown, tokenText.Substring(2, tokenText.Length - 3)));
                     } else {
-                        if (token.Type == TokenType.DM_Preproc_ParameterStringify) {
-                            expandedTokens.Add(new Token(TokenType.DM_Preproc_ConstantString, $"@#{parameterName}#", Location.Unknown, parameterName));
-                        } else if (token.Type == TokenType.DM_Preproc_TokenConcat) {
-                            expandedTokens.Add(new Token(TokenType.DM_Preproc_Identifier, parameterName, Location.Unknown, null));
-                        } else {
-                            expandedTokens.Add(token);
-                        }
+                        expandedTokens.AddRange(parameter);
+                    }
+                } else if (_overflowParameter != null && parameterName == _overflowParameter) {
+                    for (int i = _overflowParameterIndex; i < parameters.Count; i++) {
+                        expandedTokens.AddRange(parameters[i]);
+                        expandedTokens.Add(new Token(TokenType.DM_Preproc_Punctuator_Comma, ",", Location.Unknown,
+                            null));
                     }
                 } else {
-                    expandedTokens.Add(token);
+                    if (token.Type == TokenType.DM_Preproc_ParameterStringify) {
+                        expandedTokens.Add(new Token(TokenType.DM_Preproc_ConstantString, $"@#{parameterName}#",
+                            Location.Unknown, parameterName));
+                    } else if (token.Type == TokenType.DM_Preproc_TokenConcat) {
+                        expandedTokens.Add(new Token(TokenType.DM_Preproc_Identifier, parameterName,
+                            Location.Unknown, null));
+                    } else {
+                        expandedTokens.Add(token);
+                    }
                 }
             }
 

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -35,7 +35,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
         /// We do this so that we can A.) Detect whether an #else or #endif is valid and B.) Remember what to do when we find that #else.
         /// A null value indicates the last directive found was an #else that's waiting for an #endif.
         /// </summary>
-        private Stack<bool?> _lastIfEvaluations = new(); 
+        private Stack<bool?> _lastIfEvaluations = new();
         private Location _lastSeenIf = Location.Unknown; // used by the errors emitted for when the above var isn't empty at exit
 
         private static readonly TokenType[] DirectiveTypes =
@@ -402,9 +402,8 @@ namespace DMCompiler.Compiler.DMPreprocessor {
             }
 
             List<Token> expandedTokens = macro.Expand(token, parameters);
-            expandedTokens.Reverse();
-
-            foreach (Token expandedToken in expandedTokens) {
+            for (int i = expandedTokens.Count - 1; i >= 0; i--) {
+                Token expandedToken = expandedTokens[i];
                 expandedToken.Location = token.Location;
 
                 // These tokens are pushed so that nested macros get processed
@@ -427,7 +426,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
             _lastSeenIf = ifToken.Location;
             if (!VerifyDirectiveUsage(ifToken))
                 return;
-                
+
             var tokens = GetLineOfTokens();
             if (!tokens.Any()) { // If empty
                 DMCompiler.Error(new CompilerError(ifToken.Location, "Expression expected for #if"));


### PR DESCRIPTION
Fix 988 errors in goonstation in one easy step! (from 2601 to 1613)

Something like this would erroneously produce `/datum/_is_abstract /area `:
```
#define ABSTRACT_TYPE(type) /datum/_is_abstract ## type

ABSTRACT_TYPE(/area)
```

It now correctly generates `/datum/_is_abstract/area `. I also did some small clean up and optimization in DMMacro.