### PR TITLE
Fix #793 - Relative pathing for interface and fileexists check

### DIFF
--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -37,7 +37,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
         /// </summary>
         private Stack<bool?> _lastIfEvaluations = new();
         private Location _lastSeenIf = Location.Unknown; // used by the errors emitted for when the above var isn't empty at exit
-
+        private string? topLevelDirectory = null; //used to store relative paths from the .json output properly
         private static readonly TokenType[] DirectiveTypes =
         {
             TokenType.DM_Preproc_Include,
@@ -172,8 +172,10 @@ namespace DMCompiler.Compiler.DMPreprocessor {
         }
 
         public void IncludeFiles(IEnumerable<string> files) {
+            
             foreach (string file in files) {
                 string includeDir = Path.GetDirectoryName(file);
+                if(topLevelDirectory == null) topLevelDirectory = includeDir; //the first element in files is the .dme
                 string fileName = Path.GetFileName(file);
 
                 IncludeFile(includeDir, fileName);
@@ -206,9 +208,9 @@ namespace DMCompiler.Compiler.DMPreprocessor {
                     if (IncludedInterface != null) {
                         DMCompiler.Error(new CompilerError(includedFrom ?? Location.Internal, $"Attempted to include a second interface file ({filePath}) while one was already included ({IncludedInterface})"));
                         break;
-                    }
-
-                    IncludedInterface = filePath;
+                    }                    
+                    
+                    IncludedInterface = Path.GetRelativePath(topLevelDirectory, filePath);                    
                     break;
                 case ".dms":
                     // Webclient interface file. Probably never gonna be supported.

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -37,6 +37,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
         /// </summary>
         private Stack<bool?> _lastIfEvaluations = new();
         private Location _lastSeenIf = Location.Unknown; // used by the errors emitted for when the above var isn't empty at exit
+
         private static readonly TokenType[] DirectiveTypes =
         {
             TokenType.DM_Preproc_Include,
@@ -205,9 +206,9 @@ namespace DMCompiler.Compiler.DMPreprocessor {
                     if (IncludedInterface != null) {
                         DMCompiler.Error(new CompilerError(includedFrom ?? Location.Internal, $"Attempted to include a second interface file ({filePath}) while one was already included ({IncludedInterface})"));
                         break;
-                    }                    
-                    
-                    IncludedInterface = filePath;                   
+                    }
+
+                    IncludedInterface = filePath;
                     break;
                 case ".dms":
                     // Webclient interface file. Probably never gonna be supported.

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -209,7 +209,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
                         break;
                     }                    
                     
-                    IncludedInterface = Path.GetRelativePath(topLevelDirectory, filePath);                    
+                    IncludedInterface = filePath;                   
                     break;
                 case ".dms":
                     // Webclient interface file. Probably never gonna be supported.

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -172,7 +172,6 @@ namespace DMCompiler.Compiler.DMPreprocessor {
         }
 
         public void IncludeFiles(IEnumerable<string> files) {
-            
             foreach (string file in files) {
                 string includeDir = Path.GetDirectoryName(file);
                 if(topLevelDirectory == null) topLevelDirectory = includeDir; //the first element in files is the .dme

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -37,7 +37,6 @@ namespace DMCompiler.Compiler.DMPreprocessor {
         /// </summary>
         private Stack<bool?> _lastIfEvaluations = new();
         private Location _lastSeenIf = Location.Unknown; // used by the errors emitted for when the above var isn't empty at exit
-        private string? topLevelDirectory = null; //used to store relative paths from the .json output properly
         private static readonly TokenType[] DirectiveTypes =
         {
             TokenType.DM_Preproc_Include,
@@ -174,7 +173,6 @@ namespace DMCompiler.Compiler.DMPreprocessor {
         public void IncludeFiles(IEnumerable<string> files) {
             foreach (string file in files) {
                 string includeDir = Path.GetDirectoryName(file);
-                if(topLevelDirectory == null) topLevelDirectory = includeDir; //the first element in files is the .dme
                 string fileName = Path.GetFileName(file);
 
                 IncludeFile(includeDir, fileName);

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -223,7 +223,7 @@ namespace DMCompiler {
             DreamCompiledJson compiledDream = new DreamCompiledJson();
             compiledDream.Strings = DMObjectTree.StringTable;
             compiledDream.Maps = maps;
-            compiledDream.Interface = interfaceFile;
+            compiledDream.Interface = compiledDream.Interface = Path.GetRelativePath(Path.GetDirectoryName(outputFile), interfaceFile);
             var jsonRep = DMObjectTree.CreateJsonRepresentation();
             compiledDream.Types = jsonRep.Item1;
             compiledDream.Procs = jsonRep.Item2;

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -223,7 +223,7 @@ namespace DMCompiler {
             DreamCompiledJson compiledDream = new DreamCompiledJson();
             compiledDream.Strings = DMObjectTree.StringTable;
             compiledDream.Maps = maps;
-            compiledDream.Interface = Path.GetRelativePath(Path.GetDirectoryName(outputFile), interfaceFile);
+            compiledDream.Interface = string.IsNullOrEmpty(interfaceFile) ? "" : Path.GetRelativePath(Path.GetDirectoryName(outputFile), interfaceFile);
             var jsonRep = DMObjectTree.CreateJsonRepresentation();
             compiledDream.Types = jsonRep.Item1;
             compiledDream.Procs = jsonRep.Item2;

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -223,7 +223,7 @@ namespace DMCompiler {
             DreamCompiledJson compiledDream = new DreamCompiledJson();
             compiledDream.Strings = DMObjectTree.StringTable;
             compiledDream.Maps = maps;
-            compiledDream.Interface = compiledDream.Interface = Path.GetRelativePath(Path.GetDirectoryName(outputFile), interfaceFile);
+            compiledDream.Interface = Path.GetRelativePath(Path.GetDirectoryName(outputFile), interfaceFile);
             var jsonRep = DMObjectTree.CreateJsonRepresentation();
             compiledDream.Types = jsonRep.Item1;
             compiledDream.Procs = jsonRep.Item2;

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -80,7 +80,8 @@ namespace OpenDreamRuntime {
 
             _compiledJson = json;
             _dreamResourceManager.SetDirectory(Path.GetDirectoryName(jsonPath));
-
+            if(!_dreamResourceManager.DoesFileExist(_compiledJson.Interface))            
+                throw new FileNotFoundException("Interface DMF not found at "+Path.Join(Path.GetDirectoryName(jsonPath),_compiledJson.Interface));
             ObjectTree.LoadJson(json);
 
             SetMetaObjects();

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -80,8 +80,9 @@ namespace OpenDreamRuntime {
 
             _compiledJson = json;
             _dreamResourceManager.SetDirectory(Path.GetDirectoryName(jsonPath));
-            if(!_dreamResourceManager.DoesFileExist(_compiledJson.Interface))            
+            if(!string.IsNullOrEmpty(_compiledJson.Interface) && !_dreamResourceManager.DoesFileExist(_compiledJson.Interface))            
                 throw new FileNotFoundException("Interface DMF not found at "+Path.Join(Path.GetDirectoryName(jsonPath),_compiledJson.Interface));
+            //TODO: Empty or invalid _compiledJson.Interface should return default interface - see issue #851
             ObjectTree.LoadJson(json);
 
             SetMetaObjects();


### PR DESCRIPTION
Fixes #793 by storing the path of the interface file relative to the json file, and adding a check to server initialisation that ensures the existence of the interface file.