### PR TITLE
"Fixes" missing oddball behaviour with bitshift operations

### DIFF
--- a/Content.Tests/DMProject/Tests/Operators/bitshift_more_like_bullshit.dm
+++ b/Content.Tests/DMProject/Tests/Operators/bitshift_more_like_bullshit.dm
@@ -1,0 +1,16 @@
+
+/proc/RunTest()
+	//Normal bitshifting
+	ASSERT((1 << 2) == 4)
+	ASSERT((1 << 2.5) == 4)
+	ASSERT((4 >> 2) == 1)
+
+	//The silly part
+	ASSERT((2 << "seven") == 2)
+	ASSERT(("two" << 7) == 0)
+	ASSERT(("two" << "seven") == 0)
+
+	ASSERT((4 >> 2) == 1)
+	ASSERT(("four" >> 2) == 0)
+	ASSERT((4 >> "two") == 4)
+	ASSERT(("four" >> "two") == 0)

--- a/Content.Tests/DMProject/Tests/Operators/bitshift_runtime_type_mismatch.dm
+++ b/Content.Tests/DMProject/Tests/Operators/bitshift_runtime_type_mismatch.dm
@@ -1,0 +1,10 @@
+//RUNTIME ERROR
+
+/proc/RunTest()
+	//Making sure it doesn't work in non-const contexts
+	var/x = 5
+	x = 2
+	var/y = "foo"
+	y = "bar"
+	ASSERT((x << y) == 2)
+	ASSERT((y << x) == 0)

--- a/DMCompiler/DM/Expressions/Constant.cs
+++ b/DMCompiler/DM/Expressions/Constant.cs
@@ -1,6 +1,7 @@
 using OpenDreamShared.Compiler;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Json;
+using Robust.Shared.Utility;
 using System;
 using System.Collections.Generic;
 
@@ -65,11 +66,24 @@ namespace DMCompiler.DM.Expressions {
         }
 
         public virtual Constant LeftShift(Constant rhs) {
-            throw new CompileErrorException(Location, $"const operation \"{this} << {rhs}\" is invalid");
+            DebugTools.Assert(this is not Number);
+            if(rhs is Number) { // Slightly different phrasing depending on how stupid this is
+                DMCompiler.Warning(Location, "Left operand of '<<' operation is not a number and will be coerced to 0");
+            } else {
+                DMCompiler.Warning(Location, "Neither operand of '<<' operation is a number - expression will evaluate to 0");
+            }
+            
+            return new Number(Location, 0f); // 0 << (anything) is 0.
         }
 
         public virtual Constant RightShift(Constant rhs) {
-            throw new CompileErrorException(Location, $"const operation \"{this} >> {rhs}\" is invalid");
+            DebugTools.Assert(this is not Number);
+            if (rhs is Number) {
+                DMCompiler.Warning(Location, "Left operand of '>>' operation is not a number and will be coerced to 0");
+            } else {
+                DMCompiler.Warning(Location, "Neither operand of '<<' operation is a number - expression will evaluate to 0");
+            }
+            return new Number(Location, 0f); // 0 >> (anything) is 0.
         }
 
         public virtual Constant BinaryAnd(Constant rhs) {
@@ -143,7 +157,7 @@ namespace DMCompiler.DM.Expressions {
 
         public override Constant Subtract(Constant rhs) {
             if (rhs is not Number rhsNum) {
-                return base.Add(rhs);
+                return base.Subtract(rhs);
             }
 
             return new Number(Location, Value - rhsNum.Value);
@@ -151,7 +165,7 @@ namespace DMCompiler.DM.Expressions {
 
         public override Constant Multiply(Constant rhs) {
             if (rhs is not Number rhsNum) {
-                return base.Add(rhs);
+                return base.Multiply(rhs);
             }
 
             return new Number(Location, Value * rhsNum.Value);
@@ -159,7 +173,7 @@ namespace DMCompiler.DM.Expressions {
 
         public override Constant Divide(Constant rhs) {
             if (rhs is not Number rhsNum) {
-                return base.Add(rhs);
+                return base.Divide(rhs);
             }
 
             return new Number(Location, Value / rhsNum.Value);
@@ -167,7 +181,7 @@ namespace DMCompiler.DM.Expressions {
 
         public override Constant Modulo(Constant rhs) {
             if (rhs is not Number rhsNum) {
-                return base.Add(rhs);
+                return base.Modulo(rhs);
             }
 
             return new Number(Location, Value % rhsNum.Value);
@@ -175,7 +189,7 @@ namespace DMCompiler.DM.Expressions {
 
         public override Constant Power(Constant rhs) {
             if (rhs is not Number rhsNum) {
-                return base.Add(rhs);
+                return base.Power(rhs);
             }
 
             return new Number(Location, MathF.Pow(Value, rhsNum.Value));
@@ -183,7 +197,8 @@ namespace DMCompiler.DM.Expressions {
 
         public override Constant LeftShift(Constant rhs) {
             if (rhs is not Number rhsNum) {
-                return base.Add(rhs);
+                DMCompiler.Warning(rhs.Location, "Right operand of '<<' operation is not a number and will be coerced to 0");
+                return this; // x << 0 == x
             }
 
             return new Number(Location, ((int)Value) << ((int)rhsNum.Value));
@@ -191,7 +206,8 @@ namespace DMCompiler.DM.Expressions {
 
         public override Constant RightShift(Constant rhs) {
             if (rhs is not Number rhsNum) {
-                return base.Add(rhs);
+                DMCompiler.Warning(rhs.Location, "Right operand of '>>' operation is not a number and will be coerced to 0");
+                return this; // x >> 0 == x
             }
 
             return new Number(Location, ((int)Value) >> ((int)rhsNum.Value));
@@ -200,7 +216,7 @@ namespace DMCompiler.DM.Expressions {
 
         public override Constant BinaryAnd(Constant rhs) {
             if (rhs is not Number rhsNum) {
-                return base.Add(rhs);
+                return base.BinaryAnd(rhs);
             }
 
             return new Number(Location, ((int)Value) & ((int)rhsNum.Value));
@@ -209,7 +225,7 @@ namespace DMCompiler.DM.Expressions {
 
         public override Constant BinaryXor(Constant rhs) {
             if (rhs is not Number rhsNum) {
-                return base.Add(rhs);
+                return base.BinaryXor(rhs);
             }
 
             return new Number(Location, ((int)Value) ^ ((int)rhsNum.Value));
@@ -218,7 +234,7 @@ namespace DMCompiler.DM.Expressions {
 
         public override Constant BinaryOr(Constant rhs) {
             if (rhs is not Number rhsNum) {
-                return base.Add(rhs);
+                return base.BinaryOr(rhs);
             }
 
             return new Number(Location, ((int)Value) | ((int)rhsNum.Value));


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/198757332-e4af7ca7-72c3-4576-a898-73b7b81ddc9e.png)

Thanks to @mumencoder for fuzzing this one out for us.

## Summary

DM actually allows the user to do bitshifting on things that are definitely not numbers. When doing so, the values are coerced to 0 for the purposes of the calculation. We now, regrettably, replicate this behaviour.

In an effort to provide good warning, I've added a new warning in Constant evaluation that informs the user when we are doing this stupid move.

You may ask, "But, Altoids, you didn't add this to the Runtime!" That's true, I didn't. Because it is a runtime error in BYOND, when the values given are not being const-rolled.

I hope this nonsense is first on the chopping block when we add pragmas.

## Changelog
- OD now correctly replicates some nonsense with the bitshift operators.