### PR TITLE
Ports the final remaining DTT tests

### DIFF
--- a/Content.Tests/DMProject/Broken Tests/Tree/Const/Div_Zero/div_zero1.dm
+++ b/Content.Tests/DMProject/Broken Tests/Tree/Const/Div_Zero/div_zero1.dm
@@ -1,0 +1,6 @@
+// COMPILE ERROR
+
+var/a = 1 / 0
+
+/proc/RunTest()
+    return

--- a/Content.Tests/DMProject/Broken Tests/Tree/Const/Div_Zero/div_zero2.dm
+++ b/Content.Tests/DMProject/Broken Tests/Tree/Const/Div_Zero/div_zero2.dm
@@ -1,0 +1,9 @@
+// RUNTIME ERROR
+
+/proc/zero()
+	return 0
+
+var/a = 1 / zero()
+
+/proc/RunTest()
+	return

--- a/Content.Tests/DMProject/Broken Tests/Tree/Const/Div_Zero/div_zero3.dm
+++ b/Content.Tests/DMProject/Broken Tests/Tree/Const/Div_Zero/div_zero3.dm
@@ -1,0 +1,6 @@
+// COMPILE ERROR
+
+var/static/a = 1 / 0
+
+/proc/RunTest()
+	return 

--- a/Content.Tests/DMProject/Broken Tests/Tree/Const/Div_Zero/div_zero4.dm
+++ b/Content.Tests/DMProject/Broken Tests/Tree/Const/Div_Zero/div_zero4.dm
@@ -1,0 +1,9 @@
+// COMPILE ERROR
+
+/proc/one()
+	return 1
+
+var/static/a = 1 / 0 - one()
+
+/proc/RunTest()
+	return

--- a/Content.Tests/DMProject/Broken Tests/Tree/Const/Div_Zero/div_zero5.dm
+++ b/Content.Tests/DMProject/Broken Tests/Tree/Const/Div_Zero/div_zero5.dm
@@ -1,0 +1,7 @@
+// RUNTIME ERROR
+
+var/a = 0
+var/b = 1 / a
+
+/proc/RunTest()
+    return

--- a/Content.Tests/DMProject/Broken Tests/Tree/Const/Div_Zero/div_zero6.dm
+++ b/Content.Tests/DMProject/Broken Tests/Tree/Const/Div_Zero/div_zero6.dm
@@ -1,0 +1,7 @@
+// COMPILE ERROR
+
+var/const/a = 0
+var/b = 1 / a
+
+/proc/RunTest()
+    return

--- a/Content.Tests/DMProject/Broken Tests/Tree/Const/const_fn.dm
+++ b/Content.Tests/DMProject/Broken Tests/Tree/Const/const_fn.dm
@@ -1,0 +1,7 @@
+
+var/const/blu = rgb(0,0,255)
+
+/proc/RunTest()
+	var/const/lblu = rgb(0,0,255)
+	ASSERT(blu == "#0000ff")
+	ASSERT(lblu == "#0000ff")

--- a/Content.Tests/DMProject/Broken Tests/Tree/Const/sort_const_initialize.dm
+++ b/Content.Tests/DMProject/Broken Tests/Tree/Const/sort_const_initialize.dm
@@ -1,0 +1,23 @@
+
+/obj
+	var/const/c3 = se.c1 + se.c2
+
+/obj
+	var/const/c2 = se.b
+
+/obj
+	var/const/c1 = se.a
+
+/obj
+	var/static/obj/se = new
+	var/const/a = 7
+	var/const/b = 8
+
+/proc/RunTest()
+	var/obj/o = new
+	ASSERT(o.c1 == 7)
+	ASSERT(o.c2 == 8)
+	ASSERT(o.c3 == 15)
+
+	ASSERT(o.a == 7)
+	ASSERT(o.b == 8)

--- a/Content.Tests/DMProject/Broken Tests/Tree/Global/Static Scope/no_objproc_in_static.dm
+++ b/Content.Tests/DMProject/Broken Tests/Tree/Global/Static Scope/no_objproc_in_static.dm
@@ -1,0 +1,32 @@
+// RUNTIME ERROR
+
+/var/outer1 = "A"
+
+proc/test_outer1()
+	outer1 = "B"
+	return 3
+
+proc/test_inner1()
+	var/static/inner1 = test_outer1()
+	return inner1
+
+/proc/do_test()
+	test_inner1()
+
+/proc/RunTest()
+	do_test()
+
+/mob
+	var/static/outer2 = "A"
+
+	proc/test_outer2()
+		outer2 = "B"
+		return 3
+
+	proc/test_inner2()
+		var/static/inner2 = test_outer2()
+		return inner2
+
+	verb/test()
+		do_test()
+		test_inner2()

--- a/Content.Tests/DMProject/Broken Tests/Tree/Global/Static Scope/scope2.dm
+++ b/Content.Tests/DMProject/Broken Tests/Tree/Global/Static Scope/scope2.dm
@@ -1,0 +1,17 @@
+
+/proc/p1()
+	ASSERT(a == 0)
+	ASSERT(g1 == null)
+	ASSERT(g2 == 5)
+	/var/static/a = isnull(g2) ? 1 : 0
+	ASSERT(a == 0)
+	ASSERT(g1 == null)
+	ASSERT(g2 == 5)
+	return a
+
+/var/static/g2 = 5
+/var/static/g1 = p1()
+
+/proc/RunTest()
+	ASSERT(g1 == 0)
+	ASSERT(g2 == 5)

--- a/Content.Tests/DMProject/Broken Tests/Tree/Global/Static Scope/scope5.dm
+++ b/Content.Tests/DMProject/Broken Tests/Tree/Global/Static Scope/scope5.dm
@@ -1,0 +1,24 @@
+// TODO: This test needs some more work for it to be usable, as the log in aproc() is sometimes null and sometimes 5
+
+/proc/veryfalse()
+	return 0 == 1
+
+/proc/aproc()
+	var/static/a = bproc()
+	world.log << (a)
+	if (veryfalse())
+		return a
+	else
+		return 5
+
+/proc/bproc()
+	var/static/b = aproc()
+	world.log << (b)
+	if (veryfalse())
+		return b
+	else
+		return 5
+
+/proc/main()
+	world.log << (aproc())
+	world.log << (bproc())

--- a/Content.Tests/DMProject/Broken Tests/Tree/Global/Var/vars_field.dm
+++ b/Content.Tests/DMProject/Broken Tests/Tree/Global/Var/vars_field.dm
@@ -1,0 +1,7 @@
+
+//# issue 697
+
+// TODO: A lot of macros seem to also be in global.vars in BYOND but this isn't implemented in OD yet
+
+/proc/RunTest()
+	ASSERT(global.vars["TRUE"] == 1)

--- a/Content.Tests/DMProject/Broken Tests/Tree/Override/override_reverse.dm
+++ b/Content.Tests/DMProject/Broken Tests/Tree/Override/override_reverse.dm
@@ -1,0 +1,9 @@
+
+C()
+	return 1
+
+/proc/C()
+	return 2
+
+/proc/RunTest()
+	ASSERT(global.C() == 2)

--- a/Content.Tests/DMProject/Broken Tests/Tree/Override/override_toplevel1.dm
+++ b/Content.Tests/DMProject/Broken Tests/Tree/Override/override_toplevel1.dm
@@ -1,0 +1,11 @@
+
+/proc/C()
+	return 1
+
+/var/z = 5
+
+C()
+	return 2
+
+/proc/RunTest()
+	ASSERT(global.C() == 1)

--- a/Content.Tests/DMProject/Broken Tests/Tree/Override/override_toplevel_nonexist.dm
+++ b/Content.Tests/DMProject/Broken Tests/Tree/Override/override_toplevel_nonexist.dm
@@ -1,0 +1,9 @@
+// COMPILE ERROR
+
+C()
+	return 2
+
+/var/z = 5
+
+/proc/RunTest()
+	return

--- a/Content.Tests/DMProject/Broken Tests/Tree/Override/override_x.dm
+++ b/Content.Tests/DMProject/Broken Tests/Tree/Override/override_x.dm
@@ -1,0 +1,12 @@
+
+// TODO This test doesn't work in BYOND but I'm not sure why.
+var/x = 1
+
+/datum/var/x = 4
+/atom/movable/var/static/h = (x * 2)
+
+/proc/main()
+	var/atom/movable/o = new
+	var/datum/da = new
+	world.log << (o.h)
+	world.log << (da.x)

--- a/Content.Tests/DMProject/Broken Tests/Tree/pathop_lhs.dm
+++ b/Content.Tests/DMProject/Broken Tests/Tree/pathop_lhs.dm
@@ -1,0 +1,15 @@
+
+//# issue 617
+
+/atom/movable
+	var/paths = list()
+	top
+
+	proc/do_assign()
+		paths += .top
+
+/proc/RunTest()
+	var/atom/movable/t = new
+	t.do_assign()
+	ASSERT(length(t.paths) == 1)
+	ASSERT(t.paths[1] == /atom/movable/top)

--- a/Content.Tests/DMProject/Tests/Tree/Const/Assign/const_assign1.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Const/Assign/const_assign1.dm
@@ -1,0 +1,8 @@
+// COMPILE ERROR
+
+//# issue 535
+
+var/const/a = 1
+
+/proc/RunTest()
+	a = 2

--- a/Content.Tests/DMProject/Tests/Tree/Const/Assign/const_assign2.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Const/Assign/const_assign2.dm
@@ -1,0 +1,8 @@
+// COMPILE ERROR
+
+/obj
+	/var/const/a = 5
+
+/proc/RunTest()
+	var/obj/o = new
+	o.a = 6

--- a/Content.Tests/DMProject/Tests/Tree/Const/Assign/const_assign3.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Const/Assign/const_assign3.dm
@@ -1,0 +1,5 @@
+// COMPILE ERROR
+
+/proc/RunTest()
+	var/const/a = 7
+	a = 8

--- a/Content.Tests/DMProject/Tests/Tree/Const/const_fn_badarg.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Const/const_fn_badarg.dm
@@ -1,0 +1,9 @@
+// COMPILE ERROR
+
+/proc/somered()
+	return 127
+
+var/const/reddish = rgb(somered(),0,255) // error: constant initializer required
+
+/proc/RunTest()
+	var/const/reddish = rgb(somered(),0,0) // error: constant initializer required

--- a/Content.Tests/DMProject/Tests/Tree/Const/const_fn_badarg1.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Const/const_fn_badarg1.dm
@@ -1,0 +1,9 @@
+// COMPILE ERROR
+
+/proc/somered()
+	return 127
+
+var/const/reddish = rgb(somered(),0,255) // error: constant initializer required
+
+/proc/RunTest()
+	return

--- a/Content.Tests/DMProject/Tests/Tree/Const/const_fn_badarg2.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Const/const_fn_badarg2.dm
@@ -3,7 +3,5 @@
 /proc/somered()
 	return 127
 
-var/const/reddish = rgb(somered(),0,255) // error: constant initializer required
-
 /proc/RunTest()
 	var/const/reddish = rgb(somered(),0,0) // error: constant initializer required

--- a/Content.Tests/DMProject/Tests/Tree/Const/deref_as_const.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Const/deref_as_const.dm
@@ -1,0 +1,9 @@
+//# issue 616
+
+/obj
+	var/const/b = 5
+
+/proc/RunTest()
+	var/obj/o = new
+	var/const/v = o.b
+	ASSERT(v == 5)

--- a/Content.Tests/DMProject/Tests/Tree/Const/init_from_obj_var.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Const/init_from_obj_var.dm
@@ -1,0 +1,10 @@
+
+/obj
+	var/const/a = 5
+
+var/obj/o = new
+
+var/const/a = o.a
+
+/proc/RunTest()
+	ASSERT(a == 5)

--- a/Content.Tests/DMProject/Tests/Tree/Const/switch_const.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Const/switch_const.dm
@@ -1,0 +1,8 @@
+
+/proc/RunTest()
+	var/const/c = 6
+	switch (1)
+		if (c)
+			ASSERT(0)
+		else
+			ASSERT(1)

--- a/Content.Tests/DMProject/Tests/Tree/Global/Static Scope/assign_global_to_global.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Global/Static Scope/assign_global_to_global.dm
@@ -1,0 +1,8 @@
+
+//# issue 610
+
+var/global/G1 = 5
+var/global/G2 = G1
+
+/proc/RunTest()
+	ASSERT(G2 == 5)

--- a/Content.Tests/DMProject/Tests/Tree/Global/Static Scope/scope1.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Global/Static Scope/scope1.dm
@@ -1,0 +1,14 @@
+
+var/gvar = 3
+
+/obj
+	var/static/osvar = gvar
+
+/proc/sproc()
+	var/static/psvar = gvar
+	ASSERT(psvar == 3)
+
+/proc/RunTest()
+	var/obj/o = new
+	sproc()
+	ASSERT(o.osvar == 3)

--- a/Content.Tests/DMProject/Tests/Tree/Global/Static Scope/scope3.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Global/Static Scope/scope3.dm
@@ -1,0 +1,5 @@
+
+/var/static/static/g2 = 5
+
+/proc/RunTest()
+	ASSERT(g2 == 5)

--- a/Content.Tests/DMProject/Tests/Tree/Global/Static Scope/scope4.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Global/Static Scope/scope4.dm
@@ -1,0 +1,14 @@
+
+var/static/a = 2
+var/static/b = 3
+
+obj
+	var/static/hi = a + b
+
+var/obj/o = new
+
+var/static/gvar = 10
+var/static/g = o.hi + gvar
+
+/proc/RunTest()
+	ASSERT(g == 15)

--- a/Content.Tests/DMProject/Tests/Tree/Global/Static Scope/scope_in_assoc_list.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Global/Static Scope/scope_in_assoc_list.dm
@@ -1,0 +1,8 @@
+
+/obj
+	var/static/v = 5
+	var/static/list/l = list("a" = v)
+
+/proc/RunTest()
+	var/obj/o = new
+	ASSERT(o.l["a"] == 5)

--- a/Content.Tests/DMProject/Tests/Tree/Global/Static Scope/static_list.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Global/Static Scope/static_list.dm
@@ -1,0 +1,12 @@
+
+//# issue 693
+
+/obj
+	var/static/list/A1 = list(1,2)
+	var/static/list/A2 = list(1,2)
+	var/static/list/A3 = list(1,2)
+	var/static/list/B = A1 + A2 + A3
+
+/proc/RunTest()
+	var/obj/o = new
+	ASSERT(o.B.len == 6)

--- a/Content.Tests/DMProject/Tests/Tree/Global/Static Scope/static_proc.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Global/Static Scope/static_proc.dm
@@ -1,0 +1,11 @@
+
+//# issue 693
+
+#define subtypesof(T) typesof(T) - T
+/obj
+	var/static/list/C = subtypesof(/datum)
+
+/proc/RunTest()
+	var/obj/o = new
+	// We don't care about the actual number, we just want it to work at all
+	ASSERT(o.C.len > 1)

--- a/Content.Tests/DMProject/Tests/Tree/Global/Static Scope/static_vars.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Global/Static Scope/static_vars.dm
@@ -1,0 +1,45 @@
+
+var/c = 999
+
+/proc/init_static()
+	return dynamic_value()
+
+/proc/dynamic_value()
+	static_proc()
+	return --c
+
+/proc/static_proc_shadowed()
+	var/static/inner_c = 700
+	return inner_c
+
+/proc/static_proc()
+	// Inner static definitions must be recursively located
+	while (1)
+		var/static/inner_c = init_static()
+		inner_c++
+		return inner_c
+
+/obj
+	var/const/c = 5
+	subobj1
+		var/static/s = dynamic_value()
+		var/global/g = dynamic_value()
+	subobj2
+		var/static/s = dynamic_value()
+		var/global/g = dynamic_value()
+
+/proc/RunTest()
+	var/obj/subobj1/o1 = new
+	var/obj/subobj1/o2 = new
+	var/obj/subobj2/o3 = new
+
+	ASSERT(static_proc() == 1003)
+	ASSERT(static_proc_shadowed() == 700)
+	ASSERT(o1.s == 997)
+	ASSERT(o1.g == 996)
+	ASSERT(o1.c == 5)
+	o1.s -= 90
+	ASSERT(o2.s == 907)
+	ASSERT(o2.g == 996)
+	ASSERT(o3.s == 995)
+	ASSERT(o3.g == 994) 

--- a/Content.Tests/DMProject/Tests/Tree/Global/Var/global_chain_call.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Global/Var/global_chain_call.dm
@@ -1,0 +1,9 @@
+
+/obj
+	proc/TheCall()
+		return 7
+
+var/obj/i = new
+
+/proc/RunTest()
+	ASSERT(global.i.TheCall() == 7)

--- a/Content.Tests/DMProject/Tests/Tree/Global/Var/global_deref.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Global/Var/global_deref.dm
@@ -1,0 +1,25 @@
+
+var/const/a = "a"
+var/static/b = "b"
+
+/proc/fn()
+	return "fn"
+
+/datum/proc/fn()
+	return "datumfn"
+
+/datum/proc/main()
+	var/a = "aloc"
+	var/b = "bloc"
+
+	ASSERT(a == "aloc")
+	ASSERT(global.a == "a")
+	ASSERT(b == "bloc")
+	ASSERT(global.b == "b")
+	ASSERT(fn() == "datumfn")
+	ASSERT(global.fn() == "fn")
+	ASSERT(abs(-1) == 1)
+
+/proc/RunTest()
+	var/datum/d = new
+	d.main()

--- a/Content.Tests/DMProject/Tests/Tree/Global/World/deref_world.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Global/World/deref_world.dm
@@ -1,0 +1,7 @@
+
+//# issue 361
+
+var/year = world.realtime
+
+/proc/RunTest()
+	return

--- a/Content.Tests/DMProject/Tests/Tree/Override/override_const.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Override/override_const.dm
@@ -1,0 +1,8 @@
+// COMPILE ERROR
+
+/atom/var/a = 5
+/atom/const/a = 4
+/atom/var/b = a
+
+/proc/RunTest()
+	return

--- a/Content.Tests/DMProject/Tests/Tree/Override/override_double.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Override/override_double.dm
@@ -1,0 +1,14 @@
+
+/obj/proc/A()
+	return 1
+
+/obj/A()
+	return 2
+
+/obj/A()
+	return 3
+
+var/obj/a = new
+
+/proc/RunTest()
+	ASSERT(a.A() == 3)

--- a/Content.Tests/DMProject/Tests/Tree/Override/override_first.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Override/override_first.dm
@@ -1,0 +1,9 @@
+
+/obj/v = 5
+/datum/var/v = 6
+
+/proc/RunTest()
+	var/obj/o = new
+	var/datum/da = new
+	ASSERT(o.v == 5)
+	ASSERT(da.v == 6)

--- a/Content.Tests/DMProject/Tests/Tree/Override/override_global.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Override/override_global.dm
@@ -1,0 +1,10 @@
+// COMPILE ERROR
+
+/turf/C = 4
+/datum/var/const/C = 5
+
+/turf/C2 = 6
+/datum/var/static/C2 = 12
+
+/proc/RunTest()
+	return

--- a/Content.Tests/DMProject/Tests/Tree/Override/override_toplevel2.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Override/override_toplevel2.dm
@@ -1,0 +1,13 @@
+// COMPILE ERROR
+
+/datum/proc/G()
+	return 0
+
+/proc/G()
+	return 1
+
+G()
+	return 2
+
+/proc/RunTest()
+	return

--- a/Content.Tests/DMProject/Tests/Tree/Override/override_toplevel3.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Override/override_toplevel3.dm
@@ -1,0 +1,9 @@
+
+/datum/proc/G()
+	return 0
+
+/proc/G()
+	return 1
+
+/proc/RunTest()
+	ASSERT(G() == 1)

--- a/Content.Tests/DMProject/Tests/Tree/as_in_obj_var.dm
+++ b/Content.Tests/DMProject/Tests/Tree/as_in_obj_var.dm
@@ -1,0 +1,11 @@
+
+//# issue 9
+
+/procpath
+	var/name as text
+	var/desc as text
+	var/category as text
+	var/invisibility as num
+
+/proc/RunTest()
+	return

--- a/Content.Tests/DMProject/Tests/Tree/dont_override_global_proc.dm
+++ b/Content.Tests/DMProject/Tests/Tree/dont_override_global_proc.dm
@@ -1,0 +1,12 @@
+
+//# issue 564
+
+proc
+	Fn1()
+		return 1
+	Fn2()
+		return 2
+
+/proc/RunTest()
+	ASSERT(Fn1() == 1)
+	ASSERT(Fn2() == 2)

--- a/Content.Tests/DMProject/Tests/Tree/duplicate_proc.dm
+++ b/Content.Tests/DMProject/Tests/Tree/duplicate_proc.dm
@@ -1,0 +1,12 @@
+// COMPILE ERROR
+
+//# issue 172
+
+/proc/a()
+	return 1
+
+/proc/a()
+	return 2
+
+/proc/RunTest()
+	a()

--- a/Content.Tests/DMProject/Tests/Tree/global_proc_clash.dm
+++ b/Content.Tests/DMProject/Tests/Tree/global_proc_clash.dm
@@ -1,0 +1,13 @@
+
+//# issue 515
+
+/proc/a()
+	return 1
+
+/datum/proc/a()
+	return 2
+
+/proc/RunTest()
+	ASSERT(a() == 1)
+	var/datum/d = new
+	ASSERT(d.a() == 2)

--- a/Content.Tests/DMProject/Tests/Tree/keyword_type.dm
+++ b/Content.Tests/DMProject/Tests/Tree/keyword_type.dm
@@ -1,0 +1,12 @@
+
+//# issue 679
+
+/obj/step/ty
+/obj/throw/ty
+/obj/null/ty
+/obj/switch/ty
+/obj/spawn/ty
+
+/proc/RunTest()
+	var/obj/throw/o = new
+	ASSERT(istype(o, /obj/throw))

--- a/Content.Tests/DMProject/Tests/Tree/proc_and_var.dm
+++ b/Content.Tests/DMProject/Tests/Tree/proc_and_var.dm
@@ -1,0 +1,10 @@
+
+/obj
+	var/a = 5
+	proc/a()
+		ASSERT(a == 5)
+		return 5
+
+/proc/RunTest()
+	var/obj/o = new
+	ASSERT(o.a() == 5)

--- a/Content.Tests/DMProject/Tests/Tree/proc_oneliner.dm
+++ b/Content.Tests/DMProject/Tests/Tree/proc_oneliner.dm
@@ -1,0 +1,7 @@
+
+//# issue 24
+
+/proc/fn() return 5
+
+/proc/RunTest()
+	ASSERT(fn() == 5)

--- a/Content.Tests/DMProject/Tests/Tree/toplevel_notype.dm
+++ b/Content.Tests/DMProject/Tests/Tree/toplevel_notype.dm
@@ -1,0 +1,9 @@
+
+//# issue 213
+
+/usrtype
+	var/a = 5
+
+/proc/RunTest()
+	var/usrtype/o = new
+	ASSERT(o.type == /usrtype)

--- a/Content.Tests/DMProject/Tests/Tree/upward_search_path1.dm
+++ b/Content.Tests/DMProject/Tests/Tree/upward_search_path1.dm
@@ -1,0 +1,11 @@
+
+//# issue 534
+
+/proc/ffn(path)
+	return path
+
+/atom/proc/fn(a,b)
+	ASSERT(0)
+
+/proc/RunTest()
+	ASSERT(ffn(/atom./proc/fn) == /atom/proc/fn)


### PR DESCRIPTION
Ports the `tree` directory of DTT tests, which is the last of the DTT tests that we're missing.

I skipped the dot abuse tests (`.....` and friends) because almost all of the tests are broken in BYOND and we still haven't entirely figured out how we're going to implement this dot behavior.

All tests were manually verified in MoMMI/BeeBot but there's still room for human error.