### PR TITLE
Improve `replacetext()` implementation

### DIFF
--- a/Content.Tests/Content.Tests.csproj
+++ b/Content.Tests/Content.Tests.csproj
@@ -33,20 +33,14 @@
     <!-- Copy DMProject to output directory. -->
     <None Include="$(ProjectDir)\DMProject\**" CopyToOutputDirectory="PreserveNewest" LinkBase="DMProject\" />
     <!-- Copy DMStandard to output directory. -->
-    <DMStandard Include="..\DMCompiler\DMStandard\**"/>
+    <DMStandard Include="..\DMCompiler\DMStandard\**" />
   </ItemGroup>
 
   <Target Name="CopyDMStandard" AfterTargets="AfterBuild">
-    <Copy
-      SourceFiles="@(DMStandard)"
-      DestinationFiles="@(DMStandard->'$(OutDir)\DMStandard\%(RecursiveDir)%(Filename)%(Extension)')"
-    />
+    <Copy SourceFiles="@(DMStandard)" DestinationFiles="@(DMStandard->'$(OutDir)\DMStandard\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
   <Target Name="CopyDMStandardOnPublish" AfterTargets="Publish">
-    <Copy
-      SourceFiles="@(DMStandard)"
-      DestinationFiles="@(DMStandard->'$(PublishDir)\DMStandard\%(RecursiveDir)%(Filename)%(Extension)')"
-    />
+    <Copy SourceFiles="@(DMStandard)" DestinationFiles="@(DMStandard->'$(PublishDir)\DMStandard\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
   <Import Project="..\RobustToolbox\MSBuild\Robust.Analyzers.targets" />
 

--- a/Content.Tests/DMProject/Tests/Builtins/Replacetext.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Replacetext.dm
@@ -1,0 +1,33 @@
+
+/proc/RunTest()
+	var/str = "ABCDEF"
+
+	// Replacing the first char. Start=2 ignores the first char.
+	ASSERT(replacetext(str, "A", "G") == "GBCDEF")
+	ASSERT(replacetext(str, "A", "G", 1) == "GBCDEF")
+	ASSERT(replacetext(str, "A", "G", 2) == "ABCDEF")
+
+	// Replacing the last char. End=6 ignores the last char.
+	ASSERT(replacetext(str, "F", "G") == "ABCDEG")
+	ASSERT(replacetext(str, "F", "G", 1, 7) == "ABCDEG")
+	ASSERT(replacetext(str, "F", "G", 1, 6) == "ABCDEF")
+
+	// A null Needle causes the Replacement to be placed after every character but the last
+	ASSERT(replacetext(str, null, "G") == "AGBGCGDGEGF")
+	ASSERT(replacetext(str, null, "HI") == "AHIBHICHIDHIEHIF")
+
+	// Start=1 and Start=2 are the same (but only with null Needle)
+	ASSERT(replacetext(str, null, "G", 1) == "AGBGCGDGEGF")
+	ASSERT(replacetext(str, null, "G", 2) == "AGBGCGDGEGF")
+	ASSERT(replacetext(str, null, "G", 3) == "ABGCGDGEGF")
+	ASSERT(replacetext(str, null, "G", 4) == "ABCGDGEGF")
+	ASSERT(replacetext(str, null, "G", 1, 4) == "AGBGCGDEF")
+	ASSERT(replacetext(str, null, "G", 1, 5) == "AGBGCGDGEF")
+
+	// An End reaching past the end of the string still won't place the Replacement at the end
+	ASSERT(replacetext(str, null, "G", 1, 6) == "AGBGCGDGEGF")
+	ASSERT(replacetext(str, null, "G", 1, 7) == "AGBGCGDGEGF")
+
+	// /regex can be used as a Needle
+	ASSERT(replacetext(str, new /regex("."), "G") == "GBCDEF");
+	ASSERT(replacetext(str, new /regex(".", "g"), "G") == "GGGGGG");

--- a/OpenDream.sln.DotSettings
+++ b/OpenDream.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DM/@EntryIndexedValue">DM</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=noto/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=noto/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=replacetext/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Threading.Tasks;
 using OpenDreamRuntime.Objects.MetaObjects;
@@ -63,7 +64,7 @@ namespace OpenDreamRuntime.Objects {
             return GetTreeEntry(typeId).ObjectDefinition;
         }
 
-        public bool TryGetGlobalProc(string name, out DreamProc? globalProc) {
+        public bool TryGetGlobalProc(string name, [NotNullWhen(true)] out DreamProc? globalProc) {
             globalProc = _globalProcIds.TryGetValue(name, out int procId) ? Procs[procId] : null;
 
             return (globalProc != null);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Text;
+using System.Text.RegularExpressions;
 using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Objects.MetaObjects;
 using OpenDreamShared.Dream;
@@ -50,85 +51,89 @@ namespace OpenDreamRuntime.Procs.Native {
             }
         }
 
-        [DreamProc("Replace")]
-        [DreamProcParameter("haystack", Type = DreamValue.DreamValueType.String)]
-        [DreamProcParameter("replacement", Type = DreamValue.DreamValueType.String | DreamValue.DreamValueType.DreamProc)]
-        [DreamProcParameter("Start", DefaultValue = 1, Type = DreamValue.DreamValueType.Float)]
-        [DreamProcParameter("End", DefaultValue = 0, Type = DreamValue.DreamValueType.Float)]
-        public static DreamValue NativeProc_Replace(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
-            DreamRegex dreamRegex = DreamMetaObjectRegex.ObjectToDreamRegex[instance];
+        public static DreamValue RegexReplace(DreamObject regexInstance, DreamValue haystack, DreamValue replace,
+            int start, int end) {
+            DreamRegex regex = DreamMetaObjectRegex.ObjectToDreamRegex[regexInstance];
 
-            DreamValue haystack = arguments.GetArgument(0, "haystack");
-            DreamValue replace = arguments.GetArgument(1, "replacement");
-            int start = arguments.GetArgument(2, "Start").GetValueAsInteger();
-            int end = arguments.GetArgument(3, "End").GetValueAsInteger();
-
-            if (!haystack.TryGetValueAsString(out var haystackString))
-            {
-                if (haystack == DreamValue.Null)
-                {
+            if (!haystack.TryGetValueAsString(out var haystackString)) {
+                if (haystack == DreamValue.Null) {
                     return DreamValue.Null;
                 }
+
                 //TODO Check what actually happens
                 throw new ArgumentException("Bad regex haystack");
             }
+
             string haystackSubstring = haystackString;
             if (end != 0) haystackSubstring = haystackString.Substring(0, end - start);
 
             if (replace.TryGetValueAsProc(out DreamProc replaceProc)) {
                 return DoProcReplace(replaceProc);
             }
-            if (replace.TryGetValueAsString(out string replaceString))
-            {
+
+            if (replace.TryGetValueAsString(out var replaceString)) {
                 return DoTextReplace(replaceString);
             }
 
-            if (replace.TryGetValueAsPath(out var procPath) && procPath.LastElement is not null)
-            {
+            if (replace.TryGetValueAsPath(out var procPath) && procPath.LastElement is not null) {
                 var dreamMan = IoCManager.Resolve<IDreamManager>();
-                if (dreamMan.ObjectTree.TryGetGlobalProc(procPath.LastElement, out DreamProc? proc))
-                {
+                if (dreamMan.ObjectTree.TryGetGlobalProc(procPath.LastElement, out DreamProc? proc)) {
                     return DoProcReplace(proc);
                 }
             }
 
             throw new ArgumentException("Replacement argument must be a string or a proc");
 
-            DreamValue DoProcReplace(DreamProc proc)
-            {
-                if(dreamRegex.IsGlobal)
-                {
+            DreamValue DoProcReplace(DreamProc proc) {
+                if (regex.IsGlobal) {
                     throw new NotImplementedException("Proc global regex replacements are not implemented");
                 }
-                var match = dreamRegex.Regex.Match(haystackSubstring);
+
+                var match = regex.Regex.Match(haystackSubstring);
                 var groups = match.Groups;
                 List<DreamValue> args = new List<DreamValue>(groups.Count);
-                foreach (Group group in groups)
-                {
+                foreach (Group group in groups) {
                     args.Add(new DreamValue(group.Value));
                 }
-                var result = DreamThread.Run(async(state) => await state.Call(proc, instance, null, new DreamProcArguments(args)));
-                if (result.TryGetValueAsString(out var replacement))
-                {
+
+                var result = DreamThread.Run(async state =>
+                    await state.Call(proc, regexInstance, null, new DreamProcArguments(args)));
+
+                if (result.TryGetValueAsString(out var replacement)) {
                     return DoTextReplace(replacement);
                 }
+
                 //TODO Confirm this behavior
-                if (result == DreamValue.Null)
-                {
+                if (result == DreamValue.Null) {
                     return new DreamValue(haystackSubstring);
                 }
+
                 throw new ArgumentException("Replacement is not a string");
             }
 
-            DreamValue DoTextReplace(string replacement)
-            {
-                string replaced = dreamRegex.Regex.Replace(haystackSubstring, replacement, dreamRegex.IsGlobal ? -1 : 1, start - 1);
+            DreamValue DoTextReplace(string replacement) {
+                string replaced = regex.Regex.Replace(haystackSubstring, replacement, regex.IsGlobal ? -1 : 1,
+                    start - 1);
 
-                if(end != 0) replaced += haystackString.Substring(end - start + 1);
+                if (end != 0) replaced += haystackString.Substring(end - start + 1);
 
-                instance.SetVariable("text", new DreamValue(replaced));
+                regexInstance.SetVariable("text", new DreamValue(replaced));
                 return new DreamValue(replaced);
             }
+        }
+
+        [DreamProc("Replace")]
+        [DreamProcParameter("haystack", Type = DreamValue.DreamValueType.String)]
+        [DreamProcParameter("replacement", Type = DreamValue.DreamValueType.String | DreamValue.DreamValueType.DreamProc)]
+        [DreamProcParameter("Start", DefaultValue = 1, Type = DreamValue.DreamValueType.Float)]
+        [DreamProcParameter("End", DefaultValue = 0, Type = DreamValue.DreamValueType.Float)]
+        public static DreamValue NativeProc_Replace(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
+            DreamValue haystack = arguments.GetArgument(0, "haystack");
+            DreamValue replacement = arguments.GetArgument(1, "replacement");
+            int start = arguments.GetArgument(2, "Start").GetValueAsInteger();
+            int end = arguments.GetArgument(3, "End").GetValueAsInteger();
+
+            return RegexReplace(instance, haystack, replacement, start, end);
         }
 
         private static int GetNext(DreamObject regexInstance, DreamValue startParam, bool isGlobal) {


### PR DESCRIPTION
`replacetext()` can now take a `/regex` as a Needle and doesn't chop off the beginning and end of a string when using a non-default Start/End.

Also added a unit test to test some uses of the proc.