### PR TITLE
Reimplement savefiles

### DIFF
--- a/Content.Tests/DMProject/Tests/Savefile/BasicReadAndWrite.dm
+++ b/Content.Tests/DMProject/Tests/Savefile/BasicReadAndWrite.dm
@@ -1,0 +1,17 @@
+
+/proc/RunTest()
+	var/savefile/S = new("savefile.sav")
+	var/V
+
+	// Indexing the object to write/read the savefile
+	S["ABC"] = 5
+	ASSERT(V == null)
+	V = S["ABC"]
+	ASSERT(V == 5)
+
+	// << and >> can do the same thing
+	S["DEF"] << 10
+	S["DEF"] >> V
+	ASSERT(V == 10)
+
+	fdel("savefile.sav")

--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -34,6 +34,8 @@ namespace DMCompiler.Compiler.DM {
         public void VisitProcStatementBrowse(DMASTProcStatementBrowse statementBrowse) { throw new NotImplementedException(); }
         public void VisitProcStatementBrowseResource(DMASTProcStatementBrowseResource statementBrowseResource) { throw new NotImplementedException(); }
         public void VisitProcStatementOutputControl(DMASTProcStatementOutputControl statementOutputControl) { throw new NotImplementedException(); }
+        public void VisitProcStatementOutput(DMASTProcStatementOutput statementOutput) { throw new NotImplementedException(); }
+        public void VisitProcStatementInput(DMASTProcStatementInput statementInput) { throw new NotImplementedException(); }
         public void VisitProcStatementTryCatch(DMASTProcStatementTryCatch statementTryCatch) { throw new NotImplementedException(); }
         public void VisitProcStatementThrow(DMASTProcStatementThrow statementThrow) { throw new NotImplementedException(); }
         public void VisitProcDefinition(DMASTProcDefinition procDefinition) { throw new NotImplementedException(); }
@@ -629,6 +631,32 @@ namespace DMCompiler.Compiler.DM {
 
         public override void Visit(DMASTVisitor visitor) {
             visitor.VisitProcStatementOutputControl(this);
+        }
+    }
+
+    public class DMASTProcStatementOutput : DMASTProcStatement {
+        public DMASTExpression A, B;
+
+        public DMASTProcStatementOutput(Location location, DMASTExpression a, DMASTExpression b) : base(location) {
+            A = a;
+            B = b;
+        }
+
+        public override void Visit(DMASTVisitor visitor) {
+            visitor.VisitProcStatementOutput(this);
+        }
+    }
+
+    public class DMASTProcStatementInput : DMASTProcStatement {
+        public DMASTExpression A, B;
+
+        public DMASTProcStatementInput(Location location, DMASTExpression a, DMASTExpression b) : base(location) {
+            A = a;
+            B = b;
+        }
+
+        public override void Visit(DMASTVisitor visitor) {
+            visitor.VisitProcStatementInput(this);
         }
     }
 

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -23,8 +23,7 @@ namespace DMCompiler.Compiler.DM {
             _unimplementedWarnings = unimplementedWarnings;
         }
 
-        private static readonly TokenType[] AssignTypes =
-        {
+        private static readonly TokenType[] AssignTypes = {
             TokenType.DM_Equals,
             TokenType.DM_PlusEquals,
             TokenType.DM_MinusEquals,
@@ -42,51 +41,44 @@ namespace DMCompiler.Compiler.DM {
         };
 
         /// <remarks>This (and other similar TokenType[] sets here) is public because <see cref="DMPreprocessorParser"/> needs it.</remarks>
-        public static readonly TokenType[] ComparisonTypes =
-        {
+        public static readonly TokenType[] ComparisonTypes = {
             TokenType.DM_EqualsEquals,
             TokenType.DM_ExclamationEquals,
             TokenType.DM_TildeEquals,
             TokenType.DM_TildeExclamation
         };
 
-        public static readonly TokenType[] LtGtComparisonTypes =
-        {
+        public static readonly TokenType[] LtGtComparisonTypes = {
             TokenType.DM_LessThan,
             TokenType.DM_LessThanEquals,
             TokenType.DM_GreaterThan,
             TokenType.DM_GreaterThanEquals
         };
 
-        private static readonly TokenType[] ShiftTypes =
-        {
+        private static readonly TokenType[] ShiftTypes = {
             TokenType.DM_LeftShift,
             TokenType.DM_RightShift
         };
 
-        public static readonly TokenType[] PlusMinusTypes =
-        {
+        public static readonly TokenType[] PlusMinusTypes = {
             TokenType.DM_Plus,
             TokenType.DM_Minus,
         };
 
-        public static readonly TokenType[] MulDivModTypes =
-        {
+        public static readonly TokenType[] MulDivModTypes = {
             TokenType.DM_Star,
             TokenType.DM_Slash,
             TokenType.DM_Modulus
         };
 
-        private static readonly TokenType[] DereferenceTypes =
-        {
+        private static readonly TokenType[] DereferenceTypes = {
             TokenType.DM_Period,
             TokenType.DM_Colon,
             TokenType.DM_QuestionPeriod,
             TokenType.DM_QuestionColon
         };
 
-        private static readonly TokenType[] WhitespaceTypes =
-        {
+        private static readonly TokenType[] WhitespaceTypes = {
             TokenType.DM_Whitespace,
             TokenType.DM_Indent,
             TokenType.DM_Dedent
@@ -105,8 +97,7 @@ namespace DMCompiler.Compiler.DM {
             TokenType.DM_Spawn
         };
 
-        private static readonly TokenType[] ForSeparatorTypes =
-        {
+        private static readonly TokenType[] ForSeparatorTypes = {
             TokenType.DM_Semicolon,
             TokenType.DM_Comma
         };
@@ -542,8 +533,7 @@ namespace DMCompiler.Compiler.DM {
             return procStatements;
         }
 
-        public DMASTProcStatement ProcStatement()
-        {
+        public DMASTProcStatement ProcStatement() {
             var loc = Current().Location;
             var leadingColon = Check(TokenType.DM_Colon);
 
@@ -557,47 +547,55 @@ namespace DMCompiler.Compiler.DM {
                 Error("Expected a label identifier");
             }
 
-            if (expression != null)
-            {
-                switch (expression)
-                {
+            if (expression != null) {
+                switch (expression) {
                     case DMASTIdentifier identifier:
                         Check(TokenType.DM_Colon);
                         return Label(identifier);
-                    case DMASTLeftShift leftShift:
-                    {
-                        DMASTProcCall procCall = leftShift.B as DMASTProcCall;
+                    case DMASTRightShift rightShift:
+                        // A right shift on its own becomes a special "input" statement
+                        return new DMASTProcStatementInput(loc, rightShift.A, rightShift.B);
+                    case DMASTLeftShift leftShift: {
+                        // A left shift on its own becomes a special "output" statement
+                        // Or something else depending on what's on the right ( browse(), browse_rsc(), or output() )
+                        if (leftShift.B is DMASTProcCall {Callable: DMASTCallableProcIdentifier identifier} procCall) {
+                            switch (identifier.Identifier) {
+                                case "browse":
+                                    if (procCall.Parameters.Length != 1 && procCall.Parameters.Length != 2)
+                                        Error("browse() requires 1 or 2 parameters");
 
-                        if (procCall != null && procCall.Callable is DMASTCallableProcIdentifier identifier) {
-                            if (identifier.Identifier == "browse") {
-                                if (procCall.Parameters.Length != 1 && procCall.Parameters.Length != 2) Error("browse() requires 1 or 2 parameters");
+                                    DMASTExpression body = procCall.Parameters[0].Value;
+                                    DMASTExpression options = (procCall.Parameters.Length == 2)
+                                        ? procCall.Parameters[1].Value
+                                        : new DMASTConstantNull(loc);
+                                    return new DMASTProcStatementBrowse(loc, leftShift.A, body, options);
+                                case "browse_rsc":
+                                    if (procCall.Parameters.Length != 1 && procCall.Parameters.Length != 2)
+                                        Error("browse_rsc() requires 1 or 2 parameters");
 
-                                DMASTExpression body = procCall.Parameters[0].Value;
-                                DMASTExpression options = (procCall.Parameters.Length == 2) ? procCall.Parameters[1].Value : new DMASTConstantNull(loc);
-                                return new DMASTProcStatementBrowse(loc, leftShift.A, body, options);
-                            } else if (identifier.Identifier == "browse_rsc") {
-                                if (procCall.Parameters.Length != 1 && procCall.Parameters.Length != 2) Error("browse_rsc() requires 1 or 2 parameters");
+                                    DMASTExpression file = procCall.Parameters[0].Value;
+                                    DMASTExpression filepath = (procCall.Parameters.Length == 2)
+                                        ? procCall.Parameters[1].Value
+                                        : new DMASTConstantNull(loc);
+                                    return new DMASTProcStatementBrowseResource(loc, leftShift.A, file, filepath);
+                                case "output":
+                                    if (procCall.Parameters.Length != 2) Error("output() requires 2 parameters");
 
-                                DMASTExpression file = procCall.Parameters[0].Value;
-                                DMASTExpression filepath = (procCall.Parameters.Length == 2) ? procCall.Parameters[1].Value : new DMASTConstantNull(loc);
-                                return new DMASTProcStatementBrowseResource(loc, leftShift.A, file, filepath);
-                            } else if (identifier.Identifier == "output") {
-                                if (procCall.Parameters.Length != 2) Error("output() requires 2 parameters");
-
-                                DMASTExpression msg = procCall.Parameters[0].Value;
-                                DMASTExpression control = procCall.Parameters[1].Value;
-                                return new DMASTProcStatementOutputControl(loc, leftShift.A, msg, control);
+                                    DMASTExpression msg = procCall.Parameters[0].Value;
+                                    DMASTExpression control = procCall.Parameters[1].Value;
+                                    return new DMASTProcStatementOutputControl(loc, leftShift.A, msg, control);
                             }
                         }
 
-                        break;
+                        return new DMASTProcStatementOutput(loc, leftShift.A, leftShift.B);
                     }
                 }
 
                 return new DMASTProcStatementExpression(loc, expression);
             } else {
-                // These are sorted by frequency, except If() is moved to the end because it's really slow (relatively)
-                DMASTProcStatement procStatement = Return();
+                // These are sorted by frequency
+                DMASTProcStatement procStatement = If();
+                if (procStatement == null) procStatement = Return();
                 if (procStatement == null) procStatement = ProcVarDeclaration();
                 if (procStatement == null) procStatement = For();
                 if (procStatement == null) procStatement = Set();
@@ -611,7 +609,6 @@ namespace DMCompiler.Compiler.DM {
                 if (procStatement == null) procStatement = Del();
                 if (procStatement == null) procStatement = TryCatch();
                 if (procStatement == null) procStatement = Goto();
-                if (procStatement == null) procStatement = If();
 
                 if (procStatement != null) {
                     Whitespace();

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -371,6 +371,23 @@ namespace DMCompiler.DM {
             WriteOpcode(DreamProcOpcode.OutputControl);
         }
 
+        public void OutputReference(DMReference leftRef) {
+            ShrinkStack(1);
+            WriteOpcode(DreamProcOpcode.OutputReference);
+            WriteReference(leftRef);
+        }
+
+        public void Output() {
+            ShrinkStack(2);
+            WriteOpcode(DreamProcOpcode.Output);
+        }
+
+        public void Input(DMReference leftRef, DMReference rightRef) {
+            WriteOpcode(DreamProcOpcode.Input);
+            WriteReference(leftRef);
+            WriteReference(rightRef);
+        }
+
         public void Spawn(string jumpTo) {
             ShrinkStack(1);
             WriteOpcode(DreamProcOpcode.Spawn);

--- a/DMCompiler/DM/Visitors/DMASTSimplifier.cs
+++ b/DMCompiler/DM/Visitors/DMASTSimplifier.cs
@@ -150,6 +150,16 @@ namespace DMCompiler.DM.Visitors {
             SimplifyExpression(ref statementOutputControl.Control);
         }
 
+        public void VisitProcStatementOutput(DMASTProcStatementOutput statementOutput) {
+            SimplifyExpression(ref statementOutput.A);
+            SimplifyExpression(ref statementOutput.B);
+        }
+
+        public void VisitProcStatementInput(DMASTProcStatementInput statementInput) {
+            SimplifyExpression(ref statementInput.A);
+            SimplifyExpression(ref statementInput.B);
+        }
+
         public void VisitProcStatementVarDeclaration(DMASTProcStatementVarDeclaration varDeclaration) {
             SimplifyExpression(ref varDeclaration.Value);
         }

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -105,6 +105,8 @@ namespace DMCompiler.DM.Visitors {
                 case DMASTProcStatementBrowse statementBrowse: ProcessStatementBrowse(statementBrowse); break;
                 case DMASTProcStatementBrowseResource statementBrowseResource: ProcessStatementBrowseResource(statementBrowseResource); break;
                 case DMASTProcStatementOutputControl statementOutputControl: ProcessStatementOutputControl(statementOutputControl); break;
+                case DMASTProcStatementOutput statementOutput: ProcessStatementOutput(statementOutput); break;
+                case DMASTProcStatementInput statementInput: ProcessStatementInput(statementInput); break;
                 case DMASTProcStatementVarDeclaration varDeclaration: ProcessStatementVarDeclaration(varDeclaration); break;
                 case DMASTProcStatementTryCatch tryCatch: ProcessStatementTryCatch(tryCatch); break;
                 case DMASTProcStatementThrow dmThrow: ProcessStatementThrow(dmThrow); break;
@@ -771,6 +773,48 @@ namespace DMCompiler.DM.Visitors {
             DMExpression.Emit(_dmObject, _proc, statementOutputControl.Message);
             DMExpression.Emit(_dmObject, _proc, statementOutputControl.Control);
             _proc.OutputControl();
+        }
+
+        public void ProcessStatementOutput(DMASTProcStatementOutput statementOutput) {
+            DMExpression left = DMExpression.Create(_dmObject, _proc, statementOutput.A);
+            DMExpression right = DMExpression.Create(_dmObject, _proc, statementOutput.B);
+
+            if (left is LValue) {
+                // An LValue on the left needs a special opcode so that its reference can be used
+                // This allows for special operations like "savefile[...] << ..."
+
+                (DMReference leftRef, _) = left.EmitReference(_dmObject, _proc);
+                right.EmitPushValue(_dmObject, _proc);
+
+                _proc.OutputReference(leftRef);
+            } else {
+                left.EmitPushValue(_dmObject, _proc);
+                right.EmitPushValue(_dmObject, _proc);
+                _proc.Output();
+            }
+        }
+
+        public void ProcessStatementInput(DMASTProcStatementInput statementInput) {
+            DMExpression left = DMExpression.Create(_dmObject, _proc, statementInput.A);
+            DMExpression right = DMExpression.Create(_dmObject, _proc, statementInput.B);
+
+            // The left-side value of an input operation must be an LValue
+            // (I think? I haven't found an exception but there could be one)
+            if (left is not LValue) {
+                DMCompiler.Error(left.Location, "Left side must be an l-value");
+                return;
+            }
+
+            // The right side must also be an LValue. Because where else would the value go?
+            if (right is not LValue) {
+                DMCompiler.Error(left.Location, "Right side must be an l-value");
+                return;
+            }
+
+            (DMReference rightRef, _) = right.EmitReference(_dmObject, _proc);
+            (DMReference leftRef, _) = left.EmitReference(_dmObject, _proc);
+
+            _proc.Input(leftRef, rightRef);
         }
 
         public void ProcessStatementTryCatch(DMASTProcStatementTryCatch tryCatch) {

--- a/DMDisassembler/DMProc.cs
+++ b/DMDisassembler/DMProc.cs
@@ -33,7 +33,7 @@ namespace DMDisassembler {
             BinaryReader binaryReader = new BinaryReader(stream);
             long position = 0;
             DreamProcOpcode opcode;
-            while ((opcode = (DreamProcOpcode)stream.ReadByte()) != (DreamProcOpcode)(-1)) {
+            while ((opcode = (DreamProcOpcode) stream.ReadByte()) != (DreamProcOpcode) (-1)) {
                 StringBuilder text = new StringBuilder();
                 text.Append(opcode);
                 text.Append(" ");
@@ -43,7 +43,8 @@ namespace DMDisassembler {
                         text.Append('"');
                         text.Append(Program.CompiledJson.Strings[binaryReader.ReadInt32()]);
                         text.Append('"');
-                        binaryReader.ReadInt32(); // This is some metadata FormatString has that we can't really render
+                        binaryReader
+                            .ReadInt32(); // This is some metadata FormatString has that we can't really render
 
                         break;
                     }
@@ -63,9 +64,13 @@ namespace DMDisassembler {
                         break;
                     }
 
-                    case DreamProcOpcode.Prompt: text.Append((DMValueType)binaryReader.ReadInt32()); break;
+                    case DreamProcOpcode.Prompt:
+                        text.Append((DMValueType) binaryReader.ReadInt32());
+                        break;
 
-                    case DreamProcOpcode.PushFloat: text.Append(binaryReader.ReadSingle()); break;
+                    case DreamProcOpcode.PushFloat:
+                        text.Append(binaryReader.ReadSingle());
+                        break;
 
                     case DreamProcOpcode.Call:
                     case DreamProcOpcode.Assign:
@@ -79,12 +84,22 @@ namespace DMDisassembler {
                     case DreamProcOpcode.DivideReference:
                     case DreamProcOpcode.BitXorReference:
                     case DreamProcOpcode.Enumerate:
-                    case DreamProcOpcode.PushReferenceValue: text.Append(ReadReference(binaryReader).ToString()); break;
+                    case DreamProcOpcode.OutputReference:
+                    case DreamProcOpcode.PushReferenceValue:
+                        text.Append(ReadReference(binaryReader).ToString());
+                        break;
+
+                    case DreamProcOpcode.Input:
+                        text.Append(ReadReference(binaryReader).ToString());
+                        text.Append(ReadReference(binaryReader).ToString());
+                        break;
 
                     case DreamProcOpcode.CreateList:
                     case DreamProcOpcode.CreateAssociativeList:
                     case DreamProcOpcode.PickWeighted:
-                    case DreamProcOpcode.PickUnweighted: text.Append(binaryReader.ReadInt32()); break;
+                    case DreamProcOpcode.PickUnweighted:
+                        text.Append(binaryReader.ReadInt32());
+                        break;
 
                     case DreamProcOpcode.JumpIfNullDereference: {
                         DMReference reference = ReadReference(binaryReader);
@@ -99,7 +114,9 @@ namespace DMDisassembler {
 
                     case DreamProcOpcode.Initial:
                     case DreamProcOpcode.IsSaved:
-                    case DreamProcOpcode.PushPath: text.Append(Program.CompiledJson.Strings[binaryReader.ReadInt32()]); break;
+                    case DreamProcOpcode.PushPath:
+                        text.Append(Program.CompiledJson.Strings[binaryReader.ReadInt32()]);
+                        break;
 
                     case DreamProcOpcode.Spawn:
                     case DreamProcOpcode.BooleanOr:
@@ -116,7 +133,9 @@ namespace DMDisassembler {
                         break;
                     }
 
-                    case DreamProcOpcode.PushType: text.Append(Program.CompiledJson.Types[binaryReader.ReadInt32()].Path); break;
+                    case DreamProcOpcode.PushType:
+                        text.Append(Program.CompiledJson.Types[binaryReader.ReadInt32()].Path);
+                        break;
 
                     case DreamProcOpcode.PushArguments: {
                         int argCount = binaryReader.ReadInt32();
@@ -126,7 +145,8 @@ namespace DMDisassembler {
                         for (int i = 0; i < argCount; i++) {
                             text.Append(" ");
 
-                            DreamProcOpcodeParameterType argType = (DreamProcOpcodeParameterType)binaryReader.ReadByte();
+                            DreamProcOpcodeParameterType argType =
+                                (DreamProcOpcodeParameterType) binaryReader.ReadByte();
                             if (argType == DreamProcOpcodeParameterType.Named) {
                                 string argName = Program.CompiledJson.Strings[binaryReader.ReadInt32()];
 

--- a/OpenDream.sln.DotSettings
+++ b/OpenDream.sln.DotSettings
@@ -1,5 +1,8 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DM/@EntryIndexedValue">DM</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DMAST/@EntryIndexedValue">DMAST</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=noto/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=replacetext/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=replacetext/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=savefile/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Savefiles/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -80,7 +80,7 @@ namespace OpenDreamRuntime {
 
             _compiledJson = json;
             _dreamResourceManager.SetDirectory(Path.GetDirectoryName(jsonPath));
-            if(!string.IsNullOrEmpty(_compiledJson.Interface) && !_dreamResourceManager.DoesFileExist(_compiledJson.Interface))            
+            if(!string.IsNullOrEmpty(_compiledJson.Interface) && !_dreamResourceManager.DoesFileExist(_compiledJson.Interface))
                 throw new FileNotFoundException("Interface DMF not found at "+Path.Join(Path.GetDirectoryName(jsonPath),_compiledJson.Interface));
             //TODO: Empty or invalid _compiledJson.Interface should return default interface - see issue #851
             ObjectTree.LoadJson(json);
@@ -131,6 +131,7 @@ namespace OpenDreamRuntime {
             ObjectTree.SetMetaObject(DreamPath.Movable, new DreamMetaObjectMovable());
             ObjectTree.SetMetaObject(DreamPath.Mob, new DreamMetaObjectMob());
             ObjectTree.SetMetaObject(DreamPath.Icon, new DreamMetaObjectIcon());
+            ObjectTree.SetMetaObject(DreamPath.Savefile, new DreamMetaObjectSavefile());
         }
 
         public void WriteWorldLog(string message, LogLevel level = LogLevel.Info, string sawmill = "world.log") {

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
@@ -136,13 +136,12 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             }
         }
 
-        public DreamValue OperatorOutput(DreamValue a, DreamValue b) {
+        public void OperatorOutput(DreamValue a, DreamValue b) {
             if (!a.TryGetValueAsDreamObjectOfType(DreamPath.Client, out var client))
                 throw new ArgumentException($"Left-hand value was not the expected type {DreamPath.Client}");
 
             DreamConnection connection = _dreamManager.GetConnectionFromClient(client);
             connection.OutputDreamValue(b);
-            return new DreamValue(0);
         }
 
         private void ScreenValueAssigned(DreamList screenList, DreamValue screenKey, DreamValue screenValue) {

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMob.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMob.cs
@@ -61,7 +61,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             }
         }
 
-        public DreamValue OperatorOutput(DreamValue a, DreamValue b) {
+        public void OperatorOutput(DreamValue a, DreamValue b) {
             if (!a.TryGetValueAsDreamObjectOfType(DreamPath.Mob, out var mob))
                 throw new ArgumentException($"Left-hand value was not the expected type {DreamPath.Mob}");
             if (!mob.GetVariable("client").TryGetValueAsDreamObjectOfType(DreamPath.Client, out var client))
@@ -69,7 +69,6 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
             DreamConnection connection = _dreamManager.GetConnectionFromClient(client);
             connection.OutputDreamValue(b);
-            return new DreamValue(0);
         }
     }
 }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectSavefile.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectSavefile.cs
@@ -1,0 +1,122 @@
+﻿using OpenDreamRuntime.Procs;
+using OpenDreamRuntime.Resources;
+using OpenDreamShared.Dream;
+using System.Text.Json;
+
+namespace OpenDreamRuntime.Objects.MetaObjects {
+    sealed class DreamMetaObjectSavefile : IDreamMetaObject {
+        private readonly DreamResourceManager _resourceManager = IoCManager.Resolve<DreamResourceManager>();
+
+        public IDreamMetaObject? ParentType { get; set; }
+        public bool ShouldCallNew => false;
+        public sealed class Savefile {
+            public readonly DreamResource Resource;
+            public readonly Dictionary<string, SavefileDirectory> Directories;
+            public string CurrentDirPath = "/";
+            public SavefileDirectory CurrentDir => Directories[CurrentDirPath];
+
+            public Savefile(DreamResource resource) {
+                Resource = resource;
+
+                string data = resource.ReadAsString();
+                if (!String.IsNullOrEmpty(data)) {
+                    Directories = JsonSerializer.Deserialize<Dictionary<string, SavefileDirectory>>(data);
+                } else {
+                    Directories = new() {
+                        { "/", new SavefileDirectory() }
+                    };
+                }
+            }
+
+            public void ChangeDirectory(string path) {
+                CurrentDirPath = new DreamPath(CurrentDirPath).AddToPath(path).PathString;
+
+                if (!Directories.ContainsKey(CurrentDirPath)) {
+                    Directories.Add(CurrentDirPath, new SavefileDirectory());
+                }
+            }
+
+            public void Flush() {
+                Resource.Clear();
+                Resource.Output(new DreamValue(JsonSerializer.Serialize(Directories)));
+            }
+        }
+
+        public class SavefileDirectory : Dictionary<string, DreamValue> { }
+
+        public static Dictionary<DreamObject, Savefile> ObjectToSavefile = new();
+
+        public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
+            string filename = creationArguments.GetArgument(0, "filename").GetValueAsString();
+            DreamValue timeout = creationArguments.GetArgument(1, "timeout"); //TODO: timeout
+
+            DreamResource resource = _resourceManager.LoadResource(filename);
+            Savefile savefile = new Savefile(resource);
+            ObjectToSavefile.Add(dreamObject, savefile);
+
+            ParentType?.OnObjectCreated(dreamObject, creationArguments);
+        }
+
+        public void OnObjectDeleted(DreamObject dreamObject) {
+            ObjectToSavefile.Remove(dreamObject);
+
+            ParentType?.OnObjectDeleted(dreamObject);
+        }
+
+        public void OnVariableSet(DreamObject dreamObject, string variableName, DreamValue variableValue, DreamValue oldVariableValue) {
+            ParentType?.OnVariableSet(dreamObject, variableName, variableValue, oldVariableValue);
+
+            Savefile savefile = ObjectToSavefile[dreamObject];
+
+            switch (variableName) {
+                case "cd": savefile.ChangeDirectory(variableValue.GetValueAsString()); break;
+                case "eof": break; //TODO: What's a savefile buffer?
+            }
+        }
+
+        public DreamValue OnVariableGet(DreamObject dreamObject, string variableName, DreamValue variableValue) {
+            Savefile savefile = ObjectToSavefile[dreamObject];
+
+            switch (variableName) {
+                case "cd": return new DreamValue(savefile.CurrentDirPath);
+                case "eof": return new DreamValue(0); //TODO: What's a savefile buffer?
+                case "name": return new DreamValue(savefile.Resource.ResourcePath);
+                case "dir": {
+                    DreamList dirList = DreamList.Create();
+
+                    foreach (string dirPath in savefile.Directories.Keys) {
+                        if (dirPath.StartsWith(savefile.CurrentDirPath)) {
+                            dirList.AddValue(new DreamValue(dirPath));
+                        }
+                    }
+
+                    //TODO: dirList.Add(), dirList.Remove() should affect the directories in a savefile
+
+                    return new DreamValue(dirList);
+                }
+                default: return ParentType?.OnVariableGet(dreamObject, variableName, variableValue) ?? variableValue;
+            }
+        }
+
+        public DreamValue OperatorIndex(DreamObject dreamObject, DreamValue index) {
+            Savefile savefile = ObjectToSavefile[dreamObject];
+
+            if (!index.TryGetValueAsString(out string? entryName)) throw new Exception($"Invalid savefile index {index}");
+
+            if (savefile.CurrentDir.TryGetValue(entryName, out DreamValue entry)) {
+                return entry;
+            } else {
+                return DreamValue.Null;
+            }
+        }
+
+        public void OperatorIndexAssign(DreamObject dreamObject, DreamValue index, DreamValue value) {
+            Savefile savefile = ObjectToSavefile[dreamObject];
+
+            if (!index.TryGetValueAsString(out string? entryName)) throw new Exception($"Invalid savefile index {index}");
+
+            savefile.CurrentDir[entryName] = value;
+            savefile.Flush(); //TODO: Don't flush after every change
+        }
+    }
+}

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectWorld.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectWorld.cs
@@ -180,12 +180,10 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             }
         }
 
-        public DreamValue OperatorOutput(DreamValue a, DreamValue b) {
+        public void OperatorOutput(DreamValue a, DreamValue b) {
             foreach (DreamConnection connection in _dreamManager.Connections) {
                 connection.OutputDreamValue(b);
             }
-
-            return new DreamValue(0);
         }
     }
 }

--- a/OpenDreamRuntime/Objects/MetaObjects/IDreamMetaObject.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/IDreamMetaObject.cs
@@ -17,11 +17,11 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public DreamValue OnVariableGet(DreamObject dreamObject, string varName, DreamValue value) =>
             ParentType?.OnVariableGet(dreamObject, varName, value) ?? value;
 
-        public DreamValue OperatorOutput(DreamValue a, DreamValue b) {
+        public void OperatorOutput(DreamValue a, DreamValue b) {
             if (ParentType == null)
                 throw new InvalidOperationException($"Cannot output {b} to {a}");
 
-            return ParentType.OperatorOutput(a, b);
+            ParentType.OperatorOutput(a, b);
         }
 
         public DreamValue OperatorAdd(DreamValue a, DreamValue b) {

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -63,7 +63,7 @@ namespace OpenDreamRuntime.Procs {
             DMOpcodeHandlers.Modulus,
             DMOpcodeHandlers.Append,
             DMOpcodeHandlers.CreateRangeEnumerator,
-            null, //0x1C
+            DMOpcodeHandlers.Input,
             DMOpcodeHandlers.CompareLessThanOrEqual,
             DMOpcodeHandlers.CreateAssociativeList,
             DMOpcodeHandlers.Remove,
@@ -102,8 +102,8 @@ namespace OpenDreamRuntime.Procs {
             DMOpcodeHandlers.BitShiftRight,
             null, //0x41
             DMOpcodeHandlers.Power,
-            DMOpcodeHandlers.OutputReference,
-            DMOpcodeHandlers.Output,
+            null, //0x43
+            null, //0x44
             DMOpcodeHandlers.Prompt,
             DMOpcodeHandlers.PushProcArguments,
             DMOpcodeHandlers.Initial,
@@ -113,8 +113,8 @@ namespace OpenDreamRuntime.Procs {
             DMOpcodeHandlers.Locate,
             DMOpcodeHandlers.IsNull,
             DMOpcodeHandlers.Spawn,
-            DMOpcodeHandlers.Input,
-            null, //0x4F
+            DMOpcodeHandlers.OutputReference,
+            DMOpcodeHandlers.Output,
             DMOpcodeHandlers.JumpIfNullDereference,
             DMOpcodeHandlers.Pop,
             DMOpcodeHandlers.Prob,

--- a/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
+++ b/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
@@ -71,8 +71,8 @@ namespace OpenDreamShared.Dream.Procs {
         BitShiftRight = 0x40,
         //0x41
         Power = 0x42,
-        //0x43
-        //0x44
+        OutputReference = 0x43,
+        Output = 0x44,
         Prompt = 0x45,
         PushProcArguments = 0x46,
         Initial = 0x47,
@@ -82,8 +82,8 @@ namespace OpenDreamShared.Dream.Procs {
         Locate = 0x4B,
         IsNull = 0x4C,
         Spawn = 0x4D,
-        //0x4E
-        //0x4F,
+        Input = 0x4E,
+        //0x4F
         JumpIfNullDereference = 0x50,
         Pop = 0x51,
         Prob = 0x52,
@@ -134,7 +134,7 @@ namespace OpenDreamShared.Dream.Procs {
         public enum FormatSuffix : UInt16
         {
             //States that Interpolated values can have (the [] thingies)
-            StringifyWithArticle = 0x0,    //[] and we include an appropriate article for the resulting value, if necessary            
+            StringifyWithArticle = 0x0,    //[] and we include an appropriate article for the resulting value, if necessary
             StringifyNoArticle = 0x1,      //[] and we never include an article (because it's elsewhere)
             ReferenceOfValue = 0x2,        //\ref[]
 

--- a/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
+++ b/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
@@ -32,7 +32,7 @@ namespace OpenDreamShared.Dream.Procs {
         Modulus = 0x19,
         Append = 0x1A,
         CreateRangeEnumerator = 0x1B,
-        //0x1C
+        Input = 0x1C,
         CompareLessThanOrEqual = 0x1D,
         CreateAssociativeList = 0x1E,
         Remove = 0x1F,
@@ -71,8 +71,8 @@ namespace OpenDreamShared.Dream.Procs {
         BitShiftRight = 0x40,
         //0x41
         Power = 0x42,
-        OutputReference = 0x43,
-        Output = 0x44,
+        //0x43
+        //0x44
         Prompt = 0x45,
         PushProcArguments = 0x46,
         Initial = 0x47,
@@ -82,8 +82,8 @@ namespace OpenDreamShared.Dream.Procs {
         Locate = 0x4B,
         IsNull = 0x4C,
         Spawn = 0x4D,
-        Input = 0x4E,
-        //0x4F
+        OutputReference = 0x4E,
+        Output = 0x4F,
         JumpIfNullDereference = 0x50,
         Pop = 0x51,
         Prob = 0x52,


### PR DESCRIPTION
Savefiles now work again. This was achieved by turning statements containing only a left/right shift into an "output" or "input" statement. These statements can work on `DMReference` values instead of just DreamValues, allowing for special behavior with something like `savefile["ABC"] << 10`.