### PR TITLE
Fix `browse()` being used to close popups

### DIFF
--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1514,7 +1514,7 @@ namespace OpenDreamRuntime.Procs {
             string? browseValue;
             if (body.TryGetValueAsDreamResource(out var resource)) {
                 browseValue = resource.ReadAsString();
-            } else if (body.TryGetValueAsString(out browseValue)) {
+            } else if (body.TryGetValueAsString(out browseValue) || body == DreamValue.Null) {
                 // Got it.
             } else {
                 throw new Exception($"Invalid browse() body: expected resource or string, got {body}");


### PR DESCRIPTION
`usr << browse(null, "window=windowname")` can be used to close a window. This wasn't working because the browse opcode didn't recognize `null` as a valid first argument.