### PR TITLE
Implements compiler configuration through new preproc directive: `#pragma`

### DIFF
--- a/Content.Tests/DMProject/Tests/Preprocessor/Pragma/pragma_warning.dm
+++ b/Content.Tests/DMProject/Tests/Preprocessor/Pragma/pragma_warning.dm
@@ -1,0 +1,8 @@
+//COMPILE ERROR
+
+#pragma WarningDirective error
+
+#warn "I should be an error!"
+
+/proc/RunTest()
+	return

--- a/Content.Tests/DMProject/Tests/Preprocessor/Variadic/variadic_macro_functor.dm
+++ b/Content.Tests/DMProject/Tests/Preprocessor/Variadic/variadic_macro_functor.dm
@@ -1,0 +1,9 @@
+
+#define SEND_SIGNAL(target, arguments...) list(target, ##arguments)
+
+/proc/RunTest()
+	var/list/a = SEND_SIGNAL(2)
+	ASSERT(a ~= list(2,))
+	ASSERT(a ~= list(2))
+	var/list/b = SEND_SIGNAL(2,3,4,5)
+	ASSERT(b ~= list(2,3,4,5))

--- a/Content.Tests/DMProject/Tests/Preprocessor/Variadic/variadic_must_be_last.dm
+++ b/Content.Tests/DMProject/Tests/Preprocessor/Variadic/variadic_must_be_last.dm
@@ -1,0 +1,6 @@
+//COMPILE ERROR
+
+#define DAMN(what...,the...,hockeysticks...) world << list(##what)
+
+/proc/RunTest()
+	DAMN("do","re","mi","fa","so","la","ti","do!")

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -89,7 +89,7 @@ namespace DMCompiler.Compiler.DM {
 
         private static readonly TokenType[] IdentifierTypes = {TokenType.DM_Identifier, TokenType.DM_Step};
 
-        private static readonly TokenType[]  ValidPathElementTokens = {
+        private static readonly TokenType[] ValidPathElementTokens = {
             TokenType.DM_Identifier,
             TokenType.DM_Var,
             TokenType.DM_Proc,
@@ -1447,12 +1447,13 @@ namespace DMCompiler.Compiler.DM {
                 }
                 if (Check(TokenType.DM_Null)){
                     // Breaking change - BYOND creates a var named null that overrides the keyword. No error.
-                    Error($"error: 'null' is not a valid variable name", false);
-                    Advance();
-                    BracketWhitespace();
-                    Check(TokenType.DM_Comma);
-                    BracketWhitespace();
-                    parameters.AddRange(DefinitionParameters());
+                    if (Error(WarningCode.SoftReservedKeyword, "'null' is not a valid variable name")) { // If it's an error, skip over this var instantiation.
+                        Advance();
+                        BracketWhitespace();
+                        Check(TokenType.DM_Comma);
+                        BracketWhitespace();
+                        parameters.AddRange(DefinitionParameters());
+                    }
                 }
             }
 

--- a/DMCompiler/Compiler/DM/DMParserHelper.cs
+++ b/DMCompiler/Compiler/DM/DMParserHelper.cs
@@ -8,6 +8,20 @@ using System.Text;
 
 namespace DMCompiler.Compiler.DM {
     public partial class DMParser : Parser<Token> {
+
+        /// <summary>
+        /// A special override of Error() since, for DMParser, we know we are in a compilation context and can make use of error codes.
+        /// </summary>
+        /// <remarks>
+        /// Should only be called AFTER <see cref="DMCompiler"/> has built up its list of pragma configurations.
+        /// </remarks>
+        /// <returns> True if this will raise an error, false if not. You can use this return value to help improve error emission around this (depending on how permissive we're being)</returns>
+        protected bool Error(WarningCode code, string message) {
+            ErrorLevel level = DMCompiler.CodeToLevel(code);
+            Emissions.Add(new CompilerEmission(level, code, Current().Location, message));
+            return level == ErrorLevel.Error;
+        }
+
         protected bool PeekDelimiter() {
             return Current().Type == TokenType.Newline || Current().Type == TokenType.DM_Semicolon;
         }

--- a/DMCompiler/Compiler/DM/DMParserHelper.cs
+++ b/DMCompiler/Compiler/DM/DMParserHelper.cs
@@ -138,11 +138,10 @@ namespace DMCompiler.Compiler.DM {
                                     }
                                     catch (CompileErrorException e)
                                     {
-                                        Errors.Add(e.Error);
+                                        Emissions.Add(e.Error);
                                     }
 
-                                    if (expressionParser.Errors.Count > 0) Errors.AddRange(expressionParser.Errors);
-                                    if (expressionParser.Warnings.Count > 0) Warnings.AddRange(expressionParser.Warnings);
+                                    if (expressionParser.Emissions.Count > 0) Emissions.AddRange(expressionParser.Emissions);
                                     interpolationValues.Add(expression);
                                 }
                                 else

--- a/DMCompiler/Compiler/DMM/DMMParser.cs
+++ b/DMCompiler/Compiler/DMM/DMMParser.cs
@@ -68,13 +68,13 @@ namespace DMCompiler.Compiler.DMM {
                         while (statement != null) {
                             DMASTObjectVarOverride varOverride = statement as DMASTObjectVarOverride;
                             if (varOverride == null) Error("Expected a var override");
-                            if (!varOverride.ObjectPath.Equals(DreamPath.Root)) DMCompiler.Error(new CompilerError(statement.Location, $"Invalid var name '{varOverride.VarName}' in DMM on type {objectType.Path}"));
+                            if (!varOverride.ObjectPath.Equals(DreamPath.Root)) DMCompiler.ForcedError(statement.Location, $"Invalid var name '{varOverride.VarName}' in DMM on type {objectType.Path}");
                             DMExpression value = DMExpression.Create(DMObjectTree.GetDMObject(objectType.Path, false), null, varOverride.Value);
-                            if (!value.TryAsJsonRepresentation(out var valueJson)) DMCompiler.Error(new CompilerError(statement.Location, $"Failed to serialize value to json ({value})"));
+                            if (!value.TryAsJsonRepresentation(out var valueJson)) DMCompiler.ForcedError(statement.Location, $"Failed to serialize value to json ({value})");
 
                             if(!mapObject.AddVarOverride(varOverride.VarName, valueJson))
                             {
-                                DMCompiler.Warning(new CompilerWarning(statement.Location, $"Duplicate var override '{varOverride.VarName}' in DMM on type {objectType.Path}"));
+                                DMCompiler.ForcedWarning(statement.Location, $"Duplicate var override '{varOverride.VarName}' in DMM on type {objectType.Path}");
                             }
 
                             if (Check(TokenType.DM_Semicolon)) {

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -621,6 +621,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
                     break;
                 case "notice":
                 case "pedantic":
+                case "info":
                     DMCompiler.SetPragma(warningCode, ErrorLevel.Notice);
                     break;
                 case "warning":

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -344,7 +344,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
                                 token = CreateToken(TokenType.DM_Preproc_ParameterStringify, $"#{text}", text);
                                 string macroAttempt = text.ToLower();
                                 if (TryMacroKeyword(macroAttempt, out _)) { // if they miscapitalized the keyword
-                                    DMCompiler.Warning(token.Location, $"#{text} is not a valid macro keyword. Did you mean '#{text.ToLower()}'?");
+                                    DMCompiler.Emit(WarningCode.MiscapitalizedDirective, token.Location, $"#{text} is not a valid macro keyword. Did you mean '#{macroAttempt}'?");
                                 }
                             }
                         }

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -416,6 +416,8 @@ namespace DMCompiler.Compiler.DMPreprocessor {
                 case "else": token = CreateToken(TokenType.DM_Preproc_Else, "#else"); break;
                 case "endif": token = CreateToken(TokenType.DM_Preproc_EndIf, "#endif"); break;
                 case "error": token = CreateToken(TokenType.DM_Preproc_Error, "#error"); break;
+                //OD-specific directives
+                case "pragma": token = CreateToken(TokenType.DM_Preproc_Pragma, "#pragma"); break;
                 default:
                     token = null; // maybe should use ref instead of out?
                     return false;

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorParser.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorParser.cs
@@ -73,7 +73,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
             return false;
         }
         private static void Error(string msg) {
-            DMCompiler.Error(Current()?.Location ?? Location.Unknown, msg);
+            DMCompiler.Emit(WarningCode.BadDirective, Current()?.Location ?? Location.Unknown, msg);
         }
 
         private static float? Expression() {
@@ -258,7 +258,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
                         }
                         Advance();
                         if (!Check(TokenType.DM_RightParenthesis)) {
-                            Error("Expected ')' to end defined() expression");
+                            DMCompiler.Emit(WarningCode.DefinedMissingParen, token.Location, "Expected ')' to end defined() expression");
                             //Electing to not return a degenerate value here since "defined(x" actually isn't an ambiguous grammar; we can figure out what they meant.
                         }
                         return _defines!.ContainsKey(definedInner.Text) ? 1.0f : 0.0f;

--- a/DMCompiler/DM/DMExpression.cs
+++ b/DMCompiler/DM/DMExpression.cs
@@ -66,7 +66,7 @@ namespace DMCompiler.DM {
         // Emits a reference that is to be used in an opcode that assigns/gets a value
         // May throw if this expression is unable to be referenced
         public virtual (DMReference Reference, bool Conditional) EmitReference(DMObject dmObject, DMProc proc) {
-            throw new CompileErrorException(Location, $"attempt to reference r-value");
+            throw new CompileAbortException(Location, $"Cannot reference r-value");
         }
 
         public virtual DreamPath? Path => null;
@@ -111,7 +111,7 @@ namespace DMCompiler.DM {
 
                     default:
                         if (key != null) {
-                            DMCompiler.Error(new CompilerError(key.Location, "Invalid argument key"));
+                            DMCompiler.Emit(WarningCode.InvalidArgumentKey, key.Location, $"Invalid argument key");
                         }
 
                         break;
@@ -129,7 +129,7 @@ namespace DMCompiler.DM {
 
             if (Expressions[0].Name == null && Expressions[0].Expr is Expressions.Arglist arglist) {
                 if (Expressions.Length != 1) {
-                    throw new CompileErrorException(Location, "arglist expression should be the only argument");
+                    DMCompiler.Emit(WarningCode.ArglistOnlyArgument, Location, "arglist expression should be the only argument");
                 }
 
                 arglist.EmitPushArglist(dmObject, proc);

--- a/DMCompiler/DM/DMExpression.cs
+++ b/DMCompiler/DM/DMExpression.cs
@@ -111,7 +111,7 @@ namespace DMCompiler.DM {
 
                     default:
                         if (key != null) {
-                            DMCompiler.Emit(WarningCode.InvalidArgumentKey, key.Location, $"Invalid argument key");
+                            DMCompiler.Emit(WarningCode.InvalidArgumentKey, key.Location, "Invalid argument key");
                         }
 
                         break;

--- a/DMCompiler/DM/DMObject.cs
+++ b/DMCompiler/DM/DMObject.cs
@@ -190,7 +190,7 @@ namespace DMCompiler.DM {
                     try {
                         expression.EmitPushValue(this, init);
                     } catch (CompileErrorException e) {
-                        DMCompiler.Error(e.Error);
+                        DMCompiler.Emit(e.Error);
                     }
                 }
             }

--- a/DMCompiler/DM/DMObjectTree.cs
+++ b/DMCompiler/DM/DMObjectTree.cs
@@ -172,7 +172,7 @@ namespace DMCompiler.DM {
                         assign.Value.EmitPushValue(root, GlobalInitProc);
                         GlobalInitProc.Assign(DMReference.CreateGlobal(assign.GlobalId));
                     } catch (CompileErrorException e) {
-                        DMCompiler.Error(e.Error);
+                        DMCompiler.Emit(e.Error);
                     }
                 }
             }

--- a/DMCompiler/DM/Expressions/Builtins.cs
+++ b/DMCompiler/DM/Expressions/Builtins.cs
@@ -183,7 +183,7 @@ namespace DMCompiler.DM.Expressions {
 
             if (weighted) {
                 if (_values.Length == 1) {
-                    DMCompiler.Warning(new CompilerWarning(Location, "Weighted pick() with one argument"));
+                    DMCompiler.ForcedWarning(Location, "Weighted pick() with one argument");
                 }
 
                 foreach (PickValue pickValue in _values) {

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -158,7 +158,7 @@ namespace DMCompiler.DM.Expressions {
                 proc.Initial();
             } else {
                 // This happens silently in BYOND
-                DMCompiler.Warning(new CompilerWarning(Location, "calling initial() on a list index returns the current value"));
+                DMCompiler.Emit(WarningCode.PointlessBuiltinCall, Location, "calling initial() on a list index returns the current value");
                 EmitPushValue(dmObject, proc);
             }
         }
@@ -175,7 +175,7 @@ namespace DMCompiler.DM.Expressions {
                 proc.IsSaved();
             } else {
                 // Silent in BYOND
-                DMCompiler.Warning(new CompilerWarning(_expr.Location, "calling issaved() on a list index is always false"));
+                DMCompiler.Emit(WarningCode.PointlessBuiltinCall, _expr.Location, "calling issaved() on a list index is always false");
                 proc.PushFloat(0);
             }
         }

--- a/DMCompiler/DM/Expressions/LValue.cs
+++ b/DMCompiler/DM/Expressions/LValue.cs
@@ -92,7 +92,7 @@ namespace DMCompiler.DM.Expressions {
 
         public override void EmitPushInitial(DMObject dmObject, DMProc proc) {
             // This happens silently in BYOND
-            DMCompiler.Warning(new CompilerWarning(Location, "calling initial() on a local variable returns the current value"));
+            DMCompiler.Emit(WarningCode.PointlessBuiltinCall, Location, "calling initial() on a local variable returns the current value");
             EmitPushValue(dmObject, proc);
         }
     }
@@ -151,7 +151,7 @@ namespace DMCompiler.DM.Expressions {
 
         public override void EmitPushInitial(DMObject dmObject, DMProc proc) {
             // This happens silently in BYOND
-            DMCompiler.Warning(new CompilerWarning(Location, "calling initial() on a global returns the current value"));
+            DMCompiler.Emit(WarningCode.PointlessBuiltinCall, Location, "calling initial() on a global returns the current value");
             EmitPushValue(dmObject, proc);
         }
 

--- a/DMCompiler/DM/Expressions/Procs.cs
+++ b/DMCompiler/DM/Expressions/Procs.cs
@@ -21,7 +21,7 @@ namespace DMCompiler.DM.Expressions {
                 return (DMReference.CreateGlobalProc(globalProc.Id), false);
             }
             
-            DMCompiler.Error(Location, $"Type {dmObject.Path} does not have a proc named \"{_identifier}\"");
+            DMCompiler.Emit(WarningCode.ItemDoesntExist, Location, $"Type {dmObject.Path} does not have a proc named \"{_identifier}\"");
             //Just... pretend there is one for the sake of argument.
             return (DMReference.CreateSrcProc(_identifier), false);
         }
@@ -45,7 +45,7 @@ namespace DMCompiler.DM.Expressions {
         }
 
         public override void EmitPushValue(DMObject dmObject, DMProc proc) {
-            DMCompiler.Error(Location, $"Attempt to use proc \"{_name}\" as value");
+            DMCompiler.Emit(WarningCode.InvalidReference, Location, $"Attempt to use proc \"{_name}\" as value");
         }
 
         public override (DMReference Reference, bool Conditional) EmitReference(DMObject dmObject, DMProc proc) {
@@ -56,7 +56,7 @@ namespace DMCompiler.DM.Expressions {
 
         public DMProc GetProc() {
             if (!DMObjectTree.TryGetGlobalProc(_name, out DMProc globalProc)) {
-                DMCompiler.Error(Location, $"No global proc named \"{_name}\"");
+                DMCompiler.Emit(WarningCode.ItemDoesntExist, Location, $"No global proc named \"{_name}\"");
                 return DMObjectTree.GlobalInitProc; // Just give this, who cares
             }
 
@@ -83,13 +83,13 @@ namespace DMCompiler.DM.Expressions {
         public ProcSuper(Location location) : base(location) { }
 
         public override void EmitPushValue(DMObject dmObject, DMProc proc) {
-            throw new CompileErrorException(Location, "attempt to use proc as value");
+            DMCompiler.Emit(WarningCode.InvalidReference, Location, $"Attempt to use proc \"..\" as value");
         }
 
         public override (DMReference Reference, bool Conditional) EmitReference(DMObject dmObject, DMProc proc) {
             if ((proc.Attributes & ProcAttributes.IsOverride) != ProcAttributes.IsOverride)
             {
-                DMCompiler.Warning(new CompilerWarning(Location, "Calling parents via ..() in a proc definition does nothing"));
+                DMCompiler.Emit(WarningCode.PointlessParentCall, Location, "Calling parents via ..() in a proc definition does nothing");
             }
             return (DMReference.SuperProc, false);
         }

--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -198,7 +198,7 @@ namespace DMCompiler.DM.Visitors {
             var rhs = DMExpression.Create(_dmObject, _proc, assign.Value, lhs.Path);
             if(lhs.TryAsConstant(out var _))
             {
-                DMCompiler.Error(new CompilerError(assign.Expression.Location, "Cannot write to const var"));
+                DMCompiler.Emit(WarningCode.WriteToConstant, assign.Expression.Location, "Cannot write to const var");
             }
             Result = new Expressions.Assignment(assign.Location, lhs, rhs);
         }
@@ -612,7 +612,7 @@ namespace DMCompiler.DM.Visitors {
             {
                 DMASTCallParameter parameter = addText.Parameters[i];
                 if(parameter.Key != null)
-                    throw new CompileErrorException(parameter.Location, "addtext() does not take named arguments");
+                    DMCompiler.Emit(WarningCode.TooManyArguments, parameter.Location, "addtext() does not take named arguments");
                 exp_arr[i] = DMExpression.Create(_dmObject,_proc, parameter.Value, _inferredPath);
             }
             Result = new Expressions.AddText(addText.Location, exp_arr);
@@ -630,7 +630,7 @@ namespace DMCompiler.DM.Visitors {
                 DMASTCallParameter parameter = input.Parameters[i];
 
                 if (parameter.Key != null) {
-                    DMCompiler.Error(parameter.Location, "input() does not take named arguments");
+                    DMCompiler.Emit(WarningCode.TooManyArguments, parameter.Location, "input() does not take named arguments");
                 }
 
                 arguments[i] = DMExpression.Create(_dmObject, _proc, parameter.Value);
@@ -646,7 +646,7 @@ namespace DMCompiler.DM.Visitors {
                 // Default filter is "as anything" when there's a list
                 input.Types ??= DMValueType.Anything;
                 if (input.Types != DMValueType.Anything && (input.Types & objectTypes) == 0x0) {
-                    DMCompiler.Error(input.Location,
+                    DMCompiler.Emit(WarningCode.BadArgument, input.Location,
                         $"Invalid input() filter \"{input.Types}\". Filter must be \"{DMValueType.Anything}\" or at least one of \"{objectTypes}\"");
                 }
             } else {
@@ -695,13 +695,15 @@ namespace DMCompiler.DM.Visitors {
             var procArgs = new ArgumentList(call.Location, _dmObject, _proc, call.ProcParameters, _inferredPath);
 
             switch (call.CallParameters.Length) {
+                case 0:
+                    DMCompiler.Emit(WarningCode.BadArgument, call.Location, "Not enough arguments for call()");
+                    break;
                 case 1:
                     {
                         var a = DMExpression.Create(_dmObject, _proc, call.CallParameters[0].Value, _inferredPath);
                         Result = new Expressions.CallStatement(call.Location, a, procArgs);
                     }
                     break;
-
                 case 2:
                     {
                         var a = DMExpression.Create(_dmObject, _proc, call.CallParameters[0].Value, _inferredPath);
@@ -709,9 +711,9 @@ namespace DMCompiler.DM.Visitors {
                         Result = new Expressions.CallStatement(call.Location, a, b, procArgs);
                     }
                     break;
-
                 default:
-                    throw new CompileErrorException(call.Location,"invalid argument count for call()");
+                    DMCompiler.Emit(WarningCode.TooManyArguments, call.Location, "Too many arguments for call()");
+                    break;
             }
         }
     }

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -94,6 +94,7 @@ namespace DMCompiler {
                         preproc.DefineMacro(key, value);
                     }
                 }
+                DefineFatalErrors();
 
                 // NB: IncludeFile pushes newly seen files to a stack, so push
                 // them in reverse order to process them in forward order.
@@ -315,16 +316,20 @@ namespace DMCompiler {
             return string.Empty;
         }
 
+        public static void DefineFatalErrors() {
+            foreach (WarningCode code in Enum.GetValues<WarningCode>()) {
+                if((int)code < 1_000) {
+                    Config.errorConfig[code] = ErrorLevel.Error;
+                }
+            }
+        }
+
         /// <summary>
         /// This method also enforces the rule that all emissions with codes less than 1000 are mandatory errors.
         /// </summary>
         public static void CheckAllPragmasWereSet() {
             foreach(WarningCode code in Enum.GetValues<WarningCode>()) {
-                if ((int)code < 1000) {
-                    Config.errorConfig[code] = ErrorLevel.Error; // Overwriting assignment
-                }
-                else if (!Config.errorConfig.ContainsKey(code)) {
-
+                if (!Config.errorConfig.ContainsKey(code)) {
                     ForcedWarning($"Warning #{(int)code:d4} '{code.ToString()}' was never declared as error, warning, notice, or disabled.");
                     Config.errorConfig.Add(code, ErrorLevel.Disabled);
                 }

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -119,22 +119,13 @@ namespace DMCompiler {
                     pragmaDirectory = dmStandardDirectory;
                     pragmaName = "DefaultPragmaConfig.dm";
                 }
-                if(!File.Exists(pragmaFile)) {
+                if(!File.Exists(Path.Join(pragmaDirectory,pragmaName))) {
                     ForcedError($"Configuration file '{pragmaName}' not found.");
                     return null;
                 }
                 preproc.IncludeFile(pragmaDirectory,pragmaName);
-                CheckAllPragmasWereSet();
                 return preproc;
             }
-            //Do the compiler configuration file first!
-            string pragmaName = Settings.PragmaFileOverride ?? "DefaultPragmaConfig.dm";
-            string pragmaFile = Path.Join(compilerDirectory, "DMStandard", pragmaName);
-            if (!File.Exists(pragmaFile)) {
-                ForcedError($"Configuration file '{pragmaName}' not found.");
-                return null;
-            }
-            files.Add(pragmaFile);
 
             if (Settings.DumpPreprocessor) {
                 //Preprocessing is done twice because the output is used up when dumping it

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -172,13 +172,7 @@ namespace DMCompiler {
         }
 
         public static void Emit(CompilerEmission emission) {
-            Console.WriteLine(emission);
-            return;
-        }
-
-        public static void Emit(WarningCode code, Location loc, string message) {
-            ErrorLevel level = Config.errorConfig[code];
-            switch (level) {
+            switch (emission.Level) {
                 case ErrorLevel.Disabled:
                     return;
                 case ErrorLevel.Notice:
@@ -187,11 +181,18 @@ namespace DMCompiler {
                     break;
                 case ErrorLevel.Warning:
                     ++WarningCount;
-                    return;
+                    break;
                 case ErrorLevel.Error:
                     ++ErrorCount;
-                    return;
+                    break;
             }
+            Console.WriteLine(emission);
+            return;
+        }
+
+        /// <summary> Emits the given warning, according to its ErrorLevel as set in our config. </summary>
+        public static void Emit(WarningCode code, Location loc, string message) {
+            ErrorLevel level = Config.errorConfig[code];
             Emit(new CompilerEmission(level, code, loc, message));
         }
 

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -200,7 +200,6 @@ namespace DMCompiler {
         /// To be used when the compiler MUST ALWAYS give an error. <br/>
         /// Completely ignores the warning configuration. Use wisely!
         /// </summary>
-
         public static void ForcedError(string message) {
             ForcedError(Location.Internal, message);
         }
@@ -221,8 +220,7 @@ namespace DMCompiler {
         }
 
         /// <inheritdoc cref="ForcedWarning(string)"/>
-        public static void ForcedWarning(Location loc, string message)
-        {
+        public static void ForcedWarning(Location loc, string message) {
             Console.WriteLine(new CompilerEmission(ErrorLevel.Warning, loc, message));
             WarningCount++;
         }
@@ -353,8 +351,7 @@ namespace DMCompiler {
         public string? PragmaFileOverride;
     }
 
-    class DMCompilerConfiguration
-    {
+    class DMCompilerConfiguration {
         public Dictionary<WarningCode, ErrorLevel> errorConfig;
         public DMCompilerConfiguration() {
             errorConfig = new(Enum.GetValues<WarningCode>().Length);

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -16,6 +16,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 using DMCompiler.Compiler;
+using Robust.Shared.Utility;
 
 namespace DMCompiler {
     //TODO: Make this not a static class
@@ -336,6 +337,12 @@ namespace DMCompiler {
 
         public static void SetPragma(WarningCode code, ErrorLevel level) {
             Config.errorConfig[code] = level;
+        }
+
+        public static ErrorLevel CodeToLevel(WarningCode code) {
+            bool didFind = Config.errorConfig.TryGetValue(code, out var ret);
+            DebugTools.Assert(didFind);
+            return ret;
         }
     }
 

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -127,6 +127,14 @@ namespace DMCompiler {
                 CheckAllPragmasWereSet();
                 return preproc;
             }
+            //Do the compiler configuration file first!
+            string pragmaName = Settings.PragmaFileOverride ?? "DefaultPragmaConfig.dm";
+            string pragmaFile = Path.Join(compilerDirectory, "DMStandard", pragmaName);
+            if (!File.Exists(pragmaFile)) {
+                ForcedError($"Configuration file '{pragmaName}' not found.");
+                return null;
+            }
+            files.Add(pragmaFile);
 
             if (Settings.DumpPreprocessor) {
                 //Preprocessing is done twice because the output is used up when dumping it
@@ -319,7 +327,7 @@ namespace DMCompiler {
         /// <summary>
         /// This method also enforces the rule that all emissions with codes less than 1000 are mandatory errors.
         /// </summary>
-        static void CheckAllPragmasWereSet() {
+        public static void CheckAllPragmasWereSet() {
             foreach(WarningCode code in Enum.GetValues<WarningCode>()) {
                 if ((int)code < 1000) {
                     Config.errorConfig[code] = ErrorLevel.Error; // Overwriting assignment
@@ -330,6 +338,10 @@ namespace DMCompiler {
                     Config.errorConfig.Add(code, ErrorLevel.Disabled);
                 }
             }
+        }
+
+        public static void SetPragma(WarningCode code, ErrorLevel level) {
+            Config.errorConfig[code] = level;
         }
     }
 

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -13,3 +13,9 @@
 
 //2000-2999
 #pragma SoftReservedKeyword error
+#pragma DuplicateVariable error
+#pragma TooManyArguments error
+#pragma PointlessParentCall warning
+#pragma PointlessBuiltinCall warning
+#pragma MalformedRange warning
+#pragma InvalidRange error

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -1,3 +1,15 @@
 // This is the default error/warning/notice/disable setup when the user does not mandate a different file or configuration.
 // If you add a new named error with a code greater than 999, please mark it here.
 
+//1000-1999
+#pragma FileAlreadyIncluded warning
+#pragma MissingIncludedFile error
+#pragma MisplacedDirective error
+#pragma UndefineMissingDirective error
+#pragma DefinedMissingParen error
+#pragma ErrorDirective error
+#pragma WarningDirective warning
+#pragma MiscapitalizedDirective warning
+
+//2000-2999
+#pragma SoftReservedKeyword error

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -1,4 +1,3 @@
 // This is the default error/warning/notice/disable setup when the user does not mandate a different file or configuration.
-// If you add a new named error, please mark it here.
+// If you add a new named error with a code greater than 999, please mark it here.
 
-//#pragma Unknown error

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -1,0 +1,4 @@
+// This is the default error/warning/notice/disable setup when the user does not mandate a different file or configuration.
+// If you add a new named error, please mark it here.
+
+//#pragma Unknown error

--- a/DMCompiler/Program.cs
+++ b/DMCompiler/Program.cs
@@ -7,8 +7,7 @@ using OpenDreamShared.Compiler;
 
 namespace DMCompiler {
 
-    struct Argument
-    {
+    struct Argument {
         /// <summary> The text we found that's in the '--whatever' format. May be null if no such text was present.</summary>
         public string? Name;
         /// <summary> The value, either set in a '--whatever=whoever' format or just left by itself anonymously. May be null.</summary>
@@ -67,7 +66,6 @@ namespace DMCompiler {
         private static bool TryParseArguments(string[] args, out DMCompilerSettings settings) {
             settings = new();
             settings.Files = new List<string>();
-
 
             bool skipBad = args.Contains("--skip-bad-args");
 

--- a/DMCompiler/Program.cs
+++ b/DMCompiler/Program.cs
@@ -86,10 +86,14 @@ namespace DMCompiler {
                         }
                         (settings.MacroDefines ??= new())[parts[0]] = parts.Length > 1 ? parts[1] : "";
                         break;
+                    case "wall":
+                    case "notices-enabled":
+                        settings.NoticesEnabled = true;
+                        break;
                     case "pragma-config": {
                             if(arg.Value is null || !HasValidDMExtension(arg.Value)) {
                                 if(skipBad) {
-                                    DMCompiler.Warning(new CompilerWarning(Location.Internal, $"Compiler arg 'pragma-config' requires filename of valid DM file, skipping"));
+                                    DMCompiler.ForcedWarning($"Compiler arg 'pragma-config' requires filename of valid DM file, skipping");
                                     continue;
                                 }
                                 Console.WriteLine("Compiler arg 'pragma-config' requires filename of valid DM file");
@@ -107,7 +111,7 @@ namespace DMCompiler {
                             break;
                         }
                         if(skipBad) {
-                            DMCompiler.Warning(new CompilerWarning(Location.Internal, $"Invalid compiler arg '{arg.Value}', skipping"));
+                            DMCompiler.ForcedWarning($"Invalid compiler arg '{arg.Value}', skipping");
                         } else {
                             Console.WriteLine($"Invalid arg '{arg}'");
                             return false;
@@ -117,7 +121,7 @@ namespace DMCompiler {
                     }
                     default: {
                         if (skipBad) {
-                            DMCompiler.Warning(new CompilerWarning(Location.Internal, $"Unknown compiler arg '{arg.Name}', skipping"));
+                            DMCompiler.ForcedWarning($"Unknown compiler arg '{arg.Name}', skipping");
                             break;
                         } else {
                             Console.WriteLine($"Unknown arg '{arg}'");

--- a/DMCompiler/Program.cs
+++ b/DMCompiler/Program.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using OpenDreamShared.Compiler;
+using Robust.Shared.Utility;
 
 namespace DMCompiler {
 
@@ -34,7 +35,7 @@ namespace DMCompiler {
             List<Argument> retArgs = new(args.Length);
             for(var i = 0; i < args.Length;i+=1) {
                 string firstString = args[i];
-                if(firstString.Length == 0) // Is this possible? I don't even know
+                if(string.IsNullOrWhiteSpace(firstString)) // Is this possible? I don't even know. (IsNullOrWhiteSpace also checks if the string is empty, btw)
                     continue;
                 if(!firstString.StartsWith("--")) { // If it's a value-only argument
                     retArgs.Add(new Argument { Value = firstString });
@@ -77,12 +78,14 @@ namespace DMCompiler {
                     case "verbose": settings.Verbose = true; break;
                     case "skip-bad-args": break;
                     case "define":
-                        string[] parts = arg.Value.Split('=');
-                        if(parts.Length == 0) {
+                        string[] parts = arg.Value.Split('=', 2); // Only split on the first = in case of stuff like "--define AAA=0==1"
+                        if (parts.Length == 0) {
                             Console.WriteLine("Compiler arg 'define' requires macro identifier for definition directive");
                             return false;
                         }
-                        (settings.MacroDefines ??= new())[parts[0]] = parts.Length > 1 ? parts[1] : "";
+                        DebugTools.Assert(parts.Length <= 2);
+                        settings.MacroDefines ??= new();
+                        settings.MacroDefines[parts[0]] = parts.Length > 1 ? parts[1] : "";
                         break;
                     case "wall":
                     case "notices-enabled":

--- a/DMCompiler/Program.cs
+++ b/DMCompiler/Program.cs
@@ -1,10 +1,22 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using OpenDreamShared.Compiler;
 
 namespace DMCompiler {
+
+    struct Argument
+    {
+        /// <summary> The text we found that's in the '--whatever' format. May be null if no such text was present.</summary>
+        public string? Name;
+        /// <summary> The value, either set in a '--whatever=whoever' format or just left by itself anonymously. May be null.</summary>
+        public string? Value;
+    }
+
+
+
     class Program {
         static void Main(string[] args) {
             if (!TryParseArguments(args, out DMCompilerSettings settings)) {
@@ -18,41 +30,99 @@ namespace DMCompiler {
             }
         }
 
+        /// <summary> Helper for TryParseArguments(), to turn the arg array into something better-parsed.</summary>
+        private static IEnumerable<Argument> StringArrayToArguments(string[] args) {
+            List<Argument> retArgs = new(args.Length);
+            for(var i = 0; i < args.Length;i+=1) {
+                string firstString = args[i];
+                if(firstString.Length == 0) // Is this possible? I don't even know
+                    continue;
+                if(!firstString.StartsWith("--")) { // If it's a value-only argument
+                    retArgs.Add(new Argument { Value = firstString });
+                    continue;
+                }
+                firstString = firstString.TrimStart('-');
+                var split = firstString.Split('=');
+                if(split.Length == 1) { // If it's a name-only argument
+                    if(firstString == "define" && i + 1 < args.Length) { // Weird snowflaking to make our define syntax work
+                        i+=1;
+                        if(!args[i].StartsWith("--")) { // To make the error make a schmidge more sense
+                            retArgs.Add(new Argument {Name = firstString, Value = args[i] });
+                        }
+                    }
+                    retArgs.Add(new Argument { Name = firstString });
+                    continue;
+                }
+                retArgs.Add(new Argument { Name = split[0], Value = split[1] });
+            }
+
+            return retArgs.AsEnumerable();
+        }
+
+        private static bool HasValidDMExtension(string filename) {
+            string extension = Path.GetExtension(filename);
+            return !String.IsNullOrEmpty(extension) && (extension == ".dme" || extension == ".dm");
+        }
+
         private static bool TryParseArguments(string[] args, out DMCompilerSettings settings) {
             settings = new();
             settings.Files = new List<string>();
 
+
             bool skipBad = args.Contains("--skip-bad-args");
 
-            for (int i = 0; i < args.Length;) {
-                string arg = args[i++];
-                switch (arg) {
-                    case "--suppress-unimplemented": settings.SuppressUnimplementedWarnings = true; break;
-                    case "--dump-preprocessor": settings.DumpPreprocessor = true; break;
-                    case "--no-standard": settings.NoStandard = true; break;
-                    case "--verbose": settings.Verbose = true; break;
-                    case "--skip-bad-args": break;
-                    case "--define": {
-                        string[] parts = args[i++].Split("=", 2);
+            foreach (Argument arg in StringArrayToArguments(args)) {
+                switch (arg.Name) {
+                    case "suppress-unimplemented": settings.SuppressUnimplementedWarnings = true; break;
+                    case "dump-preprocessor": settings.DumpPreprocessor = true; break;
+                    case "no-standard": settings.NoStandard = true; break;
+                    case "verbose": settings.Verbose = true; break;
+                    case "skip-bad-args": break;
+                    case "define":
+                        string[] parts = arg.Value.Split('=');
+                        if(parts.Length == 0) {
+                            Console.WriteLine("Compiler arg 'define' requires macro identifier for definition directive");
+                            return false;
+                        }
                         (settings.MacroDefines ??= new())[parts[0]] = parts.Length > 1 ? parts[1] : "";
                         break;
-                    }
-                    default: {
-                        string extension = Path.GetExtension(arg);
-
-                        if (!String.IsNullOrEmpty(extension) && (extension == ".dme" || extension == ".dm")) {
-                            settings.Files.Add(arg);
-                            Console.WriteLine($"Compiling {Path.GetFileName(arg)}");
-                        } else {
-                            if(skipBad) {
-                                DMCompiler.Warning(new CompilerWarning(Location.Internal, $"Invalid compiler arg '{arg}', skipping"));
-                            } else {
-                                Console.WriteLine($"Invalid arg '{arg}'");
+                    case "pragma-config": {
+                            if(arg.Value is null || !HasValidDMExtension(arg.Value)) {
+                                if(skipBad) {
+                                    DMCompiler.Warning(new CompilerWarning(Location.Internal, $"Compiler arg 'pragma-config' requires filename of valid DM file, skipping"));
+                                    continue;
+                                }
+                                Console.WriteLine("Compiler arg 'pragma-config' requires filename of valid DM file");
                                 return false;
                             }
+                            settings.PragmaFileOverride = arg.Value;
+                            break;
+                    }
+                    case null: { // Value-only argument
+                        if (arg.Value is null) // A completely empty argument? This should be a bug.
+                            continue;
+                        if (HasValidDMExtension(arg.Value)) {
+                            settings.Files.Add(arg.Value);
+                            Console.WriteLine($"Compiling {Path.GetFileName(arg.Value)}");
+                            break;
+                        }
+                        if(skipBad) {
+                            DMCompiler.Warning(new CompilerWarning(Location.Internal, $"Invalid compiler arg '{arg.Value}', skipping"));
+                        } else {
+                            Console.WriteLine($"Invalid arg '{arg}'");
+                            return false;
                         }
 
                         break;
+                    }
+                    default: {
+                        if (skipBad) {
+                            DMCompiler.Warning(new CompilerWarning(Location.Internal, $"Unknown compiler arg '{arg.Name}', skipping"));
+                            break;
+                        } else {
+                            Console.WriteLine($"Unknown arg '{arg}'");
+                            return false;
+                        }
                     }
                 }
             }

--- a/OpenDreamShared/Compiler/CompilerError.cs
+++ b/OpenDreamShared/Compiler/CompilerError.cs
@@ -12,6 +12,7 @@ namespace OpenDreamShared.Compiler {
         Unknown = 0,
         BadToken = 1,
         BadDirective = 10,
+        BadExpression = 11,
         BadLabel = 19,
         InvalidReference = 50,
         BadArgument = 100,
@@ -19,7 +20,10 @@ namespace OpenDreamShared.Compiler {
         ArglistOnlyArgument = 102,
         HardReservedKeyword = 200, // For keywords that CANNOT be un-reserved.
         ItemDoesntExist = 404,
+        DanglingOverride = 405,
+        StaticOverride = 406,
         IAmATeaPot = 418, // TODO: Implement the HTCPC protocol for OD
+        HardConstContext = 500,
         WriteToConstant = 501,
         InvalidInclusion = 900,
         // 1000 - 1999 are reserved for preprocessor configuration.
@@ -36,7 +40,10 @@ namespace OpenDreamShared.Compiler {
         SoftReservedKeyword = 2000, // For keywords that SHOULD be reserved, but don't have to be. 'null' and 'defined', for instance
         DuplicateVariable = 2100,
         TooManyArguments = 2200,
-
+        PointlessParentCall = 2205,
+        PointlessBuiltinCall = 2206, // For pointless calls to issaved() or initial()
+        MalformedRange = 2300,
+        InvalidRange = 2301,
         // 3000 - 3999 are reserved for stylistic configuration.
 
         // 4000 - 4999 are reserved for runtime configuration. (TODO: Runtime doesn't know about configs yet!)

--- a/OpenDreamShared/Compiler/CompilerError.cs
+++ b/OpenDreamShared/Compiler/CompilerError.cs
@@ -53,7 +53,7 @@ namespace OpenDreamShared.Compiler {
     {
         //When this warning is emitted:
         Disabled, // Nothing happens.
-        Notice, // Nothing happens unless the user provides a '--wall' argument. (TODO)
+        Notice, // Nothing happens unless the user provides a '--wall' argument.
         Warning, // A warning is always emitted.
         Error // An error is always emitted.
     }

--- a/OpenDreamShared/Compiler/CompilerError.cs
+++ b/OpenDreamShared/Compiler/CompilerError.cs
@@ -2,6 +2,30 @@
 using Robust.Shared.Analyzers;
 
 namespace OpenDreamShared.Compiler {
+
+    /// <remarks>
+    /// All values should be unique.
+    /// </remarks>
+    public enum WarningCode
+    {
+        // 0 - 999 are reserved for giving codes to fatal errors which cannot reasonably be demoted to a warning/notice/disable.
+        Unknown = 0,
+        // 1000 - 1999 are reserved for compiler configuration of actual behaviour.
+
+        // 2000 - 2999 are reserved for stylistic configuration.
+
+        // 3000 - 3999 are reserved for runtime configuration. (TODO: Runtime doesn't know about configs yet!)
+    }
+
+    public enum ErrorLevel
+    {
+        //When this warning is emitted:
+        Disabled, // Nothing happens.
+        Notice, // Nothing happens unless the user provides a '--wall' argument. (TODO)
+        Warning, // A warning is always emitted.
+        Error // An error is always emitted.
+    }
+
     public struct CompilerError {
         public Location Location;
         public string Message;
@@ -22,6 +46,7 @@ namespace OpenDreamShared.Compiler {
     }
 
     public struct CompilerWarning {
+
         public Location Location;
         public string Message;
 
@@ -41,6 +66,7 @@ namespace OpenDreamShared.Compiler {
     }
 
     [Virtual]
+    [Obsolete("This is not a desirable way for the compiler to emit an error. Use CompileAbortException or ForceError() if it needs to be fatal, or an EmitWarning() otherwise.")]
     public class CompileErrorException : Exception {
         public CompilerError Error;
         public CompileErrorException(CompilerError error) : base(error.Message)

--- a/OpenDreamShared/Compiler/Parser.cs
+++ b/OpenDreamShared/Compiler/Parser.cs
@@ -86,6 +86,12 @@ namespace OpenDreamShared.Compiler {
             Error(errorMessage);
         }
 
+        /// <summary>
+        /// Emits an error discovered during parsing, optionally causing a throw.
+        /// </summary>
+        /// <remarks> This implementation on <see cref="Parser{SourceType}"/> does not make use of <see cref="WarningCode"/> <br/>
+        /// since there are some parsers that aren't always in the compilation context, like the ones for DMF and DMM. <br/>
+        /// </remarks>
         protected void Error(string message, bool throwException = true) {
             CompilerEmission error = new CompilerEmission(ErrorLevel.Error, _currentToken?.Location, message);
 
@@ -94,6 +100,12 @@ namespace OpenDreamShared.Compiler {
                 throw new CompileErrorException(error);
         }
 
+        /// <summary>
+        /// Emits a warning discovered during parsing, optionally causing a throw.
+        /// </summary>
+        /// <remarks> This implementation on <see cref="Parser{SourceType}"/> does not make use of <see cref="WarningCode"/> <br/>
+        /// since there are some parsers that aren't always in the compilation context, like the ones for DMF and DMM. <br/>
+        /// </remarks>
         protected void Warning(string message, Token token = null) {
             token ??= _currentToken;
             Emissions.Add(new CompilerEmission(ErrorLevel.Warning, token?.Location, message));

--- a/OpenDreamShared/Compiler/Parser.cs
+++ b/OpenDreamShared/Compiler/Parser.cs
@@ -4,9 +4,9 @@ using System.Collections.Generic;
 namespace OpenDreamShared.Compiler {
     [Virtual]
     public partial class Parser<SourceType> {
-        // Note: These initial capacities are arbitrary. We just assume there's a decent chance you'll get a handful of errors/warnings.
-        public readonly List<CompilerError> Errors = new(4);
-        public readonly List<CompilerWarning> Warnings = new(4);
+        /// <summary> Includes errors and warnings acccumulated by this parser. </summary>
+        /// <remarks> These initial capacities are arbitrary. We just assume there's a decent chance you'll get a handful of errors/warnings. </remarks>
+        public List<CompilerEmission> Emissions = new(8);
 
         protected Lexer<SourceType> _lexer;
         private Token _currentToken;
@@ -87,15 +87,16 @@ namespace OpenDreamShared.Compiler {
         }
 
         protected void Error(string message, bool throwException = true) {
-            CompilerError error = new CompilerError(_currentToken, message);
+            CompilerEmission error = new CompilerEmission(ErrorLevel.Error, _currentToken?.Location, message);
 
-            Errors.Add(error);
-            if (throwException) throw new CompileErrorException(error);
+            Emissions.Add(error);
+            if (throwException)
+                throw new CompileErrorException(error);
         }
 
         protected void Warning(string message, Token token = null) {
             token ??= _currentToken;
-            Warnings.Add(new CompilerWarning(token, message));
+            Emissions.Add(new CompilerEmission(ErrorLevel.Warning, token?.Location, message));
         }
     }
 }

--- a/OpenDreamShared/Compiler/ParserHelper.cs
+++ b/OpenDreamShared/Compiler/ParserHelper.cs
@@ -24,7 +24,7 @@ namespace OpenDreamShared.Compiler {
             }
         }
         protected void Fatal(string error) {
-            foreach (var err in Errors) {
+            foreach (var err in Emissions) {
                 Logger.Fatal(err.ToString());
 
             }

--- a/OpenDreamShared/Compiler/Token.cs
+++ b/OpenDreamShared/Compiler/Token.cs
@@ -26,6 +26,7 @@
         DM_Preproc_LineSplice,
         DM_Preproc_Number,
         DM_Preproc_ParameterStringify,
+        DM_Preproc_Pragma,
         DM_Preproc_Punctuator,
         DM_Preproc_Punctuator_Colon,
         DM_Preproc_Punctuator_Comma,


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29939414/202064297-d0a59359-db7b-4c00-a853-c9b23dd52aa1.png)

## Summary
The syntax for `#pragma` that I am going with is probably `#pragma errorName Value`, where errorName can be either the error code or enum name for the error code, and Value is either `disabled`, `notice`, `warning`, or `error`.

This will allow us to vary the behaviour of the compiler, adding more warnings for bad behaviour, with users having the option to forbid the bad behaviour entirely.

## Changelog
- Argument parsing is now a bit smarter, and supports setting arguments to values.
- Fixed OD accepting macro functors that had several variadic arguments.
- New directive unlocked! `#pragma`, which allows both us and the user to decide the elevation of various error emissions.