### PR TITLE
Move meat of DMDisassembler into OpenDreamRuntime

### DIFF
--- a/DMDisassembler/DMDisassembler.csproj
+++ b/DMDisassembler/DMDisassembler.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\OpenDreamShared\OpenDreamShared.csproj" />
+    <ProjectReference Include="..\OpenDreamRuntime\OpenDreamRuntime.csproj" />
   </ItemGroup>
 
 </Project>

--- a/DMDisassembler/DMProc.cs
+++ b/DMDisassembler/DMProc.cs
@@ -27,73 +27,78 @@ namespace DMDisassembler {
         public string Decompile() {
             List<DecompiledOpcode> decompiled = new();
             HashSet<int> labeledPositions = new();
+            Exception ex = null;
 
-            foreach (var (position, instruction) in new ProcDecoder(Program.CompiledJson.Strings, Bytecode).Disassemble()) {
-                StringBuilder text = new StringBuilder();
-                text.Append(instruction[0]);
-                text.Append(" ");
+            try {
+                foreach (var (position, instruction) in new ProcDecoder(Program.CompiledJson.Strings, Bytecode).Disassemble()) {
+                    StringBuilder text = new StringBuilder();
+                    text.Append(instruction[0]);
+                    text.Append(" ");
 
-                switch (instruction) {
-                    case (DreamProcOpcode.FormatString, string str, int numReplacements):
-                        text.Append(numReplacements);
-                        text.Append(' ');
-                        text.Append('"');
-                        text.Append(str);
-                        text.Append('"');
-                        break;
+                    switch (instruction) {
+                        case (DreamProcOpcode.FormatString, string str, int numReplacements):
+                            text.Append(numReplacements);
+                            text.Append(' ');
+                            text.Append('"');
+                            text.Append(str);
+                            text.Append('"');
+                            break;
 
-                    case (DreamProcOpcode.PushString, string str):
-                        text.Append('"');
-                        text.Append(str);
-                        text.Append('"');
-                        break;
+                        case (DreamProcOpcode.PushString, string str):
+                            text.Append('"');
+                            text.Append(str);
+                            text.Append('"');
+                            break;
 
-                    case (DreamProcOpcode.PushResource, string str):
-                        text.Append('\'');
-                        text.Append(str);
-                        text.Append('\'');
-                        break;
+                        case (DreamProcOpcode.PushResource, string str):
+                            text.Append('\'');
+                            text.Append(str);
+                            text.Append('\'');
+                            break;
 
-                    case (DreamProcOpcode.JumpIfNullDereference, DMReference reference, int jumpPosition):
-                        labeledPositions.Add(jumpPosition);
-                        text.Append(reference);
-                        text.Append(" ");
-                        text.Append(jumpPosition);
-                        break;
-
-                    case (DreamProcOpcode.Spawn
-                            or DreamProcOpcode.BooleanOr
-                            or DreamProcOpcode.BooleanAnd
-                            or DreamProcOpcode.SwitchCase
-                            or DreamProcOpcode.SwitchCaseRange
-                            or DreamProcOpcode.Jump
-                            or DreamProcOpcode.JumpIfFalse
-                            or DreamProcOpcode.JumpIfTrue, int jumpPosition):
-                        labeledPositions.Add(jumpPosition);
-                        text.Append(jumpPosition);
-                        break;
-
-                    case (DreamProcOpcode.PushType, int type):
-                        text.Append(Program.CompiledJson.Types[type].Path);
-                        break;
-
-                    case (DreamProcOpcode.PushArguments, int argCount, int namedCount, string[] names):
-                        text.Append(argCount);
-                        for (int i = 0; i < argCount; i++) {
+                        case (DreamProcOpcode.JumpIfNullDereference, DMReference reference, int jumpPosition):
+                            labeledPositions.Add(jumpPosition);
+                            text.Append(reference);
                             text.Append(" ");
-                            text.Append(names[i] ?? "-");
-                        }
+                            text.Append(jumpPosition);
+                            break;
 
-                        break;
+                        case (DreamProcOpcode.Spawn
+                                or DreamProcOpcode.BooleanOr
+                                or DreamProcOpcode.BooleanAnd
+                                or DreamProcOpcode.SwitchCase
+                                or DreamProcOpcode.SwitchCaseRange
+                                or DreamProcOpcode.Jump
+                                or DreamProcOpcode.JumpIfFalse
+                                or DreamProcOpcode.JumpIfTrue, int jumpPosition):
+                            labeledPositions.Add(jumpPosition);
+                            text.Append(jumpPosition);
+                            break;
 
-                    default:
-                        for (int i = 1; i < instruction.Length; ++i) {
-                            text.Append(instruction[i]);
-                            text.Append(" ");
-                        }
-                        break;
+                        case (DreamProcOpcode.PushType, int type):
+                            text.Append(Program.CompiledJson.Types[type].Path);
+                            break;
+
+                        case (DreamProcOpcode.PushArguments, int argCount, int namedCount, string[] names):
+                            text.Append(argCount);
+                            for (int i = 0; i < argCount; i++) {
+                                text.Append(" ");
+                                text.Append(names[i] ?? "-");
+                            }
+
+                            break;
+
+                        default:
+                            for (int i = 1; i < instruction.Length; ++i) {
+                                text.Append(instruction[i]);
+                                text.Append(" ");
+                            }
+                            break;
+                    }
+                    decompiled.Add(new DecompiledOpcode(position, text.ToString()));
                 }
-                decompiled.Add(new DecompiledOpcode(position, text.ToString()));
+            } catch (Exception ex2) {
+                ex = ex2;
             }
 
             StringBuilder result = new StringBuilder();
@@ -109,6 +114,10 @@ namespace DMDisassembler {
                 // In case of a Jump off the end of the proc.
                 result.Append(Bytecode.Length);
                 result.AppendLine();
+            }
+
+            if (ex != null) {
+                result.Append(ex);
             }
 
             return result.ToString();

--- a/DMDisassembler/DMProc.cs
+++ b/DMDisassembler/DMProc.cs
@@ -2,7 +2,6 @@
 using OpenDreamShared.Json;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Text;
 
 namespace DMDisassembler {
@@ -22,7 +21,7 @@ namespace DMDisassembler {
 
         public DMProc(ProcDefinitionJson json) {
             Name = json.Name;
-            Bytecode = (json.Bytecode != null) ? json.Bytecode : Array.Empty<byte>();
+            Bytecode = json.Bytecode ?? Array.Empty<byte>();
         }
 
         public string Decompile() {

--- a/DMDisassembler/DMProc.cs
+++ b/DMDisassembler/DMProc.cs
@@ -1,4 +1,5 @@
-﻿using OpenDreamShared.Dream.Procs;
+﻿using OpenDreamRuntime.Procs;
+using OpenDreamShared.Dream.Procs;
 using OpenDreamShared.Json;
 using System;
 using System.Collections.Generic;

--- a/DMDisassembler/DMProc.cs
+++ b/DMDisassembler/DMProc.cs
@@ -18,6 +18,7 @@ namespace DMDisassembler {
 
         public string Name;
         public byte[] Bytecode;
+        public Exception exception;
 
         public DMProc(ProcDefinitionJson json) {
             Name = json.Name;
@@ -27,7 +28,6 @@ namespace DMDisassembler {
         public string Decompile() {
             List<DecompiledOpcode> decompiled = new();
             HashSet<int> labeledPositions = new();
-            Exception ex = null;
 
             try {
                 foreach (var (position, instruction) in new ProcDecoder(Program.CompiledJson.Strings, Bytecode).Disassemble()) {
@@ -97,8 +97,8 @@ namespace DMDisassembler {
                     }
                     decompiled.Add(new DecompiledOpcode(position, text.ToString()));
                 }
-            } catch (Exception ex2) {
-                ex = ex2;
+            } catch (Exception ex) {
+                exception = ex;
             }
 
             StringBuilder result = new StringBuilder();
@@ -116,8 +116,8 @@ namespace DMDisassembler {
                 result.AppendLine();
             }
 
-            if (ex != null) {
-                result.Append(ex);
+            if (exception != null) {
+                result.Append(exception);
             }
 
             return result.ToString();

--- a/DMDisassembler/Program.cs
+++ b/DMDisassembler/Program.cs
@@ -49,6 +49,7 @@ namespace DMDisassembler {
                     case "list": List(split); break;
                     case "d":
                     case "decompile": Decompile(split); break;
+                    case "test-all": TestAll(); break;
                     default: Console.WriteLine("Invalid command \"" + command + "\""); break;
                 }
             }
@@ -178,6 +179,20 @@ namespace DMDisassembler {
 
                 globalType.Procs.Add(proc.Name, proc);
             }
+        }
+
+        private static void TestAll() {
+            int errored = 0, all = 0;
+            foreach (DMProc proc in Procs) {
+                string value = proc.Decompile();
+                if (proc.exception != null) {
+                    Console.WriteLine("Error disassembling " + proc.Name);
+                    Console.WriteLine(value);
+                    ++errored;
+                }
+                ++all;
+            }
+            Console.WriteLine($"Errors in {errored}/{all} procs");
         }
     }
 }

--- a/DMDisassembler/Program.cs
+++ b/DMDisassembler/Program.cs
@@ -128,7 +128,7 @@ namespace DMDisassembler {
             }
 
             string name = args[1];
-            if (name == "__global_init__") {
+            if (name == "<global_init>" || (name == "<init>" && (_selectedType == null || _selectedType.Path == DreamPath.Root))) {
                 if (GlobalInitProc != null) {
                     Console.WriteLine(GlobalInitProc.Decompile());
                 } else {
@@ -143,14 +143,14 @@ namespace DMDisassembler {
                 return;
             }
 
-            if (name == "__init__") {
+            if (name == "<init>") {
                 if (_selectedType.InitProc != null) {
-                    Console.WriteLine(_selectedType.InitProc.Decompile() + "\n");
+                    Console.WriteLine(_selectedType.InitProc.Decompile());
                 } else {
                     Console.WriteLine("Selected type does not have an init proc");
                 }
             } else if (_selectedType.Procs.TryGetValue(name, out DMProc proc)) {
-                Console.WriteLine(proc.Decompile() + "\n");
+                Console.WriteLine(proc.Decompile());
             } else {
                 Console.WriteLine("No procs named \"" + name + "\"");
             }

--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -1,8 +1,7 @@
-using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using OpenDreamShared.Dream.Procs;
 
-namespace OpenDreamShared.Dream.Procs;
+namespace OpenDreamRuntime.Procs;
 
 public struct ProcDecoder {
     public readonly IReadOnlyList<string> Strings;

--- a/OpenDreamShared/Dream/Procs/ProcDecoder.cs
+++ b/OpenDreamShared/Dream/Procs/ProcDecoder.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+
+namespace OpenDreamShared.Dream.Procs;
+
+public struct ProcDecoder {
+    public readonly IReadOnlyList<string> Strings;
+    public readonly byte[] Bytecode;
+    public int Offset;
+
+    public ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
+        Strings = strings;
+        Bytecode = bytecode;
+        Offset = 0;
+    }
+
+    public int Remaining => Bytecode.Length - Offset;
+
+    public int ReadByte() {
+        return Bytecode[Offset++];
+    }
+
+    public DreamProcOpcode ReadOpcode() {
+        return (DreamProcOpcode) ReadByte();
+    }
+
+    public DreamProcOpcodeParameterType ReadParameterType() {
+        return (DreamProcOpcodeParameterType) ReadByte();
+    }
+
+    public int ReadInt() {
+        int value = BitConverter.ToInt32(Bytecode, Offset);
+        Offset += 4;
+        return value;
+    }
+
+    public DMValueType ReadValueType() {
+        return (DMValueType) ReadInt();
+    }
+
+    public float ReadFloat() {
+        float value = BitConverter.ToSingle(Bytecode, Offset);
+        Offset += 4;
+        return value;
+    }
+
+    public string ReadString() {
+        int stringID = ReadInt();
+        return Strings[stringID];
+    }
+
+    public DMReference ReadReference() {
+        DMReference.Type refType = (DMReference.Type)ReadByte();
+
+        switch (refType) {
+            case DMReference.Type.Argument: return DMReference.CreateArgument(ReadByte());
+            case DMReference.Type.Local: return DMReference.CreateLocal(ReadByte());
+            case DMReference.Type.Global: return DMReference.CreateGlobal(ReadInt());
+            case DMReference.Type.GlobalProc: return DMReference.CreateGlobalProc(ReadInt());
+            case DMReference.Type.Field: return DMReference.CreateField(ReadString());
+            case DMReference.Type.SrcField: return DMReference.CreateSrcField(ReadString());
+            case DMReference.Type.Proc: return DMReference.CreateProc(ReadString());
+            case DMReference.Type.SrcProc: return DMReference.CreateSrcProc(ReadString());
+            case DMReference.Type.Src: return DMReference.Src;
+            case DMReference.Type.Self: return DMReference.Self;
+            case DMReference.Type.Usr: return DMReference.Usr;
+            case DMReference.Type.Args: return DMReference.Args;
+            case DMReference.Type.SuperProc: return DMReference.SuperProc;
+            case DMReference.Type.ListIndex: return DMReference.ListIndex;
+            default: throw new Exception($"Invalid reference type {refType}");
+        }
+    }
+}

--- a/OpenDreamShared/Dream/Procs/ProcDecoder.cs
+++ b/OpenDreamShared/Dream/Procs/ProcDecoder.cs
@@ -149,9 +149,9 @@ public struct ProcDecoder {
         }
     }
 
-    public IEnumerable<ITuple> Disassemble() {
+    public IEnumerable<(int Offset, ITuple Instruction)> Disassemble() {
         while (Remaining) {
-            yield return DecodeInstruction();
+            yield return (Offset, DecodeInstruction());
         }
     }
 }

--- a/OpenDreamShared/Dream/Procs/ProcDecoder.cs
+++ b/OpenDreamShared/Dream/Procs/ProcDecoder.cs
@@ -126,6 +126,7 @@ public struct ProcDecoder {
             case DreamProcOpcode.JumpIfTrue:
             case DreamProcOpcode.PushType:
             case DreamProcOpcode.DebugLine:
+            case DreamProcOpcode.MassConcatenation:
                 return (opcode, ReadInt());
 
             case DreamProcOpcode.JumpIfNullDereference:

--- a/OpenDreamShared/Dream/Procs/ProcDecoder.cs
+++ b/OpenDreamShared/Dream/Procs/ProcDecoder.cs
@@ -14,7 +14,7 @@ public struct ProcDecoder {
         Offset = 0;
     }
 
-    public int Remaining => Bytecode.Length - Offset;
+    public bool Remaining => Offset < Bytecode.Length;
 
     public int ReadByte() {
         return Bytecode[Offset++];

--- a/OpenDreamShared/Dream/Procs/ProcDecoder.cs
+++ b/OpenDreamShared/Dream/Procs/ProcDecoder.cs
@@ -103,6 +103,7 @@ public struct ProcDecoder {
             case DreamProcOpcode.MultiplyReference:
             case DreamProcOpcode.DivideReference:
             case DreamProcOpcode.BitXorReference:
+            case DreamProcOpcode.ModulusReference:
             case DreamProcOpcode.Enumerate:
             case DreamProcOpcode.OutputReference:
             case DreamProcOpcode.PushReferenceValue:


### PR DESCRIPTION
The debugger will benefit from being able to collect all `DebugLine` instructions in the code, but to do this it needs to disassemble the procs without executing them. Instead of just copy-pasting disassembly code, move much of it to a new `ProcDecoder`. Some if it may eventually be reusable in the runtime's `DMProc`, depending on memory/speed needs.