### PR TITLE
Add `--define` flag to DMCompiler

### DIFF
--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -180,8 +180,11 @@ namespace DMCompiler.Compiler.DMPreprocessor {
             _defines.Add(key, new DMMacro(null, list));
         }
 
+        // Prepare to include the given files, in order.
         public void IncludeFiles(IEnumerable<string> files) {
-            foreach (string file in files) {
+            // NB: IncludeFile pushes newly seen files to a stack, so push them
+            // in reverse order we want them processed.
+            foreach (string file in files.Reverse()) {
                 string includeDir = Path.GetDirectoryName(file);
                 string fileName = Path.GetFileName(file);
 
@@ -627,7 +630,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
 
             int parenthesisNesting = 1;
             while(true) {
-                switch (parameterToken.Type) { 
+                switch (parameterToken.Type) {
                     case TokenType.DM_Preproc_Punctuator_Comma when parenthesisNesting == 1:
                         parameters.Add(currentParameter);
                         currentParameter = new List<Token>();
@@ -655,7 +658,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
                         continue;
                 }
                 break; // If it manages to escape the switch, the loop breaks
-            } 
+            }
 
             parameters.Add(currentParameter);
             if (parameterToken.Type != TokenType.DM_Preproc_Punctuator_RightParenthesis) {

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -184,12 +184,6 @@ namespace DMCompiler.Compiler.DMPreprocessor {
         public void IncludeFiles(IEnumerable<string> files) {
             // NB: IncludeFile pushes newly seen files to a stack, so push them
             // in reverse order we want them processed.
-            foreach (string file in files.Reverse()) {
-                string includeDir = Path.GetDirectoryName(file);
-                string fileName = Path.GetFileName(file);
-
-                IncludeFile(includeDir, fileName);
-            }
         }
 
         public void IncludeFile(string includeDir, string file, Location? includedFrom = null) {

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -180,12 +180,8 @@ namespace DMCompiler.Compiler.DMPreprocessor {
             _defines.Add(key, new DMMacro(null, list));
         }
 
-        // Prepare to include the given files, in order.
-        public void IncludeFiles(IEnumerable<string> files) {
-            // NB: IncludeFile pushes newly seen files to a stack, so push them
-            // in reverse order we want them processed.
-        }
-
+        // NB: Pushes files to a stack, so call in reverse order if you are
+        // including multiple files.
         public void IncludeFile(string includeDir, string file, Location? includedFrom = null) {
             string filePath = Path.Combine(includeDir, file);
             filePath = filePath.Replace('\\', Path.DirectorySeparatorChar);

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -171,6 +171,15 @@ namespace DMCompiler.Compiler.DMPreprocessor {
             return GetEnumerator();
         }
 
+        public void DefineMacro(string key, string value) {
+            var lexer = new DMPreprocessorLexer(null, "<command line>", value);
+            var list = new List<Token>();
+            while (lexer.GetNextToken() is Token token && token.Type != TokenType.EndOfFile) {
+                list.Add(token);
+            }
+            _defines.Add(key, new DMMacro(null, list));
+        }
+
         public void IncludeFiles(IEnumerable<string> files) {
             foreach (string file in files) {
                 string includeDir = Path.GetDirectoryName(file);

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -84,27 +84,29 @@ namespace DMCompiler {
 
         [CanBeNull]
         private static DMPreprocessor Preprocess(List<string> files, Dictionary<string, string> macroDefines) {
+            string realFirstFile = files[0];
+
             if (!Settings.NoStandard) {
                 string compilerDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
                 string dmStandard = Path.Join(compilerDirectory ?? string.Empty, "DMStandard", "_Standard.dm");
 
-                if (!File.Exists(dmStandard))
-                {
+                if (!File.Exists(dmStandard)) {
                     Error(new CompilerError(Location.Internal, "DMStandard not found."));
                     return null;
                 }
 
-                files.Add(dmStandard);
+                // Insert DMStandard before the user's files.
+                files.Insert(0, dmStandard);
             }
 
             DMPreprocessor build() {
                 DMPreprocessor preproc = new DMPreprocessor(true);
-                preproc.IncludeFiles(files);
                 if (macroDefines != null) {
                     foreach (var (key, value) in macroDefines) {
                         preproc.DefineMacro(key, value);
                     }
                 }
+                preproc.IncludeFiles(files);
                 return preproc;
             }
 
@@ -117,7 +119,7 @@ namespace DMCompiler {
                     result.Append(t.Text);
                 }
 
-                string outputDir = Path.GetDirectoryName(Settings.Files[0]);
+                string outputDir = Path.GetDirectoryName(realFirstFile);
                 string outputPath = Path.Combine(outputDir, "preprocessor_dump.dm");
 
                 File.WriteAllText(outputPath, result.ToString());

--- a/DMCompiler/Program.cs
+++ b/DMCompiler/Program.cs
@@ -7,7 +7,10 @@ using OpenDreamShared.Compiler;
 namespace DMCompiler {
     class Program {
         static void Main(string[] args) {
-            if (!TryParseArguments(args, out DMCompilerSettings settings)) return;
+            if (!TryParseArguments(args, out DMCompilerSettings settings)) {
+                Environment.Exit(1);
+                return;
+            }
 
             if (!DMCompiler.Compile(settings)) {
                 //Compile errors, exit with an error code

--- a/DMCompiler/Program.cs
+++ b/DMCompiler/Program.cs
@@ -21,16 +21,22 @@ namespace DMCompiler {
         private static bool TryParseArguments(string[] args, out DMCompilerSettings settings) {
             settings = new();
             settings.Files = new List<string>();
-            
+
             bool skipBad = args.Contains("--skip-bad-args");
 
-            foreach (string arg in args) {
+            for (int i = 0; i < args.Length;) {
+                string arg = args[i++];
                 switch (arg) {
                     case "--suppress-unimplemented": settings.SuppressUnimplementedWarnings = true; break;
                     case "--dump-preprocessor": settings.DumpPreprocessor = true; break;
                     case "--no-standard": settings.NoStandard = true; break;
                     case "--verbose": settings.Verbose = true; break;
                     case "--skip-bad-args": break;
+                    case "--define": {
+                        string[] parts = args[i++].Split("=", 2);
+                        (settings.MacroDefines ??= new())[parts[0]] = parts.Length > 1 ? parts[1] : "";
+                        break;
+                    }
                     default: {
                         string extension = Path.GetExtension(arg);
 


### PR DESCRIPTION
Purpose: serve /tg/station's need to sometimes `#define CBT`, `CIBUILDING`, `AUTOWIKI`, `TGS` at build time, currently satisfied by generating a `.m.dme` file with the `#define`s prepended.

Interface:
- `--define FOO` to define a macro with no expansion, for `#ifdef`
- `--define FOO=10+7` to define a macro which expands to some tokens, for `#if`

Also:
- Exit DMCompiler with status 1 if the command-line arguments were invalid
- Fix multiple-file inputs being processed in reverse order