### PR TITLE
regex.Replace and replacetext are now AsyncNativeProcs and unit tests can be async

### DIFF
--- a/Content.Tests/DMProject/Tests/Call/AsyncReturn.dm
+++ b/Content.Tests/DMProject/Tests/Call/AsyncReturn.dm
@@ -1,0 +1,7 @@
+﻿/proc/async_return()
+	. = 420
+	sleep(0)
+	return 1337
+
+/proc/RunTest()
+	ASSERT(async_return() == 1337)

--- a/Content.Tests/DMProject/Tests/Call/StackOverflow.dm
+++ b/Content.Tests/DMProject/Tests/Call/StackOverflow.dm
@@ -1,4 +1,4 @@
-﻿// RUNTIME ERROR, RETURN TRUE
+﻿// RUNTIME ERROR, NO RETURN
 
 /proc/RunTest()
 	. = TRUE

--- a/Content.Tests/DMProject/Tests/Call/SyncReturnInAsync.dm
+++ b/Content.Tests/DMProject/Tests/Call/SyncReturnInAsync.dm
@@ -1,7 +1,0 @@
-﻿/proc/sync_return()
-	. = 420
-	sleep(0)
-	return 1337
-
-/proc/RunTest()
-	ASSERT(sync_return() == 420)

--- a/Content.Tests/DMProject/Tests/Const/Const2.dm
+++ b/Content.Tests/DMProject/Tests/Const/Const2.dm
@@ -1,4 +1,4 @@
-// RUNTIME ERROR
+// RUNTIME ERROR, NO RETURN
 
 var/ConstZero1_a
 

--- a/Content.Tests/DMProject/Tests/Regex/regex_defer.dm
+++ b/Content.Tests/DMProject/Tests/Regex/regex_defer.dm
@@ -1,0 +1,12 @@
+﻿/proc/regex_callback(match, group1, group2)
+	. = "good"
+
+	// The proc should return back to regex/Replace here despite being not being a `waitfor=0` proc
+	sleep(1)
+
+	. = "bad"
+
+/proc/RunTest()
+	var/regex/R = regex(@"\w+")
+	var/result = R.Replace("Hello, there", /proc/regex_callback)
+	ASSERT(result == "good, there")

--- a/Content.Tests/DMProject/Tests/Sleeping/New.dm
+++ b/Content.Tests/DMProject/Tests/Sleeping/New.dm
@@ -1,0 +1,24 @@
+﻿var/call_number = 0
+
+/proc/AssertCallNumber(num)
+	call_number++
+	ASSERT(call_number == num)
+
+/datum/object
+	var/datum/inner_object/i = new
+
+	New()
+		AssertCallNumber(4)
+		sleep(0)
+		AssertCallNumber(5)
+
+/datum/inner_object
+	New()
+		AssertCallNumber(2)
+		sleep(0)
+		AssertCallNumber(3)
+
+/proc/RunTest()
+	AssertCallNumber(1)
+	var/datum/object/o = new
+	AssertCallNumber(6)

--- a/Content.Tests/DMTests.cs
+++ b/Content.Tests/DMTests.cs
@@ -116,7 +116,6 @@ namespace Content.Tests
                     result = await callTask;
                     return DreamValue.Null;
                 } else {
-                    result = null;
                     Assert.Fail($"No global proc named RunTest");
                     return DreamValue.Null;
                 }

--- a/Content.Tests/DMTests.cs
+++ b/Content.Tests/DMTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using OpenDreamRuntime;
 using OpenDreamRuntime.Procs;
@@ -8,6 +9,7 @@ using OpenDreamRuntime.Rendering;
 using Robust.Shared.Asynchronous;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
+using Robust.Shared.Timing;
 
 namespace Content.Tests
 {
@@ -26,7 +28,8 @@ namespace Content.Tests
             Ignore = 1,         // Ignore entirely
             CompileError = 2,   // Should fail to compile
             RuntimeError = 4,   // Should throw an exception at runtime
-            ReturnTrue = 8      // Should return TRUE
+            ReturnTrue = 8,     // Should return TRUE
+            NoReturn = 16,      // Shouldn't return (aka stopped by a stack-overflow or runtimes)
         }
 
         [OneTimeSetUp]
@@ -72,7 +75,14 @@ namespace Content.Tests
                 Assert.IsTrue(compiledFile is not null && File.Exists(compiledFile), $"Failed to compile DM source file");
                 Assert.IsTrue(_dreamMan.LoadJson(compiledFile), $"Failed to load {compiledFile}");
 
-                (bool successfulRun, DreamValue returned, Exception? exception) = RunTest();
+                (bool successfulRun, DreamValue? returned, Exception? exception) = RunTest();
+
+                if (testFlags.HasFlag(DMTestFlags.NoReturn)) {
+                    Assert.IsFalse(returned.HasValue, "proc returned unexpectedly");
+                } else {
+                    Assert.IsTrue(returned.HasValue, "proc did not return (did it hit an exception?)");
+                }
+
                 if (testFlags.HasFlag(DMTestFlags.RuntimeError)) {
                     Assert.IsFalse(successfulRun, "A DM runtime exception was expected");
                 } else {
@@ -83,7 +93,7 @@ namespace Content.Tests
                 }
 
                 if (testFlags.HasFlag(DMTestFlags.ReturnTrue)) {
-                    returned.TryGetValueAsInteger(out int returnInt);
+                    returned.Value.TryGetValueAsInteger(out int returnInt);
                     Assert.IsTrue(returnInt != 0, "Test was expected to return TRUE");
                 }
 
@@ -94,17 +104,37 @@ namespace Content.Tests
             }
         }
 
-        private (bool Success, DreamValue Returned, Exception? except) RunTest() {
+        private (bool Success, DreamValue? Returned, Exception? except) RunTest() {
             var prev = _dreamMan.LastDMException;
 
-            var result = DreamThread.Run("RunTest", async (state) => {
+            DreamValue? result = null;
+            Task<DreamValue> callTask = null;
+
+            DreamThread.Run("RunTest", async (state) => {
                 if (_dreamMan.ObjectTree.TryGetGlobalProc("RunTest", out DreamProc proc)) {
-                    return await state.Call(proc, null, null, new DreamProcArguments(null));
+                    callTask = state.Call(proc, null, null, new DreamProcArguments(null));
+                    result = await callTask;
+                    return DreamValue.Null;
                 } else {
+                    result = null;
                     Assert.Fail($"No global proc named RunTest");
                     return DreamValue.Null;
                 }
             });
+
+            var Watch = new Stopwatch();
+            Watch.Start();
+
+            // Tick until our inner call has finished
+            while (!callTask.IsCompleted) {
+                _dreamMan.Update();
+                _taskManager.ProcessPendingTasks();
+
+                if (Watch.Elapsed.TotalMilliseconds > 500) {
+                    Assert.Fail("Test timed out");
+                }
+            }
+
             bool retSuccess = _dreamMan.LastDMException == prev; // Works because "null == null" is true in this language.
             if (retSuccess)
                 return (retSuccess, result, null);
@@ -143,6 +173,8 @@ namespace Content.Tests
                     testFlags |= DMTestFlags.RuntimeError;
                 if (firstLine.Contains("RETURN TRUE", StringComparison.InvariantCulture))
                     testFlags |= DMTestFlags.ReturnTrue;
+                if (firstLine.Contains("NO RETURN", StringComparison.InvariantCulture))
+                    testFlags |= DMTestFlags.NoReturn;
             }
 
             return testFlags;

--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -89,7 +89,7 @@ namespace OpenDreamRuntime {
         public DreamThread Thread { get; set; }
         public DreamValue Result { set; get; } = DreamValue.Null;
 
-        public bool WaitFor => Proc != null ? (Proc.Attributes & ProcAttributes.DisableWaitfor) != ProcAttributes.DisableWaitfor : true;
+        public bool WaitFor { get; set; } = true;
 
         public ProcState(DreamThread thread) {
             Thread = thread;

--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -99,6 +99,7 @@ namespace OpenDreamRuntime {
             try {
                 return InternalResume();
             } catch (CancellingRuntime exception) {
+                Thread.CancelAll();
                 Thread.HandleException(exception);
                 return ProcStatus.Cancelled;
             } catch (PropagatingRuntime exception) {
@@ -121,6 +122,8 @@ namespace OpenDreamRuntime {
 
         // Most implementations won't require this, so give it a default
         public virtual void ReturnedInto(DreamValue value) {}
+
+        public virtual void Cancel() {}
     }
 
     public sealed class DreamThread {
@@ -294,8 +297,18 @@ namespace OpenDreamRuntime {
             }
         }
 
+        public void CancelAll() {
+            _current?.Cancel();
+
+            foreach (var state in _stack) {
+                state.Cancel();
+            }
+        }
+
         public void HandleException(Exception exception)
         {
+            _current?.Cancel();
+
             if (_current is DMProcState state) {
                 state.ReturnPools();
             }

--- a/OpenDreamRuntime/Procs/AsyncNativeProc.cs
+++ b/OpenDreamRuntime/Procs/AsyncNativeProc.cs
@@ -70,6 +70,9 @@ namespace OpenDreamRuntime.Procs {
                 // We don't call `_callTcs.SetResult` here because we're about to be resumed and can do it there.
                 _callResult = value;
             }
+            public override void Cancel() {
+                _callTcs.SetCanceled();
+            }
 
             private async Task InternalResumeAsync() {
                 Result = await _taskFunc(this);

--- a/OpenDreamRuntime/Procs/AsyncNativeProc.cs
+++ b/OpenDreamRuntime/Procs/AsyncNativeProc.cs
@@ -55,6 +55,17 @@ namespace OpenDreamRuntime.Procs {
                 return callTcs.Task;
             }
 
+            public Task<DreamValue> CallNoWait(DreamProc proc, DreamObject src, DreamObject usr, DreamProcArguments arguments) {
+                _callTcs = new();
+                _callProcNotify = proc.CreateState(Thread, src, usr, arguments);
+                _callProcNotify.WaitFor = false;
+
+                // The field may be mutated by SafeResume, so cache the task
+                var callTcs = _callTcs;
+                SafeResume();
+                return callTcs.Task;
+            }
+
             public override void ReturnedInto(DreamValue value) {
                 // We don't call `_callTcs.SetResult` here because we're about to be resumed and can do it there.
                 _callResult = value;

--- a/OpenDreamRuntime/Procs/AsyncNativeProc.cs
+++ b/OpenDreamRuntime/Procs/AsyncNativeProc.cs
@@ -71,7 +71,7 @@ namespace OpenDreamRuntime.Procs {
                 _callResult = value;
             }
             public override void Cancel() {
-                _callTcs.SetCanceled();
+                _callTcs?.SetCanceled();
             }
 
             private async Task InternalResumeAsync() {

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -173,6 +173,7 @@ namespace OpenDreamRuntime.Procs {
             _localVariables = _dreamValuePool.Rent(256);
             CurrentSource = proc.Source;
             CurrentLine = proc.Line;
+            WaitFor = _proc != null ? (_proc.Attributes & ProcAttributes.DisableWaitfor) != ProcAttributes.DisableWaitfor : true;
 
             //TODO: Positional arguments must precede all named arguments, this needs to be enforced somehow
             //Positional arguments
@@ -209,6 +210,8 @@ namespace OpenDreamRuntime.Procs {
 
             _localVariables = _dreamValuePool.Rent(256);
             Array.Copy(other._localVariables, _localVariables, 256);
+
+            WaitFor = other.WaitFor;
         }
 
         protected override ProcStatus InternalResume() {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1369,17 +1369,16 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("Replacement", Type = DreamValueType.String)]
         [DreamProcParameter("Start", Type = DreamValueType.Float, DefaultValue = 1)]
         [DreamProcParameter("End", Type = DreamValueType.Float, DefaultValue = 0)]
-        public static DreamValue NativeProc_replacetext(DreamObject instance, DreamObject usr,
-            DreamProcArguments arguments) {
-            DreamValue haystack = arguments.GetArgument(0, "Haystack");
-            DreamValue needle = arguments.GetArgument(1, "Needle");
-            DreamValue replacementArg = arguments.GetArgument(2, "Replacement");
-            int start = arguments.GetArgument(3, "Start").GetValueAsInteger(); //1-indexed
-            int end = arguments.GetArgument(4, "End").GetValueAsInteger(); //1-indexed
+        public static async Task<DreamValue> NativeProc_replacetext(AsyncNativeProc.State state) {
+            DreamValue haystack = state.Arguments.GetArgument(0, "Haystack");
+            DreamValue needle = state.Arguments.GetArgument(1, "Needle");
+            DreamValue replacementArg = state.Arguments.GetArgument(2, "Replacement");
+            int start = state.Arguments.GetArgument(3, "Start").GetValueAsInteger(); //1-indexed
+            int end = state.Arguments.GetArgument(4, "End").GetValueAsInteger(); //1-indexed
 
             if (needle.TryGetValueAsDreamObjectOfType(DreamPath.Regex, out var regexObject)) {
                 // According to the docs, this is the same as /regex.Replace()
-                return DreamProcNativeRegex.RegexReplace(regexObject, haystack, replacementArg, start, end);
+                return await DreamProcNativeRegex.RegexReplace(state, regexObject, haystack, replacementArg, start, end);
             }
 
             if (!haystack.TryGetValueAsString(out var text)) {


### PR DESCRIPTION
This allows them to properly call procs in the current thread.

I've introduced `AsyncNativeProc.State.CallNoWait` here, which calls procs in the current thread but will force the called proc to have `waitfor=0` behaviour. This is something BYOND does in a few places.

I suppose the question is... is this a good approach, or do we want a `SyncNativeProc`?

~~This does require a test... a unit test will probably work since it doesn't defer~~