### PR TITLE
Unicode test correction?

### DIFF
--- a/Content.Tests/DMProject/Broken Tests/Text/UnicodeProcs.dm
+++ b/Content.Tests/DMProject/Broken Tests/Text/UnicodeProcs.dm
@@ -1,8 +1,8 @@
 ﻿/proc/RunTest()
-	ASSERT(length("😀") == 2)
+	ASSERT(length("😀") == 4)
 	ASSERT(length_char("😀") == 1)
 
 	// This is the combination of the Man, Woman, Girl and Boy emojis.
 	// It's 1 character per emoji, plus 3 zero-width joiner characters between them.
-	ASSERT(length("👨‍👩‍👧‍👦") == 11)
+	ASSERT(length("👨‍👩‍👧‍👦") == 25)
 	ASSERT(length_char("👨‍👩‍👧‍👦") == 7)


### PR DESCRIPTION
Dunno if this is intended but the test is wrong when compared to byond parity