### PR TITLE
list(a = x, (b)= y) support

### DIFF
--- a/Content.Tests/DMProject/Tests/List/CreateAssociativeList.dm
+++ b/Content.Tests/DMProject/Tests/List/CreateAssociativeList.dm
@@ -1,0 +1,15 @@
+﻿/proc/RunTest()
+	var/a = "World"
+	var/b = "Hello"
+	var/c = "Goodbye"
+
+	// "a" = 1
+	// "Hello" = 2
+	// "c" = 3
+	var/list/L = list(a = 1, (b) = 2, c = 3)
+
+	ASSERT(L["a"] == 1)
+	ASSERT(L["b"] == null)
+	ASSERT(L[b] == 2)
+	ASSERT(L["c"] == 3)
+	ASSERT(L[c] == null)

--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -40,6 +40,7 @@ namespace DMCompiler.Compiler.DM {
         public void VisitProcStatementThrow(DMASTProcStatementThrow statementThrow) { throw new NotImplementedException(); }
         public void VisitProcDefinition(DMASTProcDefinition procDefinition) { throw new NotImplementedException(); }
         public void VisitIdentifier(DMASTIdentifier identifier) { throw new NotImplementedException(); }
+        public void VisitIdentifierWrapped(DMASTIdentifierWrapped identifier) { throw new NotImplementedException(); }
         public void VisitGlobalIdentifier(DMASTGlobalIdentifier globalIdentifier) { throw new NotImplementedException(); }
         public void VisitConstantInteger(DMASTConstantInteger constant) { throw new NotImplementedException(); }
         public void VisitConstantFloat(DMASTConstantFloat constant) { throw new NotImplementedException(); }
@@ -697,6 +698,18 @@ namespace DMCompiler.Compiler.DM {
 
         public override void Visit(DMASTVisitor visitor) {
             visitor.VisitIdentifier(this);
+        }
+    }
+
+    public class DMASTIdentifierWrapped : DMASTExpression {
+        public DMASTIdentifier Identifier;
+
+        public DMASTIdentifierWrapped(Location location, DMASTIdentifier identifier) : base(location) {
+            Identifier = identifier;
+        }
+
+        public override void Visit(DMASTVisitor visitor) {
+            visitor.VisitIdentifierWrapped(this);
         }
     }
 

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -1937,6 +1937,10 @@ namespace DMCompiler.Compiler.DM {
                 BracketWhitespace();
                 ConsumeRightParenthesis();
 
+                if (inner is DMASTIdentifier identifier) {
+                    inner = new DMASTIdentifierWrapped(identifier.Location, identifier);
+                }
+
                 return inner;
             }
 

--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -126,6 +126,10 @@ namespace DMCompiler.DM.Visitors {
             }
         }
 
+        public void VisitIdentifierWrapped(DMASTIdentifierWrapped identifier) {
+            VisitIdentifier(identifier.Identifier);
+        }
+
         public void VisitVarDeclExpression(DMASTVarDeclExpression declExpr) {
             VisitIdentifier( new DMASTIdentifier(declExpr.Location, declExpr.DeclPath.Path.LastElement) );
         }


### PR DESCRIPTION
I wrap `DMASTIdentifier` nodes with `DMASTIdentifierWrapped` if they are surrounded in brackets.

Spooky... is this workable?