### PR TITLE
Only emit one `DebugSource` opcode per proc

### DIFF
--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -19,6 +19,8 @@ namespace DMCompiler.DM.Visitors {
         public void ProcessProcDefinition(DMASTProcDefinition procDefinition) {
             if (procDefinition.Body == null) return;
 
+            _proc.DebugSource(procDefinition.Location.SourceFile);
+
             foreach (DMASTDefinitionParameter parameter in procDefinition.Parameters) {
                 string parameterName = parameter.Name;
 
@@ -65,8 +67,6 @@ namespace DMCompiler.DM.Visitors {
                     }
                 }
             }
-
-            _proc.DebugSource(block.Location.SourceFile);
 
             foreach (DMASTProcStatement statement in block.Statements) {
                 // see above


### PR DESCRIPTION
Procs would have a `DebugSource` opcode at the beginning of every code block. This is unnecessary because the body of a proc is typically only ever in one file.

Now there is only one `DebugSource` opcode at the very beginning of every proc.