### PR TITLE
Fixes `<<=` and `>>=` use on complicated references, fixes `null << 1` not being `0`

### DIFF
--- a/Content.Tests/DMProject/Tests/Operators/bitshift_assign.dm
+++ b/Content.Tests/DMProject/Tests/Operators/bitshift_assign.dm
@@ -15,7 +15,12 @@
 	for(var/i = 1; i < 6; i += 1)
 		a[i] <<= 1
 		ASSERT(a[i] == (i << 1))
+		a[i] >>= 1
+		ASSERT(a[i] == i)
 	//Make sure cursed behaviour still works in the assignment situation
 	var/n = null
 	n <<= 1
+	ASSERT(n == 0)
+	n = null
+	n >>= 1
 	ASSERT(n == 0)

--- a/Content.Tests/DMProject/Tests/Operators/bitshift_assign.dm
+++ b/Content.Tests/DMProject/Tests/Operators/bitshift_assign.dm
@@ -1,0 +1,21 @@
+
+// Issue OD#922: https://github.com/OpenDreamProject/OpenDream/issues/922
+
+/proc/RunTest()
+	//Easy references
+	var/x = 1
+	var/y = 2
+	x <<= 5
+	y <<= 5
+	x >>= 4
+	y >>= 5
+	ASSERT(x == y)
+	//Compound references
+	var/list/a = list(1,2,3,4,5)
+	for(var/i = 1; i < 6; i += 1)
+		a[i] <<= 1
+		ASSERT(a[i] == (i << 1))
+	//Make sure cursed behaviour still works in the assignment situation
+	var/n = null
+	n <<= 1
+	ASSERT(n == 0)

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -731,9 +731,19 @@ namespace DMCompiler.DM {
             WriteOpcode(DreamProcOpcode.BitShiftLeft);
         }
 
+        public void BitShiftLeftReference(DMReference reference) {
+            WriteOpcode(DreamProcOpcode.BitShiftLeftReference);
+            WriteReference(reference);
+        }
+
         public void BitShiftRight() {
             ShrinkStack(1);
             WriteOpcode(DreamProcOpcode.BitShiftRight);
+        }
+
+        public void BitShiftRightReference(DMReference reference) {
+            WriteOpcode(DreamProcOpcode.BitShiftRightReference);
+            WriteReference(reference);
         }
 
         public void BinaryNot() {

--- a/DMCompiler/DM/Expressions/Binary.cs
+++ b/DMCompiler/DM/Expressions/Binary.cs
@@ -494,6 +494,11 @@ namespace DMCompiler.DM.Expressions {
         public AssignmentBinaryOp(Location location, DMExpression lhs, DMExpression rhs)
             : base(location, lhs, rhs) { }
 
+        /// <summary>
+        /// Generic interface for emitting the assignment operation. Has its conditionality and reference generation already handled.
+        /// </summary>
+        /// <remarks>You should always make use of the reference argument, unless you totally override AssignmentBinaryOp's EmitPushValue method.</remarks>
+        /// <param name="reference">A reference to the LHS emitted via <see cref="DMExpression.EmitReference(DMObject, DMProc)"/></param>
         public abstract void EmitOp(DMObject dmObject, DMProc proc, DMReference reference);
 
         public override void EmitPushValue(DMObject dmObject, DMProc proc) {
@@ -642,10 +647,8 @@ namespace DMCompiler.DM.Expressions {
             : base(location, lhs, rhs) { }
 
         public override void EmitOp(DMObject dmObject, DMProc proc, DMReference reference) {
-            proc.PushReferenceValue(reference);
             RHS.EmitPushValue(dmObject, proc);
-            proc.BitShiftLeft();
-            proc.Assign(reference);
+            proc.BitShiftLeftReference(reference);
         }
     }
 
@@ -655,10 +658,8 @@ namespace DMCompiler.DM.Expressions {
             : base(location, lhs, rhs) { }
 
         public override void EmitOp(DMObject dmObject, DMProc proc, DMReference reference) {
-            proc.PushReferenceValue(reference);
             RHS.EmitPushValue(dmObject, proc);
-            proc.BitShiftRight();
-            proc.Assign(reference);
+            proc.BitShiftRightReference(reference);
         }
     }
 

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -781,6 +781,9 @@ namespace OpenDreamRuntime.Procs {
             DreamValue first = state.Pop();
 
             switch (first.Type) {
+                case DreamValue.DreamValueType.DreamObject when first == DreamValue.Null:
+                    state.Push(new DreamValue(0));
+                    break;
                 case DreamValue.DreamValueType.Float when second.Type == DreamValue.DreamValueType.Float:
                     state.Push(new DreamValue(first.MustGetValueAsInteger() << second.MustGetValueAsInteger()));
                     break;

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -794,6 +794,27 @@ namespace OpenDreamRuntime.Procs {
             return null;
         }
 
+
+        public static ProcStatus? BitShiftLeftReference(DMProcState state) {
+            DMReference reference = state.ReadReference();
+            DreamValue second = state.Pop();
+            DreamValue first = state.GetReferenceValue(reference, peek: true);
+            DreamValue result;
+            switch (first.Type) {
+                case DreamValue.DreamValueType.DreamObject when first == DreamValue.Null:
+                    result = new DreamValue(0);
+                    break;
+                case DreamValue.DreamValueType.Float when second.Type == DreamValue.DreamValueType.Float:
+                    result = new DreamValue(first.GetValueAsInteger() << second.GetValueAsInteger());
+                    break;
+                default:
+                    throw new Exception($"Invalid bit shift left operation on {first} and {second}");
+            }
+            state.AssignReference(reference, result);
+            state.Push(result);
+            return null;
+        }
+
         public static ProcStatus? BitShiftRight(DMProcState state) {
             DreamValue second = state.Pop();
             DreamValue first = state.Pop();
@@ -806,6 +827,26 @@ namespace OpenDreamRuntime.Procs {
                 throw new Exception($"Invalid bit shift right operation on {first} and {second}");
             }
 
+            return null;
+        }
+
+        public static ProcStatus? BitShiftRightReference(DMProcState state) {
+            DMReference reference = state.ReadReference();
+            DreamValue second = state.Pop();
+            DreamValue first = state.GetReferenceValue(reference, peek: true);
+            DreamValue result;
+            switch (first.Type) {
+                case DreamValue.DreamValueType.DreamObject when first == DreamValue.Null:
+                    result = new DreamValue(0);
+                    break;
+                case DreamValue.DreamValueType.Float when second.Type == DreamValue.DreamValueType.Float:
+                    result = new DreamValue(first.GetValueAsInteger() >> second.GetValueAsInteger());
+                    break;
+                default:
+                    throw new Exception($"Invalid bit shift right operation on {first} and {second}");
+            }
+            state.AssignReference(reference, result);
+            state.Push(result);
             return null;
         }
 

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -805,7 +805,7 @@ namespace OpenDreamRuntime.Procs {
                     result = new DreamValue(0);
                     break;
                 case DreamValue.DreamValueType.Float when second.Type == DreamValue.DreamValueType.Float:
-                    result = new DreamValue(first.GetValueAsInteger() << second.GetValueAsInteger());
+                    result = new DreamValue(first.MustGetValueAsInteger() << second.MustGetValueAsInteger());
                     break;
                 default:
                     throw new Exception($"Invalid bit shift left operation on {first} and {second}");
@@ -840,7 +840,7 @@ namespace OpenDreamRuntime.Procs {
                     result = new DreamValue(0);
                     break;
                 case DreamValue.DreamValueType.Float when second.Type == DreamValue.DreamValueType.Float:
-                    result = new DreamValue(first.GetValueAsInteger() >> second.GetValueAsInteger());
+                    result = new DreamValue(first.MustGetValueAsInteger() >> second.MustGetValueAsInteger());
                     break;
                 default:
                     throw new Exception($"Invalid bit shift right operation on {first} and {second}");

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -175,6 +175,8 @@ namespace OpenDreamRuntime.Procs {
             {DreamProcOpcode.ModulusModulusReference, DMOpcodeHandlers.ModulusModulusReference},
             {DreamProcOpcode.PushProcStub, DMOpcodeHandlers.PushProcStub},
             {DreamProcOpcode.PushVerbStub, DMOpcodeHandlers.PushVerbStub},
+            {DreamProcOpcode.BitShiftLeftReference,DMOpcodeHandlers.BitShiftLeftReference},
+            {DreamProcOpcode.BitShiftRightReference, DMOpcodeHandlers.BitShiftRightReference},
         };
 
         private static readonly OpcodeHandler?[] _opcodeHandlers;

--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -101,6 +101,8 @@ public struct ProcDecoder {
             case DreamProcOpcode.DivideReference:
             case DreamProcOpcode.BitXorReference:
             case DreamProcOpcode.ModulusReference:
+            case DreamProcOpcode.BitShiftLeftReference:
+            case DreamProcOpcode.BitShiftRightReference:
             case DreamProcOpcode.OutputReference:
             case DreamProcOpcode.PushReferenceValue:
                 return (opcode, ReadReference());

--- a/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
+++ b/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
@@ -103,7 +103,9 @@ namespace OpenDreamShared.Dream.Procs {
         ModulusModulus = 0x60,
         ModulusModulusReference = 0x61,
         PushProcStub = 0x62,
-        PushVerbStub = 0x63
+        PushVerbStub = 0x63,
+        BitShiftLeftReference = 0x64,
+        BitShiftRightReference = 0x65,
     }
 
     public enum DreamProcOpcodeParameterType {


### PR DESCRIPTION
Fixes #922.
## Summary
I just went ahead and added new opcodes for these, in symmetry with basically all of the other compound assignments.

&&= and ||= also could use some clean-up but I'm going to elect to leave that for after the Reference refactor gets merged, or whatever.

## Changelog
- Using `<<=` and `>>=` on complicated references no longer fails to compile.
- OD now "correctly" evaluates `null << 1` as `0`.