### PR TITLE
Adds /world/proc/{Error,Topic} and /client/proc/Del() to standard

### DIFF
--- a/DMCompiler/DMStandard/Types/Client.dm
+++ b/DMCompiler/DMStandard/Types/Client.dm
@@ -51,6 +51,9 @@
 		mob = new world.mob(null)
 		return mob
 
+	proc/Del()
+		set opendream_unimplemented = TRUE
+
 	proc/Topic(href, list/href_list, datum/hsrc)
 		if (hsrc != null)
 			hsrc.Topic(href, href_list)

--- a/DMCompiler/DMStandard/Types/World.dm
+++ b/DMCompiler/DMStandard/Types/World.dm
@@ -66,6 +66,9 @@
 		set opendream_unimplemented = TRUE
 		return FALSE;
 
+	proc/Error(exception)
+		set opendream_unimplemented = TRUE
+
 	proc/Reboot()
 		set opendream_unimplemented = TRUE
 
@@ -74,6 +77,8 @@
 
 	proc/Export(Addr, File, Persist, Clients)
 	proc/Import()
+		set opendream_unimplemented = TRUE
+	proc/Topic(T,Addr,Master,Keys)
 		set opendream_unimplemented = TRUE
 
 	proc/SetScores()


### PR DESCRIPTION
Picked up that these were missing after doing some work on proc overrides.

## Changelog
- Fixed /world/proc/Error, /world/proc/Topic, and /client/proc/Del not being defined.