### PR TITLE
Proper `/icon` support

### DIFF
--- a/OpenDream.sln.DotSettings
+++ b/OpenDream.sln.DotSettings
@@ -3,6 +3,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DMI/@EntryIndexedValue">DMI</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DMAST/@EntryIndexedValue">DMAST</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=BYOND/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Debuggee/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fcopy/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=noto/@EntryIndexedValue">True</s:Boolean>

--- a/OpenDreamClient/Audio/DreamSoundEngine.cs
+++ b/OpenDreamClient/Audio/DreamSoundEngine.cs
@@ -5,10 +5,8 @@ using Robust.Client.Graphics;
 using Robust.Shared.Audio;
 using Robust.Shared.Network;
 
-namespace OpenDreamClient.Audio
-{
-    public sealed class DreamSoundEngine : IDreamSoundEngine
-    {
+namespace OpenDreamClient.Audio {
+    public sealed class DreamSoundEngine : IDreamSoundEngine {
         private const int SoundChannelLimit = 1024;
 
         [Dependency] private readonly IDreamResourceManager _resourceManager = default!;
@@ -16,22 +14,17 @@ namespace OpenDreamClient.Audio
 
         private readonly DreamSoundChannel[] _channels = new DreamSoundChannel[SoundChannelLimit];
 
-        public void Initialize()
-        {
+        public void Initialize() {
             _netManager.RegisterNetMessage<MsgSound>(RxSound);
 
             _netManager.Disconnect += DisconnectedFromServer;
         }
 
-        public void PlaySound(int channel, ResourceSound sound, float volume)
-        {
-            if (channel == 0)
-            {
+        public void PlaySound(int channel, MsgSound.FormatType format, ResourceSound sound, float volume) {
+            if (channel == 0) {
                 //First available channel
-                for (int i = 0; i < _channels.Length; i++)
-                {
-                    if (_channels[i] == null || !_channels[i].Source.IsPlaying)
-                    {
+                for (int i = 0; i < _channels.Length; i++) {
+                    if (_channels[i] == null || !_channels[i].Source.IsPlaying) {
                         _channels[i]?.Dispose();
                         channel = i + 1;
                         break;
@@ -45,15 +38,13 @@ namespace OpenDreamClient.Audio
             StopChannel(channel);
 
             // convert from DM volume (0-100) to OpenAL volume (db)
-            IClydeAudioSource source = sound.Play(AudioParams.Default.WithVolume(20 * MathF.Log10(volume)));
+            IClydeAudioSource source = sound.Play(format, AudioParams.Default.WithVolume(20 * MathF.Log10(volume)));
             _channels[channel - 1] = new DreamSoundChannel(source);
         }
 
 
-        public void StopChannel(int channel)
-        {
-            if (_channels[channel - 1] != null)
-            {
+        public void StopChannel(int channel) {
+            if (_channels[channel - 1] != null) {
                 ref DreamSoundChannel ch = ref _channels[channel - 1];
                 ch.Dispose();
                 // This will null the corresponding index in the array.
@@ -61,29 +52,22 @@ namespace OpenDreamClient.Audio
             }
         }
 
-        public void StopAllChannels()
-        {
-            for (int i = 0; i < SoundChannelLimit; i++)
-            {
+        public void StopAllChannels() {
+            for (int i = 0; i < SoundChannelLimit; i++) {
                 StopChannel(i + 1);
             }
         }
 
-        private void RxSound(MsgSound msg)
-        {
-            if (!string.IsNullOrEmpty(msg.File))
-            {
-                _resourceManager.LoadResourceAsync<ResourceSound>(msg.File,
-                    sound => PlaySound(msg.Channel, sound, msg.Volume / 100.0f));
-            }
-            else
-            {
+        private void RxSound(MsgSound msg) {
+            if (msg.ResourceId.HasValue) {
+                _resourceManager.LoadResourceAsync<ResourceSound>(msg.ResourceId.Value,
+                    sound => PlaySound(msg.Channel, msg.Format!.Value, sound, msg.Volume / 100.0f));
+            } else {
                 StopChannel(msg.Channel);
             }
         }
 
-        private void DisconnectedFromServer(object? sender, NetDisconnectedArgs e)
-        {
+        private void DisconnectedFromServer(object? sender, NetDisconnectedArgs e) {
             StopAllChannels();
         }
     }

--- a/OpenDreamClient/Audio/IDreamSoundEngine.cs
+++ b/OpenDreamClient/Audio/IDreamSoundEngine.cs
@@ -1,12 +1,11 @@
 using OpenDreamClient.Resources.ResourceTypes;
+using OpenDreamShared.Network.Messages;
 
-namespace OpenDreamClient.Audio
-{
-    public interface IDreamSoundEngine
-    {
-        void Initialize();
-        void PlaySound(int channel, ResourceSound sound, float volume);
-        void StopChannel(int channel);
-        void StopAllChannels();
-    }
+namespace OpenDreamClient.Audio;
+
+public interface IDreamSoundEngine {
+    void Initialize();
+    void PlaySound(int channel, MsgSound.FormatType format, ResourceSound sound, float volume);
+    void StopChannel(int channel);
+    void StopAllChannels();
 }

--- a/OpenDreamClient/Rendering/DreamIcon.cs
+++ b/OpenDreamClient/Rendering/DreamIcon.cs
@@ -195,7 +195,7 @@ namespace OpenDreamClient.Rendering {
         }
 
         private void UpdateAnimation() {
-            DMIParser.ParsedDMIState dmiState = DMI.Description.GetState(Appearance.IconState);
+            DMIParser.ParsedDMIState dmiState = DMI.Description.GetStateOrDefault(Appearance.IconState);
             DMIParser.ParsedDMIFrame[] frames = dmiState.GetFrames(Appearance.Direction);
 
             if (_animationFrame == frames.Length - 1 && !dmiState.Loop) return;

--- a/OpenDreamClient/Rendering/DreamIcon.cs
+++ b/OpenDreamClient/Rendering/DreamIcon.cs
@@ -253,8 +253,8 @@ namespace OpenDreamClient.Rendering {
                 return;
             }
 
-            IoCManager.Resolve<IDreamResourceManager>().LoadResourceAsync<DMIResource>(Appearance.Icon, dmi => {
-                if (dmi.ResourcePath != Appearance.Icon) return; //Icon changed while resource was loading
+            IoCManager.Resolve<IDreamResourceManager>().LoadResourceAsync<DMIResource>(Appearance.Icon.Value, dmi => {
+                if (dmi.Id != Appearance.Icon) return; //Icon changed while resource was loading
 
                 DMI = dmi;
                 _animationFrame = 0;
@@ -278,7 +278,7 @@ namespace OpenDreamClient.Rendering {
             }
 
             Overlays.Sort(LayerSort);
-            Underlays.Sort(LayerSort);           
+            Underlays.Sort(LayerSort);
         }
 
         private void CheckSizeChange() {

--- a/OpenDreamClient/Resources/ResourceTypes/DMIResource.cs
+++ b/OpenDreamClient/Resources/ResourceTypes/DMIResource.cs
@@ -16,8 +16,7 @@ namespace OpenDreamClient.Resources.ResourceTypes {
 
         private Dictionary<string, State> _states;
 
-        public DMIResource(string resourcePath, byte[] data) : base(resourcePath, data)
-        {
+        public DMIResource(int id, byte[] data) : base(id, data) {
             if (!IsValidPNG()) throw new Exception("Attempted to create a DMI using an invalid PNG");
 
             Stream dmiStream = new MemoryStream(data);

--- a/OpenDreamClient/Resources/ResourceTypes/DreamResource.cs
+++ b/OpenDreamClient/Resources/ResourceTypes/DreamResource.cs
@@ -1,13 +1,12 @@
-﻿namespace OpenDreamClient.Resources.ResourceTypes
-{
-    public abstract class DreamResource
-    {
-        public string ResourcePath;
-        public byte[] Data;
+﻿namespace OpenDreamClient.Resources.ResourceTypes;
 
-        protected DreamResource(string resourcePath, byte[] data) {
-            ResourcePath = resourcePath;
-            Data = data;
-        }
+public abstract class DreamResource {
+    public readonly int Id;
+
+    protected readonly byte[] Data;
+
+    protected DreamResource(int id, byte[] data) {
+        Id = id;
+        Data = data;
     }
 }

--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -93,7 +93,7 @@ namespace OpenDreamRuntime {
             IconAppearance appearance = new IconAppearance();
 
             if (atom.GetVariable("icon").TryGetValueAsDreamResource(out DreamResource icon)) {
-                appearance.Icon = icon.ResourcePath;
+                appearance.Icon = icon.Id;
             }
 
             if (atom.GetVariable("icon_state").TryGetValueAsString(out string iconState)) {
@@ -135,14 +135,14 @@ namespace OpenDreamRuntime {
             IconAppearance appearance = new IconAppearance();
 
             if (def.TryGetVariable("icon", out var iconVar) && iconVar.TryGetValueAsDreamResource(out DreamResource icon)) {
-                appearance.Icon = icon.ResourcePath;
+                appearance.Icon = icon.Id;
             }
 
-            if (def.TryGetVariable("icon_state", out var stateVar) && stateVar.TryGetValueAsString(out string iconState)) {
+            if (def.TryGetVariable("icon_state", out var stateVar) && stateVar.TryGetValueAsString(out var iconState)) {
                 appearance.IconState = iconState;
             }
 
-            if (def.TryGetVariable("color", out var colorVar) && colorVar.TryGetValueAsString(out string color)) {
+            if (def.TryGetVariable("color", out var colorVar) && colorVar.TryGetValueAsString(out var color)) {
                 appearance.SetColor(color);
             }
 

--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -235,7 +235,7 @@ namespace OpenDreamRuntime
                     msg.ResourceId = soundResource?.Id;
                     if (soundResource?.ResourcePath is { } resourcePath) {
                         if (resourcePath.EndsWith(".ogg"))
-                            msg.Format = MsgSound.FormatType.Wav;
+                            msg.Format = MsgSound.FormatType.Ogg;
                         else if (resourcePath.EndsWith(".wav"))
                             msg.Format = MsgSound.FormatType.Wav;
                         else

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -46,11 +46,10 @@ namespace OpenDreamRuntime {
         //TODO This arg is awful and temporary until RT supports cvar overrides in unit tests
         public void PreInitialize(string jsonPath) {
             InitializeConnectionManager();
-            _dreamResourceManager.Initialize(jsonPath);
+            _dreamResourceManager.Initialize();
 
             if (!LoadJson(jsonPath)) {
                 IoCManager.Resolve<ITaskManager>().RunOnMainThread(() => { IoCManager.Resolve<IBaseServer>().Shutdown("Error while loading the compiled json. The opendream.json_path CVar may be empty, or points to a file that doesn't exist"); });
-                return;
             }
         }
 

--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -164,7 +164,7 @@ namespace OpenDreamRuntime {
             return (DreamResource)GetValueExpectingType(DreamValueType.DreamResource);
         }
 
-        public bool TryGetValueAsDreamResource(out DreamResource value) {
+        public bool TryGetValueAsDreamResource([NotNullWhen(true)] out DreamResource? value) {
             if (Type == DreamValueType.DreamResource) {
                 value = (DreamResource)Value;
                 return true;

--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -334,10 +334,10 @@ namespace OpenDreamRuntime {
                 {
                     // TODO Check what happens with multiple states
                     var icon = DreamMetaObjectIcon.ObjectToDreamIcon[iconObj];
-                    var rscMan = IoCManager.Resolve<DreamResourceManager>();
-                    var resource = rscMan.LoadResource(icon.Icon);
+                    var (resource, _) = icon.GenerateDMI();
                     var base64 = Convert.ToBase64String(resource.ResourceData);
-                    writer.WriteString("Value",base64); break;
+                    writer.WriteString("Value", base64);
+                    break;
                 }
                 default: throw new NotImplementedException("Json serialization for " + value + " is not implemented");
             }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -236,10 +236,18 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     ? colorString
                     : "#FFFFFF"; // Defaults to white
                 appearance.SetColor(color);
-                appearance.Direction = (AtomDirection)image.GetVariable("dir").GetValueAsInteger();
+                appearance.Direction = (AtomDirection) image.GetVariable("dir").GetValueAsInteger();
                 image.GetVariable("layer").TryGetValueAsFloat(out appearance.Layer);
                 image.GetVariable("pixel_x").TryGetValueAsInteger(out appearance.PixelOffset.X);
                 image.GetVariable("pixel_y").TryGetValueAsInteger(out appearance.PixelOffset.Y);
+            } else if (value.TryGetValueAsDreamObjectOfType(DreamPath.Icon, out var icon)) {
+                var iconObj = DreamMetaObjectIcon.ObjectToDreamIcon[icon];
+                var (resource, dmiDescription) = iconObj.GenerateDMI();
+
+                atom.GetVariable("icon_state").TryGetValueAsString(out var iconState);
+
+                appearance.Icon = resource.Id;
+                appearance.IconState = dmiDescription.GetStateOrDefault(iconState)?.Name;
             } else if (value.TryGetValueAsDreamObjectOfType(DreamPath.Atom, out var overlayAtom)) {
                 appearance = _atomManager.CreateAppearanceFromAtom(overlayAtom);
             } else if (value.TryGetValueAsPath(out DreamPath path)) {

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -48,13 +48,11 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     _atomManager.UpdateAppearance(dreamObject, appearance => {
                         if (value.TryGetValueAsDreamResource(out DreamResource resource)) {
                             appearance.Icon = resource.ResourcePath;
-                        } else if (value.TryGetValueAsDreamObjectOfType(DreamPath.Icon, out DreamObject iconObject)) {
+                        } else if (value.TryGetValueAsDreamObjectOfType(DreamPath.Icon, out var iconObject)) {
                             DreamMetaObjectIcon.DreamIconObject icon = DreamMetaObjectIcon.ObjectToDreamIcon[iconObject];
 
-                            appearance.Icon = icon.Icon;
-                            if (icon.State != null) appearance.IconState = icon.State;
-                            //TODO: If a dir is set, the icon will stay that direction. Likely will be a part of "icon generation" when that's implemented.
-                            if (icon.Direction != null) appearance.Direction = icon.Direction.Value;
+                            (resource, _) = icon.GenerateDMI();
+                            // TODO: Use generated DMI
                         } else {
                             appearance.Icon = null;
                         }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectIcon.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectIcon.cs
@@ -3,6 +3,12 @@ using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Resources;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.PixelFormats;
+using ParsedDMIDescription = OpenDreamShared.Resources.DMIParser.ParsedDMIDescription;
+using ParsedDMIState = OpenDreamShared.Resources.DMIParser.ParsedDMIState;
+using ParsedDMIFrame = OpenDreamShared.Resources.DMIParser.ParsedDMIFrame;
 
 namespace OpenDreamRuntime.Objects.MetaObjects {
     sealed class DreamMetaObjectIcon : IDreamMetaObject
@@ -16,86 +22,193 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             IoCManager.InjectDependencies(this);
         }
 
-        public enum DreamIconMovingMode : byte
-        {
-            Both = 0,
-            Movement = 1,
-            NonMovement = 2,
-
-        }
-
         public static readonly Dictionary<DreamObject, DreamIconObject> ObjectToDreamIcon = new();
 
-        public struct DreamIconObject {
-            // Actual DMI data
-            public DMIParser.ParsedDMIDescription Description; // TODO Eventually this should probably be removed in favor of just directly storing the data for the subset of the DMI that we actually care about
+        public sealed class DreamIconObject {
+            public int Width = 0, Height = 0;
+            public readonly Dictionary<string, IconState> States = new();
 
-            // These vars correspond to the args in icon/new() and the resulting /icon obj, not the actual DMI data
-            public string Icon;
-            public string? State; // Specific icon_state. Null is all states.
-            public AtomDirection? Direction; // Specific dir. Null is all dirs.
-            public byte? Frame; //1-indexed. Specific frame. Null is all frames.
-            public DreamIconMovingMode Moving;
+            private readonly DreamResourceManager _resourceManager;
 
-            public DreamIconObject(DreamResource rsc, DreamValue state, DreamValue dir, DreamValue frame,
-                DreamValue moving) {
-                if (Path.GetExtension(rsc.ResourcePath) != ".dmi") {
-                    throw new Exception("Invalid icon file");
+            private int _frameCount = 0;
+
+            /// <summary>
+            /// Represents one of the icon states this icon is made of.
+            /// Contains everything needed to create a new DMI in <see cref="DreamIconObject.GenerateDMI()"/>
+            /// </summary>
+            public struct IconState {
+                /// <summary>
+                /// The image this icon state originally comes from
+                /// </summary>
+                public Image<Rgba32> Image;
+
+                /// <summary>
+                /// The DMI information about this icon state
+                /// </summary>
+                public ParsedDMIState DMIState;
+
+                /// <summary>
+                /// The size of the original icon state
+                /// </summary>
+                public int Width, Height;
+            }
+
+            public DreamIconObject(DreamResourceManager resourceManager) {
+                _resourceManager = resourceManager;
+            }
+
+            /// <summary>
+            /// Generate a DMI using all the inserted icon states
+            /// </summary>
+            /// <remarks>The resulting DMI will consist of one long flat row of frames</remarks>
+            /// <returns>The DreamResource containing the DMI and the ParsedDMIDescription used to construct it</returns>
+            /// <exception cref="NotImplementedException">Using icon states of various sizes is unimplemented</exception>
+            public (DreamResource, ParsedDMIDescription) GenerateDMI() {
+                Dictionary<string, ParsedDMIState> dmiStates = new(States.Count);
+                int frameWidth = Width, frameHeight = Height;
+                int span = frameWidth * _frameCount;
+                Rgba32[] pixels = new Rgba32[span * frameHeight];
+
+                int currentFrame = 0;
+                foreach (var iconState in States.Values) {
+                    ParsedDMIState state = iconState.DMIState;
+                    ParsedDMIState newState = new() { Name = state.Name, Loop = state.Loop, Rewind = state.Rewind };
+
+                    dmiStates.Add(newState.Name, newState);
+
+                    if (iconState.Width != frameWidth || iconState.Height != frameHeight)
+                        throw new NotImplementedException("Icon scaling is not implemented");
+
+                    iconState.Image.ProcessPixelRows(accessor => {
+                        foreach (var stateDir in state.Directions) {
+                            ParsedDMIFrame[] newFrames = new ParsedDMIFrame[stateDir.Value.Length];
+
+                            for (int frameIndex = 0; frameIndex < stateDir.Value.Length; frameIndex++) {
+                                ParsedDMIFrame frame = stateDir.Value[frameIndex];
+                                int x = currentFrame * frameWidth;
+
+                                for (int y = 0; y < frameHeight; y++) {
+                                    var rowSpan = accessor.GetRowSpan(frame.Y + y);
+
+                                    for (int frameX = 0; frameX < frameWidth; frameX++) {
+                                        int pixelLocation = (y * span) + x + frameX;
+
+                                        pixels[pixelLocation] = rowSpan[frame.X + frameX];
+                                    }
+                                }
+
+                                newFrames[frameIndex] = new ParsedDMIFrame { X = x, Y = 0, Delay = frame.Delay};
+                                currentFrame++;
+                            }
+
+                            newState.Directions.Add(stateDir.Key, newFrames);
+                        }
+                    });
                 }
 
-                Description = DMIParser.ParseDMI(new MemoryStream(rsc.ResourceData));
-                Icon = rsc.ResourcePath;
+                Image<Rgba32> dmiImage = Image.LoadPixelData(pixels, span, frameHeight);
+                ParsedDMIDescription newDescription = new() {Width = Width, Height = Height, States = dmiStates};
 
-                // TODO confirm BYOND behavior of invalid args for icon, dir, and frame
+                using (MemoryStream dmiImageStream = new MemoryStream()) {
+                    var pngTextData = new PngTextData("Description", newDescription.ExportAsText(), null, null);
+                    var pngMetadata = dmiImage.Metadata.GetPngMetadata();
+                    pngMetadata.TextData.Add(pngTextData);
 
-                state.TryGetValueAsString(out State);
-
-                if (dir.TryGetValueAsInteger(out var dirVal) && (AtomDirection) dirVal != AtomDirection.None) {
-                    Direction = (AtomDirection) dirVal;
-                } else {
-                    Direction = null;
+                    dmiImage.SaveAsPng(dmiImageStream);
                 }
 
-                if (frame.TryGetValueAsInteger(out var frameVal)) {
-                    //TODO: Figure out how many frames an icon can have and see if this needs to be bigger than a byte
-                    Frame = Convert.ToByte(frameVal - 1); //1-indexed
-                } else {
-                    Frame = null;
+                // TODO: Overhaul the resource system so all the above can actually be used
+                return (null, new ParsedDMIDescription());
+            }
+
+            public void InsertStates(DreamResource resource, ParsedDMIDescription fromDescription, DreamValue state,
+                DreamValue dir, DreamValue frame) {
+                bool copyingAllDirs = !dir.TryGetValueAsInteger(out var dirVal);
+                bool copyingAllStates = !(state.TryGetValueAsString(out var copyingState) && fromDescription.States.ContainsKey(copyingState));
+                bool copyingAllFrames = !frame.TryGetValueAsInteger(out var copyingFrame);
+                // TODO: Copy movement states?
+
+                AtomDirection copyingDirection = (AtomDirection) dirVal;
+                if (!Enum.IsDefined(copyingDirection) || copyingDirection == AtomDirection.None) {
+                    copyingAllDirs = true;
                 }
 
-                if (moving != DreamValue.Null) {
-                    if (moving.TryGetValueAsInteger(out var movingVal) && movingVal == 0) {
-                        Moving = DreamIconMovingMode.NonMovement;
-                    } else {
-                        Moving = DreamIconMovingMode.Movement;
+                // The size of every state will be resized to match the largest state
+                Width = Math.Max(Width, fromDescription.Width);
+                Height = Math.Max(Height, fromDescription.Height);
+
+                Image<Rgba32> image = _resourceManager.LoadImage(resource);
+
+                if (copyingAllStates) {
+                    foreach (var copyStateName in fromDescription.States.Keys) {
+                        InsertState(image, fromDescription, copyStateName,
+                            copyingAllDirs ? null : copyingDirection, copyingAllFrames ? null : copyingFrame);
                     }
                 } else {
-                    Moving = DreamIconMovingMode.Both;
+                    InsertState(image, fromDescription, copyingState!,
+                        copyingAllDirs ? null : copyingDirection, copyingAllFrames ? null : copyingFrame);
                 }
+            }
+
+            private void InsertState(Image<Rgba32> image, ParsedDMIDescription description, string stateName, AtomDirection? dir = null, int? frame = null) {
+                ParsedDMIState state = description.States[stateName];
+
+                // Only create a copy if we're using a specific dir or frame
+                if (dir != null || frame != null)
+                    state = state.Copy(dir, frame - 1);
+
+                _frameCount += state.FrameCount;
+                States.Add(stateName, new IconState {
+                    Image = image,
+                    DMIState = state,
+                    Width = description.Width,
+                    Height = description.Height
+                });
             }
         }
 
         public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
             ParentType?.OnObjectCreated(dreamObject, creationArguments);
 
+            // TODO confirm BYOND behavior of invalid args for icon, dir, and frame
             DreamValue icon = creationArguments.GetArgument(0, "icon");
             DreamValue state = creationArguments.GetArgument(1, "icon_state");
             DreamValue dir = creationArguments.GetArgument(2, "dir");
             DreamValue frame = creationArguments.GetArgument(3, "frame");
             DreamValue moving = creationArguments.GetArgument(4, "moving");
 
-            DreamIconObject dreamIconObject;
+            var (iconRsc, iconDescription) = GetIconResourceAndDescription(_rscMan, icon);
 
-            if (icon.TryGetValueAsDreamObjectOfType(DreamPath.Icon, out DreamObject copyFrom)) {
-                dreamIconObject = ObjectToDreamIcon[copyFrom];
-            } else if (icon.TryGetValueAsString(out string fileString))
-            {
+            DreamIconObject dreamIconObject = new(_rscMan);
+            dreamIconObject.InsertStates(iconRsc, iconDescription, state, dir, frame);
+            ObjectToDreamIcon.Add(dreamObject, dreamIconObject);
+        }
+
+        public void OnObjectDeleted(DreamObject dreamObject) {
+            ObjectToDreamIcon.Remove(dreamObject);
+
+            ParentType?.OnObjectDeleted(dreamObject);
+        }
+
+        public static (DreamResource Resource, ParsedDMIDescription Description) GetIconResourceAndDescription(
+            DreamResourceManager resourceManager, DreamValue value) {
+            if (value.TryGetValueAsDreamObjectOfType(DreamPath.Icon, out var iconObj)) {
+                DreamIconObject dreamIconObject = ObjectToDreamIcon[iconObj];
+
+                return dreamIconObject.GenerateDMI();
+            }
+
+            DreamResource iconRsc;
+
+            if (value.TryGetValueAsString(out var fileString)) {
                 var ext = Path.GetExtension(fileString);
-                switch (ext) // TODO implement other icon file types
-                {
+
+                switch (ext) {
                     case ".dmi":
-                        dreamIconObject = new DreamIconObject(_rscMan.LoadResource(fileString), state, dir, frame, moving);
+                        iconRsc = resourceManager.LoadResource(fileString);
                         break;
+
+                    // TODO implement other icon file types
                     case ".png":
                     case ".jpg":
                     case ".rsi": // RT-specific, not in BYOND
@@ -105,21 +218,15 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     default:
                         throw new Exception($"Invalid icon file {fileString}");
                 }
-
-            } else if (icon.TryGetValueAsDreamResource(out var rsc))
-            {
-                dreamIconObject = new DreamIconObject(rsc, state, dir, frame, moving);
-            } else {
-                throw new Exception("Invalid icon file " + icon);
+            } else if (!value.TryGetValueAsDreamResource(out iconRsc)) {
+                throw new Exception($"Invalid icon {value}");
             }
 
-            ObjectToDreamIcon.Add(dreamObject, dreamIconObject);
-        }
+            byte[]? rscData = iconRsc.ResourceData;
+            if (rscData == null)
+                throw new Exception($"No data in file {iconRsc} to construct icon from");
 
-        public void OnObjectDeleted(DreamObject dreamObject) {
-            ObjectToDreamIcon.Remove(dreamObject);
-
-            ParentType?.OnObjectDeleted(dreamObject);
+            return (iconRsc, DMIParser.ParseDMI(new MemoryStream(rscData)));
         }
     }
 }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectIcon.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectIcon.cs
@@ -41,19 +41,33 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
                 /// <summary>
                 /// The total directions present in an exported DMI.<br/>
-                /// An icon state in a DMI can only contain either 1, 4, or 8 directions.
+                /// An icon state in a DMI must contain either 1, 4, or 8 directions.
                 /// </summary>
                 public int ExportedDirectionCount {
                     get {
-                        // TODO: Should also verify the existing directions fit
-                        // For example, having only a NORTH direction should export 4 directions
-                        // Right now it just wouldn't be exported at all because only SOUTH would attempt to be exported
+                        // If we have any of these directions then we export 8 directions
+                        foreach (var direction in Directions.Keys) {
+                            switch (direction) {
+                                case AtomDirection.Northeast:
+                                case AtomDirection.Southeast:
+                                case AtomDirection.Southwest:
+                                case AtomDirection.Northwest:
+                                    return 8;
+                            }
+                        }
 
-                        if (Directions.Count is 0 or 1)
-                            return 1;
-                        if (Directions.Count <= 4)
-                            return 4;
-                        return 8;
+                        // Any of these means 4 directions
+                        foreach (var direction in Directions.Keys) {
+                            switch (direction) {
+                                case AtomDirection.North:
+                                case AtomDirection.East:
+                                case AtomDirection.West:
+                                    return 4;
+                            }
+                        }
+
+                        // Otherwise, 1 direction
+                        return 1;
                     }
                 }
             }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectIcon.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectIcon.cs
@@ -33,7 +33,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             private (DreamResource, ParsedDMIDescription)? _cachedDMI;
 
             /// <summary>
-            /// Represents one of the icon states an icon is made of.<br/>
+            /// Represents one of the icon states an icon is made of.
             /// </summary>
             public class IconState {
                 public int Frames = 0;
@@ -71,7 +71,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             /// <remarks>The resulting DMI will consist of one long flat row of frames</remarks>
             /// <returns>The DreamResource containing the DMI and the ParsedDMIDescription used to construct it</returns>
             /// <exception cref="NotImplementedException">Using icon states of various sizes is unimplemented</exception>
-            public (DreamResource, ParsedDMIDescription) GenerateDMI() {
+            public (DreamResource Resource, ParsedDMIDescription Description) GenerateDMI() {
                 if (_cachedDMI != null)
                     return _cachedDMI.Value;
 

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectIcon.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectIcon.cs
@@ -115,10 +115,10 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     pngMetadata.TextData.Add(pngTextData);
 
                     dmiImage.SaveAsPng(dmiImageStream);
-                }
 
-                // TODO: Overhaul the resource system so all the above can actually be used
-                return (null, new ParsedDMIDescription());
+                    DreamResource newResource = _resourceManager.CreateResource(dmiImageStream.GetBuffer());
+                    return (newResource, newDescription);
+                }
             }
 
             public void InsertStates(DreamResource resource, ParsedDMIDescription fromDescription, DreamValue state,
@@ -188,6 +188,20 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             ObjectToDreamIcon.Remove(dreamObject);
 
             ParentType?.OnObjectDeleted(dreamObject);
+        }
+
+        public void OnVariableSet(DreamObject dreamObject, string varName, DreamValue value, DreamValue oldValue) {
+            ParentType?.OnVariableSet(dreamObject, varName, value, oldValue);
+
+            switch (varName) {
+                case "icon":
+                    // Setting the icon to anything other than a DreamResource will actually set it to null
+                    if (value.Type != DreamValue.DreamValueType.DreamResource) {
+                        dreamObject.SetVariableValue("icon", DreamValue.Null);
+                    }
+
+                    break;
+            }
         }
 
         public static (DreamResource Resource, ParsedDMIDescription Description) GetIconResourceAndDescription(

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1612,19 +1612,14 @@ namespace OpenDreamRuntime.Procs {
             DreamValue filename = state.Pop();
             var value = state.Pop();
             DreamResource file;
-            if (!value.TryGetValueAsDreamResource(out file))
-            {
-                if (value.TryGetValueAsDreamObjectOfType(DreamPath.Icon, out var icon))
-                {
-                    // TODO Only load the correct state/dir
-                    file = IoCManager.Resolve<DreamResourceManager>()
-                        .LoadResource(DreamMetaObjectIcon.ObjectToDreamIcon[icon].Icon);
-                }
-                else
-                {
+            if (!value.TryGetValueAsDreamResource(out file)) {
+                if (value.TryGetValueAsDreamObjectOfType(DreamPath.Icon, out var icon)) {
+                    (file, _) = DreamMetaObjectIcon.ObjectToDreamIcon[icon].GenerateDMI();
+                } else {
                     throw new NotImplementedException();
                 }
             }
+
             DreamObject receiver = state.Pop().GetValueAsDreamObject();
 
             DreamObject client;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
@@ -1,6 +1,6 @@
 using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Objects.MetaObjects;
-using OpenDreamShared.Dream;
+using OpenDreamRuntime.Resources;
 
 namespace OpenDreamRuntime.Procs.Native {
     static class DreamProcNativeIcon {
@@ -8,14 +8,14 @@ namespace OpenDreamRuntime.Procs.Native {
         public static DreamValue NativeProc_Width(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
             DreamMetaObjectIcon.DreamIconObject dreamIconObject = DreamMetaObjectIcon.ObjectToDreamIcon[instance];
 
-            return new DreamValue(dreamIconObject.Description.Width);
+            return new DreamValue(dreamIconObject.Width);
         }
 
         [DreamProc("Height")]
         public static DreamValue NativeProc_Height(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
             DreamMetaObjectIcon.DreamIconObject dreamIconObject = DreamMetaObjectIcon.ObjectToDreamIcon[instance];
 
-            return new DreamValue(dreamIconObject.Description.Height);
+            return new DreamValue(dreamIconObject.Height);
         }
 
         [DreamProc("Insert")]
@@ -28,37 +28,20 @@ namespace OpenDreamRuntime.Procs.Native {
         public static DreamValue NativeProc_Insert(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
             //TODO Figure out what happens when you pass the wrong types as args
 
-            if (!arguments.GetArgument(0, "new_icon").TryGetValueAsDreamObject(out var new_icon))
-            {
-                // TODO: Implement this
-                if (arguments.GetArgument(0, "new_icon").TryGetValueAsDreamResource(out _))
-                {
-                    throw new NotImplementedException("icon.Insert() doesn't support DreamResources yet");
-                }
-            }
-            arguments.GetArgument(1, "icon_state").TryGetValueAsString(out var icon_state);
-            AtomDirection? dir = null;
-            if (arguments.GetArgument(2, "dir").TryGetValueAsInteger(out var dirNum))
-            {
-                dir = (AtomDirection)dirNum;
-            }
-            int? frame = null;
-            if (arguments.GetArgument(3, "frame").TryGetValueAsInteger(out var frameNum))
-            {
-                frame = frameNum;
-            }
-            bool moving = !(arguments.GetArgument(4, "moving").TryGetValueAsInteger(out var movingNum) && movingNum == 0);
-            int? delay = null;
-            if (arguments.GetArgument(5, "delay").TryGetValueAsInteger(out var delayNum))
-            {
-                delay = delayNum;
-            }
+            DreamValue newIcon = arguments.GetArgument(0, "new_icon");
+            DreamValue iconState = arguments.GetArgument(1, "icon_state");
+            DreamValue dir = arguments.GetArgument(2, "dir");
+            DreamValue frame = arguments.GetArgument(3, "frame");
+            DreamValue moving = arguments.GetArgument(4, "moving");
+            DreamValue delay = arguments.GetArgument(5, "delay");
 
-            DreamMetaObjectIcon.DreamIconObject instanceIconObject = DreamMetaObjectIcon.ObjectToDreamIcon[instance];
-            DreamMetaObjectIcon.DreamIconObject newIconObject = DreamMetaObjectIcon.ObjectToDreamIcon[new_icon];
-            instanceIconObject.Description.InsertIcon(newIconObject.Description, icon_state, dir, frame, delay);
+            // TODO: moving & delay
 
-            instanceIconObject.Moving = moving ? DreamMetaObjectIcon.DreamIconMovingMode.Movement : DreamMetaObjectIcon.DreamIconMovingMode.NonMovement;
+            var resourceManager = IoCManager.Resolve<DreamResourceManager>();
+            var (iconRsc, iconDescription) = DreamMetaObjectIcon.GetIconResourceAndDescription(resourceManager, newIcon);
+
+            DreamMetaObjectIcon.DreamIconObject iconObj = DreamMetaObjectIcon.ObjectToDreamIcon[instance];
+            iconObj.InsertStates(iconRsc, iconDescription, iconState, dir, frame); // TODO: moving & delay
             return DreamValue.Null;
         }
     }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -730,16 +730,15 @@ namespace OpenDreamRuntime.Procs.Native {
                 return DreamValue.Null;
             }
 
-            DMIParser.ParsedDMIDescription dmiDescription;
             if (arg.TryGetValueAsDreamResource(out var resource)) {
-                dmiDescription = DMIParser.ParseDMI(new MemoryStream(resource.ResourceData));
+                var dmiDescription = DMIParser.ParseDMI(new MemoryStream(resource.ResourceData));
+
+                return new DreamValue(DreamList.Create(dmiDescription.States.Keys.ToArray()));
             } else if (arg.TryGetValueAsDreamObjectOfType(DreamPath.Icon, out var icon)) {
-                dmiDescription = DreamMetaObjectIcon.ObjectToDreamIcon[icon].Description;
+                return new DreamValue(DreamList.Create(DreamMetaObjectIcon.ObjectToDreamIcon[icon].States.Keys.ToArray()));
             } else {
                 throw new Exception($"Bad icon {arg}");
             }
-
-            return new DreamValue(DreamList.Create(dmiDescription.States.Keys.ToArray()));
         }
 
         [DreamProc("image")]

--- a/OpenDreamRuntime/Resources/ConsoleOutputResource.cs
+++ b/OpenDreamRuntime/Resources/ConsoleOutputResource.cs
@@ -1,25 +1,24 @@
 using OpenDreamRuntime.Procs.DebugAdapter;
 
-namespace OpenDreamRuntime.Resources
-{
-    /// <summary>
-    /// A special resource that outputs to the console
-    /// <c>world.log</c> defaults to this
-    /// </summary>
-    sealed class ConsoleOutputResource : DreamResource {
-        public ConsoleOutputResource() : base(null, null) { }
+namespace OpenDreamRuntime.Resources;
 
-        public override string ReadAsString() {
-            return null;
-        }
+/// <summary>
+/// A special resource that outputs to the console
+/// <c>world.log</c> defaults to this
+/// </summary>
+sealed class ConsoleOutputResource : DreamResource {
+    public ConsoleOutputResource() : base(0, null, null) { }
 
-        public void WriteConsole(LogLevel logLevel, string sawmill, string message) {
-            IoCManager.Resolve<IDreamDebugManager>().HandleOutput(logLevel, message);
-            Logger.LogS(logLevel, sawmill, message);
-        }
+    public override string ReadAsString() {
+        return null;
+    }
 
-        public override void Output(DreamValue value) {
-            WriteConsole(LogLevel.Info, "world.log", value.Stringify());
-        }
+    public void WriteConsole(LogLevel logLevel, string sawmill, string message) {
+        IoCManager.Resolve<IDreamDebugManager>().HandleOutput(logLevel, message);
+        Logger.LogS(logLevel, sawmill, message);
+    }
+
+    public override void Output(DreamValue value) {
+        WriteConsole(LogLevel.Info, "world.log", value.Stringify());
     }
 }

--- a/OpenDreamRuntime/Resources/DreamResource.cs
+++ b/OpenDreamRuntime/Resources/DreamResource.cs
@@ -4,10 +4,11 @@ using System.Text;
 namespace OpenDreamRuntime.Resources {
     [Virtual]
     public class DreamResource {
-        public string ResourcePath;
+        public readonly string? ResourcePath;
+        public readonly int Id;
         public byte[]? ResourceData {
             get {
-                if (_resourceData == null && Exists()) {
+                if (_resourceData == null && File.Exists(_filePath)) {
                     _resourceData = File.ReadAllBytes(_filePath);
                 }
 
@@ -15,16 +16,18 @@ namespace OpenDreamRuntime.Resources {
             }
         }
 
-        private string _filePath;
+        private readonly string? _filePath;
         private byte[]? _resourceData = null;
 
-        public DreamResource(string filePath, string resourcePath) {
-            _filePath = filePath;
+        public DreamResource(int id, string? filePath, string? resourcePath) {
+            Id = id;
             ResourcePath = resourcePath;
+            _filePath = filePath;
         }
 
-        public bool Exists() {
-            return File.Exists(_filePath);
+        public DreamResource(int id, byte[] data) {
+            Id = id;
+            _resourceData = data;
         }
 
         public virtual string? ReadAsString() {
@@ -36,7 +39,7 @@ namespace OpenDreamRuntime.Resources {
             return resourceString;
         }
 
-        public virtual void Clear() {
+        public void Clear() {
             CreateDirectory();
             File.WriteAllText(_filePath, String.Empty);
         }
@@ -57,7 +60,7 @@ namespace OpenDreamRuntime.Resources {
             Directory.CreateDirectory(Path.GetDirectoryName(_filePath));
         }
 
-        public override string? ToString() {
+        public override string ToString() {
             return $"'{ResourcePath}'";
         }
     }

--- a/OpenDreamShared/Dream/IconAppearance.cs
+++ b/OpenDreamShared/Dream/IconAppearance.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 namespace OpenDreamShared.Dream {
     [Serializable, NetSerializable]
     public sealed class IconAppearance : IEquatable<IconAppearance> {
-        [ViewVariables] public string Icon;
+        [ViewVariables] public int? Icon;
         [ViewVariables] public string IconState;
         [ViewVariables] public AtomDirection Direction;
         [ViewVariables] public Vector2i PixelOffset;

--- a/OpenDreamShared/Network/Messages/MsgRequestResource.cs
+++ b/OpenDreamShared/Network/Messages/MsgRequestResource.cs
@@ -2,22 +2,18 @@
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
-namespace OpenDreamShared.Network.Messages
-{
-    public sealed class MsgRequestResource : NetMessage
-    {
-        public override NetDeliveryMethod DeliveryMethod => NetDeliveryMethod.ReliableUnordered;
+namespace OpenDreamShared.Network.Messages;
 
-        public string ResourcePath;
+public sealed class MsgRequestResource : NetMessage {
+    public override NetDeliveryMethod DeliveryMethod => NetDeliveryMethod.ReliableUnordered;
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
-        {
-            ResourcePath = buffer.ReadString();
-        }
+    public int ResourceId;
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
-        {
-            buffer.Write(ResourcePath);
-        }
+    public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer) {
+        ResourceId = buffer.ReadInt32();
+    }
+
+    public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer) {
+        buffer.Write(ResourceId);
     }
 }

--- a/OpenDreamShared/Network/Messages/MsgResource.cs
+++ b/OpenDreamShared/Network/Messages/MsgResource.cs
@@ -2,27 +2,23 @@
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
-namespace OpenDreamShared.Network.Messages
-{
-    public sealed class MsgResource : NetMessage
-    {
-        public override NetDeliveryMethod DeliveryMethod => NetDeliveryMethod.ReliableUnordered;
+namespace OpenDreamShared.Network.Messages;
 
-        public string ResourcePath;
-        public byte[] ResourceData;
+public sealed class MsgResource : NetMessage {
+    public override NetDeliveryMethod DeliveryMethod => NetDeliveryMethod.ReliableUnordered;
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
-        {
-            ResourcePath = buffer.ReadString();
-            var dataLen = buffer.ReadVariableInt32();
-            ResourceData = buffer.ReadBytes(dataLen);
-        }
+    public int ResourceId;
+    public byte[] ResourceData;
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
-        {
-            buffer.Write(ResourcePath);
-            buffer.WriteVariableInt32(ResourceData.Length);
-            buffer.Write(ResourceData);
-        }
+    public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer) {
+        ResourceId = buffer.ReadInt32();
+        var dataLen = buffer.ReadVariableInt32();
+        ResourceData = buffer.ReadBytes(dataLen);
+    }
+
+    public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer) {
+        buffer.Write(ResourceId);
+        buffer.WriteVariableInt32(ResourceData.Length);
+        buffer.Write(ResourceData);
     }
 }

--- a/OpenDreamShared/Network/Messages/MsgSound.cs
+++ b/OpenDreamShared/Network/Messages/MsgSound.cs
@@ -1,3 +1,4 @@
+using System;
 using Lidgren.Network;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;
@@ -5,23 +6,41 @@ using Robust.Shared.Serialization;
 namespace OpenDreamShared.Network.Messages
 {
     public sealed class MsgSound : NetMessage {
+        public enum FormatType : byte {
+            Ogg,
+            Wav
+        }
+
         public override MsgGroups MsgGroup => MsgGroups.EntityEvent;
 
         public ushort Channel;
         public ushort Volume;
-        public string File;
+        public int? ResourceId;
+        public FormatType? Format; // TODO: This should probably be sent along with the sound resource instead somehow
         //TODO: Frequency and friends
 
         public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer) {
             Channel = buffer.ReadUInt16();
             Volume = buffer.ReadUInt16();
-            File = buffer.ReadString();
+
+            if (buffer.ReadBoolean()) {
+                ResourceId = buffer.ReadInt32();
+                Format = (FormatType)buffer.ReadByte();
+            }
         }
 
         public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer) {
             buffer.Write(Channel);
             buffer.Write(Volume);
-            buffer.Write(File);
+
+            buffer.Write(ResourceId != null);
+            if (ResourceId != null) {
+                buffer.Write(ResourceId.Value);
+
+                if (Format == null)
+                    throw new InvalidOperationException("Format cannot be null if there is a resource");
+                buffer.Write((byte)Format);
+            }
         }
     }
 }

--- a/OpenDreamShared/Resources/DMIParser.cs
+++ b/OpenDreamShared/Resources/DMIParser.cs
@@ -139,7 +139,7 @@ namespace OpenDreamShared.Resources {
                     directions.Add(AtomDirection.South, frames);
                 }
 
-                if (frame != null) { // Only copy a specified frame
+                if (frame != null) { // Only get a specified frame
                     foreach (var direction in directions) {
                         ParsedDMIFrame[] newFrames = new ParsedDMIFrame[1];
 

--- a/OpenDreamShared/Resources/DMIParser.cs
+++ b/OpenDreamShared/Resources/DMIParser.cs
@@ -237,11 +237,11 @@ namespace OpenDreamShared.Resources {
                 if (line.StartsWith('#') || string.IsNullOrWhiteSpace(line))
                     continue;
 
-                string[] split = line.Split('=');
+                int equalsIndex = line.IndexOf('=');
 
-                if (split.Length == 2) {
-                    string key = split[0].Trim();
-                    string value = split[1].Trim();
+                if (equalsIndex != -1) {
+                    string key = line.Substring(0, equalsIndex-1).Trim();
+                    string value = line.Substring(equalsIndex + 1).Trim();
 
                     switch (key) {
                         case "version":

--- a/OpenDreamShared/Resources/DMIParser.cs
+++ b/OpenDreamShared/Resources/DMIParser.cs
@@ -11,8 +11,7 @@ using JetBrains.Annotations;
 
 namespace OpenDreamShared.Resources {
     public static class DMIParser {
-        private static readonly byte[] PngHeader = { 0x89, 0x50, 0x4E, 0x47, 0xD, 0xA, 0x1A, 0xA };
-        private static readonly AtomDirection[] DMIFrameDirections = {
+        public static readonly AtomDirection[] DMIFrameDirections = {
             AtomDirection.South,
             AtomDirection.North,
             AtomDirection.East,
@@ -22,6 +21,8 @@ namespace OpenDreamShared.Resources {
             AtomDirection.Northeast,
             AtomDirection.Northwest
         };
+
+        private static readonly byte[] PngHeader = { 0x89, 0x50, 0x4E, 0x47, 0xD, 0xA, 0x1A, 0xA };
 
         public sealed class ParsedDMIDescription {
             public int Width, Height;
@@ -134,7 +135,8 @@ namespace OpenDreamShared.Resources {
                     if (!Directions.TryGetValue(dir.Value, out var frames))
                         frames = Array.Empty<ParsedDMIFrame>();
 
-                    directions.Add(dir.Value, frames);
+                    // Getting only one direction will give it to you with AtomDirection.South
+                    directions.Add(AtomDirection.South, frames);
                 }
 
                 if (frame != null) { // Only copy a specified frame

--- a/OpenDreamShared/Resources/DMIParser.cs
+++ b/OpenDreamShared/Resources/DMIParser.cs
@@ -69,15 +69,14 @@ namespace OpenDreamShared.Resources {
             public bool Rewind = false;
 
             /// <summary>
-            /// The total amount of frames in this icon state
+            /// The amount of animation frames this state has
             /// </summary>
             public int FrameCount {
                 get {
                     if (Directions.Count == 0)
                         return 0;
 
-                    // Every direction should have the same amount of frames
-                    return Directions.Values.First().Length * Directions.Count;
+                    return Directions.Values.First().Length;
                 }
             }
 
@@ -110,22 +109,22 @@ namespace OpenDreamShared.Resources {
             }
 
             /// <summary>
-            /// Create a copy of this ParsedDMIState
+            /// Get this state's frames
             /// </summary>
-            /// <param name="dir">Which direction to copy. Every direction if null.</param>
-            /// <param name="frame">Which frame to copy. Every frame if null.</param>
-            /// <returns>A copy of this state with the specified directions and frames</returns>
-            public ParsedDMIState Copy(AtomDirection? dir = null, int? frame = null) {
+            /// <param name="dir">Which direction to get. Every direction if null.</param>
+            /// <param name="frame">Which frame to get. Every frame if null.</param>
+            /// <returns>A dictionary containing the specified frames for each specified direction</returns>
+            public Dictionary<AtomDirection, ParsedDMIFrame[]> GetFrames(AtomDirection? dir = null, int? frame = null) {
                 Dictionary<AtomDirection, ParsedDMIFrame[]> directions;
-                if (dir == null) { // Copy every direction
+                if (dir == null) { // Get every direction
                     directions = new(Directions);
                 } else {
-                    directions = new();
+                    directions = new(1);
 
-                    // This will intentionally create an empty state if the dir doesn't exist
-                    if (Directions.TryGetValue(dir.Value, out var frames)) {
-                        directions.Add(AtomDirection.South, frames);
-                    }
+                    if (!Directions.TryGetValue(dir.Value, out var frames))
+                        frames = Array.Empty<ParsedDMIFrame>();
+
+                    directions.Add(dir.Value, frames);
                 }
 
                 if (frame != null) { // Only copy a specified frame
@@ -137,9 +136,7 @@ namespace OpenDreamShared.Resources {
                     }
                 }
 
-                return new ParsedDMIState {
-                    Name = String.Empty, Directions = directions, Loop = Loop, Rewind = Rewind
-                };
+                return directions;
             }
         }
 

--- a/OpenDreamShared/Resources/DMIParser.cs
+++ b/OpenDreamShared/Resources/DMIParser.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using OpenDreamShared.Dream;
 using System.Globalization;
+using JetBrains.Annotations;
 
 namespace OpenDreamShared.Resources {
     public static class DMIParser {
@@ -26,8 +27,17 @@ namespace OpenDreamShared.Resources {
             public int Width, Height;
             public Dictionary<string, ParsedDMIState> States;
 
-            public ParsedDMIState GetState(string stateName = null) {
-                States.TryGetValue(stateName ?? "", out var state);
+            /// <summary>
+            /// Gets the requested state, or the default if it doesn't exist
+            /// </summary>
+            /// <remarks>The default state could also not exist</remarks>
+            /// <param name="stateName">The requested state's name</param>
+            /// <returns>The requested state, default state, or null</returns>
+            [CanBeNull]
+            public ParsedDMIState GetStateOrDefault(string stateName) {
+                if (!States.TryGetValue(stateName, out var state)) {
+                    States.TryGetValue(String.Empty, out state);
+                }
 
                 return state;
             }


### PR DESCRIPTION
These changes fix up the `/icon` implementation quite a bit and lay a lot of the foundation needed for more complex operations.

- Icons can now contain icon states from multiple different images
- Icons can now generate their final .dmi file with the `GenerateDMI()` method
- These .dmi files can be sent to the client for use & display
- Resources now internally use IDs rather than file paths

Fixes #719 