### PR TITLE
Implement two `/icon.Blend()` blend functions

### DIFF
--- a/DMCompiler/DMStandard/Types/Icon.dm
+++ b/DMCompiler/DMStandard/Types/Icon.dm
@@ -5,7 +5,6 @@
 	New(icon, icon_state, dir, frame, moving)
 
 	proc/Blend(icon, function = ICON_ADD, x = 1, y = 1)
-		set opendream_unimplemented = TRUE
 
 	proc/Crop(x1, y1, x2, y2)
 		set opendream_unimplemented = TRUE

--- a/OpenDreamRuntime/Objects/DreamIcon.cs
+++ b/OpenDreamRuntime/Objects/DreamIcon.cs
@@ -1,0 +1,237 @@
+﻿using System.IO;
+using OpenDreamRuntime.Resources;
+using OpenDreamShared.Dream;
+using OpenDreamShared.Resources;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.PixelFormats;
+using ParsedDMIDescription = OpenDreamShared.Resources.DMIParser.ParsedDMIDescription;
+using ParsedDMIState = OpenDreamShared.Resources.DMIParser.ParsedDMIState;
+using ParsedDMIFrame = OpenDreamShared.Resources.DMIParser.ParsedDMIFrame;
+
+namespace OpenDreamRuntime.Objects;
+
+public sealed class DreamIcon {
+    public int Width, Height;
+    public readonly Dictionary<string, IconState> States = new();
+
+    private readonly DreamResourceManager _resourceManager;
+
+    private int _frameCount;
+    private (DreamResource, ParsedDMIDescription)? _cachedDMI;
+
+    /// <summary>
+    /// Represents one of the icon states an icon is made of.
+    /// </summary>
+    public sealed class IconState {
+        public int Frames;
+        public readonly Dictionary<AtomDirection, List<IconFrame>> Directions = new();
+
+        /// <summary>
+        /// The total directions present in an exported DMI.<br/>
+        /// An icon state in a DMI must contain either 1, 4, or 8 directions.
+        /// </summary>
+        public int ExportedDirectionCount {
+            get {
+                // If we have any of these directions then we export 8 directions
+                foreach (var direction in Directions.Keys) {
+                    switch (direction) {
+                        case AtomDirection.Northeast:
+                        case AtomDirection.Southeast:
+                        case AtomDirection.Southwest:
+                        case AtomDirection.Northwest:
+                            return 8;
+                    }
+                }
+
+                // Any of these means 4 directions
+                foreach (var direction in Directions.Keys) {
+                    switch (direction) {
+                        case AtomDirection.North:
+                        case AtomDirection.East:
+                        case AtomDirection.West:
+                            return 4;
+                    }
+                }
+
+                // Otherwise, 1 direction
+                return 1;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Represents one of the icon frames an icon is made of.<br/>
+    /// Contains everything needed to create a new DMI in <see cref="DreamIcon.GenerateDMI()"/>
+    /// </summary>
+    public struct IconFrame {
+        /// <summary>
+        /// The image this icon frame originally comes from
+        /// </summary>
+        public Image<Rgba32> Image;
+
+        /// <summary>
+        /// The DMI information about this icon frame
+        /// </summary>
+        public ParsedDMIFrame DMIFrame;
+
+        /// <summary>
+        /// The size of the original icon frame
+        /// </summary>
+        public int Width, Height;
+    }
+
+    public DreamIcon(DreamResourceManager resourceManager) {
+        _resourceManager = resourceManager;
+    }
+
+    /// <summary>
+    /// Generate a DMI using all the inserted icon states
+    /// </summary>
+    /// <remarks>The resulting DMI will consist of one long flat row of frames</remarks>
+    /// <returns>The DreamResource containing the DMI and the ParsedDMIDescription used to construct it</returns>
+    /// <exception cref="NotImplementedException">Using icon states of various sizes is unimplemented</exception>
+    public (DreamResource Resource, ParsedDMIDescription Description) GenerateDMI() {
+        if (_cachedDMI != null)
+            return _cachedDMI.Value;
+
+        int frameWidth = Width, frameHeight = Height;
+        if (_frameCount == 0) { // No frames creates a blank 32x32 image (TODO: should be world.icon_size)
+            frameWidth = 32;
+            frameHeight = 32;
+        }
+
+        Dictionary<string, ParsedDMIState> dmiStates = new(States.Count);
+        int span = frameWidth * Math.Max(_frameCount, 1);
+        Rgba32[] pixels = new Rgba32[span * frameHeight];
+
+        int currentFrame = 0;
+        foreach (var iconStatePair in States) {
+            var iconState = iconStatePair.Value;
+            ParsedDMIState newState = new() { Name = iconStatePair.Key, Loop = false, Rewind = false };
+
+            dmiStates.Add(newState.Name, newState);
+
+            int exportedDirectionCount = iconState.ExportedDirectionCount;
+            for (int directionIndex = 0; directionIndex < exportedDirectionCount; directionIndex++) {
+                AtomDirection direction = DMIParser.DMIFrameDirections[directionIndex];
+                int x = currentFrame * frameWidth;
+
+                currentFrame += iconState.Frames;
+                if (!iconState.Directions.TryGetValue(direction, out var frames))
+                    continue; // Blank frames
+
+                var newFrames = DrawFrames(pixels, x, frames);
+                newState.Directions.Add(direction, newFrames);
+            }
+        }
+
+        Image<Rgba32> dmiImage = Image.LoadPixelData(pixels, span, frameHeight);
+        ParsedDMIDescription newDescription = new() {Width = frameWidth, Height = frameHeight, States = dmiStates};
+
+        using (MemoryStream dmiImageStream = new MemoryStream()) {
+            var pngTextData = new PngTextData("Description", newDescription.ExportAsText(), null, null);
+            var pngMetadata = dmiImage.Metadata.GetPngMetadata();
+            pngMetadata.TextData.Add(pngTextData);
+
+            dmiImage.SaveAsPng(dmiImageStream);
+
+            DreamResource newResource = _resourceManager.CreateResource(dmiImageStream.GetBuffer());
+            _cachedDMI = (newResource, newDescription);
+            return _cachedDMI.Value;
+        }
+    }
+
+    public void InsertStates(DreamResource resource, ParsedDMIDescription fromDescription, DreamValue state,
+        DreamValue dir, DreamValue frame) {
+        bool copyingAllDirs = !dir.TryGetValueAsInteger(out var dirVal);
+        bool copyingAllStates = !(state.TryGetValueAsString(out var copyingState) && fromDescription.States.ContainsKey(copyingState));
+        bool copyingAllFrames = !frame.TryGetValueAsInteger(out var copyingFrame);
+        // TODO: Copy movement states?
+
+        AtomDirection copyingDirection = (AtomDirection) dirVal;
+        if (!Enum.IsDefined(copyingDirection) || copyingDirection == AtomDirection.None) {
+            copyingAllDirs = true;
+        }
+
+        // The size of every state will be resized to match the largest state
+        Width = Math.Max(Width, fromDescription.Width);
+        Height = Math.Max(Height, fromDescription.Height);
+
+        Image<Rgba32> image = _resourceManager.LoadImage(resource);
+
+        if (copyingAllStates) {
+            foreach (var copyStateName in fromDescription.States.Keys) {
+                InsertState(image, fromDescription, copyStateName, copyStateName,
+                    copyingAllDirs ? null : copyingDirection, copyingAllFrames ? null : copyingFrame);
+            }
+        } else {
+            InsertState(image, fromDescription, String.Empty, copyingState!,
+                copyingAllDirs ? null : copyingDirection, copyingAllFrames ? null : copyingFrame);
+        }
+    }
+
+    private void InsertState(Image<Rgba32> image, ParsedDMIDescription description, string stateName, string copyingState, AtomDirection? dir = null, int? frame = null) {
+        ParsedDMIState inserting = description.States[copyingState];
+        Dictionary<AtomDirection, ParsedDMIFrame[]> insertingDirections = inserting.GetFrames(dir, frame - 1);
+
+        if (!States.TryGetValue(stateName, out var iconState)) {
+            iconState = new IconState();
+            States.Add(stateName, iconState);
+        }
+
+        _frameCount -= iconState.Frames * iconState.ExportedDirectionCount;
+
+        foreach (var insertingPair in insertingDirections) {
+            List<IconFrame> iconFrames = new(insertingPair.Value.Length);
+
+            foreach (var dmiFrame in insertingPair.Value) {
+                iconFrames.Add(new IconFrame {
+                    Image = image,
+                    DMIFrame = dmiFrame,
+                    Width = description.Width, Height = description.Height
+                });
+            }
+
+            iconState.Directions[insertingPair.Key] = iconFrames;
+            iconState.Frames = Math.Max(iconState.Frames, iconFrames.Count);
+        }
+
+        _frameCount += iconState.Frames * iconState.ExportedDirectionCount;
+        _cachedDMI = null;
+    }
+
+    private ParsedDMIFrame[] DrawFrames(Rgba32[] pixels, int x, List<IconFrame> frames) {
+        ParsedDMIFrame[] newFrames = new ParsedDMIFrame[frames.Count];
+
+        for (var frameIndex = 0; frameIndex < frames.Count; frameIndex++) {
+            var frame = frames[frameIndex];
+
+            newFrames[frameIndex] = new ParsedDMIFrame {X = x, Y = 0, Delay = frame.DMIFrame.Delay};
+            if (frameIndex > frames.Count)
+                continue; // Empty frame
+
+            if (frame.Width != Width || frame.Height != Height)
+                throw new NotImplementedException("Icon scaling is not implemented");
+
+            // Copy the frame from the original image to the new one
+            frame.Image.ProcessPixelRows(accessor => {
+                ParsedDMIFrame dmiFrame = frame.DMIFrame;
+
+                for (int y = 0; y < Height; y++) {
+                    var rowSpan = accessor.GetRowSpan(dmiFrame.Y + y);
+
+                    for (int frameX = 0; frameX < Width; frameX++) {
+                        int pixelLocation = (y * Width * _frameCount) + x + frameX;
+
+                        pixels[pixelLocation] = rowSpan[dmiFrame.X + frameX];
+                    }
+                }
+            });
+
+            x += Width;
+        }
+
+        return newFrames;
+    }
+}

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -45,10 +45,10 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             switch (varName) {
                 case "icon":
                     _atomManager.UpdateAppearance(dreamObject, appearance => {
-                        if (value.TryGetValueAsDreamResource(out DreamResource resource)) {
+                        if (value.TryGetValueAsDreamResource(out var resource)) {
                             appearance.Icon = resource.Id;
                         } else if (value.TryGetValueAsDreamObjectOfType(DreamPath.Icon, out var iconObject)) {
-                            DreamMetaObjectIcon.DreamIconObject icon = DreamMetaObjectIcon.ObjectToDreamIcon[iconObject];
+                            DreamIcon icon = DreamMetaObjectIcon.ObjectToDreamIcon[iconObject];
 
                             (resource, _) = icon.GenerateDMI();
                             appearance.Icon = resource.Id;

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectIcon.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectIcon.cs
@@ -36,7 +36,7 @@ sealed class DreamMetaObjectIcon : IDreamMetaObject {
             // TODO: Could maybe have an alternative path for /icon values so the DMI doesn't have to be generated
             var (iconRsc, iconDescription) = GetIconResourceAndDescription(_rscMan, icon);
 
-            dreamIcon.InsertStates(iconRsc, iconDescription, state, dir, frame);
+            dreamIcon.InsertStates(iconRsc, iconDescription, state, dir, frame, useStateName: false);
         }
     }
 

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectIcon.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectIcon.cs
@@ -3,329 +3,99 @@ using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Resources;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Formats.Png;
-using SixLabors.ImageSharp.PixelFormats;
 using ParsedDMIDescription = OpenDreamShared.Resources.DMIParser.ParsedDMIDescription;
-using ParsedDMIState = OpenDreamShared.Resources.DMIParser.ParsedDMIState;
-using ParsedDMIFrame = OpenDreamShared.Resources.DMIParser.ParsedDMIFrame;
 
-namespace OpenDreamRuntime.Objects.MetaObjects {
-    sealed class DreamMetaObjectIcon : IDreamMetaObject {
-        public bool ShouldCallNew => true;
-        public IDreamMetaObject? ParentType { get; set; }
+namespace OpenDreamRuntime.Objects.MetaObjects;
 
-        [Dependency] private readonly DreamResourceManager _rscMan = default!;
+sealed class DreamMetaObjectIcon : IDreamMetaObject {
+    public bool ShouldCallNew => true;
+    public IDreamMetaObject? ParentType { get; set; }
 
-        public DreamMetaObjectIcon() {
-            IoCManager.InjectDependencies(this);
+    [Dependency] private readonly DreamResourceManager _rscMan = default!;
+
+    public DreamMetaObjectIcon() {
+        IoCManager.InjectDependencies(this);
+    }
+
+    public static readonly Dictionary<DreamObject, DreamIcon> ObjectToDreamIcon = new();
+
+    public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
+        ParentType?.OnObjectCreated(dreamObject, creationArguments);
+
+        // TODO confirm BYOND behavior of invalid args for icon, dir, and frame
+        DreamValue icon = creationArguments.GetArgument(0, "icon");
+        DreamValue state = creationArguments.GetArgument(1, "icon_state");
+        DreamValue dir = creationArguments.GetArgument(2, "dir");
+        DreamValue frame = creationArguments.GetArgument(3, "frame");
+        DreamValue moving = creationArguments.GetArgument(4, "moving");
+
+        DreamIcon dreamIcon = new(_rscMan);
+        ObjectToDreamIcon.Add(dreamObject, dreamIcon);
+
+        if (icon != DreamValue.Null) {
+            // TODO: Could maybe have an alternative path for /icon values so the DMI doesn't have to be generated
+            var (iconRsc, iconDescription) = GetIconResourceAndDescription(_rscMan, icon);
+
+            dreamIcon.InsertStates(iconRsc, iconDescription, state, dir, frame);
+        }
+    }
+
+    public void OnObjectDeleted(DreamObject dreamObject) {
+        ObjectToDreamIcon.Remove(dreamObject);
+
+        ParentType?.OnObjectDeleted(dreamObject);
+    }
+
+    public void OnVariableSet(DreamObject dreamObject, string varName, DreamValue value, DreamValue oldValue) {
+        ParentType?.OnVariableSet(dreamObject, varName, value, oldValue);
+
+        switch (varName) {
+            case "icon":
+                // Setting the icon to anything other than a DreamResource will actually set it to null
+                if (value.Type != DreamValue.DreamValueType.DreamResource) {
+                    dreamObject.SetVariableValue("icon", DreamValue.Null);
+                }
+
+                break;
+        }
+    }
+
+    public static (DreamResource Resource, ParsedDMIDescription Description) GetIconResourceAndDescription(
+        DreamResourceManager resourceManager, DreamValue value) {
+        if (value.TryGetValueAsDreamObjectOfType(DreamPath.Icon, out var iconObj)) {
+            DreamIcon dreamIcon = ObjectToDreamIcon[iconObj];
+
+            return dreamIcon.GenerateDMI();
         }
 
-        public static readonly Dictionary<DreamObject, DreamIconObject> ObjectToDreamIcon = new();
+        DreamResource? iconRsc;
 
-        public sealed class DreamIconObject {
-            public int Width, Height;
-            public readonly Dictionary<string, IconState> States = new();
+        if (value.TryGetValueAsString(out var fileString)) {
+            var ext = Path.GetExtension(fileString);
 
-            private readonly DreamResourceManager _resourceManager;
-
-            private int _frameCount;
-            private (DreamResource, ParsedDMIDescription)? _cachedDMI;
-
-            /// <summary>
-            /// Represents one of the icon states an icon is made of.
-            /// </summary>
-            public sealed class IconState {
-                public int Frames;
-                public readonly Dictionary<AtomDirection, List<IconFrame>> Directions = new();
-
-                /// <summary>
-                /// The total directions present in an exported DMI.<br/>
-                /// An icon state in a DMI must contain either 1, 4, or 8 directions.
-                /// </summary>
-                public int ExportedDirectionCount {
-                    get {
-                        // If we have any of these directions then we export 8 directions
-                        foreach (var direction in Directions.Keys) {
-                            switch (direction) {
-                                case AtomDirection.Northeast:
-                                case AtomDirection.Southeast:
-                                case AtomDirection.Southwest:
-                                case AtomDirection.Northwest:
-                                    return 8;
-                            }
-                        }
-
-                        // Any of these means 4 directions
-                        foreach (var direction in Directions.Keys) {
-                            switch (direction) {
-                                case AtomDirection.North:
-                                case AtomDirection.East:
-                                case AtomDirection.West:
-                                    return 4;
-                            }
-                        }
-
-                        // Otherwise, 1 direction
-                        return 1;
-                    }
-                }
-            }
-
-            /// <summary>
-            /// Represents one of the icon frames an icon is made of.<br/>
-            /// Contains everything needed to create a new DMI in <see cref="DreamIconObject.GenerateDMI()"/>
-            /// </summary>
-            public struct IconFrame {
-                /// <summary>
-                /// The image this icon frame originally comes from
-                /// </summary>
-                public Image<Rgba32> Image;
-
-                /// <summary>
-                /// The DMI information about this icon frame
-                /// </summary>
-                public ParsedDMIFrame DMIFrame;
-
-                /// <summary>
-                /// The size of the original icon frame
-                /// </summary>
-                public int Width, Height;
-            }
-
-            public DreamIconObject(DreamResourceManager resourceManager) {
-                _resourceManager = resourceManager;
-            }
-
-            /// <summary>
-            /// Generate a DMI using all the inserted icon states
-            /// </summary>
-            /// <remarks>The resulting DMI will consist of one long flat row of frames</remarks>
-            /// <returns>The DreamResource containing the DMI and the ParsedDMIDescription used to construct it</returns>
-            /// <exception cref="NotImplementedException">Using icon states of various sizes is unimplemented</exception>
-            public (DreamResource Resource, ParsedDMIDescription Description) GenerateDMI() {
-                if (_cachedDMI != null)
-                    return _cachedDMI.Value;
-
-                int frameWidth = Width, frameHeight = Height;
-                if (_frameCount == 0) { // No frames creates a blank 32x32 image (TODO: should be world.icon_size)
-                    frameWidth = 32;
-                    frameHeight = 32;
-                }
-
-                Dictionary<string, ParsedDMIState> dmiStates = new(States.Count);
-                int span = frameWidth * Math.Max(_frameCount, 1);
-                Rgba32[] pixels = new Rgba32[span * frameHeight];
-
-                int currentFrame = 0;
-                foreach (var iconStatePair in States) {
-                    var iconState = iconStatePair.Value;
-                    ParsedDMIState newState = new() { Name = iconStatePair.Key, Loop = false, Rewind = false };
-
-                    dmiStates.Add(newState.Name, newState);
-
-                    int exportedDirectionCount = iconState.ExportedDirectionCount;
-                    for (int directionIndex = 0; directionIndex < exportedDirectionCount; directionIndex++) {
-                        AtomDirection direction = DMIParser.DMIFrameDirections[directionIndex];
-                        int x = currentFrame * frameWidth;
-
-                        currentFrame += iconState.Frames;
-                        if (!iconState.Directions.TryGetValue(direction, out var frames))
-                            continue; // Blank frames
-
-                        var newFrames = DrawFrames(pixels, x, frames);
-                        newState.Directions.Add(direction, newFrames);
-                    }
-                }
-
-                Image<Rgba32> dmiImage = Image.LoadPixelData(pixels, span, frameHeight);
-                ParsedDMIDescription newDescription = new() {Width = frameWidth, Height = frameHeight, States = dmiStates};
-
-                using (MemoryStream dmiImageStream = new MemoryStream()) {
-                    var pngTextData = new PngTextData("Description", newDescription.ExportAsText(), null, null);
-                    var pngMetadata = dmiImage.Metadata.GetPngMetadata();
-                    pngMetadata.TextData.Add(pngTextData);
-
-                    dmiImage.SaveAsPng(dmiImageStream);
-
-                    DreamResource newResource = _resourceManager.CreateResource(dmiImageStream.GetBuffer());
-                    _cachedDMI = (newResource, newDescription);
-                    return _cachedDMI.Value;
-                }
-            }
-
-            public void InsertStates(DreamResource resource, ParsedDMIDescription fromDescription, DreamValue state,
-                DreamValue dir, DreamValue frame) {
-                bool copyingAllDirs = !dir.TryGetValueAsInteger(out var dirVal);
-                bool copyingAllStates = !(state.TryGetValueAsString(out var copyingState) && fromDescription.States.ContainsKey(copyingState));
-                bool copyingAllFrames = !frame.TryGetValueAsInteger(out var copyingFrame);
-                // TODO: Copy movement states?
-
-                AtomDirection copyingDirection = (AtomDirection) dirVal;
-                if (!Enum.IsDefined(copyingDirection) || copyingDirection == AtomDirection.None) {
-                    copyingAllDirs = true;
-                }
-
-                // The size of every state will be resized to match the largest state
-                Width = Math.Max(Width, fromDescription.Width);
-                Height = Math.Max(Height, fromDescription.Height);
-
-                Image<Rgba32> image = _resourceManager.LoadImage(resource);
-
-                if (copyingAllStates) {
-                    foreach (var copyStateName in fromDescription.States.Keys) {
-                        InsertState(image, fromDescription, copyStateName, copyStateName,
-                            copyingAllDirs ? null : copyingDirection, copyingAllFrames ? null : copyingFrame);
-                    }
-                } else {
-                    InsertState(image, fromDescription, String.Empty, copyingState!,
-                        copyingAllDirs ? null : copyingDirection, copyingAllFrames ? null : copyingFrame);
-                }
-            }
-
-            private void InsertState(Image<Rgba32> image, ParsedDMIDescription description, string stateName, string copyingState, AtomDirection? dir = null, int? frame = null) {
-                ParsedDMIState inserting = description.States[copyingState];
-                Dictionary<AtomDirection, ParsedDMIFrame[]> insertingDirections = inserting.GetFrames(dir, frame - 1);
-
-                if (!States.TryGetValue(stateName, out var iconState)) {
-                    iconState = new IconState();
-                    States.Add(stateName, iconState);
-                }
-
-                _frameCount -= iconState.Frames * iconState.ExportedDirectionCount;
-
-                foreach (var insertingPair in insertingDirections) {
-                    List<IconFrame> iconFrames = new(insertingPair.Value.Length);
-
-                    foreach (var dmiFrame in insertingPair.Value) {
-                        iconFrames.Add(new IconFrame {
-                            Image = image,
-                            DMIFrame = dmiFrame,
-                            Width = description.Width, Height = description.Height
-                        });
-                    }
-
-                    iconState.Directions[insertingPair.Key] = iconFrames;
-                    iconState.Frames = Math.Max(iconState.Frames, iconFrames.Count);
-                }
-
-                _frameCount += iconState.Frames * iconState.ExportedDirectionCount;
-                _cachedDMI = null;
-            }
-
-            private ParsedDMIFrame[] DrawFrames(Rgba32[] pixels, int x, List<IconFrame> frames) {
-                ParsedDMIFrame[] newFrames = new ParsedDMIFrame[frames.Count];
-
-                for (var frameIndex = 0; frameIndex < frames.Count; frameIndex++) {
-                    var frame = frames[frameIndex];
-
-                    newFrames[frameIndex] = new ParsedDMIFrame {X = x, Y = 0, Delay = frame.DMIFrame.Delay};
-                    if (frameIndex > frames.Count)
-                        continue; // Empty frame
-
-                    if (frame.Width != Width || frame.Height != Height)
-                        throw new NotImplementedException("Icon scaling is not implemented");
-
-                    // Copy the frame from the original image to the new one
-                    frame.Image.ProcessPixelRows(accessor => {
-                        ParsedDMIFrame dmiFrame = frame.DMIFrame;
-
-                        for (int y = 0; y < Height; y++) {
-                            var rowSpan = accessor.GetRowSpan(dmiFrame.Y + y);
-
-                            for (int frameX = 0; frameX < Width; frameX++) {
-                                int pixelLocation = (y * Width * _frameCount) + x + frameX;
-
-                                pixels[pixelLocation] = rowSpan[dmiFrame.X + frameX];
-                            }
-                        }
-                    });
-
-                    x += Width;
-                }
-
-                return newFrames;
-            }
-        }
-
-        public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
-            ParentType?.OnObjectCreated(dreamObject, creationArguments);
-
-            // TODO confirm BYOND behavior of invalid args for icon, dir, and frame
-            DreamValue icon = creationArguments.GetArgument(0, "icon");
-            DreamValue state = creationArguments.GetArgument(1, "icon_state");
-            DreamValue dir = creationArguments.GetArgument(2, "dir");
-            DreamValue frame = creationArguments.GetArgument(3, "frame");
-            DreamValue moving = creationArguments.GetArgument(4, "moving");
-
-            DreamIconObject dreamIconObject = new(_rscMan);
-            ObjectToDreamIcon.Add(dreamObject, dreamIconObject);
-
-            if (icon != DreamValue.Null) {
-                // TODO: Could maybe have an alternative path for /icon values so the DMI doesn't have to be generated
-                var (iconRsc, iconDescription) = GetIconResourceAndDescription(_rscMan, icon);
-
-                dreamIconObject.InsertStates(iconRsc, iconDescription, state, dir, frame);
-            }
-        }
-
-        public void OnObjectDeleted(DreamObject dreamObject) {
-            ObjectToDreamIcon.Remove(dreamObject);
-
-            ParentType?.OnObjectDeleted(dreamObject);
-        }
-
-        public void OnVariableSet(DreamObject dreamObject, string varName, DreamValue value, DreamValue oldValue) {
-            ParentType?.OnVariableSet(dreamObject, varName, value, oldValue);
-
-            switch (varName) {
-                case "icon":
-                    // Setting the icon to anything other than a DreamResource will actually set it to null
-                    if (value.Type != DreamValue.DreamValueType.DreamResource) {
-                        dreamObject.SetVariableValue("icon", DreamValue.Null);
-                    }
-
+            switch (ext) {
+                case ".dmi":
+                    iconRsc = resourceManager.LoadResource(fileString);
                     break;
+
+                // TODO implement other icon file types
+                case ".png":
+                case ".jpg":
+                case ".rsi": // RT-specific, not in BYOND
+                case ".gif":
+                case ".bmp":
+                    throw new NotImplementedException($"Unimplemented icon type '{ext}'");
+                default:
+                    throw new Exception($"Invalid icon file {fileString}");
             }
+        } else if (!value.TryGetValueAsDreamResource(out iconRsc)) {
+            throw new Exception($"Invalid icon {value}");
         }
 
-        public static (DreamResource Resource, ParsedDMIDescription Description) GetIconResourceAndDescription(
-            DreamResourceManager resourceManager, DreamValue value) {
-            if (value.TryGetValueAsDreamObjectOfType(DreamPath.Icon, out var iconObj)) {
-                DreamIconObject dreamIconObject = ObjectToDreamIcon[iconObj];
+        byte[]? rscData = iconRsc.ResourceData;
+        if (rscData == null)
+            throw new Exception($"No data in file {iconRsc} to construct icon from");
 
-                return dreamIconObject.GenerateDMI();
-            }
-
-            DreamResource? iconRsc;
-
-            if (value.TryGetValueAsString(out var fileString)) {
-                var ext = Path.GetExtension(fileString);
-
-                switch (ext) {
-                    case ".dmi":
-                        iconRsc = resourceManager.LoadResource(fileString);
-                        break;
-
-                    // TODO implement other icon file types
-                    case ".png":
-                    case ".jpg":
-                    case ".rsi": // RT-specific, not in BYOND
-                    case ".gif":
-                    case ".bmp":
-                        throw new NotImplementedException($"Unimplemented icon type '{ext}'");
-                    default:
-                        throw new Exception($"Invalid icon file {fileString}");
-                }
-            } else if (!value.TryGetValueAsDreamResource(out iconRsc)) {
-                throw new Exception($"Invalid icon {value}");
-            }
-
-            byte[]? rscData = iconRsc.ResourceData;
-            if (rscData == null)
-                throw new Exception($"No data in file {iconRsc} to construct icon from");
-
-            return (iconRsc, DMIParser.ParseDMI(new MemoryStream(rscData)));
-        }
+        return (iconRsc, DMIParser.ParseDMI(new MemoryStream(rscData)));
     }
 }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -128,6 +128,7 @@ namespace OpenDreamRuntime.Procs.Native {
             icon.SetNativeProc(DreamProcNativeIcon.NativeProc_Width);
             icon.SetNativeProc(DreamProcNativeIcon.NativeProc_Height);
             icon.SetNativeProc(DreamProcNativeIcon.NativeProc_Insert);
+            icon.SetNativeProc(DreamProcNativeIcon.NativeProc_Blend);
 
             //DreamObjectDefinition savefile = objectTree.GetObjectDefinitionFromPath(DreamPath.Savefile);
             //savefile.SetNativeProc(DreamProcNativeSavefile.NativeProc_Flush);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
@@ -6,14 +6,14 @@ namespace OpenDreamRuntime.Procs.Native {
     static class DreamProcNativeIcon {
         [DreamProc("Width")]
         public static DreamValue NativeProc_Width(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
-            DreamMetaObjectIcon.DreamIconObject dreamIconObject = DreamMetaObjectIcon.ObjectToDreamIcon[instance];
+            DreamIcon dreamIconObject = DreamMetaObjectIcon.ObjectToDreamIcon[instance];
 
             return new DreamValue(dreamIconObject.Width);
         }
 
         [DreamProc("Height")]
         public static DreamValue NativeProc_Height(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
-            DreamMetaObjectIcon.DreamIconObject dreamIconObject = DreamMetaObjectIcon.ObjectToDreamIcon[instance];
+            DreamIcon dreamIconObject = DreamMetaObjectIcon.ObjectToDreamIcon[instance];
 
             return new DreamValue(dreamIconObject.Height);
         }
@@ -40,8 +40,32 @@ namespace OpenDreamRuntime.Procs.Native {
             var resourceManager = IoCManager.Resolve<DreamResourceManager>();
             var (iconRsc, iconDescription) = DreamMetaObjectIcon.GetIconResourceAndDescription(resourceManager, newIcon);
 
-            DreamMetaObjectIcon.DreamIconObject iconObj = DreamMetaObjectIcon.ObjectToDreamIcon[instance];
+            DreamIcon iconObj = DreamMetaObjectIcon.ObjectToDreamIcon[instance];
             iconObj.InsertStates(iconRsc, iconDescription, iconState, dir, frame); // TODO: moving & delay
+            return DreamValue.Null;
+        }
+
+        [DreamProc("Blend")]
+        [DreamProcParameter("icon", Type = DreamValue.DreamValueType.DreamObject)]
+        [DreamProcParameter("function", Type = DreamValue.DreamValueType.Float)]
+        [DreamProcParameter("x", Type = DreamValue.DreamValueType.Float)]
+        [DreamProcParameter("y", Type = DreamValue.DreamValueType.Float)]
+        public static DreamValue NativeProc_Blend(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
+            //TODO Figure out what happens when you pass the wrong types as args
+
+            DreamValue icon = arguments.GetArgument(0, "icon");
+            DreamValue function = arguments.GetArgument(1, "function");
+
+            arguments.GetArgument(2, "x").TryGetValueAsInteger(out var x);
+            arguments.GetArgument(3, "y").TryGetValueAsInteger(out var y);
+
+            if (!function.TryGetValueAsInteger(out var functionValue))
+                throw new Exception($"Invalid 'function' argument {function}");
+
+            var blendType = (DreamIconOperationBlend.BlendType) functionValue;
+
+            DreamIcon iconObj = DreamMetaObjectIcon.ObjectToDreamIcon[instance];
+            iconObj.ApplyOperation(new DreamIconOperationBlend(blendType, icon, x, y));
             return DreamValue.Null;
         }
     }


### PR DESCRIPTION
`/icon.Blend()` now supports two blend functions, `ICON_OVERLAY` and `ICON_UNDERLAY`.

A basic framework was created for applying extra operations during the generation of an `/icon`'s DMI. This will be useful for implementing the other icon procs.