### PR TITLE
Include maps with warnings in the output json

### DIFF
--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -253,15 +253,18 @@ namespace DMCompiler {
                 DMMParser parser = new DMMParser(lexer);
                 DreamMapJson map = parser.ParseMap();
 
+                bool hadErrors = false;
                 if (parser.Emissions.Count > 0) {
                     foreach (CompilerEmission error in parser.Emissions) {
+                        if (error.Level == ErrorLevel.Error)
+                            hadErrors = true;
+
                         Emit(error);
                     }
-
-                    continue;
                 }
 
-                maps.Add(map);
+                if (!hadErrors)
+                    maps.Add(map);
             }
 
             return maps;


### PR DESCRIPTION
Maps can emit warnings, such as `Skipping type '/mob/living/simple_animal/cow'` when an invalid type is encountered,

The compiler would previously treat these like errors and not include them in the output.