### PR TITLE
Make `/atom/movable.locs` return `list(src.loc)`

### DIFF
--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMovable.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMovable.cs
@@ -128,6 +128,13 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
                     return new(contents);
                 }
+                case "locs": {
+                    // Unimplemented; just return a list containing src.loc
+                    DreamList locs = DreamList.Create();
+                    locs.AddValue(dreamObject.GetVariable("loc"));
+
+                    return new DreamValue(locs);
+                }
                 default:
                     return ParentType?.OnVariableGet(dreamObject, varName, value) ?? value;
             }


### PR DESCRIPTION
Until a more complete implementation comes around.

Fixes close-up interactions in Paradise by fixing `/atom/movable.Adjacent()`