### PR TITLE
Optimize for loops with implicit `istype()`s

### DIFF
--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -293,9 +293,13 @@ namespace DMCompiler.DM {
         }
 
         public void Enumerate(DMReference output) {
-            GrowStack(1);
-            WriteOpcode(DreamProcOpcode.Enumerate);
-            WriteReference(output);
+            if (_loopStack?.TryPeek(out var peek) ?? false) {
+                WriteOpcode(DreamProcOpcode.Enumerate);
+                WriteReference(output);
+                WriteLabel($"{peek}_end");
+            } else {
+                DMCompiler.ForcedError(Location, "Cannot peek empty loop stack");
+            }
         }
 
         public void DestroyEnumerator() {
@@ -326,16 +330,14 @@ namespace DMCompiler.DM {
             StartScope();
         }
 
-        public void LoopContinue(string loopLabel) {
-            AddLabel(loopLabel + "_continue");
+        public void MarkLoopContinue(string loopLabel) {
+            AddLabel($"{loopLabel}_continue");
         }
 
-        public void BackgroundSleep()
-        {
+        public void BackgroundSleep() {
             // TODO This seems like a bad way to handle background, doesn't it?
 
-            if ((Attributes & ProcAttributes.Background) == ProcAttributes.Background)
-            {
+            if ((Attributes & ProcAttributes.Background) == ProcAttributes.Background) {
                 if (!DMObjectTree.TryGetGlobalProc("sleep", out DMProc sleepProc)) {
                     throw new CompileErrorException(Location, "Cannot do a background sleep without a sleep proc");
                 }
@@ -347,10 +349,9 @@ namespace DMCompiler.DM {
             }
         }
 
-        public void LoopJumpToStart(string loopLabel)
-        {
+        public void LoopJumpToStart(string loopLabel) {
             BackgroundSleep();
-            Jump(loopLabel + "_start");
+            Jump($"{loopLabel}_start");
         }
 
         public void LoopEnd() {
@@ -428,12 +429,9 @@ namespace DMCompiler.DM {
         }
 
         public void BreakIfFalse() {
-            if (_loopStack?.TryPeek(out var peek) ?? false)
-            {
-                JumpIfFalse(peek + "_end");
-            }
-            else
-            {
+            if (_loopStack?.TryPeek(out var peek) ?? false) {
+                JumpIfFalse($"{peek}_end");
+            } else {
                 DMCompiler.ForcedError(Location, "Cannot peek empty loop stack");
             }
         }

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -272,6 +272,16 @@ namespace DMCompiler.DM {
             WriteOpcode(DreamProcOpcode.CreateListEnumerator);
         }
 
+        public void CreateFilteredListEnumerator(DreamPath filterType) {
+            if (!DMObjectTree.TryGetTypeId(filterType, out var filterTypeId)) {
+                DMCompiler.ForcedError($"Cannot filter enumeration by type {filterType}");
+            }
+
+            ShrinkStack(1);
+            WriteOpcode(DreamProcOpcode.CreateFilteredListEnumerator);
+            WriteInt(filterTypeId);
+        }
+
         public void CreateTypeEnumerator() {
             ShrinkStack(1);
             WriteOpcode(DreamProcOpcode.CreateTypeEnumerator);

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -478,7 +478,7 @@ namespace DMCompiler.DM.Visitors {
 
                     ProcessBlockInner(body);
 
-                    _proc.LoopContinue(loopLabel);
+                    _proc.MarkLoopContinue(loopLabel);
                     if (incrementor != null) {
                         incrementor.EmitPushValue(_dmObject, _proc);
                         _proc.Pop();
@@ -520,15 +520,14 @@ namespace DMCompiler.DM.Visitors {
                 string loopLabel = _proc.NewLabelName();
                 _proc.LoopStart(loopLabel);
                 {
+                    _proc.MarkLoopContinue(loopLabel);
+
                     if (lValue != null) {
                         (DMReference outputRef, _) = lValue.EmitReference(_dmObject, _proc);
                         _proc.Enumerate(outputRef);
-                        _proc.BreakIfFalse();
                     }
 
                     ProcessBlockInner(body);
-
-                    _proc.LoopContinue(loopLabel);
                     _proc.LoopJumpToStart(loopLabel);
                 }
                 _proc.LoopEnd();
@@ -558,17 +557,16 @@ namespace DMCompiler.DM.Visitors {
                 string loopLabel = _proc.NewLabelName();
                 _proc.LoopStart(loopLabel);
                 {
+                    _proc.MarkLoopContinue(loopLabel);
+
                     if (outputVar is Expressions.LValue lValue) {
                         (DMReference outputRef, _) = lValue.EmitReference(_dmObject, _proc);
                         _proc.Enumerate(outputRef);
-                        _proc.BreakIfFalse();
                     } else {
                         DMCompiler.Emit(WarningCode.BadExpression, outputVar.Location, "Invalid output var");
                     }
 
                     ProcessBlockInner(body);
-
-                    _proc.LoopContinue(loopLabel);
                     _proc.LoopJumpToStart(loopLabel);
                 }
                 _proc.LoopEnd();
@@ -597,17 +595,16 @@ namespace DMCompiler.DM.Visitors {
                 string loopLabel = _proc.NewLabelName();
                 _proc.LoopStart(loopLabel);
                 {
+                    _proc.MarkLoopContinue(loopLabel);
+
                     if (outputVar is Expressions.LValue lValue) {
                         (DMReference outputRef, _) = lValue.EmitReference(_dmObject, _proc);
                         _proc.Enumerate(outputRef);
-                        _proc.BreakIfFalse();
                     } else {
                         DMCompiler.Emit(WarningCode.BadExpression, outputVar.Location, "Invalid output var");
                     }
 
                     ProcessBlockInner(body);
-
-                    _proc.LoopContinue(loopLabel);
                     _proc.LoopJumpToStart(loopLabel);
                 }
                 _proc.LoopEnd();
@@ -623,8 +620,8 @@ namespace DMCompiler.DM.Visitors {
                 string loopLabel = _proc.NewLabelName();
                 _proc.LoopStart(loopLabel);
                 {
+                    _proc.MarkLoopContinue(loopLabel);
                     ProcessBlockInner(statementInfLoop.Body);
-                    _proc.LoopContinue(loopLabel);
                     _proc.LoopJumpToStart(loopLabel);
                 }
                 _proc.LoopEnd();
@@ -642,9 +639,8 @@ namespace DMCompiler.DM.Visitors {
 
                 _proc.StartScope();
                 {
+                    _proc.MarkLoopContinue(loopLabel);
                     ProcessBlockInner(statementWhile.Body);
-
-                    _proc.LoopContinue(loopLabel);
                     _proc.LoopJumpToStart(loopLabel);
                 }
                 _proc.EndScope();
@@ -660,7 +656,7 @@ namespace DMCompiler.DM.Visitors {
             {
                 ProcessBlockInner(statementDoWhile.Body);
 
-                _proc.LoopContinue(loopLabel);
+                _proc.MarkLoopContinue(loopLabel);
                 DMExpression.Emit(_dmObject, _proc, statementDoWhile.Conditional);
                 _proc.JumpIfFalse(loopEndLabel);
                 _proc.LoopJumpToStart(loopLabel);

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -500,7 +500,7 @@ namespace DMCompiler.DM.Visitors {
             DreamPath? implicitTypeCheck = null;
             if (dmTypes == null) {
                 // No "as" means the var's type will be used
-                implicitTypeCheck = lValue.Path;
+                implicitTypeCheck = lValue?.Path;
             } else if (dmTypes != DMValueType.Anything) {
                 // "as anything" performs no check. Other values are unimplemented.
                 DMCompiler.UnimplementedWarning(outputVar.Location,

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -300,21 +300,17 @@ namespace DMCompiler {
                 compiledDream.Globals = globalListJson;
             }
 
-            if (DMObjectTree.GlobalProcs.Count > 0)
-            {
+            if (DMObjectTree.GlobalProcs.Count > 0) {
                 compiledDream.GlobalProcs = DMObjectTree.GlobalProcs.Values.ToList();
             }
 
-            string json = JsonSerializer.Serialize(compiledDream, new JsonSerializerOptions() {
-                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault
-            });
-
             // Successful serialization
-            if (ErrorCount == 0)
-            {
-                File.WriteAllText(outputFile, json);
-                return "Saved to " + outputFile;
+            if (ErrorCount == 0) {
+                JsonSerializer.Serialize(File.Create(outputFile), compiledDream,
+                    new JsonSerializerOptions() {DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault});
+                return $"Saved to {outputFile}";
             }
+
             return string.Empty;
         }
 

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -306,8 +306,11 @@ namespace DMCompiler {
 
             // Successful serialization
             if (ErrorCount == 0) {
-                JsonSerializer.Serialize(File.Create(outputFile), compiledDream,
+                var outputFileHandle = File.Create(outputFile);
+
+                JsonSerializer.Serialize(outputFileHandle, compiledDream,
                     new JsonSerializerOptions() {DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault});
+                outputFileHandle.Close();
                 return $"Saved to {outputFile}";
             }
 

--- a/DMDisassembler/DMProc.cs
+++ b/DMDisassembler/DMProc.cs
@@ -34,7 +34,7 @@ namespace DMDisassembler {
                 foreach (var (position, instruction) in new ProcDecoder(Program.CompiledJson.Strings, Bytecode).Disassemble()) {
                     StringBuilder text = new StringBuilder();
                     text.Append(instruction[0]);
-                    text.Append(" ");
+                    text.Append(' ');
 
                     switch (instruction) {
                         case (DreamProcOpcode.FormatString, string str, int numReplacements):
@@ -59,8 +59,8 @@ namespace DMDisassembler {
 
                         case (DreamProcOpcode.JumpIfNullDereference, DMReference reference, int jumpPosition):
                             labeledPositions.Add(jumpPosition);
-                            text.Append(reference);
-                            text.Append(" ");
+                            text.Append(reference.ToString());
+                            text.Append(' ');
                             text.Append(jumpPosition);
                             break;
 
@@ -76,6 +76,13 @@ namespace DMDisassembler {
                             text.Append(jumpPosition);
                             break;
 
+                        case (DreamProcOpcode.Enumerate, DMReference reference, int jumpPosition):
+                            labeledPositions.Add(jumpPosition);
+                            text.Append(reference.ToString());
+                            text.Append(' ');
+                            text.Append(jumpPosition);
+                            break;
+
                         case (DreamProcOpcode.PushType, int type):
                             text.Append(Program.CompiledJson.Types[type].Path);
                             break;
@@ -83,7 +90,7 @@ namespace DMDisassembler {
                         case (DreamProcOpcode.PushArguments, int argCount, int namedCount, string[] names):
                             text.Append(argCount);
                             for (int i = 0; i < argCount; i++) {
-                                text.Append(" ");
+                                text.Append(' ');
                                 text.Append(names[i] ?? "-");
                             }
 
@@ -92,7 +99,7 @@ namespace DMDisassembler {
                         default:
                             for (int i = 1; i < instruction.Length; ++i) {
                                 text.Append(instruction[i]);
-                                text.Append(" ");
+                                text.Append(' ');
                             }
                             break;
                     }

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -176,10 +176,13 @@ namespace OpenDreamRuntime.Procs {
         public static ProcStatus? Enumerate(DMProcState state) {
             IEnumerator<DreamValue> enumerator = state.EnumeratorStack.Peek();
             DMReference reference = state.ReadReference();
+            int jumpToIfFailure = state.ReadInt();
             bool successfulEnumeration = enumerator.MoveNext();
 
             state.AssignReference(reference, enumerator.Current);
-            state.Push(new DreamValue(successfulEnumeration ? 1 : 0));
+            if (!successfulEnumeration)
+                state.Jump(jumpToIfFailure);
+
             return null;
         }
 

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -104,7 +104,7 @@ namespace OpenDreamRuntime.Procs {
             DMOpcodeHandlers.BrowseResource,
             DMOpcodeHandlers.OutputControl,
             DMOpcodeHandlers.BitShiftRight,
-            null, //0x41
+            DMOpcodeHandlers.CreateFilteredListEnumerator,
             DMOpcodeHandlers.Power,
             DMOpcodeHandlers.DebugSource,
             DMOpcodeHandlers.DebugLine,

--- a/OpenDreamRuntime/Procs/DreamEnumerators.cs
+++ b/OpenDreamRuntime/Procs/DreamEnumerators.cs
@@ -4,9 +4,9 @@ using OpenDreamShared.Dream;
 namespace OpenDreamRuntime.Procs {
     sealed class DreamProcRangeEnumerator : IEnumerator<DreamValue> {
         private float _current;
-        private float _start;
-        private float _end;
-        private float _step;
+        private readonly float _start;
+        private readonly float _end;
+        private readonly float _step;
 
         public DreamProcRangeEnumerator(float rangeStart, float rangeEnd, float step) {
             _current = rangeStart - step;
@@ -35,8 +35,8 @@ namespace OpenDreamRuntime.Procs {
     }
 
     sealed class DreamObjectEnumerator : IEnumerator<DreamValue> {
-        private IEnumerator<DreamObject> _dreamObjectEnumerator;
-        private DreamPath? _filterType;
+        private readonly IEnumerator<DreamObject> _dreamObjectEnumerator;
+        private readonly DreamPath? _filterType;
 
         public DreamObjectEnumerator(IEnumerable<DreamObject> dreamObjects, DreamPath? filterType = null) {
             _dreamObjectEnumerator = dreamObjects.GetEnumerator();
@@ -68,8 +68,8 @@ namespace OpenDreamRuntime.Procs {
     }
 
     sealed class DreamValueAsObjectEnumerator : IEnumerator<DreamValue> {
-        private IEnumerator<DreamValue> _dreamValueEnumerator;
-        private DreamPath? _filterType;
+        private readonly IEnumerator<DreamValue> _dreamValueEnumerator;
+        private readonly DreamPath? _filterType;
 
         public DreamValueAsObjectEnumerator(IEnumerable<DreamValue> dreamValues, DreamPath? filterType = null) {
             _dreamValueEnumerator = dreamValues.GetEnumerator();
@@ -83,15 +83,11 @@ namespace OpenDreamRuntime.Procs {
         public bool MoveNext() {
             bool hasNext = _dreamValueEnumerator.MoveNext();
             if (_filterType != null) {
-                while (hasNext && !_dreamValueEnumerator.Current.TryGetValueAsDreamObjectOfType(_filterType.Value, out _))
-                {
+                while (hasNext && !_dreamValueEnumerator.Current.TryGetValueAsDreamObjectOfType(_filterType.Value, out _)) {
                     hasNext = _dreamValueEnumerator.MoveNext();
                 }
-            }
-            else
-            {
-                while (hasNext && (_dreamValueEnumerator.Current.Type != DreamValue.DreamValueType.DreamObject || _dreamValueEnumerator.Current == DreamValue.Null))
-                {
+            } else {
+                while (hasNext && (_dreamValueEnumerator.Current.Type != DreamValue.DreamValueType.DreamObject || _dreamValueEnumerator.Current == DreamValue.Null)) {
                     hasNext = _dreamValueEnumerator.MoveNext();
                 }
             }

--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -111,6 +111,7 @@ public struct ProcDecoder {
 
             case DreamProcOpcode.CreateList:
             case DreamProcOpcode.CreateAssociativeList:
+            case DreamProcOpcode.CreateFilteredListEnumerator:
             case DreamProcOpcode.PickWeighted:
             case DreamProcOpcode.PickUnweighted:
             case DreamProcOpcode.Spawn:

--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -101,7 +101,6 @@ public struct ProcDecoder {
             case DreamProcOpcode.DivideReference:
             case DreamProcOpcode.BitXorReference:
             case DreamProcOpcode.ModulusReference:
-            case DreamProcOpcode.Enumerate:
             case DreamProcOpcode.OutputReference:
             case DreamProcOpcode.PushReferenceValue:
                 return (opcode, ReadReference());
@@ -127,6 +126,7 @@ public struct ProcDecoder {
             case DreamProcOpcode.MassConcatenation:
                 return (opcode, ReadInt());
 
+            case DreamProcOpcode.Enumerate:
             case DreamProcOpcode.JumpIfNullDereference:
                 return (opcode, ReadReference(), ReadInt());
 

--- a/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
+++ b/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
@@ -69,7 +69,7 @@ namespace OpenDreamShared.Dream.Procs {
         BrowseResource = 0x3E,
         OutputControl = 0x3F,
         BitShiftRight = 0x40,
-        //0x41
+        CreateFilteredListEnumerator = 0x41,
         Power = 0x42,
         DebugSource = 0x43,
         DebugLine = 0x44,


### PR DESCRIPTION
There is now a CreateFilteredListEnumerator which creates an enumerator that behaves like CreateListEnumerator's, except it will only enumerate DreamObjects of a certain type.

This removes the need to perform this filtering in the bytecode, cutting out 4 opcodes for every filtered for-loop.