### PR TITLE
Stop running unit tests in the compiler CI action

### DIFF
--- a/.github/workflows/compiler-test.yml
+++ b/.github/workflows/compiler-test.yml
@@ -34,8 +34,6 @@ jobs:
       run: dotnet build main/OpenDream.sln --configuration Release --no-restore /m
     - name: Compile TestGame
       run: main\DMCompiler\bin\Release\net6.0\DMCompiler.exe main\TestGame\environment.dme
-    - name: Run Unit Tests
-      run: dotnet test --no-build main\Content.Tests\Content.Tests.csproj --configuration Release
     - name: Checkout Modified /tg/station
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
We already run unit tests in both Windows and Linux in the other GitHub Actions workflow.