### PR TITLE
Compile Paradise in CI

### DIFF
--- a/.github/workflows/compiler-test.yml
+++ b/.github/workflows/compiler-test.yml
@@ -41,3 +41,11 @@ jobs:
         path: tg
     - name: Compile Modified /tg/station
       run: main\DMCompiler\bin\Release\net6.0\DMCompiler.exe tg\tgstation.dme 
+    - name: Checkout 64-bit Paradise
+      uses: actions/checkout@v2
+      with:
+        repository: ike709/Paradise
+        ref: rustg_64
+        path: para
+    - name: Compile 64-bit Paradise
+      run: main\DMCompiler\bin\Release\net6.0\DMCompiler.exe para\paradise.dme


### PR DESCRIPTION
Just another check to prevent compiler regressions. Uses my 64-bit rustg branch instead of actual Paradise master so we don't have to worry about Para breaking OD compilation.