### PR TITLE
Faster Typechecking - It's Finished Again Edition

### DIFF
--- a/Content.Tests/DMTests.cs
+++ b/Content.Tests/DMTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using OpenDreamRuntime;
+using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Rendering;
 using Robust.Shared.Asynchronous;
@@ -14,12 +15,12 @@ using Robust.Shared.Timing;
 namespace Content.Tests
 {
     [TestFixture]
-    public sealed partial class DMTests : ContentUnitTest
-    {
+    public sealed class DMTests : ContentUnitTest {
         public const string TestProject = "DMProject";
         public const string InitializeEnvironment = "./environment.dme";
 
         private IDreamManager _dreamMan;
+        private IDreamObjectTree _objectTree;
         private ITaskManager _taskManager;
 
         [Flags]
@@ -41,6 +42,7 @@ namespace Content.Tests
             componentFactory.RegisterClass<DMISpriteComponent>();
             componentFactory.GenerateNetIds();
             _dreamMan = IoCManager.Resolve<IDreamManager>();
+            _objectTree = IoCManager.Resolve<IDreamObjectTree>();
             Compile(InitializeEnvironment);
             _dreamMan.PreInitialize(Path.ChangeExtension(InitializeEnvironment, "json"));
         }
@@ -61,8 +63,7 @@ namespace Content.Tests
         }
 
         [Test, TestCaseSource(nameof(GetTests))]
-        public void TestFiles(string sourceFile, DMTestFlags testFlags)
-        {
+        public void TestFiles(string sourceFile, DMTestFlags testFlags) {
             string initialDirectory = Directory.GetCurrentDirectory();
             try {
                 string compiledFile = Compile(Path.Join(initialDirectory, "Tests", sourceFile));
@@ -112,7 +113,7 @@ namespace Content.Tests
             Task<DreamValue> callTask = null;
 
             DreamThread.Run("RunTest", async (state) => {
-                if (_dreamMan.ObjectTree.TryGetGlobalProc("RunTest", out DreamProc proc)) {
+                if (_objectTree.TryGetGlobalProc("RunTest", out DreamProc proc)) {
                     callTask = state.Call(proc, null, null, new DreamProcArguments(null));
                     result = await callTask;
                     return DreamValue.Null;

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -270,8 +270,7 @@ namespace DMCompiler {
             return maps;
         }
 
-        private static string SaveJson(List<DreamMapJson> maps, string interfaceFile, string outputFile)
-        {
+        private static string SaveJson(List<DreamMapJson> maps, string interfaceFile, string outputFile) {
             DreamCompiledJson compiledDream = new DreamCompiledJson();
             compiledDream.Strings = DMObjectTree.StringTable;
             compiledDream.Maps = maps;

--- a/OpenDream.sln.DotSettings
+++ b/OpenDream.sln.DotSettings
@@ -7,6 +7,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Debuggee/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fcopy/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=noto/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Procs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=replacetext/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=savefile/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Savefiles/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -12,6 +12,7 @@ namespace OpenDreamRuntime {
         public Dictionary<DreamList, DreamObject> UnderlaysListToAtom { get; } = new();
 
         [Dependency] private readonly IEntityManager _entityManager = default!;
+        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
         [Dependency] private readonly IDreamMapManager _dreamMapManager = default!;
 
         private readonly Dictionary<DreamObject, EntityUid> _atomToEntity = new();
@@ -52,17 +53,17 @@ namespace OpenDreamRuntime {
         }
 
         public IconAppearance? GetAppearance(DreamObject atom) {
-            return atom.IsSubtypeOf(DreamPath.Turf)
+            return atom.IsSubtypeOf(_objectTree.Turf)
                 ? _dreamMapManager.GetTurfAppearance(atom)
                 : _entityManager.GetComponent<DMISpriteComponent>(GetMovableEntity(atom)).Appearance;
         }
 
         public void UpdateAppearance(DreamObject atom, Action<IconAppearance> update) {
-            if (atom.IsSubtypeOf(DreamPath.Turf)) {
+            if (atom.IsSubtypeOf(_objectTree.Turf)) {
                 IconAppearance appearance = new IconAppearance(_dreamMapManager.GetTurfAppearance(atom));
                 update(appearance);
                 _dreamMapManager.SetTurfAppearance(atom, appearance);
-            } else if (atom.IsSubtypeOf(DreamPath.Movable)) {
+            } else if (atom.IsSubtypeOf(_objectTree.Movable)) {
                 if (!_entityManager.TryGetComponent<DMISpriteComponent>(GetMovableEntity(atom), out var sprite))
                     return;
 
@@ -73,7 +74,7 @@ namespace OpenDreamRuntime {
         }
 
         public void AnimateAppearance(DreamObject atom, TimeSpan duration, Action<IconAppearance> animate) {
-            if (!atom.IsSubtypeOf(DreamPath.Movable))
+            if (!atom.IsSubtypeOf(_objectTree.Movable))
                 return; //Animating non-movables is unimplemented
             if (!_entityManager.TryGetComponent<DMISpriteComponent>(GetMovableEntity(atom), out var sprite))
                 return;

--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -15,6 +15,7 @@ namespace OpenDreamRuntime
     public sealed class DreamConnection
     {
         [Dependency] private readonly IDreamManager _dreamManager = default!;
+        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
         [Dependency] private readonly IAtomManager _atomManager = default!;
         [Dependency] private readonly DreamResourceManager _resourceManager = default!;
 
@@ -47,22 +48,18 @@ namespace OpenDreamRuntime
             get => _mobDreamObject;
             set
             {
-                if (_mobDreamObject != value)
-                {
+                if (_mobDreamObject != value) {
                     if (_mobDreamObject != null) _mobDreamObject.SpawnProc("Logout");
 
-                    if (value != null && value.IsSubtypeOf(DreamPath.Mob))
-                    {
+                    if (value != null && value.IsSubtypeOf(_objectTree.Mob)) {
                         DreamConnection oldMobConnection = _dreamManager.GetConnectionFromMob(value);
                         if (oldMobConnection != null) oldMobConnection.MobDreamObject = null;
 
                         _mobDreamObject = value;
                         ClientDreamObject?.SetVariable("eye", new DreamValue(_mobDreamObject));
-                        _mobDreamObject.SpawnProc("Login", usr: _mobDreamObject );
+                        _mobDreamObject.SpawnProc("Login", usr: _mobDreamObject);
                         Session.AttachToEntity(_atomManager.GetMovableEntity(_mobDreamObject));
-                    }
-                    else
-                    {
+                    } else {
                         Session.DetachFromEntity();
                         _mobDreamObject = null;
                     }
@@ -212,7 +209,7 @@ namespace OpenDreamRuntime
 
         public void OutputDreamValue(DreamValue value) {
             if (value.TryGetValueAsDreamObject(out DreamObject outputObject)) {
-                if (outputObject?.IsSubtypeOf(DreamPath.Sound) == true) {
+                if (outputObject?.IsSubtypeOf(_objectTree.Sound) == true) {
                     UInt16 channel = (UInt16)outputObject.GetVariable("channel").GetValueAsInteger();
                     UInt16 volume = (UInt16)outputObject.GetVariable("volume").GetValueAsInteger();
                     DreamValue file = outputObject.GetVariable("file");
@@ -317,13 +314,13 @@ namespace OpenDreamRuntime
             for (int i = 0; i < listValues.Count; i++) {
                 DreamValue value = listValues[i];
 
-                if (types.HasFlag(DMValueType.Obj) && !value.TryGetValueAsDreamObjectOfType(DreamPath.Movable, out _))
+                if (types.HasFlag(DMValueType.Obj) && !value.TryGetValueAsDreamObjectOfType(_objectTree.Movable, out _))
                     continue;
-                if (types.HasFlag(DMValueType.Mob) && !value.TryGetValueAsDreamObjectOfType(DreamPath.Mob, out _))
+                if (types.HasFlag(DMValueType.Mob) && !value.TryGetValueAsDreamObjectOfType(_objectTree.Mob, out _))
                     continue;
-                if (types.HasFlag(DMValueType.Turf) && !value.TryGetValueAsDreamObjectOfType(DreamPath.Turf, out _))
+                if (types.HasFlag(DMValueType.Turf) && !value.TryGetValueAsDreamObjectOfType(_objectTree.Turf, out _))
                     continue;
-                if (types.HasFlag(DMValueType.Area) && !value.TryGetValueAsDreamObjectOfType(DreamPath.Area, out _))
+                if (types.HasFlag(DMValueType.Area) && !value.TryGetValueAsDreamObjectOfType(_objectTree.Area, out _))
                     continue;
 
                 promptValues.Add(value.Stringify());

--- a/OpenDreamRuntime/DreamManager.Connections.cs
+++ b/OpenDreamRuntime/DreamManager.Connections.cs
@@ -87,7 +87,7 @@ namespace OpenDreamRuntime
                 case SessionStatus.InGame:
                 {
                     var connection = new DreamConnection(e.Session);
-                    var client = ObjectTree.CreateObject(DreamPath.Client);
+                    var client = _objectTree.CreateObject(DreamPath.Client);
                     connection.ClientDreamObject = client;
 
                     _clientToConnection.Add(client, connection);

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -49,7 +49,6 @@ namespace OpenDreamRuntime {
 
         //TODO This arg is awful and temporary until RT supports cvar overrides in unit tests
         public void PreInitialize(string jsonPath) {
-            ObjectTree = new(); // cheesy, sorts out a load order conflict.
             InitializeConnectionManager();
             _dreamResourceManager.Initialize();
 

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -22,8 +22,8 @@ namespace OpenDreamRuntime {
         [Dependency] private readonly IDreamMapManager _dreamMapManager = default!;
         [Dependency] private readonly IProcScheduler _procScheduler = default!;
         [Dependency] private readonly DreamResourceManager _dreamResourceManager = default!;
+        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
 
-        public DreamObjectTree ObjectTree { get; private set; } = new();
         public DreamObject WorldInstance { get; private set; }
         public Exception? LastDMException { get; set; }
 
@@ -59,7 +59,7 @@ namespace OpenDreamRuntime {
 
             // Call global <init> with waitfor=FALSE
             if (_compiledJson.GlobalInitProc is ProcDefinitionJson initProcDef) {
-                var globalInitProc = new DMProc(DreamPath.Root, "(global init)", null, null, null, initProcDef.Bytecode, initProcDef.MaxStackSize, initProcDef.Attributes, initProcDef.VerbName, initProcDef.VerbCategory, initProcDef.VerbDesc, initProcDef.Invisibility);
+                var globalInitProc = new DMProc(DreamPath.Root, "(global init)", null, null, null, initProcDef.Bytecode, initProcDef.MaxStackSize, initProcDef.Attributes, initProcDef.VerbName, initProcDef.VerbCategory, initProcDef.VerbDesc, initProcDef.Invisibility, _objectTree);
                 globalInitProc.Spawn(WorldInstance, new DreamProcArguments());
             }
 
@@ -100,15 +100,15 @@ namespace OpenDreamRuntime {
             if(!string.IsNullOrEmpty(_compiledJson.Interface) && !_dreamResourceManager.DoesFileExist(_compiledJson.Interface))
                 throw new FileNotFoundException("Interface DMF not found at "+Path.Join(Path.GetDirectoryName(jsonPath),_compiledJson.Interface));
             //TODO: Empty or invalid _compiledJson.Interface should return default interface - see issue #851
-            ObjectTree.LoadJson(json);
+            _objectTree.LoadJson(json);
 
             SetMetaObjects();
 
-            DreamProcNative.SetupNativeProcs(ObjectTree);
+            DreamProcNative.SetupNativeProcs(_objectTree);
 
             _dreamMapManager.Initialize();
             WorldContentsList = DreamList.Create();
-            WorldInstance = ObjectTree.CreateObject(DreamPath.World);
+            WorldInstance = _objectTree.CreateObject(DreamPath.World);
 
             // Call /world/<init>. This is an IMPLEMENTATION DETAIL and non-DMStandard should NOT be run here.
             WorldInstance.InitSpawn(new DreamProcArguments());
@@ -119,7 +119,7 @@ namespace OpenDreamRuntime {
 
                 for (int i = 0; i < jsonGlobals.GlobalCount; i++) {
                     object globalValue = jsonGlobals.Globals.GetValueOrDefault(i, null);
-                    Globals.Add(ObjectTree.GetDreamValueFromJsonElement(globalValue));
+                    Globals.Add(_objectTree.GetDreamValueFromJsonElement(globalValue));
                 }
             }
 
@@ -134,22 +134,22 @@ namespace OpenDreamRuntime {
 
         private void SetMetaObjects() {
             // Datum needs to be set first
-            ObjectTree.SetMetaObject(DreamPath.Datum, new DreamMetaObjectDatum());
+            _objectTree.SetMetaObject(DreamPath.Datum, new DreamMetaObjectDatum());
 
             //TODO Investigate what types BYOND can reparent without exploding and only allow reparenting those
-            ObjectTree.SetMetaObject(DreamPath.List, new DreamMetaObjectList());
-            ObjectTree.SetMetaObject(DreamPath.Client, new DreamMetaObjectClient());
-            ObjectTree.SetMetaObject(DreamPath.World, new DreamMetaObjectWorld());
-            ObjectTree.SetMetaObject(DreamPath.Matrix, new DreamMetaObjectMatrix());
-            ObjectTree.SetMetaObject(DreamPath.Regex, new DreamMetaObjectRegex());
-            ObjectTree.SetMetaObject(DreamPath.Atom, new DreamMetaObjectAtom());
-            ObjectTree.SetMetaObject(DreamPath.Area, new DreamMetaObjectArea());
-            ObjectTree.SetMetaObject(DreamPath.Turf, new DreamMetaObjectTurf());
-            ObjectTree.SetMetaObject(DreamPath.Movable, new DreamMetaObjectMovable());
-            ObjectTree.SetMetaObject(DreamPath.Mob, new DreamMetaObjectMob());
-            ObjectTree.SetMetaObject(DreamPath.Icon, new DreamMetaObjectIcon());
-            ObjectTree.SetMetaObject(DreamPath.Filter, new DreamMetaObjectFilter());
-            ObjectTree.SetMetaObject(DreamPath.Savefile, new DreamMetaObjectSavefile());
+            _objectTree.SetMetaObject(DreamPath.List, new DreamMetaObjectList());
+            _objectTree.SetMetaObject(DreamPath.Client, new DreamMetaObjectClient());
+            _objectTree.SetMetaObject(DreamPath.World, new DreamMetaObjectWorld());
+            _objectTree.SetMetaObject(DreamPath.Matrix, new DreamMetaObjectMatrix());
+            _objectTree.SetMetaObject(DreamPath.Regex, new DreamMetaObjectRegex());
+            _objectTree.SetMetaObject(DreamPath.Atom, new DreamMetaObjectAtom());
+            _objectTree.SetMetaObject(DreamPath.Area, new DreamMetaObjectArea());
+            _objectTree.SetMetaObject(DreamPath.Turf, new DreamMetaObjectTurf());
+            _objectTree.SetMetaObject(DreamPath.Movable, new DreamMetaObjectMovable());
+            _objectTree.SetMetaObject(DreamPath.Mob, new DreamMetaObjectMob());
+            _objectTree.SetMetaObject(DreamPath.Icon, new DreamMetaObjectIcon());
+            _objectTree.SetMetaObject(DreamPath.Filter, new DreamMetaObjectFilter());
+            _objectTree.SetMetaObject(DreamPath.Savefile, new DreamMetaObjectSavefile());
         }
 
         public void WriteWorldLog(string message, LogLevel level = LogLevel.Info, string sawmill = "world.log") {
@@ -195,14 +195,14 @@ namespace OpenDreamRuntime {
                 }
             } else if (value.TryGetValueAsString(out var refStr)) {
                 refType = RefType.String;
-                idx = ObjectTree.Strings.IndexOf(refStr);
+                idx = _objectTree.Strings.IndexOf(refStr);
 
                 if (idx == -1) {
-                    ObjectTree.Strings.Add(refStr);
-                    idx = ObjectTree.Strings.Count - 1;
+                    _objectTree.Strings.Add(refStr);
+                    idx = _objectTree.Strings.Count - 1;
                 }
             } else if (value.TryGetValueAsPath(out var refPath)) {
-                var treeEntry = ObjectTree.GetTreeEntry(refPath);
+                var treeEntry = _objectTree.GetTreeEntry(refPath);
 
                 refType = RefType.DreamPath;
                 idx = treeEntry.Id;
@@ -247,12 +247,12 @@ namespace OpenDreamRuntime {
 
                         return DreamValue.Null;
                     case RefType.String:
-                        return ObjectTree.Strings.Count > refId
-                            ? new DreamValue(ObjectTree.Strings[refId])
+                        return _objectTree.Strings.Count > refId
+                            ? new DreamValue(_objectTree.Strings[refId])
                             : DreamValue.Null;
                     case RefType.DreamPath:
-                        return ObjectTree.Types.Length > refId
-                            ? new DreamValue(ObjectTree.Types[refId].Path)
+                        return _objectTree.Types.Length > refId
+                            ? new DreamValue(_objectTree.Types[refId].Path)
                             : DreamValue.Null;
                     default:
                         throw new Exception($"Invalid reference type for ref {refString}");

--- a/OpenDreamRuntime/IDreamManager.cs
+++ b/OpenDreamRuntime/IDreamManager.cs
@@ -6,7 +6,6 @@ namespace OpenDreamRuntime {
     public interface IDreamManager {
         public bool Initialized { get; }
         public GameTick InitializedTick { get; }
-        public DreamObjectTree ObjectTree { get; }
         public DreamObject WorldInstance { get; }
 
         /// <summary>

--- a/OpenDreamRuntime/Objects/DreamIcon.cs
+++ b/OpenDreamRuntime/Objects/DreamIcon.cs
@@ -302,8 +302,9 @@ public sealed class DreamIconOperationBlend : IDreamIconOperation {
         _xOffset = xOffset;
         _yOffset = yOffset;
 
+        var objectTree = IoCManager.Resolve<IDreamObjectTree>();
         var resourceManager = IoCManager.Resolve<DreamResourceManager>();
-        (var blendingResource, _blendingDescription) = DreamMetaObjectIcon.GetIconResourceAndDescription(resourceManager, blending);
+        (var blendingResource, _blendingDescription) = DreamMetaObjectIcon.GetIconResourceAndDescription(objectTree, resourceManager, blending);
         _blending = resourceManager.LoadImage(blendingResource);
 
         if (_type is not BlendType.Overlay and not BlendType.Underlay)

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -1,5 +1,4 @@
 ﻿using OpenDreamRuntime.Procs;
-using OpenDreamShared.Dream;
 using OpenDreamShared.Dream.Procs;
 using System.Globalization;
 
@@ -45,8 +44,8 @@ namespace OpenDreamRuntime.Objects {
             _variables.Clear();
         }
 
-        public bool IsSubtypeOf(DreamPath path) {
-            return ObjectDefinition.IsSubtypeOf(path);
+        public bool IsSubtypeOf(IDreamObjectTree.TreeEntry ancestor) {
+            return ObjectDefinition.IsSubtypeOf(ancestor);
         }
 
         public bool HasVariable(string name) {

--- a/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
@@ -8,7 +8,7 @@ namespace OpenDreamRuntime.Objects {
 
         public DreamPath Type => _treeNode.Path;
         public DreamObjectDefinition? Parent => _treeNode.ParentEntry?.ObjectDefinition;
-        public IDreamMetaObject MetaObject = null;
+        public IDreamMetaObject? MetaObject = null;
         public int? InitializationProc;
         public readonly Dictionary<string, int> Procs = new();
         public readonly Dictionary<string, int> OverridingProcs = new();

--- a/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
@@ -1,14 +1,12 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
 using OpenDreamRuntime.Objects.MetaObjects;
-using OpenDreamRuntime.Procs;
 using OpenDreamShared.Dream;
 
 namespace OpenDreamRuntime.Objects {
-    public sealed class DreamObjectDefinition
-    {
+    public sealed class DreamObjectDefinition {
         [Dependency] private readonly IDreamManager _dreamMan = default!;
-        public DreamPath Type;
+        public DreamPath Type => _treeNode.Path;
+        public DreamObjectDefinition? Parent => _treeNode.ParentEntry?.ObjectDefinition;
         public IDreamMetaObject MetaObject = null;
         public int? InitializationProc;
         public readonly Dictionary<string, int> Procs = new();
@@ -16,20 +14,15 @@ namespace OpenDreamRuntime.Objects {
         public readonly Dictionary<string, DreamValue> Variables = new();
         public readonly Dictionary<string, int> GlobalVariables = new();
 
-        private readonly DreamObjectDefinition? _parentObjectDefinition = null;
-
-        public DreamObjectDefinition(DreamPath type)
-        {
-            IoCManager.InjectDependencies(this);
-            Type = type;
-        }
+        private readonly IDreamObjectTree _objectTree;
+        private readonly IDreamObjectTree.TreeEntry _treeNode;
 
         public DreamObjectDefinition(DreamObjectDefinition copyFrom) {
             IoCManager.InjectDependencies(this);
-            Type = copyFrom.Type;
+            _objectTree = copyFrom._objectTree;
+            _treeNode = copyFrom._treeNode;
             MetaObject = copyFrom.MetaObject;
             InitializationProc = copyFrom.InitializationProc;
-            _parentObjectDefinition = copyFrom._parentObjectDefinition;
 
             Variables = new Dictionary<string, DreamValue>(copyFrom.Variables);
             GlobalVariables = new Dictionary<string, int>(copyFrom.GlobalVariables);
@@ -37,14 +30,16 @@ namespace OpenDreamRuntime.Objects {
             OverridingProcs = new Dictionary<string, int>(copyFrom.OverridingProcs);
         }
 
-        public DreamObjectDefinition(DreamPath type, DreamObjectDefinition parentObjectDefinition) {
+        public DreamObjectDefinition(IDreamObjectTree objectTree, IDreamObjectTree.TreeEntry treeNode) {
             IoCManager.InjectDependencies(this);
-            Type = type;
-            InitializationProc = parentObjectDefinition.InitializationProc;
-            _parentObjectDefinition = parentObjectDefinition;
+            _objectTree = objectTree;
+            _treeNode = treeNode;
 
-            Variables = new Dictionary<string, DreamValue>(parentObjectDefinition.Variables);
-            GlobalVariables = new Dictionary<string, int>(parentObjectDefinition.GlobalVariables);
+            if (Parent != null) {
+                InitializationProc = Parent.InitializationProc;
+                Variables = new Dictionary<string, DreamValue>(Parent.Variables);
+                GlobalVariables = new Dictionary<string, int>(Parent.GlobalVariables);
+            }
         }
 
         public void SetVariableDefinition(string variableName, DreamValue value) {
@@ -54,23 +49,12 @@ namespace OpenDreamRuntime.Objects {
         public void SetProcDefinition(string procName, int procId) {
             if (HasProc(procName))
             {
-                var proc = _dreamMan.ObjectTree.Procs[procId];
+                var proc = _objectTree.Procs[procId];
                 proc.SuperProc = GetProc(procName);
                 OverridingProcs[procName] = procId;
             } else {
                 Procs[procName] = procId;
             }
-        }
-
-        public void SetNativeProc(NativeProc.HandlerFn func)
-        {
-            var proc = _dreamMan.ObjectTree.CreateNativeProc(Type, func, out var procId);
-            SetProcDefinition(proc.Name, procId);
-        }
-
-        public void SetNativeProc(Func<AsyncNativeProc.State, Task<DreamValue>> func) {
-            var proc = _dreamMan.ObjectTree.CreateAsyncNativeProc(Type, func, out var procId);
-            SetProcDefinition(proc.Name, procId);
         }
 
         public DreamProc GetProc(string procName) {
@@ -82,17 +66,15 @@ namespace OpenDreamRuntime.Objects {
         }
 
         public bool TryGetProc(string procName, [NotNullWhen(true)] out DreamProc? proc) {
-            if (OverridingProcs.TryGetValue(procName, out var procId))
-            {
-                proc = _dreamMan.ObjectTree.Procs[procId];
+            if (OverridingProcs.TryGetValue(procName, out var procId)) {
+                proc = _objectTree.Procs[procId];
                 return true;
             } else if (Procs.TryGetValue(procName, out procId)) {
-                proc = _dreamMan.ObjectTree.Procs[procId];
+                proc = _objectTree.Procs[procId];
                 return true;
-            } else if (_parentObjectDefinition != null) {
-                return _parentObjectDefinition.TryGetProc(procName, out proc);
-            } else
-            {
+            } else if (Parent != null) {
+                return Parent.TryGetProc(procName, out proc);
+            } else {
                 proc = null;
                 return false;
             }
@@ -101,8 +83,8 @@ namespace OpenDreamRuntime.Objects {
         public bool HasProc(string procName) {
             if (Procs.ContainsKey(procName)) {
                 return true;
-            } else if (_parentObjectDefinition != null) {
-                return _parentObjectDefinition.HasProc(procName);
+            } else if (Parent != null) {
+                return Parent.HasProc(procName);
             } else {
                 return false;
             }
@@ -115,17 +97,16 @@ namespace OpenDreamRuntime.Objects {
         public bool TryGetVariable(string varName, out DreamValue value) {
             if (Variables.TryGetValue(varName, out value)) {
                 return true;
-            } else if (_parentObjectDefinition != null) {
-                return _parentObjectDefinition.TryGetVariable(varName, out value);
+            } else if (Parent != null) {
+                return Parent.TryGetVariable(varName, out value);
             } else {
                 return false;
             }
         }
 
-        public bool IsSubtypeOf(DreamPath path) {
-            if (Type.IsDescendantOf(path)) return true;
-            else if (_parentObjectDefinition != null) return _parentObjectDefinition.IsSubtypeOf(path);
-            else return false;
+        public bool IsSubtypeOf(IDreamObjectTree.TreeEntry ancestor) {
+            // Unsigned underflow is desirable here
+            return (_treeNode.TreeIndex - ancestor.TreeIndex) <= ancestor.ChildCount;
         }
     }
 }

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -6,7 +6,6 @@ using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Procs.DebugAdapter;
 using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
-using OpenDreamShared.Dream.Procs;
 using OpenDreamShared.Json;
 using TreeEntry = OpenDreamRuntime.Objects.IDreamObjectTree.TreeEntry;
 
@@ -15,6 +14,7 @@ namespace OpenDreamRuntime.Objects {
         public TreeEntry[] Types { get; private set; }
         public List<DreamProc> Procs { get; private set; }
         public List<string> Strings { get; private set; } //TODO: Store this somewhere else
+        public DreamProc? GlobalInitProc { get; private set; }
 
         public TreeEntry Root { get; private set; }
         public TreeEntry World { get; private set; }
@@ -48,7 +48,7 @@ namespace OpenDreamRuntime.Objects {
             Strings = json.Strings;
 
             if (json.GlobalInitProc is ProcDefinitionJson initProcDef) {
-                GlobalInitProc = new DMProc(DreamPath.Root, initProcDef, "<global init>", DreamManager, DreamMapManager, DreamDebugManager, DreamResourceManager);
+                GlobalInitProc = new DMProc(DreamPath.Root, initProcDef, "<global init>", DreamManager, DreamMapManager, DreamDebugManager, DreamResourceManager, this);
             } else {
                 GlobalInitProc = null;
             }
@@ -401,6 +401,7 @@ namespace OpenDreamRuntime.Objects {
         public TreeEntry[] Types { get; }
         public List<DreamProc> Procs { get; }
         public List<string> Strings { get; }
+        public DreamProc? GlobalInitProc { get; }
 
         // All the built-in types
         public TreeEntry World { get; }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectArea.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectArea.cs
@@ -7,6 +7,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public IDreamMetaObject? ParentType { get; set; }
 
         [Dependency] private readonly IDreamManager _dreamManager = default!;
+        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
         [Dependency] private readonly IDreamMapManager _dreamMapManager = default!;
 
         public DreamMetaObjectArea() {
@@ -17,7 +18,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             DreamList contents = DreamList.Create();
 
             contents.ValueAssigned += (_, _, value) => {
-                if (!value.TryGetValueAsDreamObjectOfType(DreamPath.Turf, out DreamObject turf))
+                if (!value.TryGetValueAsDreamObjectOfType(_objectTree.Turf, out DreamObject turf))
                     return;
 
                 (Vector2i pos, DreamMapManager.Level level) = _dreamMapManager.GetTurfPosition(turf);

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -9,6 +9,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public IDreamMetaObject? ParentType { get; set; }
 
         [Dependency] private readonly IDreamManager _dreamManager = default!;
+        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
         [Dependency] private readonly IAtomManager _atomManager = default!;
 
         private readonly Dictionary<DreamObject, DreamFilterList> _filterLists = new();
@@ -19,7 +20,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
         public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
             // Turfs can be new()ed multiple times, so let DreamMapManager handle it.
-            if (!dreamObject.IsSubtypeOf(DreamPath.Turf)) {
+            if (!dreamObject.IsSubtypeOf(_objectTree.Turf)) {
                 _dreamManager.WorldContentsList.AddValue(new DreamValue(dreamObject));
             }
 
@@ -47,7 +48,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     _atomManager.UpdateAppearance(dreamObject, appearance => {
                         if (value.TryGetValueAsDreamResource(out var resource)) {
                             appearance.Icon = resource.Id;
-                        } else if (value.TryGetValueAsDreamObjectOfType(DreamPath.Icon, out var iconObject)) {
+                        } else if (value.TryGetValueAsDreamObjectOfType(_objectTree.Icon, out var iconObject)) {
                             DreamIcon icon = DreamMetaObjectIcon.ObjectToDreamIcon[iconObject];
 
                             (resource, _) = icon.GenerateDMI();
@@ -118,7 +119,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 case "transform":
                 {
                     _atomManager.UpdateAppearance(dreamObject, appearance => {
-                        float[] matrixArray = value.TryGetValueAsDreamObjectOfType(DreamPath.Matrix, out var matrix)
+                        float[] matrixArray = value.TryGetValueAsDreamObjectOfType(_objectTree.Matrix, out var matrix)
                             ? DreamMetaObjectMatrix.MatrixToTransformFloatArray(matrix)
                             : DreamMetaObjectMatrix.IdentityMatrixArray;
 
@@ -187,7 +188,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             switch (varName) {
                 case "transform":
                     // Clone the matrix
-                    DreamObject matrix = _dreamManager.ObjectTree.CreateObject(DreamPath.Matrix);
+                    DreamObject matrix = _objectTree.CreateObject(DreamPath.Matrix);
                     matrix.InitSpawn(new DreamProcArguments(new() { value }));
 
                     return new DreamValue(matrix);
@@ -204,7 +205,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             if (value.TryGetValueAsString(out string valueString)) {
                 appearance.Icon = _atomManager.GetAppearance(atom)?.Icon;
                 appearance.IconState = valueString;
-            } else if (value.TryGetValueAsDreamObjectOfType(DreamPath.MutableAppearance, out var mutableAppearance)) {
+            } else if (value.TryGetValueAsDreamObjectOfType(_objectTree.MutableAppearance, out var mutableAppearance)) {
                 DreamValue icon = mutableAppearance.GetVariable("icon");
                 if (icon.TryGetValueAsDreamResource(out var iconResource)) {
                     appearance.Icon = iconResource.Id;
@@ -223,7 +224,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 mutableAppearance.GetVariable("layer").TryGetValueAsFloat(out appearance.Layer);
                 mutableAppearance.GetVariable("pixel_x").TryGetValueAsInteger(out appearance.PixelOffset.X);
                 mutableAppearance.GetVariable("pixel_y").TryGetValueAsInteger(out appearance.PixelOffset.Y);
-            } else if (value.TryGetValueAsDreamObjectOfType(DreamPath.Image, out var image)) {
+            } else if (value.TryGetValueAsDreamObjectOfType(_objectTree.Image, out var image)) {
                 DreamValue icon = image.GetVariable("icon");
                 DreamValue iconState = image.GetVariable("icon_state");
 
@@ -240,7 +241,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 image.GetVariable("layer").TryGetValueAsFloat(out appearance.Layer);
                 image.GetVariable("pixel_x").TryGetValueAsInteger(out appearance.PixelOffset.X);
                 image.GetVariable("pixel_y").TryGetValueAsInteger(out appearance.PixelOffset.Y);
-            } else if (value.TryGetValueAsDreamObjectOfType(DreamPath.Icon, out var icon)) {
+            } else if (value.TryGetValueAsDreamObjectOfType(_objectTree.Icon, out var icon)) {
                 var iconObj = DreamMetaObjectIcon.ObjectToDreamIcon[icon];
                 var (resource, dmiDescription) = iconObj.GenerateDMI();
 
@@ -248,10 +249,10 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
                 appearance.Icon = resource.Id;
                 appearance.IconState = dmiDescription.GetStateOrDefault(iconState)?.Name;
-            } else if (value.TryGetValueAsDreamObjectOfType(DreamPath.Atom, out var overlayAtom)) {
+            } else if (value.TryGetValueAsDreamObjectOfType(_objectTree.Atom, out var overlayAtom)) {
                 appearance = _atomManager.CreateAppearanceFromAtom(overlayAtom);
             } else if (value.TryGetValueAsPath(out DreamPath path)) {
-                var def = _dreamManager.ObjectTree.GetObjectDefinition(path);
+                var def = _objectTree.GetObjectDefinition(path);
                 appearance = _atomManager.CreateAppearanceFromDefinition(def);
             } else {
                 throw new Exception($"Invalid overlay {value}");

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
@@ -11,7 +11,12 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
         private readonly Dictionary<DreamList, DreamObject> _screenListToClient = new();
 
-        private readonly IDreamManager _dreamManager = IoCManager.Resolve<IDreamManager>();
+        [Dependency] private readonly IDreamManager _dreamManager = default!;
+        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
+
+        public DreamMetaObjectClient() {
+            IoCManager.InjectDependencies(this);
+        }
 
         public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
             ParentType?.OnObjectCreated(dreamObject, creationArguments);
@@ -137,7 +142,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         }
 
         public void OperatorOutput(DreamValue a, DreamValue b) {
-            if (!a.TryGetValueAsDreamObjectOfType(DreamPath.Client, out var client))
+            if (!a.TryGetValueAsDreamObjectOfType(_objectTree.Client, out var client))
                 throw new ArgumentException($"Left-hand value was not the expected type {DreamPath.Client}");
 
             DreamConnection connection = _dreamManager.GetConnectionFromClient(client);
@@ -145,7 +150,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         }
 
         private void ScreenValueAssigned(DreamList screenList, DreamValue screenKey, DreamValue screenValue) {
-            if (!screenValue.TryGetValueAsDreamObjectOfType(DreamPath.Movable, out var movable))
+            if (!screenValue.TryGetValueAsDreamObjectOfType(_objectTree.Movable, out var movable))
                 return;
 
             DreamConnection connection = _dreamManager.GetConnectionFromClient(_screenListToClient[screenList]);
@@ -153,7 +158,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         }
 
         private void ScreenBeforeValueRemoved(DreamList screenList, DreamValue screenKey, DreamValue screenValue) {
-            if (!screenValue.TryGetValueAsDreamObjectOfType(DreamPath.Movable, out var movable))
+            if (!screenValue.TryGetValueAsDreamObjectOfType(_objectTree.Movable, out var movable))
                 return;
 
             DreamConnection connection = _dreamManager.GetConnectionFromClient(_screenListToClient[screenList]);

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectDatum.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectDatum.cs
@@ -8,11 +8,16 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public bool ShouldCallNew => true;
         public IDreamMetaObject? ParentType { get; set; }
 
-        private readonly IDreamManager _dreamManager = IoCManager.Resolve<IDreamManager>();
+        [Dependency] private readonly IDreamManager _dreamManager = default!;
+        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
+
+        public DreamMetaObjectDatum() {
+            IoCManager.InjectDependencies(this);
+        }
 
         public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
-            if (!dreamObject.IsSubtypeOf(DreamPath.Atom)) // Atoms are in world.contents
-            {
+            // Atoms are in world.contents
+            if (!dreamObject.IsSubtypeOf(_objectTree.Atom)) {
                 _dreamManager.Datums.Add(dreamObject);
             }
 
@@ -22,8 +27,8 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public void OnObjectDeleted(DreamObject dreamObject) {
             ParentType?.OnObjectDeleted(dreamObject);
 
-            if (!dreamObject.IsSubtypeOf(DreamPath.Atom)) // Atoms are in world.contents
-            {
+            // Atoms are in world.contents
+            if (!dreamObject.IsSubtypeOf(_objectTree.Atom)) {
                 _dreamManager.Datums.Remove(dreamObject);
             }
 
@@ -36,7 +41,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             return varName switch
             {
                 "type" => new DreamValue(dreamObject.ObjectDefinition.Type),
-                "parent_type" => new DreamValue(_dreamManager.ObjectTree.GetTreeEntry(dreamObject.ObjectDefinition.Type)
+                "parent_type" => new DreamValue(_objectTree.GetTreeEntry(dreamObject.ObjectDefinition.Type)
                     .ParentEntry.ObjectDefinition.Type),
                 "vars" => new DreamValue(DreamListVars.Create(dreamObject)),
                 _ => ParentType?.OnVariableGet(dreamObject, varName, value) ?? value

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectIcon.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectIcon.cs
@@ -12,6 +12,7 @@ sealed class DreamMetaObjectIcon : IDreamMetaObject {
     public IDreamMetaObject? ParentType { get; set; }
 
     [Dependency] private readonly DreamResourceManager _rscMan = default!;
+    [Dependency] private readonly IDreamObjectTree _objectTree = default!;
 
     public DreamMetaObjectIcon() {
         IoCManager.InjectDependencies(this);
@@ -34,7 +35,7 @@ sealed class DreamMetaObjectIcon : IDreamMetaObject {
 
         if (icon != DreamValue.Null) {
             // TODO: Could maybe have an alternative path for /icon values so the DMI doesn't have to be generated
-            var (iconRsc, iconDescription) = GetIconResourceAndDescription(_rscMan, icon);
+            var (iconRsc, iconDescription) = GetIconResourceAndDescription(_objectTree, _rscMan, icon);
 
             dreamIcon.InsertStates(iconRsc, iconDescription, state, dir, frame, useStateName: false);
         }
@@ -61,8 +62,8 @@ sealed class DreamMetaObjectIcon : IDreamMetaObject {
     }
 
     public static (DreamResource Resource, ParsedDMIDescription Description) GetIconResourceAndDescription(
-        DreamResourceManager resourceManager, DreamValue value) {
-        if (value.TryGetValueAsDreamObjectOfType(DreamPath.Icon, out var iconObj)) {
+        IDreamObjectTree objectTree, DreamResourceManager resourceManager, DreamValue value) {
+        if (value.TryGetValueAsDreamObjectOfType(objectTree.Icon, out var iconObj)) {
             DreamIcon dreamIcon = ObjectToDreamIcon[iconObj];
 
             return dreamIcon.GenerateDMI();

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMatrix.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMatrix.cs
@@ -7,15 +7,17 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public bool ShouldCallNew => true;
         public IDreamMetaObject? ParentType { get; set; }
 
-        private readonly IDreamManager _dreamManager = IoCManager.Resolve<IDreamManager>();
+        [Dependency] private readonly IDreamManager _dreamManager = default!;
+        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
+
+        public DreamMetaObjectMatrix() {
+            IoCManager.InjectDependencies(this);
+        }
 
         /// <summary> Used to create a float array understandable by <see cref="IconAppearance.Transform"/> to be a transform. </summary>
         /// <returns>The matrix's values in an array, in [a,d,b,e,c,f] order.</returns>
-        /// <exception cref="ArgumentException">Thrown when matrix is invalid.</exception>
+        /// <remarks>This will not verify that this is a /matrix</remarks>
         public static float[] MatrixToTransformFloatArray(DreamObject matrix) {
-            if (!matrix.IsSubtypeOf(DreamPath.Matrix))
-                throw new ArgumentException($"Invalid matrix {matrix}");
-
             float[] array = new float[6];
             matrix.GetVariable("a").TryGetValueAsFloat(out array[0]);
             matrix.GetVariable("d").TryGetValueAsFloat(out array[1]);
@@ -30,11 +32,8 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         /// Used when printing this matrix to enumerate its values in order.
         /// </summary>
         /// <returns>The matrix's values in [a,b,c,d,e,f] order.</returns>
-        /// <exception cref="ArgumentException">Thrown when matrix is invalid.</exception>
+        /// <remarks>This will not verify that this is a /matrix</remarks>
         public static IEnumerable<float> EnumerateMatrix(DreamObject matrix) {
-            if (!matrix.IsSubtypeOf(DreamPath.Matrix))
-                throw new ArgumentException($"Invalid matrix {matrix}");
-
             float ret = 0f;
             matrix.GetVariable("a").TryGetValueAsFloat(out ret);
             yield return ret;
@@ -51,7 +50,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         }
 
         public DreamValue OperatorMultiply(DreamValue a, DreamValue b) {
-            if (!a.TryGetValueAsDreamObjectOfType(DreamPath.Matrix, out DreamObject left))
+            if (!a.TryGetValueAsDreamObjectOfType(_objectTree.Matrix, out DreamObject left))
                 throw new ArgumentException($"Invalid matrix {a}");
 
             left.GetVariable("a").TryGetValueAsFloat(out float lA);
@@ -62,7 +61,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             left.GetVariable("f").TryGetValueAsFloat(out float lF);
 
             if (b.TryGetValueAsFloat(out float bFloat)) {
-                DreamObject output = _dreamManager.ObjectTree.CreateObject(DreamPath.Matrix);
+                DreamObject output = _objectTree.CreateObject(DreamPath.Matrix);
                 output.SetVariable("a", new(lA * bFloat));
                 output.SetVariable("b", new(lB * bFloat));
                 output.SetVariable("c", new(lC * bFloat));
@@ -71,7 +70,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 output.SetVariable("f", new(lF * bFloat));
 
                 return new(output);
-            } else if (b.TryGetValueAsDreamObjectOfType(DreamPath.Matrix, out DreamObject right)) {
+            } else if (b.TryGetValueAsDreamObjectOfType(_objectTree.Matrix, out DreamObject right)) {
                 right.GetVariable("a").TryGetValueAsFloat(out float rA);
                 right.GetVariable("b").TryGetValueAsFloat(out float rB);
                 right.GetVariable("c").TryGetValueAsFloat(out float rC);
@@ -79,7 +78,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 right.GetVariable("e").TryGetValueAsFloat(out float rE);
                 right.GetVariable("f").TryGetValueAsFloat(out float rF);
 
-                DreamObject output = _dreamManager.ObjectTree.CreateObject(DreamPath.Matrix);
+                DreamObject output = _objectTree.CreateObject(DreamPath.Matrix);
                 output.SetVariable("a", new(rA * lA + rD * lB));
                 output.SetVariable("b", new(rB * lA + rE * lB));
                 output.SetVariable("c", new(rC * lA + rF * lB + lC));
@@ -97,7 +96,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         }
 
         public DreamValue OperatorEquivalent(DreamValue a, DreamValue b) {
-            if (a.TryGetValueAsDreamObjectOfType(DreamPath.Matrix, out DreamObject? left) && b.TryGetValueAsDreamObjectOfType(DreamPath.Matrix, out DreamObject? right)) {
+            if (a.TryGetValueAsDreamObjectOfType(_objectTree.Matrix, out DreamObject? left) && b.TryGetValueAsDreamObjectOfType(_objectTree.Matrix, out DreamObject? right)) {
                 const string elements = "abcdef";
                 for (int i = 0; i < elements.Length; i++) {
                     left.GetVariable(elements[i].ToString()).TryGetValueAsFloat(out var leftValue); // sets leftValue to 0 if this isn't a float

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMob.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMob.cs
@@ -8,6 +8,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public IDreamMetaObject? ParentType { get; set; }
 
         [Dependency] private readonly IDreamManager _dreamManager = default!;
+        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
 
         public DreamMetaObjectMob() {
@@ -49,7 +50,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
         public DreamValue OnVariableGet(DreamObject dreamObject, string varName, DreamValue value) {
             if (varName == "key" || varName == "ckey") {
-                if (dreamObject.GetVariable("client").TryGetValueAsDreamObjectOfType(DreamPath.Client, out var client)) {
+                if (dreamObject.GetVariable("client").TryGetValueAsDreamObjectOfType(_objectTree.Client, out var client)) {
                     return client.GetVariable(varName);
                 } else {
                     return DreamValue.Null;
@@ -62,9 +63,9 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         }
 
         public void OperatorOutput(DreamValue a, DreamValue b) {
-            if (!a.TryGetValueAsDreamObjectOfType(DreamPath.Mob, out var mob))
+            if (!a.TryGetValueAsDreamObjectOfType(_objectTree.Mob, out var mob))
                 throw new ArgumentException($"Left-hand value was not the expected type {DreamPath.Mob}");
-            if (!mob.GetVariable("client").TryGetValueAsDreamObjectOfType(DreamPath.Client, out var client))
+            if (!mob.GetVariable("client").TryGetValueAsDreamObjectOfType(_objectTree.Client, out var client))
                 throw new Exception($"Failed to get client from {mob}");
 
             DreamConnection connection = _dreamManager.GetConnectionFromClient(client);

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMovable.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMovable.cs
@@ -10,6 +10,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public IDreamMetaObject? ParentType { get; set; }
 
         [Dependency] private readonly IMapManager _mapManager = default!;
+        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
         [Dependency] private readonly IDreamMapManager _dreamMapManager = default!;
         [Dependency] private readonly IAtomManager _atomManager = default!;
         [Dependency] private readonly IEntityManager _entityManager = default!;
@@ -22,7 +23,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             ParentType?.OnObjectCreated(dreamObject, creationArguments);
 
             DreamValue locArgument = creationArguments.GetArgument(0, "loc");
-            if (locArgument.TryGetValueAsDreamObjectOfType(DreamPath.Atom, out _)) {
+            if (locArgument.TryGetValueAsDreamObjectOfType(_objectTree.Atom, out _)) {
                 dreamObject.SetVariable("loc", locArgument); //loc is set before /New() is ever called
             }
 
@@ -54,11 +55,11 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     if (!_entityManager.TryGetComponent<TransformComponent>(entity, out var transform))
                         return;
 
-                    if (value.TryGetValueAsDreamObjectOfType(DreamPath.Turf, out var turfLoc)) {
+                    if (value.TryGetValueAsDreamObjectOfType(_objectTree.Turf, out var turfLoc)) {
                         (Vector2i pos, DreamMapManager.Level level) = _dreamMapManager.GetTurfPosition(turfLoc);
                         transform.AttachParent(level.Grid.Owner);
                         transform.WorldPosition = pos;
-                    } else if (value.TryGetValueAsDreamObjectOfType(DreamPath.Movable, out var movableLoc)) {
+                    } else if (value.TryGetValueAsDreamObjectOfType(_objectTree.Movable, out var movableLoc)) {
                         EntityUid locEntity = _atomManager.GetMovableEntity(movableLoc);
                         transform.AttachParent(locEntity);
                         transform.LocalPosition = Vector2.Zero;

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectRegex.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectRegex.cs
@@ -9,6 +9,12 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public bool ShouldCallNew => false;
         public IDreamMetaObject? ParentType { get; set; }
 
+        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
+
+        public DreamMetaObjectRegex() {
+            IoCManager.InjectDependencies(this);
+        }
+
         public struct DreamRegex {
             public Regex Regex;
             public bool IsGlobal;
@@ -19,7 +25,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             DreamValue flags = creationArguments.GetArgument(1, "flags");
             DreamRegex regex;
 
-            if (pattern.TryGetValueAsDreamObjectOfType(DreamPath.Regex, out DreamObject copyFrom)) {
+            if (pattern.TryGetValueAsDreamObjectOfType(_objectTree.Regex, out DreamObject copyFrom)) {
                 regex = ObjectToDreamRegex[copyFrom];
             } else if (pattern.TryGetValueAsString(out string patternString)) {
                 regex = new DreamRegex();

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -11,10 +11,7 @@ using OpenDreamShared.Json;
 
 namespace OpenDreamRuntime.Procs {
     sealed class DMProc : DreamProc {
-        public readonly IDreamObjectTree ObjectTree;
         public byte[] Bytecode { get; }
-
-        private readonly int _maxStackSize;
 
         public string? Source { get; }
         public int Line { get; }
@@ -25,6 +22,8 @@ namespace OpenDreamRuntime.Procs {
         public readonly IDreamDebugManager DreamDebugManager;
         public readonly DreamResourceManager DreamResourceManager;
         public readonly IDreamObjectTree ObjectTree;
+
+        private readonly int _maxStackSize;
 
         public DMProc(DreamPath owningType, ProcDefinitionJson json, string? name, IDreamManager dreamManager, IDreamMapManager dreamMapManager, IDreamDebugManager dreamDebugManager, DreamResourceManager dreamResourceManager, IDreamObjectTree objectTree)
             : base(owningType, name ?? json.Name, null, json.Attributes, GetArgumentNames(json), GetArgumentTypes(json), json.VerbName, json.VerbCategory, json.VerbDesc, json.Invisibility)

--- a/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
@@ -10,6 +10,7 @@ namespace OpenDreamRuntime.Procs.DebugAdapter;
 
 sealed class DreamDebugManager : IDreamDebugManager {
     [Dependency] private readonly IDreamManager _dreamManager = default!;
+    [Dependency] private readonly IDreamObjectTree _objectTree = default!;
     [Dependency] private readonly DreamResourceManager _resourceManager = default!;
     [Dependency] private readonly IProcScheduler _procScheduler = default!;
     [Dependency] private readonly IBaseServer _server = default!;
@@ -323,12 +324,12 @@ sealed class DreamDebugManager : IDreamDebugManager {
     }
 
     private IEnumerable<(string Source, int Line)> IteratePossibleBreakpoints() {
-        foreach (var proc in _dreamManager.ObjectTree.Procs.Concat(new[] { _dreamManager.ObjectTree.GlobalInitProc }).OfType<DMProc>()) {
+        foreach (var proc in _objectTree.Procs.Concat(new[] { _objectTree.GlobalInitProc }).OfType<DMProc>()) {
             string? source = proc.Source;
             if (source != null) {
                 yield return (source, proc.Line);
             }
-            foreach (var (_, instruction) in new ProcDecoder(_dreamManager.ObjectTree.Strings, proc.Bytecode).Disassemble()) {
+            foreach (var (_, instruction) in new ProcDecoder(_objectTree.Strings, proc.Bytecode).Disassemble()) {
                 switch (instruction) {
                     case (DreamProcOpcode.DebugSource, string newSource):
                         source = newSource;
@@ -342,7 +343,7 @@ sealed class DreamDebugManager : IDreamDebugManager {
     }
 
     private IEnumerable<(string Type, string Proc)> IterateProcs() {
-        foreach (var proc in _dreamManager.ObjectTree.Procs) {
+        foreach (var proc in _objectTree.Procs) {
             yield return (proc.OwningType.PathString, proc.Name);
         }
     }

--- a/OpenDreamRuntime/Procs/DreamEnumerators.cs
+++ b/OpenDreamRuntime/Procs/DreamEnumerators.cs
@@ -1,106 +1,133 @@
 ﻿using OpenDreamRuntime.Objects;
-using OpenDreamShared.Dream;
 
 namespace OpenDreamRuntime.Procs {
-    sealed class DreamProcRangeEnumerator : IEnumerator<DreamValue> {
+    internal interface IDreamValueEnumerator {
+        public DreamValue Current { get; }
+
+        public bool MoveNext();
+    }
+
+    /// <summary>
+    /// Enumerates a range of numbers with a given step
+    /// <code>for (var/i in 1 to 10 step 2)</code>
+    /// </summary>
+    sealed class DreamValueRangeEnumerator : IDreamValueEnumerator {
+        public DreamValue Current => new DreamValue(_current);
+
         private float _current;
-        private readonly float _start;
         private readonly float _end;
         private readonly float _step;
 
-        public DreamProcRangeEnumerator(float rangeStart, float rangeEnd, float step) {
+        public DreamValueRangeEnumerator(float rangeStart, float rangeEnd, float step) {
             _current = rangeStart - step;
-            _start = rangeStart;
             _end = rangeEnd;
             _step = step;
         }
-
-        DreamValue IEnumerator<DreamValue>.Current => new DreamValue(_current);
-
-        public object Current => new DreamValue(_current);
 
         public bool MoveNext() {
             _current += _step;
 
             return (_step > 0) ? _current <= _end : _current >= _end;
         }
-
-        public void Reset() {
-            _current = _start - _step;
-        }
-
-        public void Dispose() {
-
-        }
     }
 
-    sealed class DreamObjectEnumerator : IEnumerator<DreamValue> {
-        private readonly IEnumerator<DreamObject> _dreamObjectEnumerator;
-        private readonly DreamPath? _filterType;
+    /// <summary>
+    /// Enumerates over an IEnumerable of DreamObjects, possibly filtering for a certain type
+    /// </summary>
+    sealed class DreamObjectEnumerator : IDreamValueEnumerator {
+        public DreamValue Current => new DreamValue(_dreamObjectEnumerator.Current);
 
-        public DreamObjectEnumerator(IEnumerable<DreamObject> dreamObjects, DreamPath? filterType = null) {
+        private readonly IEnumerator<DreamObject> _dreamObjectEnumerator;
+        private readonly IDreamObjectTree.TreeEntry? _filterType;
+
+        public DreamObjectEnumerator(IEnumerable<DreamObject> dreamObjects, IDreamObjectTree.TreeEntry? filterType = null) {
             _dreamObjectEnumerator = dreamObjects.GetEnumerator();
             _filterType = filterType;
         }
 
-        DreamValue IEnumerator<DreamValue>.Current => new DreamValue(_dreamObjectEnumerator.Current);
-
-        public object Current => new DreamValue(_dreamObjectEnumerator.Current);
-
         public bool MoveNext() {
             bool hasNext = _dreamObjectEnumerator.MoveNext();
             if (_filterType != null) {
-                while (hasNext && !_dreamObjectEnumerator.Current.IsSubtypeOf(_filterType.Value)) {
+                while (hasNext && !_dreamObjectEnumerator.Current.IsSubtypeOf(_filterType)) {
                     hasNext = _dreamObjectEnumerator.MoveNext();
                 }
             }
 
             return hasNext;
         }
+    }
 
-        public void Reset() {
-            _dreamObjectEnumerator.Reset();
+    /// <summary>
+    /// Enumerates over an array of DreamValues
+    /// <code>for (var/i in list(1, 2, 3))</code>
+    /// </summary>
+    sealed class DreamValueArrayEnumerator : IDreamValueEnumerator {
+        private readonly DreamValue[]? _dreamValueArray;
+        private int _current = -1;
+
+        public DreamValueArrayEnumerator(DreamValue[]? dreamValueArray) {
+            _dreamValueArray = dreamValueArray;
         }
 
-        public void Dispose() {
-            _dreamObjectEnumerator.Dispose();
+        public DreamValue Current {
+            get {
+                if (_dreamValueArray == null)
+                    return DreamValue.Null;
+                if (_current < _dreamValueArray.Length)
+                    return _dreamValueArray[_current];
+                return DreamValue.Null;
+            }
+        }
+
+        public bool MoveNext() {
+            if (_dreamValueArray == null)
+                return false;
+
+            _current++;
+            if (_current >= _dreamValueArray.Length)
+                return false;
+
+            return true;
         }
     }
 
-    sealed class DreamValueAsObjectEnumerator : IEnumerator<DreamValue> {
-        private readonly IEnumerator<DreamValue> _dreamValueEnumerator;
-        private readonly DreamPath? _filterType;
+    /// <summary>
+    /// Enumerates over an array of DreamValues, filtering for a certain type
+    /// <code>for (var/obj/item/I in contents)</code>
+    /// </summary>
+    sealed class FilteredDreamValueArrayEnumerator : IDreamValueEnumerator {
+        private readonly DreamValue[]? _dreamValueArray;
+        private readonly IDreamObjectTree.TreeEntry _filterType;
+        private int _current = -1;
 
-        public DreamValueAsObjectEnumerator(IEnumerable<DreamValue> dreamValues, DreamPath? filterType = null) {
-            _dreamValueEnumerator = dreamValues.GetEnumerator();
+        public FilteredDreamValueArrayEnumerator(DreamValue[]? dreamValueArray, IDreamObjectTree.TreeEntry filterType) {
+            _dreamValueArray = dreamValueArray;
             _filterType = filterType;
         }
 
-        DreamValue IEnumerator<DreamValue>.Current => _dreamValueEnumerator.Current;
-
-        public object Current => _dreamValueEnumerator.Current;
+        public DreamValue Current {
+            get {
+                if (_dreamValueArray == null)
+                    return DreamValue.Null;
+                if (_current < _dreamValueArray.Length)
+                    return _dreamValueArray[_current];
+                return DreamValue.Null;
+            }
+        }
 
         public bool MoveNext() {
-            bool hasNext = _dreamValueEnumerator.MoveNext();
-            if (_filterType != null) {
-                while (hasNext && !_dreamValueEnumerator.Current.TryGetValueAsDreamObjectOfType(_filterType.Value, out _)) {
-                    hasNext = _dreamValueEnumerator.MoveNext();
-                }
-            } else {
-                while (hasNext && (_dreamValueEnumerator.Current.Type != DreamValue.DreamValueType.DreamObject || _dreamValueEnumerator.Current == DreamValue.Null)) {
-                    hasNext = _dreamValueEnumerator.MoveNext();
-                }
-            }
+            if (_dreamValueArray == null)
+                return false;
 
-            return hasNext;
-        }
+            do {
+                _current++;
+                if (_current >= _dreamValueArray.Length)
+                    return false;
 
-        public void Reset() {
-            _dreamValueEnumerator.Reset();
-        }
-
-        public void Dispose() {
-            _dreamValueEnumerator.Dispose();
+                DreamValue value = _dreamValueArray[_current];
+                if (value.TryGetValueAsDreamObjectOfType(_filterType, out _))
+                    return true;
+            } while (true);
         }
     }
 }

--- a/OpenDreamRuntime/Procs/InitDreamObject.cs
+++ b/OpenDreamRuntime/Procs/InitDreamObject.cs
@@ -5,6 +5,8 @@ namespace OpenDreamRuntime.Procs {
     sealed class InitDreamObjectState : ProcState
     {
         [Dependency] private readonly IDreamManager _dreamMan = default!;
+        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
+
         enum Stage {
             // Need to call the object's (init) proc
             Init,
@@ -50,7 +52,7 @@ namespace OpenDreamRuntime.Procs {
                         goto switch_start;
                     }
 
-                    var proc = _dreamMan.ObjectTree.Procs[src.ObjectDefinition.InitializationProc.Value];
+                    var proc = _objectTree.Procs[src.ObjectDefinition.InitializationProc.Value];
                     var initProcState = proc.CreateState(Thread, src, _usr, new(null));
                     Thread.PushProcState(initProcState);
                     return ProcStatus.Called;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -3,8 +3,9 @@ using OpenDreamShared.Dream;
 
 namespace OpenDreamRuntime.Procs.Native {
     static class DreamProcNative {
-        public static void SetupNativeProcs(DreamObjectTree objectTree) {
+        public static void SetupNativeProcs(IDreamObjectTree objectTree) {
             DreamProcNativeRoot.DreamManager = IoCManager.Resolve<IDreamManager>();
+            DreamProcNativeRoot.ObjectTree = objectTree;
 
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_abs);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_alert);
@@ -112,32 +113,32 @@ namespace OpenDreamRuntime.Procs.Native {
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_winset);
 
             DreamObjectDefinition list = objectTree.GetObjectDefinition(DreamPath.List);
-            list.SetNativeProc(DreamProcNativeList.NativeProc_Add);
-            list.SetNativeProc(DreamProcNativeList.NativeProc_Copy);
-            list.SetNativeProc(DreamProcNativeList.NativeProc_Cut);
-            list.SetNativeProc(DreamProcNativeList.NativeProc_Find);
-            list.SetNativeProc(DreamProcNativeList.NativeProc_Insert);
-            list.SetNativeProc(DreamProcNativeList.NativeProc_Remove);
-            list.SetNativeProc(DreamProcNativeList.NativeProc_Swap);
+            objectTree.SetNativeProc(list, DreamProcNativeList.NativeProc_Add);
+            objectTree.SetNativeProc(list, DreamProcNativeList.NativeProc_Copy);
+            objectTree.SetNativeProc(list, DreamProcNativeList.NativeProc_Cut);
+            objectTree.SetNativeProc(list, DreamProcNativeList.NativeProc_Find);
+            objectTree.SetNativeProc(list, DreamProcNativeList.NativeProc_Insert);
+            objectTree.SetNativeProc(list, DreamProcNativeList.NativeProc_Remove);
+            objectTree.SetNativeProc(list, DreamProcNativeList.NativeProc_Swap);
 
             DreamObjectDefinition regex = objectTree.GetObjectDefinition(DreamPath.Regex);
-            regex.SetNativeProc(DreamProcNativeRegex.NativeProc_Find);
-            regex.SetNativeProc(DreamProcNativeRegex.NativeProc_Replace);
+            objectTree.SetNativeProc(regex, DreamProcNativeRegex.NativeProc_Find);
+            objectTree.SetNativeProc(regex, DreamProcNativeRegex.NativeProc_Replace);
 
             DreamObjectDefinition icon = objectTree.GetObjectDefinition(DreamPath.Icon);
-            icon.SetNativeProc(DreamProcNativeIcon.NativeProc_Width);
-            icon.SetNativeProc(DreamProcNativeIcon.NativeProc_Height);
-            icon.SetNativeProc(DreamProcNativeIcon.NativeProc_Insert);
-            icon.SetNativeProc(DreamProcNativeIcon.NativeProc_Blend);
-            icon.SetNativeProc(DreamProcNativeIcon.NativeProc_Scale);
+            objectTree.SetNativeProc(icon, DreamProcNativeIcon.NativeProc_Width);
+            objectTree.SetNativeProc(icon, DreamProcNativeIcon.NativeProc_Height);
+            objectTree.SetNativeProc(icon, DreamProcNativeIcon.NativeProc_Insert);
+            objectTree.SetNativeProc(icon, DreamProcNativeIcon.NativeProc_Blend);
+            objectTree.SetNativeProc(icon, DreamProcNativeIcon.NativeProc_Scale);
 
             //DreamObjectDefinition savefile = objectTree.GetObjectDefinitionFromPath(DreamPath.Savefile);
             //savefile.SetNativeProc(DreamProcNativeSavefile.NativeProc_Flush);
 
             DreamObjectDefinition world = objectTree.GetObjectDefinition(DreamPath.World);
-            world.SetNativeProc(DreamProcNativeWorld.NativeProc_Export);
-            world.SetNativeProc(DreamProcNativeWorld.NativeProc_GetConfig);
-            world.SetNativeProc(DreamProcNativeWorld.NativeProc_SetConfig);
+            objectTree.SetNativeProc(world, DreamProcNativeWorld.NativeProc_Export);
+            objectTree.SetNativeProc(world, DreamProcNativeWorld.NativeProc_GetConfig);
+            objectTree.SetNativeProc(world, DreamProcNativeWorld.NativeProc_SetConfig);
         }
     }
 }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
@@ -37,8 +37,9 @@ namespace OpenDreamRuntime.Procs.Native {
 
             // TODO: moving & delay
 
+            var objectTree = IoCManager.Resolve<IDreamObjectTree>();
             var resourceManager = IoCManager.Resolve<DreamResourceManager>();
-            var (iconRsc, iconDescription) = DreamMetaObjectIcon.GetIconResourceAndDescription(resourceManager, newIcon);
+            var (iconRsc, iconDescription) = DreamMetaObjectIcon.GetIconResourceAndDescription(objectTree, resourceManager, newIcon);
 
             DreamIcon iconObj = DreamMetaObjectIcon.ObjectToDreamIcon[instance];
             iconObj.InsertStates(iconRsc, iconDescription, iconState, dir, frame); // TODO: moving & delay

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
@@ -77,8 +77,8 @@ namespace OpenDreamRuntime.Procs.Native {
             }
 
             if (replace.TryGetValueAsPath(out var procPath) && procPath.LastElement is not null) {
-                var dreamMan = IoCManager.Resolve<IDreamManager>();
-                if (dreamMan.ObjectTree.TryGetGlobalProc(procPath.LastElement, out DreamProc? proc)) {
+                var objectTree = IoCManager.Resolve<IDreamObjectTree>();
+                if (objectTree.TryGetGlobalProc(procPath.LastElement, out DreamProc? proc)) {
                     return await DoProcReplace(state, proc);
                 }
             }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -23,6 +23,7 @@ namespace OpenDreamRuntime.Procs.Native {
     static class DreamProcNativeRoot {
         // I don't want to edit 100 procs to have the DreamManager passed to them
         public static IDreamManager DreamManager;
+        public static IDreamObjectTree ObjectTree;
 
         [DreamProc("abs")]
         [DreamProcParameter("A", Type = DreamValueType.Float)]
@@ -43,7 +44,7 @@ namespace OpenDreamRuntime.Procs.Native {
             string message, title, button1, button2, button3;
 
             DreamValue usrArgument = state.Arguments.GetArgument(0, "Usr");
-            if (usrArgument.TryGetValueAsDreamObjectOfType(DreamPath.Mob, out var mob)) {
+            if (usrArgument.TryGetValueAsDreamObjectOfType(ObjectTree.Mob, out var mob)) {
                 message = state.Arguments.GetArgument(1, "Message").Stringify();
                 title = state.Arguments.GetArgument(2, "Title").Stringify();
                 button1 = state.Arguments.GetArgument(3, "Button1").Stringify();
@@ -72,7 +73,7 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("flags", Type = DreamValueType.Float)]
         public static DreamValue NativeProc_animate(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
             // TODO: Leaving out the Object var adds a new step to the previous animation
-            if (!arguments.GetArgument(0, "Object").TryGetValueAsDreamObjectOfType(DreamPath.Atom, out var obj))
+            if (!arguments.GetArgument(0, "Object").TryGetValueAsDreamObjectOfType(ObjectTree.Atom, out var obj))
                 return DreamValue.Null;
             // TODO: Is this the correct behavior for invalid time?
             if (!arguments.GetArgument(0, "time").TryGetValueAsFloat(out float time))
@@ -321,7 +322,7 @@ namespace OpenDreamRuntime.Procs.Native {
             string? src;
             if (arg1.TryGetValueAsDreamResource(out DreamResource arg1Rsc)) {
                 src = arg1Rsc.ResourcePath;
-            } else if (arg1.TryGetValueAsDreamObjectOfType(DreamPath.Savefile, out var savefile)) {
+            } else if (arg1.TryGetValueAsDreamObjectOfType(ObjectTree.Savefile, out var savefile)) {
                 src = DreamMetaObjectSavefile.ObjectToSavefile[savefile].Resource.ResourcePath;
             } else if (!arg1.TryGetValueAsString(out src)) {
                 throw new Exception($"Bad src file {arg1}");
@@ -467,7 +468,7 @@ namespace OpenDreamRuntime.Procs.Native {
             if (filter == null)
                 throw new Exception($"Failed to create filter of type {filterType}");
 
-            DreamObject filterObject = DreamManager.ObjectTree.CreateObject(DreamPath.Filter);
+            DreamObject filterObject = ObjectTree.CreateObject(DreamPath.Filter);
             DreamMetaObjectFilter.DreamObjectToFilter[filterObject] = filter;
             return new DreamValue(filterObject);
         }
@@ -735,7 +736,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 var dmiDescription = DMIParser.ParseDMI(new MemoryStream(resource.ResourceData));
 
                 return new DreamValue(DreamList.Create(dmiDescription.States.Keys.ToArray()));
-            } else if (arg.TryGetValueAsDreamObjectOfType(DreamPath.Icon, out var icon)) {
+            } else if (arg.TryGetValueAsDreamObjectOfType(ObjectTree.Icon, out var icon)) {
                 return new DreamValue(DreamList.Create(DreamMetaObjectIcon.ObjectToDreamIcon[icon].States.Keys.ToArray()));
             } else {
                 throw new Exception($"Bad icon {arg}");
@@ -749,7 +750,7 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("layer", Type = DreamValueType.Float)]
         [DreamProcParameter("dir", Type = DreamValueType.Float)]
         public static DreamValue NativeProc_image(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
-            DreamObject imageObject = DreamManager.ObjectTree.CreateObject(DreamPath.Image);
+            DreamObject imageObject = ObjectTree.CreateObject(DreamPath.Image);
             imageObject.InitSpawn(arguments);
             return new DreamValue(imageObject);
         }
@@ -760,7 +761,7 @@ namespace OpenDreamRuntime.Procs.Native {
             List<DreamValue> locs = arguments.GetAllArguments();
 
             foreach (DreamValue loc in locs) {
-                if (!loc.TryGetValueAsDreamObjectOfType(DreamPath.Area, out _)) return new DreamValue(0);
+                if (!loc.TryGetValueAsDreamObjectOfType(ObjectTree.Area, out _)) return new DreamValue(0);
             }
 
             return new DreamValue(1);
@@ -778,7 +779,7 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("Icon")]
         public static DreamValue NativeProc_isicon(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
             DreamValue icon = arguments.GetArgument(0, "Icon");
-            if (icon.TryGetValueAsDreamObjectOfType(DreamPath.Icon, out _))
+            if (icon.TryGetValueAsDreamObjectOfType(ObjectTree.Icon, out _))
                 return new DreamValue(1);
             else if (icon.TryGetValueAsDreamResource(out DreamResource resource)) {
                 switch (Path.GetExtension(resource.ResourcePath)) {
@@ -819,7 +820,7 @@ namespace OpenDreamRuntime.Procs.Native {
 
             foreach (DreamValue loc in locs) {
                 if (loc.TryGetValueAsDreamObject(out DreamObject? locObject) && locObject is not null) {
-                    bool isLoc = locObject.IsSubtypeOf(DreamPath.Mob) || locObject.IsSubtypeOf(DreamPath.Obj) || locObject.IsSubtypeOf(DreamPath.Turf) || locObject.IsSubtypeOf(DreamPath.Area);
+                    bool isLoc = locObject.IsSubtypeOf(ObjectTree.Mob) || locObject.IsSubtypeOf(ObjectTree.Obj) || locObject.IsSubtypeOf(ObjectTree.Turf) || locObject.IsSubtypeOf(ObjectTree.Area);
 
                     if (!isLoc) {
                         return new DreamValue(0);
@@ -838,7 +839,7 @@ namespace OpenDreamRuntime.Procs.Native {
             List<DreamValue> locs = arguments.GetAllArguments();
 
             foreach (DreamValue loc in locs) {
-                if (!loc.TryGetValueAsDreamObjectOfType(DreamPath.Mob, out _))
+                if (!loc.TryGetValueAsDreamObjectOfType(ObjectTree.Mob, out _))
                     return new DreamValue(0);
             }
 
@@ -851,7 +852,7 @@ namespace OpenDreamRuntime.Procs.Native {
             List<DreamValue> locs = arguments.GetAllArguments();
 
             foreach (DreamValue loc in locs) {
-                if (!loc.TryGetValueAsDreamObjectOfType(DreamPath.Movable, out _)) {
+                if (!loc.TryGetValueAsDreamObjectOfType(ObjectTree.Movable, out _)) {
                     return new DreamValue(0);
                 }
             }
@@ -893,9 +894,9 @@ namespace OpenDreamRuntime.Procs.Native {
 
             if (value.TryGetValueAsPath(out DreamPath valuePath)) {
                 if (type.TryGetValueAsPath(out DreamPath typePath)) {
-                    DreamObjectDefinition valueDefinition = DreamManager.ObjectTree.GetObjectDefinition(valuePath);
+                    DreamObjectDefinition valueDefinition = ObjectTree.GetObjectDefinition(valuePath);
 
-                    return new DreamValue(valueDefinition.IsSubtypeOf(typePath) ? 1 : 0);
+                    return new DreamValue(valueDefinition.IsSubtypeOf(ObjectTree.GetTreeEntry(typePath)) ? 1 : 0);
                 } else {
                     return new DreamValue(1);
                 }
@@ -918,7 +919,7 @@ namespace OpenDreamRuntime.Procs.Native {
             List<DreamValue> locs = arguments.GetAllArguments();
 
             foreach (DreamValue loc in locs) {
-                if (!loc.TryGetValueAsDreamObjectOfType(DreamPath.Turf, out _)) {
+                if (!loc.TryGetValueAsDreamObjectOfType(ObjectTree.Turf, out _)) {
                     return new DreamValue(0);
                 }
             }
@@ -1018,7 +1019,7 @@ namespace OpenDreamRuntime.Procs.Native {
             }
             if (value.Type == DreamValueType.DreamObject) {
                 if (value.Value == null) return null;
-                if(value.TryGetValueAsDreamObjectOfType(DreamPath.Matrix,out var matrix)) { // Special behaviour for /matrix values
+                if(value.TryGetValueAsDreamObjectOfType(ObjectTree.Matrix, out var matrix)) { // Special behaviour for /matrix values
                     StringBuilder builder = new(13); // 13 is the minimum character count this could have: "[1,2,3,4,5,6]"
                     builder.Append('[');
                     builder.AppendJoin(',',DreamMetaObjectMatrix.EnumerateMatrix(matrix));
@@ -1479,7 +1480,7 @@ namespace OpenDreamRuntime.Procs.Native {
                         return new DreamValue(text.Replace("$", "$$"));
                 };
             }
-            var newRegex = DreamManager.ObjectTree.CreateObject(DreamPath.Regex);
+            var newRegex = ObjectTree.CreateObject(DreamPath.Regex);
             newRegex.InitSpawn(arguments);
             return new DreamValue(newRegex);
         }
@@ -1497,7 +1498,7 @@ namespace OpenDreamRuntime.Procs.Native {
             int start = state.Arguments.GetArgument(3, "Start").GetValueAsInteger(); //1-indexed
             int end = state.Arguments.GetArgument(4, "End").GetValueAsInteger(); //1-indexed
 
-            if (needle.TryGetValueAsDreamObjectOfType(DreamPath.Regex, out var regexObject)) {
+            if (needle.TryGetValueAsDreamObjectOfType(ObjectTree.Regex, out var regexObject)) {
                 // According to the docs, this is the same as /regex.Replace()
                 return await DreamProcNativeRegex.RegexReplace(state, regexObject, haystack, replacementArg, start, end);
             }
@@ -1853,7 +1854,7 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("channel", Type = DreamValueType.Float)]
         [DreamProcParameter("volume", Type = DreamValueType.Float)]
         public static DreamValue NativeProc_sound(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
-            DreamObject soundObject = DreamManager.ObjectTree.CreateObject(DreamPath.Sound);
+            DreamObject soundObject = ObjectTree.CreateObject(DreamPath.Sound);
             soundObject.InitSpawn(arguments);
             return new DreamValue(soundObject);
         }
@@ -2015,7 +2016,7 @@ namespace OpenDreamRuntime.Procs.Native {
             }
             DreamPath path = new DreamPath(text);
 
-            if (DreamManager.ObjectTree.HasTreeEntry(path)) {
+            if (ObjectTree.HasTreeEntry(path)) {
                 return new DreamValue(path);
             } else {
                 return DreamValue.Null;
@@ -2091,12 +2092,12 @@ namespace OpenDreamRuntime.Procs.Native {
                             var stringToPath = new DreamPath(typeString);
                             if (stringToPath.LastElement == "proc") {
                                 DreamPath objectPath = stringToPath.AddToPath("..");
-                                if (!DreamManager.ObjectTree.HasTreeEntry(objectPath))
+                                if (!ObjectTree.HasTreeEntry(objectPath))
                                 {
                                     continue;
                                 }
                             }
-                            else if (!DreamManager.ObjectTree.HasTreeEntry(stringToPath)) {
+                            else if (!ObjectTree.HasTreeEntry(stringToPath)) {
                                 continue;
                             }
                             typePath = stringToPath;
@@ -2110,13 +2111,13 @@ namespace OpenDreamRuntime.Procs.Native {
 
                 if (typePath.LastElement == "proc") {
                     DreamPath objectTypePath = typePath.AddToPath("..");
-                    DreamObjectDefinition objectDefinition = DreamManager.ObjectTree.GetObjectDefinition(objectTypePath);
+                    DreamObjectDefinition objectDefinition = ObjectTree.GetObjectDefinition(objectTypePath);
 
                     foreach (KeyValuePair<string, int> proc in objectDefinition.Procs) {
                         list.AddValue(new DreamValue(proc.Key));
                     }
                 } else {
-                    var descendants = DreamManager.ObjectTree.GetAllDescendants(typePath);
+                    var descendants = ObjectTree.GetAllDescendants(typePath);
 
                     foreach (var descendant in descendants) {
                         list.AddValue(new DreamValue(descendant.ObjectDefinition.Type));
@@ -2287,9 +2288,9 @@ namespace OpenDreamRuntime.Procs.Native {
             }
 
             DreamConnection connection;
-            if (player.TryGetValueAsDreamObjectOfType(DreamPath.Mob, out DreamObject mob)) {
+            if (player.TryGetValueAsDreamObjectOfType(ObjectTree.Mob, out DreamObject mob)) {
                 connection = DreamManager.GetConnectionFromMob(mob);
-            } else if (player.TryGetValueAsDreamObjectOfType(DreamPath.Client, out DreamObject client)) {
+            } else if (player.TryGetValueAsDreamObjectOfType(ObjectTree.Client, out DreamObject client)) {
                 connection = DreamManager.GetConnectionFromClient(client);
             } else {
                 throw new Exception($"Invalid client {player}");
@@ -2309,9 +2310,9 @@ namespace OpenDreamRuntime.Procs.Native {
             string winsetParams = arguments.GetArgument(2, "params").GetValueAsString();
             DreamConnection connection;
 
-            if (player.TryGetValueAsDreamObjectOfType(DreamPath.Mob, out var mob)) {
+            if (player.TryGetValueAsDreamObjectOfType(ObjectTree.Mob, out var mob)) {
                 connection = DreamManager.GetConnectionFromMob(mob);
-            } else if (player.TryGetValueAsDreamObjectOfType(DreamPath.Client, out var client)) {
+            } else if (player.TryGetValueAsDreamObjectOfType(ObjectTree.Client, out var client)) {
                 connection = DreamManager.GetConnectionFromClient(client);
             } else {
                 throw new ArgumentException($"Invalid \"player\" argument {player}");

--- a/OpenDreamRuntime/ServerContentIoC.cs
+++ b/OpenDreamRuntime/ServerContentIoC.cs
@@ -1,4 +1,5 @@
-﻿using OpenDreamRuntime.Procs;
+﻿using OpenDreamRuntime.Objects;
+using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Procs.DebugAdapter;
 using OpenDreamRuntime.Resources;
 
@@ -6,6 +7,7 @@ namespace OpenDreamRuntime {
     public static class ServerContentIoC {
         public static void Register(bool unitTests = false) {
             IoCManager.Register<IDreamManager, DreamManager>();
+            IoCManager.Register<IDreamObjectTree, DreamObjectTree>();
             IoCManager.Register<IAtomManager, AtomManager>();
             IoCManager.Register<IProcScheduler, ProcScheduler>();
             IoCManager.Register<DreamResourceManager, DreamResourceManager>();


### PR DESCRIPTION
Basically #664 which is a continuation of #587

- `DreamObjectDefinition.IsSubtypeOf()` was reworked to take a `IDreamObjectTree.TreeEntry` instead of a `DreamPath` and now operates in O(1) time.
- `IDreamObjectTree` is now IoC-resolvable instead of sitting in `IDreamManager`.
- `IDreamObjectTree.Atom` now takes the place of `DreamPath.Atom` (I hope to replace more uses of `DreamPath` with this later).
- DM enumerators now implement our own `IDreamValueEnumerator` interface instead of `IEnumerator<DreamValue>` to speed up enumeration.

This greatly speeds up anything that does a lot of inheritance checking, most notably the filtered DreamObject enumerator.

`Enumerate` opcode before:

![image](https://user-images.githubusercontent.com/30789242/207658989-b0b9a89c-b3b5-42ce-8cf8-82c264df577b.png)
After:

![image](https://user-images.githubusercontent.com/30789242/207659078-b4ef5f86-b7b0-4e57-8540-98d7a9e67d45.png)
