### PR TITLE
Fixes infinite spin / memory usage bug when a braced block can't find its ending brace

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -468,7 +468,9 @@ namespace DMCompiler.Compiler.DM {
                         if (blockInner != null) statements.AddRange(blockInner);
 
                         if (!Check(TokenType.DM_RightCurlyBracket)) {
-                            Error("Expected end of proc statement", throwException: false);
+                            Error(WarningCode.BadToken, "Expected end of braced block");
+                            Check(TokenType.DM_Dedent); // Have to do this ensure that the current token will ALWAYS move forward,
+                                                        // and not get stuck once we reach this branch!
                             LocateNextStatement();
                             Delimiter();
                         } else {

--- a/DMCompiler/Compiler/DM/DMParserHelper.cs
+++ b/DMCompiler/Compiler/DM/DMParserHelper.cs
@@ -18,7 +18,8 @@ namespace DMCompiler.Compiler.DM {
         /// <returns> True if this will raise an error, false if not. You can use this return value to help improve error emission around this (depending on how permissive we're being)</returns>
         protected bool Error(WarningCode code, string message) {
             ErrorLevel level = DMCompiler.CodeToLevel(code);
-            Emissions.Add(new CompilerEmission(level, code, Current().Location, message));
+            if (Emissions.Count < MAX_EMISSIONS_RECORDED)
+                Emissions.Add(new CompilerEmission(level, code, Current().Location, message));
             return level == ErrorLevel.Error;
         }
 

--- a/OpenDreamShared/Compiler/Parser.cs
+++ b/OpenDreamShared/Compiler/Parser.cs
@@ -11,6 +11,8 @@ namespace OpenDreamShared.Compiler {
         protected Lexer<SourceType> _lexer;
         private Token _currentToken;
         private readonly Stack<Token> _tokenStack = new(1);
+        /// <summary>The maximum number of errors or warnings we'd ever place into <see cref="Emissions"/>.</summary>
+        protected const int MAX_EMISSIONS_RECORDED = 50_000_000;
 
         protected Parser(Lexer<SourceType> lexer) {
             _lexer = lexer;
@@ -95,7 +97,8 @@ namespace OpenDreamShared.Compiler {
         protected void Error(string message, bool throwException = true) {
             CompilerEmission error = new CompilerEmission(ErrorLevel.Error, _currentToken?.Location, message);
 
-            Emissions.Add(error);
+            if(Emissions.Count < MAX_EMISSIONS_RECORDED)
+                Emissions.Add(error);
             if (throwException)
                 throw new CompileErrorException(error);
         }


### PR DESCRIPTION
![image](https://cdn.discordapp.com/attachments/847318834952405045/1053077491541102592/image.png)
Whoops!
## Summary
I noticed this, not in Yogs but in a stripped version of it where I had accidentally caused a brace block to not have its closing brace.

This resulted in the parser spinning indefinitely, creating a 200 MB/s memory leak. This fixes that :^)

## Changelog
- Fixed infinite loop in the compiler when a braced block could never find its end brace.
- Parsers now only attempt to record the first 50,000,000 warning/error emissions.
