### PR TITLE
Fix default `Blend()` arg values

### DIFF
--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
@@ -61,9 +61,9 @@ namespace OpenDreamRuntime.Procs.Native {
 
         [DreamProc("Blend")]
         [DreamProcParameter("icon", Type = DreamValue.DreamValueType.DreamObject)]
-        [DreamProcParameter("function", Type = DreamValue.DreamValueType.Float)]
-        [DreamProcParameter("x", Type = DreamValue.DreamValueType.Float)]
-        [DreamProcParameter("y", Type = DreamValue.DreamValueType.Float)]
+        [DreamProcParameter("function", Type = DreamValue.DreamValueType.Float, DefaultValue = 0)] // ICON_ADD
+        [DreamProcParameter("x", Type = DreamValue.DreamValueType.Float, DefaultValue = 1)]
+        [DreamProcParameter("y", Type = DreamValue.DreamValueType.Float, DefaultValue = 1)]
         public static DreamValue NativeProc_Blend(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
             //TODO Figure out what happens when you pass the wrong types as args
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
@@ -61,7 +61,7 @@ namespace OpenDreamRuntime.Procs.Native {
 
         [DreamProc("Blend")]
         [DreamProcParameter("icon", Type = DreamValue.DreamValueType.DreamObject)]
-        [DreamProcParameter("function", Type = DreamValue.DreamValueType.Float, DefaultValue = 0)] // ICON_ADD
+        [DreamProcParameter("function", Type = DreamValue.DreamValueType.Float, DefaultValue = BlendType.Add)] // ICON_ADD
         [DreamProcParameter("x", Type = DreamValue.DreamValueType.Float, DefaultValue = 1)]
         [DreamProcParameter("y", Type = DreamValue.DreamValueType.Float, DefaultValue = 1)]
         public static DreamValue NativeProc_Blend(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
@@ -61,7 +61,7 @@ namespace OpenDreamRuntime.Procs.Native {
 
         [DreamProc("Blend")]
         [DreamProcParameter("icon", Type = DreamValue.DreamValueType.DreamObject)]
-        [DreamProcParameter("function", Type = DreamValue.DreamValueType.Float, DefaultValue = BlendType.Add)] // ICON_ADD
+        [DreamProcParameter("function", Type = DreamValue.DreamValueType.Float, DefaultValue = (int)BlendType.Add)] // ICON_ADD
         [DreamProcParameter("x", Type = DreamValue.DreamValueType.Float, DefaultValue = 1)]
         [DreamProcParameter("y", Type = DreamValue.DreamValueType.Float, DefaultValue = 1)]
         public static DreamValue NativeProc_Blend(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {


### PR DESCRIPTION
TIL that native procs ignore the DM stub arg values.