### PR TITLE
Remove `PushPath` opcode

### DIFF
--- a/DMCompiler/Compiler/DMM/DMMParser.cs
+++ b/DMCompiler/Compiler/DMM/DMMParser.cs
@@ -72,8 +72,7 @@ namespace DMCompiler.Compiler.DMM {
                             DMExpression value = DMExpression.Create(DMObjectTree.GetDMObject(objectType.Path, false), null, varOverride.Value);
                             if (!value.TryAsJsonRepresentation(out var valueJson)) DMCompiler.ForcedError(statement.Location, $"Failed to serialize value to json ({value})");
 
-                            if(!mapObject.AddVarOverride(varOverride.VarName, valueJson))
-                            {
+                            if(!mapObject.AddVarOverride(varOverride.VarName, valueJson)) {
                                 DMCompiler.ForcedWarning(statement.Location, $"Duplicate var override '{varOverride.VarName}' in DMM on type {objectType.Path}");
                             }
 
@@ -96,7 +95,6 @@ namespace DMCompiler.Compiler.DMM {
                             cellDefinition.Objects.Add(mapObject);
                         }
                     }
-
 
                     if (Check(TokenType.DM_Comma)) {
                         objectType = Path();

--- a/DMCompiler/DM/DMObject.cs
+++ b/DMCompiler/DM/DMObject.cs
@@ -4,13 +4,14 @@ using OpenDreamShared.Dream;
 using OpenDreamShared.Json;
 using System;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 using OpenDreamShared.Compiler;
 using OpenDreamShared.Dream.Procs;
 
 namespace DMCompiler.DM {
     /// <remarks>
     /// This doesn't represent a particular, specific instance of an object, <br/>
-    /// but rather stores the compiletime information necessary to describe a certain object definition, <br/>
+    /// but rather stores the compile-time information necessary to describe a certain object definition, <br/>
     /// including its procs, vars, path, parent, etc.
     /// </remarks>
     class DMObject {
@@ -25,7 +26,9 @@ namespace DMCompiler.DM {
         /// <summary>A list of var and verb initializations implicitly done before the user's New() is called.</summary>
         public List<DMExpression> InitializationProcExpressions = new();
         public int? InitializationProc;
-        private bool IAmRoot => Path == DreamPath.Root;
+
+        private bool IsRoot => Path == DreamPath.Root;
+        [CanBeNull] private List<DMProc> _verbs;
 
         public List<DMASTObjectVarOverride>? danglingOverrides = null; // Overrides waiting for the LateVarDef event to happen
         private bool _isSubscribedToVarDef = false;
@@ -35,6 +38,7 @@ namespace DMCompiler.DM {
             Path = path;
             Parent = parent;
         }
+
         public void AddProc(string name, DMProc proc) {
             if (!Procs.ContainsKey(name)) Procs.Add(name, new List<int>(1));
 
@@ -114,17 +118,16 @@ namespace DMCompiler.DM {
 
         /// <summary> Similar to <see cref="HasLocalVariable"/>, just checks our globals/statics instead. </summary>
         /// <remarks> Does NOT return true if the global variable is in the root namespace, unless called on the Root object itself.</remarks>
-        public bool HasGlobalVariable(string name)
-        {
-            if (IAmRoot)
+        public bool HasGlobalVariable(string name) {
+            if (IsRoot)
                 return GlobalVariables.ContainsKey(name);
             return HasGlobalVariableNotInRoot(name);
         }
-        private bool HasGlobalVariableNotInRoot(string name)
-        {
+
+        private bool HasGlobalVariableNotInRoot(string name) {
             if (GlobalVariables.ContainsKey(name))
                 return true;
-            if (Parent == null || Parent.IAmRoot)
+            if (Parent == null || Parent.IsRoot)
                 return false;
             return Parent.HasGlobalVariable(name);
         }
@@ -135,22 +138,14 @@ namespace DMCompiler.DM {
             return Parent?.HasProc(name) ?? false;
         }
 
+        [CanBeNull]
         public List<int> GetProcs(string name) {
             return Procs.GetValueOrDefault(name, Parent?.GetProcs(name) ?? null);
         }
 
-        public bool IsProcUnimplemented(string name) {
-            List<int> procs = GetProcs(name);
-
-            if (procs != null) {
-                foreach (int procId in procs)
-                {
-                    DMProc proc = DMObjectTree.AllProcs[procId];
-                    if ((proc.Attributes & ProcAttributes.Unimplemented) == ProcAttributes.Unimplemented) return true;
-                }
-            }
-
-            return false;
+        public void AddVerb(DMProc verb) {
+            _verbs ??= new();
+            _verbs.Add(verb);
         }
 
         public DMVariable CreateGlobalVariable(DreamPath? type, string name, bool isConst, DMValueType valType = DMValueType.Anything) {
@@ -185,12 +180,19 @@ namespace DMCompiler.DM {
                 init.PushArguments(0);
                 init.Call(DMReference.SuperProc);
 
+                string lastSource = null;
                 foreach (DMExpression expression in InitializationProcExpressions) {
                     try {
                         if (expression.Location.Line is int line) {
-                            init.DebugSource(expression.Location.SourceFile);
+                            // Only emit DebugSource when source changes
+                            if (expression.Location.SourceFile != lastSource) {
+                                init.DebugSource(expression.Location.SourceFile);
+                                lastSource = expression.Location.SourceFile;
+                            }
+
                             init.DebugLine(line);
                         }
+
                         expression.EmitPushValue(this, init);
                     } catch (CompileErrorException e) {
                         DMCompiler.Emit(e.Error);
@@ -227,15 +229,22 @@ namespace DMCompiler.DM {
                 typeJson.GlobalVariables = GlobalVariables;
             }
 
-            if (InitializationProc != null)
-            {
+            if (InitializationProc != null) {
                 typeJson.InitProc = InitializationProc;
             }
 
-            if (Procs.Count > 0)
-            {
+            if (Procs.Count > 0) {
                 typeJson.Procs = new List<List<int>>(Procs.Values);
             }
+
+            if (_verbs != null) {
+                typeJson.Verbs = new List<int>(_verbs.Count);
+
+                foreach (var verb in _verbs) {
+                    typeJson.Verbs.Add(verb.Id);
+                }
+            }
+
             return typeJson;
         }
 

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -818,17 +818,28 @@ namespace DMCompiler.DM {
             WriteString(value);
         }
 
-        public void PushPath(DreamPath value) {
+        public void PushType(int typeId) {
             GrowStack(1);
-            if (DMObjectTree.TryGetTypeId(value, out int typeId)) {
-                WriteOpcode(DreamProcOpcode.PushType);
-                WriteInt(typeId);
-            } else {
-                //TODO: Remove PushPath?
-                //It's currently still used by things like paths to procs
-                WriteOpcode(DreamProcOpcode.PushPath);
-                WriteString(value.PathString);
-            }
+            WriteOpcode(DreamProcOpcode.PushType);
+            WriteInt(typeId);
+        }
+
+        public void PushProc(int procId) {
+            GrowStack(1);
+            WriteOpcode(DreamProcOpcode.PushProc);
+            WriteInt(procId);
+        }
+
+        public void PushProcStub(int typeId) {
+            GrowStack(1);
+            WriteOpcode(DreamProcOpcode.PushProcStub);
+            WriteInt(typeId);
+        }
+
+        public void PushVerbStub(int typeId) {
+            GrowStack(1);
+            WriteOpcode(DreamProcOpcode.PushVerbStub);
+            WriteInt(typeId);
         }
 
         public void PushNull() {

--- a/DMCompiler/DM/DMVariable.cs
+++ b/DMCompiler/DM/DMVariable.cs
@@ -22,20 +22,18 @@ namespace DMCompiler.DM {
             ValType = valType;
         }
 
-
         /// <summary>
         /// This is a copy-on-write proc used to set the DMVariable to a constant value. <br/>
         /// In some contexts, doing so would clobber pre-existing constants, <br/>
         /// and so this sometimes creates a copy of <see langword="this"/>, with the new constant value.
         /// </summary>
-        public DMVariable WriteToValue(Expressions.Constant value)
-        {
-            if(Value == null)
-            {
+        public DMVariable WriteToValue(Expressions.Constant value) {
+            if (Value == null) {
                 Value = value;
                 return this;
             }
-            DMVariable clone = new DMVariable(Type,Name,IsGlobal,IsConst,ValType);
+
+            DMVariable clone = new DMVariable(Type, Name, IsGlobal, IsConst, ValType);
             clone.Value = value;
             return clone;
         }

--- a/DMCompiler/DM/Expressions/Builtins.cs
+++ b/DMCompiler/DM/Expressions/Builtins.cs
@@ -72,7 +72,13 @@ namespace DMCompiler.DM.Expressions {
         }
 
         public override void EmitPushValue(DMObject dmObject, DMProc proc) {
-            proc.PushPath(TargetPath);
+            if (!DMObjectTree.TryGetTypeId(TargetPath, out var typeId)) {
+                DMCompiler.Emit(WarningCode.ItemDoesntExist, Location, $"Type {TargetPath} does not exist");
+
+                return;
+            }
+
+            proc.PushType(typeId);
             Arguments.EmitPushArguments(dmObject, proc);
             proc.CreateObject();
         }
@@ -89,7 +95,13 @@ namespace DMCompiler.DM.Expressions {
         }
 
         public override void EmitPushValue(DMObject dmObject, DMProc proc) {
-            proc.PushPath(_path);
+            if (!DMObjectTree.TryGetTypeId(_path, out var typeId)) {
+                DMCompiler.Emit(WarningCode.ItemDoesntExist, Location, $"Type {_path} does not exist");
+
+                return;
+            }
+
+            proc.PushType(typeId);
 
             if (_container != null) {
                 _container.EmitPushValue(dmObject, proc);
@@ -306,8 +318,14 @@ namespace DMCompiler.DM.Expressions {
         }
 
         public override void EmitPushValue(DMObject dmObject, DMProc proc) {
+            if (!DMObjectTree.TryGetTypeId(_path, out var typeId)) {
+                DMCompiler.Emit(WarningCode.ItemDoesntExist, Location, $"Type {_path} does not exist");
+
+                return;
+            }
+
             _expr.EmitPushValue(dmObject, proc);
-            proc.PushPath(_path);
+            proc.PushType(typeId);
             proc.IsType();
         }
     }

--- a/DMCompiler/DM/Expressions/Constant.cs
+++ b/DMCompiler/DM/Expressions/Constant.cs
@@ -3,6 +3,7 @@ using OpenDreamShared.Dream;
 using OpenDreamShared.Json;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DMCompiler.DM.Expressions {
     abstract class Constant : DMExpression {
@@ -296,31 +297,145 @@ namespace DMCompiler.DM.Expressions {
     class Path : Constant {
         public DreamPath Value { get; }
 
-        public Path(Location location, DreamPath value) : base(location) {
+        /// <summary>
+        /// The DMObject this expression resides in. Used for path searches.
+        /// </summary>
+        private readonly DMObject _dmObject;
+
+        private enum PathType {
+            TypeReference,
+            ProcReference,
+            ProcStub,
+            VerbStub
+        }
+
+        public Path(Location location, DMObject dmObject, DreamPath value) : base(location) {
             Value = value;
+            _dmObject = dmObject;
         }
 
         public override void EmitPushValue(DMObject dmObject, DMProc proc) {
-            proc.PushPath(Value);
+            if (!TryResolvePath(out var pathInfo)) {
+                proc.PushNull();
+                return;
+            }
+
+            switch (pathInfo.Value.Type) {
+                case PathType.TypeReference:
+                    proc.PushType(pathInfo.Value.Id);
+                    break;
+                case PathType.ProcReference:
+                    proc.PushProc(pathInfo.Value.Id);
+                    break;
+                case PathType.ProcStub:
+                    proc.PushProcStub(pathInfo.Value.Id);
+                    break;
+                case PathType.VerbStub:
+                    proc.PushVerbStub(pathInfo.Value.Id);
+                    break;
+                default:
+                    DMCompiler.ForcedError(Location, $"Invalid PathType {pathInfo.Value.Type}");
+                    break;
+            }
         }
 
         public override bool IsTruthy() => true;
 
         public override bool TryAsJsonRepresentation(out object json) {
-            object value;
-
-            if (DMObjectTree.TryGetTypeId(Value, out int typeId)) {
-                value = typeId;
-            } else {
-                value = Value.PathString;
+            if (!TryResolvePath(out var pathInfo)) {
+                json = null;
+                return false;
             }
 
+            JsonVariableType jsonType = pathInfo.Value.Type switch {
+                PathType.TypeReference => JsonVariableType.Type,
+                PathType.ProcReference => JsonVariableType.Proc,
+                PathType.ProcStub => JsonVariableType.ProcStub,
+                PathType.VerbStub => JsonVariableType.VerbStub
+            };
+
             json = new Dictionary<string, object>() {
-                { "type", JsonVariableType.Path },
-                { "value", value }
+                { "type", jsonType },
+                { "value", pathInfo.Value.Id }
             };
 
             return true;
+        }
+
+        private bool TryResolvePath([NotNullWhen(true)] out (PathType Type, int Id)? pathInfo) {
+            DreamPath path = Value;
+
+            // An upward search with no left-hand side
+            if (Value.Type == DreamPath.PathType.UpwardSearch) {
+                DreamPath? foundPath = DMObjectTree.UpwardSearch(_dmObject.Path, path);
+                if (foundPath == null) {
+                    DMCompiler.Emit(WarningCode.ItemDoesntExist, Location, $"Could not find path {path}");
+
+                    pathInfo = null;
+                    return false;
+                }
+
+                path = foundPath.Value;
+            }
+
+            // /datum/proc and /datum/verb
+            if (Value.LastElement is "proc" or "verb") {
+                DreamPath typePath = Value.FromElements(0, -2);
+                if (!DMObjectTree.TryGetTypeId(typePath, out var ownerId)) {
+                    DMCompiler.Emit(WarningCode.ItemDoesntExist, Location, $"Type {typePath} does not exist");
+
+                    pathInfo = null;
+                    return false;
+                }
+
+                pathInfo = Value.LastElement switch {
+                    "proc" => (PathType.ProcStub, ownerId),
+                    "verb" => (PathType.VerbStub, ownerId),
+                    _ => throw new InvalidOperationException($"Last element of {Value} is not \"proc\" or \"verb\"")
+                };
+                return true;
+            }
+
+            // /datum/proc/foo
+            int procIndex = path.FindElement("proc");
+            if (procIndex == -1) procIndex = path.FindElement("verb");
+            if (procIndex != -1) {
+                DreamPath withoutProcElement = path.RemoveElement(procIndex);
+                DreamPath ownerPath = withoutProcElement.FromElements(0, -2);
+                DMObject owner = DMObjectTree.GetDMObject(ownerPath, createIfNonexistent: false);
+                string procName = path.LastElement;
+
+                int? procId;
+                if (owner == DMObjectTree.Root && DMObjectTree.TryGetGlobalProc(procName, out var globalProc)) {
+                    procId = globalProc.Id;
+                } else {
+                    var procs = owner.GetProcs(procName);
+
+                    procId = procs?[^1];
+                }
+
+                if (procId == null) {
+                    DMCompiler.Emit(WarningCode.ItemDoesntExist, Location,
+                        $"Type {ownerPath} does not have a proc named {procName}");
+
+                    pathInfo = null;
+                    return false;
+                }
+
+                pathInfo = (PathType.ProcReference, procId.Value);
+                return true;
+            }
+
+            // Any other path
+            if (DMObjectTree.TryGetTypeId(Value, out var typeId)) {
+                pathInfo = (PathType.TypeReference, typeId);
+                return true;
+            } else {
+                DMCompiler.Emit(WarningCode.ItemDoesntExist, Location, $"Type {Value} does not exist");
+
+                pathInfo = null;
+                return false;
+            }
         }
     }
 }

--- a/DMCompiler/DM/Visitors/DMObjectBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMObjectBuilder.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 
 namespace DMCompiler.DM.Visitors {
     static class DMObjectBuilder {
-
         /// <summary>
         /// In DM, the definition of a base class may occur way after the definition of (perhaps numerous) derived classes. <br/>
         /// At the time that we first evaluate the derived class, we do not know some important information, like the implicit type of certain things.<br/>
@@ -227,12 +226,7 @@ namespace DMCompiler.DM.Visitors {
                 }
 
                 if (procDefinition.IsVerb && (dmObject.IsSubtypeOf(DreamPath.Atom) || dmObject.IsSubtypeOf(DreamPath.Client)) && !DMCompiler.Settings.NoStandard) {
-                    var initLoc = procDefinition.Location;
-                    Expressions.Field field = new Expressions.Field(initLoc, dmObject.GetVariable("verbs"));
-                    DreamPath procPath = new DreamPath(".proc/" + procName);
-                    Expressions.Append append = new Expressions.Append(initLoc, field, new Expressions.Path(initLoc, procPath));
-
-                    dmObject.InitializationProcExpressions.Add(append);
+                    dmObject.AddVerb(proc);
                 }
             } catch (CompileErrorException e) {
                 DMCompiler.Emit(e.Error);

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -544,8 +544,12 @@ namespace DMCompiler.DM.Visitors {
                 return;
             }
 
-            _proc.PushPath(type.Value);
-            _proc.CreateTypeEnumerator();
+            if (DMObjectTree.TryGetTypeId(type.Value, out var typeId)) {
+                _proc.PushType(typeId);
+                _proc.CreateTypeEnumerator();
+            } else {
+                DMCompiler.Emit(WarningCode.ItemDoesntExist, initializer.Location, $"Type {type.Value} does not exist");
+            }
 
             _proc.StartScope();
             {

--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -16,8 +16,7 @@ namespace DMCompiler.DM.Visitors {
         // NOTE This needs to be turned into a Stack of modes if more complicated scope changes are added in the future
         public static string _scopeMode;
 
-        internal DMVisitorExpression(DMObject dmObject, DMProc proc, DreamPath? inferredPath)
-        {
+        internal DMVisitorExpression(DMObject dmObject, DMProc proc, DreamPath? inferredPath) {
             _dmObject = dmObject;
             _proc = proc;
             _inferredPath = inferredPath;
@@ -26,7 +25,6 @@ namespace DMCompiler.DM.Visitors {
         public void VisitProcStatementExpression(DMASTProcStatementExpression statement) {
             statement.Expression.Visit(this);
         }
-
 
         public void VisitConstantNull(DMASTConstantNull constant) {
             Result = new Expressions.Null(constant.Location);
@@ -49,12 +47,13 @@ namespace DMCompiler.DM.Visitors {
         }
 
         public void VisitConstantPath(DMASTConstantPath constant) {
-            Result = new Expressions.Path(constant.Location, constant.Value.Path);
+            Result = new Expressions.Path(constant.Location, _dmObject, constant.Value.Path);
         }
 
         public void VisitUpwardPathSearch(DMASTUpwardPathSearch constant) {
             DMExpression.TryConstant(_dmObject, _proc, constant.Path, out var pathExpr);
-            if (pathExpr is not Expressions.Path expr) throw new CompileErrorException(constant.Location, "Cannot do an upward path search on " + pathExpr);
+            if (pathExpr is not Expressions.Path expr)
+                throw new CompileErrorException(constant.Location, $"Cannot do an upward path search on {pathExpr}");
 
             DreamPath path = expr.Value;
             DreamPath? foundPath = DMObjectTree.UpwardSearch(path, constant.Search.Path);
@@ -63,7 +62,7 @@ namespace DMCompiler.DM.Visitors {
                 throw new CompileErrorException(constant.Location,$"Invalid path {path}.{constant.Search.Path}");
             }
 
-            Result = new Expressions.Path(constant.Location, foundPath.Value);
+            Result = new Expressions.Path(constant.Location, _dmObject, foundPath.Value);
         }
 
         public void VisitStringFormat(DMASTStringFormat stringFormat) {

--- a/OpenDream.sln.DotSettings
+++ b/OpenDream.sln.DotSettings
@@ -10,4 +10,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Procs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=replacetext/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=savefile/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Savefiles/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Savefiles/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=typesof/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
@@ -12,6 +12,7 @@ namespace OpenDreamRuntime.Objects {
         public int? InitializationProc;
         public readonly Dictionary<string, int> Procs = new();
         public readonly Dictionary<string, int> OverridingProcs = new();
+        public List<int>? Verbs;
 
         // Maps variables from their name to their initial value.
         public readonly Dictionary<string, DreamValue> Variables = new();
@@ -32,6 +33,8 @@ namespace OpenDreamRuntime.Objects {
             GlobalVariables = new Dictionary<string, int>(copyFrom.GlobalVariables);
             Procs = new Dictionary<string, int>(copyFrom.Procs);
             OverridingProcs = new Dictionary<string, int>(copyFrom.OverridingProcs);
+            if (copyFrom.Verbs != null)
+                Verbs = new List<int>(copyFrom.Verbs);
         }
 
         public DreamObjectDefinition(IDreamObjectTree objectTree, IDreamObjectTree.TreeEntry treeNode) {

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -24,6 +24,20 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 _dreamManager.WorldContentsList.AddValue(new DreamValue(dreamObject));
             }
 
+            // TODO: Create a special list to prevent this needless list creation
+            List<int>? objectVerbs = dreamObject.ObjectDefinition.Verbs;
+            if (objectVerbs != null) {
+                DreamList verbsList = DreamList.Create(objectVerbs.Count);
+
+                foreach (int verbId in objectVerbs) {
+                    DreamProc verb = _objectTree.Procs[verbId];
+
+                    verbsList.AddValue(new DreamValue(verb));
+                }
+
+                dreamObject.SetVariableValue("verbs", new DreamValue(verbsList));
+            }
+
             _filterLists[dreamObject] = new DreamFilterList(dreamObject);
 
             ParentType?.OnObjectCreated(dreamObject, creationArguments);

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -41,6 +41,17 @@ namespace OpenDreamRuntime.Procs {
             ObjectTree = objectTree;
         }
 
+        public override DMProcState CreateState(DreamThread thread, DreamObject? src, DreamObject? usr, DreamProcArguments arguments) {
+            return new DMProcState(this, thread, _maxStackSize, src, usr, arguments);
+        }
+
+        public override string ToString() {
+            var procElement = (SuperProc == null) ? "proc/" : String.Empty; // Has "proc/" only if it's not an override
+            // TODO: "verb/" proc element
+
+            return $"{OwningType}/{procElement}{Name}";
+        }
+
         private static List<string>? GetArgumentNames(ProcDefinitionJson json) {
             if (json.Arguments == null) {
                 return new();
@@ -60,14 +71,9 @@ namespace OpenDreamRuntime.Procs {
                 return argumentTypes;
             }
         }
-
-        public override DMProcState CreateState(DreamThread thread, DreamObject? src, DreamObject? usr, DreamProcArguments arguments) {
-            return new DMProcState(this, thread, _maxStackSize, src, usr, arguments);
-        }
     }
 
-    sealed class DMProcState : ProcState
-    {
+    sealed class DMProcState : ProcState {
         delegate ProcStatus? OpcodeHandler(DMProcState state);
 
         // TODO: These pools are not returned to if the proc runtimes while _current is null
@@ -84,7 +90,7 @@ namespace OpenDreamRuntime.Procs {
             DMOpcodeHandlers.FormatString,
             DMOpcodeHandlers.SwitchCaseRange,
             DMOpcodeHandlers.PushReferenceValue,
-            DMOpcodeHandlers.PushPath,
+            null, //0x7
             DMOpcodeHandlers.Add,
             DMOpcodeHandlers.Assign,
             DMOpcodeHandlers.Call,
@@ -115,7 +121,7 @@ namespace OpenDreamRuntime.Procs {
             DMOpcodeHandlers.CallStatement,
             DMOpcodeHandlers.BitAnd,
             DMOpcodeHandlers.CompareNotEquals,
-            DMOpcodeHandlers.ListAppend,
+            DMOpcodeHandlers.PushProc,
             DMOpcodeHandlers.Divide,
             DMOpcodeHandlers.Multiply,
             DMOpcodeHandlers.BitXorReference,
@@ -129,7 +135,7 @@ namespace OpenDreamRuntime.Procs {
             DMOpcodeHandlers.CompareGreaterThanOrEqual,
             DMOpcodeHandlers.SwitchCase,
             DMOpcodeHandlers.Mask,
-            DMOpcodeHandlers.ListAppendAssociated,
+            null, //0x34
             DMOpcodeHandlers.Error,
             DMOpcodeHandlers.IsInList,
             DMOpcodeHandlers.PushArguments,
@@ -174,7 +180,9 @@ namespace OpenDreamRuntime.Procs {
             null, //0x5E
             DMOpcodeHandlers.PushGlobalVars,
             DMOpcodeHandlers.ModulusModulus,
-            DMOpcodeHandlers.ModulusModulusReference
+            DMOpcodeHandlers.ModulusModulusReference,
+            DMOpcodeHandlers.PushProcStub,
+            DMOpcodeHandlers.PushVerbStub
         };
         #endregion
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2089,43 +2089,46 @@ namespace OpenDreamRuntime.Procs.Native {
         }
 
         [DreamProc("typesof")]
-        [DreamProcParameter("Item1")]
+        [DreamProcParameter("Item1", Type = DreamValueType.DreamPath | DreamValueType.DreamObject | DreamValueType.ProcStub | DreamValueType.VerbStub)]
         public static DreamValue NativeProc_typesof(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
             DreamList list = DreamList.Create();
 
-            foreach (DreamValue type in arguments.GetAllArguments()) {
-                if (!type.TryGetValueAsPath(out var typePath)) {
-                    if (!type.TryGetValueAsDreamObject(out var typeObj) || typeObj?.ObjectDefinition is null || typeObj is DreamList) {
-                        if (type.TryGetValueAsString(out var typeString)) {
-                            var stringToPath = new DreamPath(typeString);
-                            if (stringToPath.LastElement == "proc") {
-                                DreamPath objectPath = stringToPath.AddToPath("..");
-                                if (!ObjectTree.HasTreeEntry(objectPath))
-                                {
-                                    continue;
-                                }
-                            }
-                            else if (!ObjectTree.HasTreeEntry(stringToPath)) {
-                                continue;
-                            }
-                            typePath = stringToPath;
-                        } else {
-                            continue;
-                        }
+            foreach (DreamValue typeValue in arguments.GetAllArguments()) {
+                DreamObjectDefinition type;
+                IEnumerable<int>? addingProcs = null;
+
+                if (typeValue.TryGetValueAsPath(out var typePath)) {
+                    type = ObjectTree.GetObjectDefinition(typePath);
+                } else if (typeValue.TryGetValueAsDreamObject(out var typeObj)) {
+                    if (typeObj is null or DreamList) // typesof() ignores nulls and lists
+                        continue;
+
+                    type = typeObj.ObjectDefinition;
+                } else if (typeValue.TryGetValueAsString(out var typeString)) {
+                    DreamPath path = new DreamPath(typeString);
+
+                    if (path.LastElement is "proc" or "verb") {
+                        type = ObjectTree.GetObjectDefinition(path.FromElements(0, -2));
+                        addingProcs = type.Procs.Values;
                     } else {
-                        typePath = typeObj.ObjectDefinition.Type;
+                        type = ObjectTree.GetObjectDefinition(path);
                     }
+                } else if (typeValue.TryGetValueAsProcStub(out var owner)) {
+                    type = owner.ObjectDefinition;
+                    addingProcs = type.Procs.Values;
+                } else if (typeValue.TryGetValueAsVerbStub(out owner)) {
+                    type = owner.ObjectDefinition;
+                    addingProcs = type.Verbs;
+                } else {
+                    continue;
                 }
 
-                if (typePath.LastElement == "proc") {
-                    DreamPath objectTypePath = typePath.AddToPath("..");
-                    DreamObjectDefinition objectDefinition = ObjectTree.GetObjectDefinition(objectTypePath);
-
-                    foreach (KeyValuePair<string, int> proc in objectDefinition.Procs) {
-                        list.AddValue(new DreamValue(proc.Key));
+                if (addingProcs != null) {
+                    foreach (var procId in addingProcs) {
+                        list.AddValue(new DreamValue(ObjectTree.Procs[procId]));
                     }
                 } else {
-                    var descendants = ObjectTree.GetAllDescendants(typePath);
+                    var descendants = ObjectTree.GetAllDescendants(type.Type);
 
                     foreach (var descendant in descendants) {
                         list.AddValue(new DreamValue(descendant.ObjectDefinition.Type));

--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -79,7 +79,6 @@ public struct ProcDecoder {
 
             case DreamProcOpcode.PushString:
             case DreamProcOpcode.PushResource:
-            case DreamProcOpcode.PushPath:
             case DreamProcOpcode.DebugSource:
                 return (opcode, ReadString());
 
@@ -122,6 +121,9 @@ public struct ProcDecoder {
             case DreamProcOpcode.JumpIfFalse:
             case DreamProcOpcode.JumpIfTrue:
             case DreamProcOpcode.PushType:
+            case DreamProcOpcode.PushProc:
+            case DreamProcOpcode.PushProcStub:
+            case DreamProcOpcode.PushVerbStub:
             case DreamProcOpcode.DebugLine:
             case DreamProcOpcode.MassConcatenation:
                 return (opcode, ReadInt());

--- a/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
+++ b/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
@@ -11,7 +11,7 @@ namespace OpenDreamShared.Dream.Procs {
         FormatString = 0x4,
         SwitchCaseRange = 0x5,
         PushReferenceValue = 0x6,
-        PushPath = 0x7,
+        //0x7
         Add = 0x8,
         Assign = 0x9,
         Call = 0xA,
@@ -42,7 +42,7 @@ namespace OpenDreamShared.Dream.Procs {
         CallStatement = 0x23,
         BitAnd = 0x24,
         CompareNotEquals = 0x25,
-        //0x26
+        PushProc = 0x26,
         Divide = 0x27,
         Multiply = 0x28,
         BitXorReference = 0x29,
@@ -101,7 +101,9 @@ namespace OpenDreamShared.Dream.Procs {
         //0x5E
         PushGlobalVars = 0x5F,
         ModulusModulus = 0x60,
-        ModulusModulusReference = 0x61
+        ModulusModulusReference = 0x61,
+        PushProcStub = 0x62,
+        PushVerbStub = 0x63
     }
 
     public enum DreamProcOpcodeParameterType {

--- a/OpenDreamShared/Json/DreamObjectJson.cs
+++ b/OpenDreamShared/Json/DreamObjectJson.cs
@@ -3,8 +3,11 @@
 namespace OpenDreamShared.Json {
     public enum JsonVariableType {
         Resource = 0,
-        Path = 1,
-        List = 2
+        Type = 1,
+        Proc = 2,
+        List = 3,
+        ProcStub = 4,
+        VerbStub = 5
     }
 
     public sealed class DreamTypeJson {
@@ -12,9 +15,9 @@ namespace OpenDreamShared.Json {
         public int? Parent { get; set; }
         public int? InitProc { get; set; }
         public List<List<int>> Procs { get; set; }
+        public List<int> Verbs { get; set; }
         public Dictionary<string, object> Variables { get; set; }
         public Dictionary<string, int> GlobalVariables { get; set; }
-        public List<int> Children { get; set; }
     }
 
     public sealed class GlobalListJson {


### PR DESCRIPTION
The `PushPath` opcode has been split into 4 opcodes:

- `PushType`
    - This existed before; it pushes an object type to the stack.
- `PushProc`
    - This pushes a proc to the stack using its ID
- `PushProcStub`
    - Pushes a `DreamValueType.DreamProcStub` DreamValue to the stack. This represents `/datum/proc`-like paths which point to all the procs of a type.
- `PushVerbStub`
    - Like `PushProcStub` but for `/datum/verb` paths.

The compiler now tries to determine if a path points to a type, proc, or proc/verb-stub instead of this happening at runtime. This paves the way to removing heavy DreamPath usage.