### PR TITLE
Add support for secondary map controls in `screen_loc`

### DIFF
--- a/OpenDreamClient/Rendering/DreamScreenOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamScreenOverlay.cs
@@ -45,7 +45,10 @@ public sealed class DreamScreenOverlay : Overlay {
 
         List<DMISpriteComponent> sprites = new();
         foreach (DMISpriteComponent sprite in screenOverlaySystem.EnumerateScreenObjects()) {
-            if (!sprite.IsVisible(checkWorld: false, mapManager: _mapManager)) continue;
+            if (!sprite.IsVisible(checkWorld: false, mapManager: _mapManager))
+                continue;
+            if (sprite.ScreenLocation.MapControl != null) // Don't render screen objects meant for other map controls
+                continue;
 
             sprites.Add(sprite);
         }


### PR DESCRIPTION
`/atom/movable.screen_loc` values formatted like `MAP:CENTER:16,CENTER` now parse correctly. They currently don't get rendered because we don't support secondary map controls yet.