### PR TITLE
Optimize procs that enumerate over all arguments

### DIFF
--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using DMCompiler.Compiler.DM;
-using DMCompiler.DM;
 using OpenDreamShared.Compiler;
 using Robust.Shared.Utility;
 
@@ -315,7 +314,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
                                 continue;
                             }
                             parameters.Add(parameterToken.Text);
-                            
+
                             continue;
                         case TokenType.DM_Preproc_Punctuator_Period: // One of those "..." things, maybe?
                             if (!Check(TokenType.DM_Preproc_Punctuator_Period) || !Check(TokenType.DM_Preproc_Punctuator_Period)) {

--- a/OpenDream.sln.DotSettings
+++ b/OpenDream.sln.DotSettings
@@ -4,10 +4,20 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DMAST/@EntryIndexedValue">DMAST</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=BYOND/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=cmptext/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Debuggee/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fcopy/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=isarea/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=isfile/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=isinf/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=islist/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=isloc/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ismob/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ismovable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=isnum/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ispath/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=issaved/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=isturf/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=noto/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Procs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=replacetext/@EntryIndexedValue">True</s:Boolean>

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -11,7 +11,7 @@ using OpenDreamShared.Json;
 
 namespace OpenDreamRuntime.Procs {
     sealed class DMProc : DreamProc {
-        public byte[] Bytecode { get; }
+        public readonly byte[] Bytecode;
 
         public string? Source { get; }
         public int Line { get; }

--- a/OpenDreamRuntime/Procs/DreamProcArguments.cs
+++ b/OpenDreamRuntime/Procs/DreamProcArguments.cs
@@ -18,12 +18,26 @@ namespace OpenDreamRuntime.Procs {
         }
 
         public List<DreamValue> GetAllArguments() {
-            List<DreamValue> allArguments = new List<DreamValue>();
+            List<DreamValue> allArguments = new List<DreamValue>(ArgumentCount);
             if (OrderedArguments != null)
                 allArguments.AddRange(OrderedArguments);
             if (NamedArguments != null)
                 allArguments.AddRange(NamedArguments.Values);
             return allArguments;
+        }
+
+        public IEnumerator<DreamValue> AllArgumentsEnumerator() {
+            if (OrderedArguments != null) {
+                foreach (DreamValue arg in OrderedArguments) {
+                    yield return arg;
+                }
+            }
+
+            if (NamedArguments != null) {
+                foreach (DreamValue arg in NamedArguments.Values) {
+                    yield return arg;
+                }
+            }
         }
 
         public DreamValue GetArgument(int argumentPosition, string argumentName) {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeList.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeList.cs
@@ -86,10 +86,12 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("Item1")]
         public static DreamValue NativeProc_Remove(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
             DreamList list = (DreamList)instance;
-            List<DreamValue> argumentValues = arguments.GetAllArguments();
             bool itemRemoved = false;
+            var argEnumerator = arguments.AllArgumentsEnumerator();
 
-            foreach (DreamValue argument in argumentValues) {
+            while (argEnumerator.MoveNext()) {
+                DreamValue argument = argEnumerator.Current;
+
                 if (argument.TryGetValueAsDreamList(out DreamList argumentList)) {
                     foreach (DreamValue value in argumentList.GetValues()) {
                         if (list.ContainsValue(value)) {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -235,19 +235,22 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProc("cmptext")]
         [DreamProcParameter("T1", Type = DreamValueType.String)]
         public static DreamValue NativeProc_cmptext(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
-            List<DreamValue> values = arguments.GetAllArguments();
-            if (!values[0].TryGetValueAsString(out var t1))
-            {
-                return new DreamValue(0);
+            var argEnumerator = arguments.AllArgumentsEnumerator();
+
+            if (!argEnumerator.MoveNext() || !argEnumerator.Current.TryGetValueAsString(out var t1))
+                return DreamValue.False;
+
+            while (argEnumerator.MoveNext()) {
+                DreamValue arg = argEnumerator.Current;
+
+                if (!arg.TryGetValueAsString(out var t2))
+                    return DreamValue.False;
+
+                if (!t2.Equals(t1, StringComparison.InvariantCultureIgnoreCase))
+                    return DreamValue.False;
             }
 
-            t1 = t1.ToLower();
-
-            for (int i = 1; i < values.Count; i++) {
-                if (!values[i].TryGetValueAsString(out var t2) || t2.ToLower() != t1) return new DreamValue(0);
-            }
-
-            return new DreamValue(1);
+            return DreamValue.True;
         }
 
         [DreamProc("copytext")]
@@ -707,7 +710,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 namedLookup.TryGetValueAsInteger(out colorSpace);
             }
 
-            /// true: look for int: false look for color
+            // true: look for int: false look for color
             bool colorOrInt = true;
 
             float workingFloat = 0;
@@ -736,7 +739,7 @@ namespace OpenDreamRuntime.Procs.Native {
 
                 if (!ColorHelpers.TryParseColor(strValue, out Color color))
                     color = new(0, 0, 0, 0);
-                
+
 
                 if (loop && index >= maxValue) {
                     index %= maxValue;
@@ -759,10 +762,10 @@ namespace OpenDreamRuntime.Procs.Native {
                 colorOrInt = true;
             }
 
-            /// Convert the index to a 0-1 range
+            // Convert the index to a 0-1 range
             float normalized = (index - leftBound) / (rightBound - leftBound);
 
-            /// Cheap way to make sure the gradient works at the extremes (eg 1 and 0)
+            // Cheap way to make sure the gradient works at the extremes (eg 1 and 0)
             if (!left.HasValue || (right.HasValue && normalized == 1) || (right.HasValue && normalized == 0)) {
                 if (right?.AByte == 255) {
                     return new DreamValue(right?.ToHexNoAlpha().ToLower() ?? "#00000000");
@@ -786,13 +789,13 @@ namespace OpenDreamRuntime.Procs.Native {
                     Vector4 vect1 = new(Color.ToHsv(left.GetValueOrDefault()));
                     Vector4 vect2 = new(Color.ToHsv(right.GetValueOrDefault()));
 
-                    /// Some precision is lost when coverting back to HSV at very small values this fixes that issue
+                    // Some precision is lost when coverting back to HSV at very small values this fixes that issue
                     if (normalized < 0.05f) {
                         normalized += 0.001f;
                     }
 
-                    /// This time it's overshooting
-                    /// dw these numbers are insanely arbitrary
+                    // This time it's overshooting
+                    // dw these numbers are insanely arbitrary
                     if(normalized > 0.9f) {
                         normalized -= 0.00445f;
                     }
@@ -916,13 +919,14 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProc("isarea")]
         [DreamProcParameter("Loc1", Type = DreamValueType.DreamObject)]
         public static DreamValue NativeProc_isarea(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
-            List<DreamValue> locs = arguments.GetAllArguments();
+            var argEnumerator = arguments.AllArgumentsEnumerator();
 
-            foreach (DreamValue loc in locs) {
-                if (!loc.TryGetValueAsDreamObjectOfType(ObjectTree.Area, out _)) return new DreamValue(0);
+            while (argEnumerator.MoveNext()) {
+                if (!argEnumerator.Current.TryGetValueAsDreamObjectOfType(ObjectTree.Area, out _))
+                    return DreamValue.False;
             }
 
-            return new DreamValue(1);
+            return DreamValue.True;
         }
 
         [DreamProc("isfile")]
@@ -974,48 +978,46 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProc("isloc")]
         [DreamProcParameter("Loc1", Type = DreamValueType.DreamObject)]
         public static DreamValue NativeProc_isloc(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
-            List<DreamValue> locs = arguments.GetAllArguments();
+            var argEnumerator = arguments.AllArgumentsEnumerator();
 
-            foreach (DreamValue loc in locs) {
-                if (loc.TryGetValueAsDreamObject(out DreamObject? locObject) && locObject is not null) {
-                    bool isLoc = locObject.IsSubtypeOf(ObjectTree.Mob) || locObject.IsSubtypeOf(ObjectTree.Obj) || locObject.IsSubtypeOf(ObjectTree.Turf) || locObject.IsSubtypeOf(ObjectTree.Area);
+            while (argEnumerator.MoveNext()) {
+                if (!argEnumerator.Current.TryGetValueAsDreamObject(out var loc))
+                    return DreamValue.False;
 
-                    if (!isLoc) {
-                        return new DreamValue(0);
-                    }
-                } else {
-                    return new DreamValue(0);
-                }
+                bool isLoc = loc.IsSubtypeOf(ObjectTree.Mob) || loc.IsSubtypeOf(ObjectTree.Obj) ||
+                             loc.IsSubtypeOf(ObjectTree.Turf) || loc.IsSubtypeOf(ObjectTree.Area);
+
+                if (!isLoc)
+                    return DreamValue.False;
             }
 
-            return new DreamValue(1);
+            return DreamValue.True;
         }
 
         [DreamProc("ismob")]
         [DreamProcParameter("Loc1", Type = DreamValueType.DreamObject)]
         public static DreamValue NativeProc_ismob(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
-            List<DreamValue> locs = arguments.GetAllArguments();
+            var argEnumerator = arguments.AllArgumentsEnumerator();
 
-            foreach (DreamValue loc in locs) {
-                if (!loc.TryGetValueAsDreamObjectOfType(ObjectTree.Mob, out _))
-                    return new DreamValue(0);
+            while (argEnumerator.MoveNext()) {
+                if (!argEnumerator.Current.TryGetValueAsDreamObjectOfType(ObjectTree.Mob, out _))
+                    return DreamValue.False;
             }
 
-            return new DreamValue(1);
+            return DreamValue.True;
         }
 
         [DreamProc("ismovable")]
         [DreamProcParameter("Loc1", Type = DreamValueType.DreamObject)]
         public static DreamValue NativeProc_ismovable(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
-            List<DreamValue> locs = arguments.GetAllArguments();
+            var argEnumerator = arguments.AllArgumentsEnumerator();
 
-            foreach (DreamValue loc in locs) {
-                if (!loc.TryGetValueAsDreamObjectOfType(ObjectTree.Movable, out _)) {
-                    return new DreamValue(0);
-                }
+            while (argEnumerator.MoveNext()) {
+                if (!argEnumerator.Current.TryGetValueAsDreamObjectOfType(ObjectTree.Movable, out _))
+                    return DreamValue.False;
             }
 
-            return new DreamValue(1);
+            return DreamValue.True;
         }
 
         [DreamProc("isnan")]
@@ -1072,15 +1074,14 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProc("isturf")]
         [DreamProcParameter("Loc1", Type = DreamValueType.DreamObject)]
         public static DreamValue NativeProc_isturf(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
-            List<DreamValue> locs = arguments.GetAllArguments();
+            var argEnumerator = arguments.AllArgumentsEnumerator();
 
-            foreach (DreamValue loc in locs) {
-                if (!loc.TryGetValueAsDreamObjectOfType(ObjectTree.Turf, out _)) {
-                    return new DreamValue(0);
-                }
+            while (argEnumerator.MoveNext()) {
+                if (!argEnumerator.Current.TryGetValueAsDreamObjectOfType(ObjectTree.Turf, out _))
+                    return DreamValue.False;
             }
 
-            return new DreamValue(1);
+            return DreamValue.True;
         }
 
         private static DreamValue CreateValueFromJsonElement(JsonElement jsonElement)
@@ -1304,25 +1305,25 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProc("max")]
         [DreamProcParameter("A")]
         public static DreamValue NativeProc_max(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
-            List<DreamValue> values;
+            IEnumerator<DreamValue> values;
 
             if (arguments.ArgumentCount == 1) {
                 DreamValue arg = arguments.GetArgument(0, "A");
                 if (!arg.TryGetValueAsDreamList(out var list))
                     return arg;
 
-                values = list.GetValues();
+                values = list.GetValues().GetEnumerator();
             } else {
-                values = arguments.GetAllArguments();
+                values = arguments.AllArgumentsEnumerator();
             }
 
-            if (values.Count == 0)
+            if (!values.MoveNext())
                 return DreamValue.Null;
 
-            DreamValue max = values[0];
+            DreamValue max = values.Current;
 
-            for (int i = 1; i < values.Count; i++) {
-                DreamValue value = values[i];
+            while (values.MoveNext()) {
+                DreamValue value = values.Current;
 
                 if (value.TryGetValueAsFloat(out var lFloat)) {
                     if (max == DreamValue.Null && lFloat >= 0)
@@ -1342,6 +1343,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 }
             }
 
+            values.Dispose();
             return max;
         }
 
@@ -1377,35 +1379,39 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProc("min")]
         [DreamProcParameter("A")]
         public static DreamValue NativeProc_min(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
-            List<DreamValue> values;
+            IEnumerator<DreamValue> values;
 
             if (arguments.ArgumentCount == 1) {
                 DreamValue arg = arguments.GetArgument(0, "A");
                 if (!arg.TryGetValueAsDreamList(out var list))
                     return arg;
 
-                values = list.GetValues();
+                values = list.GetValues().GetEnumerator();
             } else {
-                values = arguments.GetAllArguments();
+                values = arguments.AllArgumentsEnumerator();
             }
 
-            DreamValue min = values[0];
-            if (min == DreamValue.Null) return min;
+            if (!values.MoveNext())
+                return DreamValue.Null;
 
-            for (int i = 1; i < values.Count; i++) {
-                DreamValue value = values[i];
+            DreamValue min = values.Current;
+
+            while (values.MoveNext()) {
+                DreamValue value = values.Current;
 
                 if (value.TryGetValueAsFloat(out var lFloat) && min.TryGetValueAsFloat(out var rFloat)) {
                     if (lFloat < rFloat) min = value;
                 } else if (value.TryGetValueAsString(out var lString) && min.TryGetValueAsString(out var rString)) {
                     if (string.Compare(lString, rString, StringComparison.Ordinal) < 0) min = value;
                 } else if (value == DreamValue.Null) {
-                    return value;
+                    min = value;
+                    break;
                 } else {
                     throw new Exception($"Cannot compare {min} and {value}");
                 }
             }
 
+            values.Dispose();
             return min;
         }
 
@@ -2251,9 +2257,11 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProc("typesof")]
         [DreamProcParameter("Item1", Type = DreamValueType.DreamType | DreamValueType.DreamObject | DreamValueType.ProcStub | DreamValueType.VerbStub)]
         public static DreamValue NativeProc_typesof(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
-            DreamList list = DreamList.Create();
+            DreamList list = DreamList.Create(arguments.ArgumentCount); // Assume every arg will add at least one type
+            var argEnumerator = arguments.AllArgumentsEnumerator();
 
-            foreach (DreamValue typeValue in arguments.GetAllArguments()) {
+            while (argEnumerator.MoveNext()) {
+                DreamValue typeValue = argEnumerator.Current;
                 IEnumerable<int>? addingProcs = null;
 
                 if (!typeValue.TryGetValueAsType(out var type)) {


### PR DESCRIPTION
Optimizes several procs by using an `IEnumerator<DreamValue>` to enumerate all of their given arguments instead of concatenating them into a new list.

- `cmptext()`
- `isarea()`
- `isloc()`
- `ismob()`
- `ismovable()`
- `isturf()`
- `max()`
- `min()`
- `typesof()`
- `/list.Remove()`