### PR TITLE
Optimize `world.contents`

### DIFF
--- a/Content.Tests/DummyDreamMapManager.cs
+++ b/Content.Tests/DummyDreamMapManager.cs
@@ -10,6 +10,7 @@ namespace Content.Tests {
     public sealed class DummyDreamMapManager : IDreamMapManager {
         public Vector2i Size => Vector2i.Zero;
         public int Levels => 0;
+        public List<DreamObject> AllAtoms { get; } = new();
 
         public void Initialize() { }
 

--- a/OpenDream.sln.DotSettings
+++ b/OpenDream.sln.DotSettings
@@ -13,4 +13,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=replacetext/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=savefile/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Savefiles/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=typesof/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=typesof/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=waitfor/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/OpenDreamRuntime/DreamMapManager.cs
+++ b/OpenDreamRuntime/DreamMapManager.cs
@@ -57,7 +57,7 @@ namespace OpenDreamRuntime {
 
         public Vector2i Size { get; private set; }
         public int Levels => _levels.Count;
-        public List<DreamObject> AllAtoms { get; } = new();
+        public List<DreamObject> AllAtoms { get; } = new(410000); // ~400K elements after Paradise init
 
         private readonly List<Level> _levels = new();
         private readonly Dictionary<DreamObject, (Vector2i Pos, Level Level)> _turfToTilePos = new();

--- a/OpenDreamRuntime/DreamMapManager.cs
+++ b/OpenDreamRuntime/DreamMapManager.cs
@@ -57,7 +57,7 @@ namespace OpenDreamRuntime {
 
         public Vector2i Size { get; private set; }
         public int Levels => _levels.Count;
-        public List<DreamObject> AllAtoms { get; } = new(410000); // ~400K elements after Paradise init
+        public List<DreamObject> AllAtoms { get; } = new();
 
         private readonly List<Level> _levels = new();
         private readonly Dictionary<DreamObject, (Vector2i Pos, Level Level)> _turfToTilePos = new();

--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -117,7 +117,9 @@ namespace OpenDreamRuntime {
         }
 
         public override string ToString() {
-            if (_refValue == null) {
+            if (Type == DreamValueType.Float)
+                return _floatValue.ToString();
+            else if (_refValue == null) {
                 return "null";
             } else if (Type == DreamValueType.String) {
                 return $"\"{_refValue}\"";

--- a/OpenDreamRuntime/IDreamManager.cs
+++ b/OpenDreamRuntime/IDreamManager.cs
@@ -15,7 +15,6 @@ namespace OpenDreamRuntime {
 
         public List<DreamValue> Globals { get; }
         public IReadOnlyList<string> GlobalNames { get; }
-        public DreamList WorldContentsList { get; }
         public Dictionary<DreamObject, DreamList> AreaContents { get; set; }
         public Dictionary<DreamObject, int> ReferenceIDs { get; set; }
         public List<DreamObject> Mobs { get; set; }

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -414,4 +414,43 @@ namespace OpenDreamRuntime.Objects {
             return appearance;
         }
     }
+
+    // world.contents list
+    // Operates on a list of all atoms
+    public sealed class WorldContentsList : DreamList {
+        private readonly IDreamMapManager _mapManager;
+
+        public WorldContentsList(IDreamMapManager mapManager) {
+            _mapManager = mapManager;
+        }
+
+        public override DreamValue GetValue(DreamValue key) {
+            if (!key.TryGetValueAsInteger(out var index))
+                throw new Exception($"Invalid index into world contents list: {key}");
+            if (index < 1 || index > _mapManager.AllAtoms.Count)
+                throw new Exception($"Out of bounds index on world contents list: {index}");
+
+            return new DreamValue(_mapManager.AllAtoms[index - 1]);
+        }
+
+        public override List<DreamValue> GetValues() {
+            throw new NotImplementedException("Getting all values of the world contents list is not implemented");
+        }
+
+        public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
+            throw new Exception("Cannot set the value of world contents list");
+        }
+
+        public override void AddValue(DreamValue value) {
+            throw new Exception("Cannot append to world contents list");
+        }
+
+        public override void Cut(int start = 1, int end = 0) {
+            throw new Exception("Cannot cut world contents list");
+        }
+
+        public override int GetLength() {
+            return _mapManager.AllAtoms.Count;
+        }
+    }
 }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -51,6 +51,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
             // Replace our world.contents spot with the last so this doesn't mess with enumerators
             // Results in a different order than BYOND, but nothing about our order resembles BYOND at all right now
+            // TODO: Handle this placing atoms earlier than an enumerator's index
             int worldContentsIndex = _mapManager.AllAtoms.IndexOf(dreamObject);
             _mapManager.AllAtoms.RemoveSwap(worldContentsIndex);
 

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectWorld.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectWorld.cs
@@ -60,8 +60,6 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
             ParentType?.OnObjectCreated(dreamObject, creationArguments);
 
-            dreamObject.SetVariable("contents", new(_dreamManager.WorldContentsList));
-
             DreamValue log = dreamObject.ObjectDefinition.Variables["log"];
             dreamObject.SetVariable("log", log);
 
@@ -113,6 +111,8 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
         public DreamValue OnVariableGet(DreamObject dreamObject, string varName, DreamValue value) {
             switch (varName) {
+                case "contents":
+                    return new DreamValue(new WorldContentsList(_dreamMapManager));
                 case "process":
                     return new DreamValue(Environment.ProcessId);
                 case "tick_lag":

--- a/OpenDreamRuntime/Procs/DreamEnumerators.cs
+++ b/OpenDreamRuntime/Procs/DreamEnumerators.cs
@@ -130,4 +130,42 @@ namespace OpenDreamRuntime.Procs {
             } while (true);
         }
     }
+
+    /// <summary>
+    /// Enumerates over all atoms in the world, possibly filtering for a certain type
+    /// <code>for (var/obj/item/I in world)</code>
+    /// </summary>
+    sealed class WorldContentsEnumerator : IDreamValueEnumerator {
+        private readonly IDreamMapManager _mapManager;
+        private readonly IDreamObjectTree.TreeEntry? _filterType;
+        private int _current = -1;
+
+        public WorldContentsEnumerator(IDreamMapManager mapManager, IDreamObjectTree.TreeEntry? filterType) {
+            _mapManager = mapManager;
+            _filterType = filterType;
+        }
+
+        public DreamValue Current {
+            get {
+                if (_current < _mapManager.AllAtoms.Count)
+                    return new(_mapManager.AllAtoms[_current]);
+                return DreamValue.Null;
+            }
+        }
+
+        public bool MoveNext() {
+            do {
+                _current++;
+                if (_current >= _mapManager.AllAtoms.Count)
+                    return false;
+
+                if (_filterType != null) {
+                    if (_mapManager.AllAtoms[_current].IsSubtypeOf(_filterType))
+                        return true;
+                } else {
+                    return true;
+                }
+            } while (true);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #633 

A list of all atoms is now held in `DreamMapManager` instead of a DreamList on the `world` object. This speeds up the creation/deletion of atoms.

There is also now a special enumerator for `world.contents` which greatly speeds up loops like `for(var/atom/A in world)` by preventing an unnecessary copy of the huge list.

The `CreateFilteredEnumerator` opcode during Paradise initialization,

Before:
![image](https://user-images.githubusercontent.com/30789242/208792551-8ea75b6c-f7da-4477-8192-0c5d7415cd43.png)
After:
![image](https://user-images.githubusercontent.com/30789242/208792561-8db30481-5d8f-4a3f-84fd-539a681f8423.png)