### PR TITLE
Fix verb inheritance

### DIFF
--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -4,7 +4,6 @@ using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Procs.Native;
 using OpenDreamRuntime.Resources;
-using OpenDreamShared.Dream;
 using OpenDreamShared.Dream.Procs;
 using OpenDreamShared.Network.Messages;
 using Robust.Server.Player;
@@ -12,8 +11,7 @@ using Robust.Shared.Enums;
 
 namespace OpenDreamRuntime
 {
-    public sealed class DreamConnection
-    {
+    public sealed class DreamConnection {
         [Dependency] private readonly IDreamManager _dreamManager = default!;
         [Dependency] private readonly IDreamObjectTree _objectTree = default!;
         [Dependency] private readonly IAtomManager _atomManager = default!;

--- a/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
@@ -46,6 +46,8 @@ namespace OpenDreamRuntime.Objects {
                 InitializationProc = Parent.InitializationProc;
                 Variables = new Dictionary<string, DreamValue>(Parent.Variables);
                 GlobalVariables = new Dictionary<string, int>(Parent.GlobalVariables);
+                if (Parent.Verbs != null)
+                    Verbs = new List<int>(Parent.Verbs);
             }
         }
 

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -268,7 +268,8 @@ namespace OpenDreamRuntime.Objects {
                 }
 
                 if (jsonType.Verbs != null) {
-                    definition.Verbs = jsonType.Verbs;
+                    definition.Verbs ??= new(jsonType.Verbs.Count);
+                    definition.Verbs.AddRange(jsonType.Verbs);
                 }
 
                 if (jsonType.InitProc != null) {


### PR DESCRIPTION
Verb inheritance was broken in #974 as part of the change to how `/atom.verbs` is constructed. This makes objects inherit verbs from their parents again.