### PR TITLE
Cache DMI parsing on the server

### DIFF
--- a/OpenDreamClient/Resources/ResourceTypes/DMIResource.cs
+++ b/OpenDreamClient/Resources/ResourceTypes/DMIResource.cs
@@ -19,7 +19,7 @@ namespace OpenDreamClient.Resources.ResourceTypes {
         public DMIResource(int id, byte[] data) : base(id, data) {
             if (!IsValidPNG()) throw new Exception("Attempted to create a DMI using an invalid PNG");
 
-            Stream dmiStream = new MemoryStream(data);
+            using Stream dmiStream = new MemoryStream(data);
             DMIParser.ParsedDMIDescription description = DMIParser.ParseDMI(dmiStream);
 
             dmiStream.Seek(0, SeekOrigin.Begin);

--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -454,7 +454,7 @@ namespace OpenDreamRuntime {
                 {
                     // TODO Check what happens with multiple states
                     var icon = DreamMetaObjectIcon.ObjectToDreamIcon[iconObj];
-                    var (resource, _) = icon.GenerateDMI();
+                    var resource = icon.GenerateDMI();
                     var base64 = Convert.ToBase64String(resource.ResourceData);
                     writer.WriteString("Value", base64);
                     break;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -1,10 +1,11 @@
 ﻿using OpenDreamRuntime.Objects;
-using OpenDreamShared.Dream;
+using OpenDreamRuntime.Resources;
 
 namespace OpenDreamRuntime.Procs.Native {
     static class DreamProcNative {
         public static void SetupNativeProcs(IDreamObjectTree objectTree) {
             DreamProcNativeRoot.DreamManager = IoCManager.Resolve<IDreamManager>();
+            DreamProcNativeRoot.ResourceManager = IoCManager.Resolve<DreamResourceManager>();
             DreamProcNativeRoot.ObjectTree = objectTree;
 
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_abs);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
@@ -39,12 +39,12 @@ namespace OpenDreamRuntime.Procs.Native {
 
             // TODO: moving & delay
 
-            var objectTree = IoCManager.Resolve<IDreamObjectTree>();
             var resourceManager = IoCManager.Resolve<DreamResourceManager>();
-            var (iconRsc, iconDescription) = DreamMetaObjectIcon.GetIconResourceAndDescription(objectTree, resourceManager, newIcon);
+            if (!resourceManager.TryLoadIcon(newIcon, out var iconRsc))
+                throw new Exception($"Cannot insert {newIcon}");
 
             DreamIcon iconObj = DreamMetaObjectIcon.ObjectToDreamIcon[instance];
-            iconObj.InsertStates(iconRsc, iconDescription, iconState, dir, frame); // TODO: moving & delay
+            iconObj.InsertStates(iconRsc, iconState, dir, frame); // TODO: moving & delay
             return DreamValue.Null;
         }
 

--- a/OpenDreamRuntime/Resources/DreamResourceManager.cs
+++ b/OpenDreamRuntime/Resources/DreamResourceManager.cs
@@ -17,7 +17,6 @@ namespace OpenDreamRuntime.Resources {
 
         private readonly List<DreamResource> _resourceCache = new();
         private readonly Dictionary<string, int> _resourcePathToId = new();
-        private readonly Dictionary<DreamResource, Image<Rgba32>> _imageCache = new();
 
         private ISawmill _sawmill;
 
@@ -28,7 +27,6 @@ namespace OpenDreamRuntime.Resources {
 
             _resourceCache.Clear();
             _resourcePathToId.Clear();
-            _imageCache.Clear();
 
             // An empty resource path is the console
             _resourceCache.Add(new ConsoleOutputResource());
@@ -89,15 +87,6 @@ namespace OpenDreamRuntime.Resources {
 
             resource = null;
             return false;
-        }
-
-        public Image<Rgba32> LoadImage(DreamResource resource) {
-            if (_imageCache.TryGetValue(resource, out var image))
-                return image;
-
-            image = Image.Load<Rgba32>(resource.ResourceData);
-            _imageCache.Add(resource, image);
-            return image;
         }
 
         public bool TryLoadIcon(DreamValue value, [NotNullWhen(true)] out IconResource? icon) {

--- a/OpenDreamRuntime/Resources/IconResource.cs
+++ b/OpenDreamRuntime/Resources/IconResource.cs
@@ -1,0 +1,22 @@
+﻿using System.IO;
+using OpenDreamShared.Resources;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace OpenDreamRuntime.Resources;
+
+public sealed class IconResource : DreamResource {
+    public Image<Rgba32> Texture => _texture ??= Image.Load<Rgba32>(ResourceData);
+    public DMIParser.ParsedDMIDescription DMI => _dmi ??= DMIParser.ParseDMI(new MemoryStream(ResourceData));
+
+    private Image<Rgba32>? _texture;
+    private DMIParser.ParsedDMIDescription? _dmi;
+
+    public IconResource(int id, string? filePath, string? resourcePath) : base(id, filePath, resourcePath) { }
+
+    public IconResource(int id, byte[] data, Image<Rgba32> texture, DMIParser.ParsedDMIDescription dmi) :
+        base(id, data) {
+        _texture = texture;
+        _dmi = dmi;
+    }
+}


### PR DESCRIPTION
The server now caches the results of `DMIParse.ParseDMI()` instead of calling it again for every icon operation and `icon_states()` call. Based off of file extension, `DreamResourceManager.LoadResource()` will create an `IconResource` class holding the (lazily-loaded) texture and DMI info.

Paradise init before:
![image](https://user-images.githubusercontent.com/30789242/209409371-82a5d276-ee38-4ae1-894c-8eae550caaa2.png)
![image](https://user-images.githubusercontent.com/30789242/209409136-2b9aa187-90e7-47d3-9e35-c1aa13642667.png)

After:
![image](https://user-images.githubusercontent.com/30789242/209409080-71b77323-02ab-40c8-bea6-a0ff306fa46d.png)
![image](https://user-images.githubusercontent.com/30789242/209409151-ba118f47-43f1-478f-acff-c1ff33704f07.png)