### PR TITLE
Pool all the types of `ProcState`

### DIFF
--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -120,23 +120,18 @@ namespace OpenDreamRuntime
             _currentlyUpdatingStat = true;
             _statPanels.Clear();
 
-            DreamThread.Run("Stat", async (state) =>
-            {
-                try
-                {
+            DreamThread.Run("Stat", async (state) => {
+                try {
                     var statProc = ClientDreamObject.GetProc("Stat");
 
                     await state.Call(statProc, ClientDreamObject, _mobDreamObject, new DreamProcArguments(null));
-                    if (Session.Status == SessionStatus.InGame)
-                    {
+                    if (Session.Status == SessionStatus.InGame) {
                         var msg = new MsgUpdateStatPanels() { StatPanels = _statPanels };
                         Session.ConnectedClient.SendMessage(msg);
                     }
 
                     return DreamValue.Null;
-                }
-                finally
-                {
+                } finally {
                     _currentlyUpdatingStat = false;
                 }
             });

--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Threading.Tasks;
 using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Procs;
+using OpenDreamRuntime.Procs.DebugAdapter;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Dream.Procs;
 
@@ -101,18 +102,14 @@ namespace OpenDreamRuntime {
         {}
     }
 
-    public abstract class ProcState {
+    public abstract class ProcState : IDisposable {
         private static int _idCounter = 0;
         public int Id { get; } = ++_idCounter;
 
         public DreamThread Thread { get; set; }
-        public DreamValue Result { set; get; } = DreamValue.Null;
+        public DreamValue Result { protected set; get; } = DreamValue.Null;
 
         public bool WaitFor { get; set; } = true;
-
-        public ProcState(DreamThread thread) {
-            Thread = thread;
-        }
 
         public ProcStatus Resume() {
             try {
@@ -135,6 +132,11 @@ namespace OpenDreamRuntime {
 
         public abstract DreamProc? Proc { get; }
 
+        protected void Initialize(DreamThread thread, bool waitFor) {
+            Thread = thread;
+            WaitFor = waitFor;
+        }
+
         protected abstract ProcStatus InternalResume();
 
         public abstract void AppendStackFrame(StringBuilder builder);
@@ -143,6 +145,12 @@ namespace OpenDreamRuntime {
         public virtual void ReturnedInto(DreamValue value) {}
 
         public virtual void Cancel() {}
+
+        public virtual void Dispose() {
+            Thread = null;
+            Result = DreamValue.Null;
+            WaitFor = true;
+        }
 
         public override string ToString() {
             var sb = new StringBuilder();
@@ -170,7 +178,7 @@ namespace OpenDreamRuntime {
 
         public string Name { get; }
 
-        internal Procs.DebugAdapter.DreamDebugManager.ThreadStepMode? StepMode { get; set; }
+        internal DreamDebugManager.ThreadStepMode? StepMode { get; set; }
 
         public DreamThread(string name) {
             Name = name;
@@ -254,9 +262,14 @@ namespace OpenDreamRuntime {
             _current = state;
         }
 
-        public void PopProcState() {
+        public void PopProcState(bool dispose = true) {
             if (_current?.WaitFor == false) {
                 _syncCount--;
+            }
+
+            // Maybe a bit of a hack? If the state got deferred to another thread it shouldn't be disposed.
+            if (dispose && _current.Thread == this) {
+                _current.Dispose();
             }
 
             if (!_stack.TryPop(out _current)) {
@@ -278,14 +291,14 @@ namespace OpenDreamRuntime {
             // `WaitFor = true` frames
             while (_current is not null && _current.WaitFor) {
                 newStackReversed.Push(_current);
-                PopProcState();
+                PopProcState(dispose: false); // Dont dispose; this proc state is just being moved to another thread.
             }
 
             // `WaitFor = false` frame
             if(_current == null) throw new InvalidOperationException();
             var threadName = _current.ToString();
             newStackReversed.Push(_current);
-            PopProcState();
+            PopProcState(dispose: false);
 
             DreamThread newThread = new DreamThread(threadName);
             foreach (var frame in newStackReversed) {
@@ -296,11 +309,6 @@ namespace OpenDreamRuntime {
             // Our returning proc state is expected to be on the stack at this point, so put it back
             // For this small moment, the proc state will be on both threads.
             PushProcState(newStackReversed.Peek());
-
-            // The old thread was emptied?
-            if (_current == null) {
-                throw new InvalidOperationException();
-            }
 
             return ProcStatus.Returned;
         }
@@ -351,12 +359,7 @@ namespace OpenDreamRuntime {
 
             dreamMan.WriteWorldLog(builder.ToString(), LogLevel.Error);
 
-            IoCManager.Resolve<Procs.DebugAdapter.IDreamDebugManager>()?.HandleException(this, exception);
-
-            // Only return pools after giving the debugger a chance to inspect them.
-            if (_current is DMProcState state) {
-                state.ReturnPools();
-            }
+            IoCManager.Resolve<IDreamDebugManager>().HandleException(this, exception);
         }
 
         public IEnumerable<ProcState> InspectStack() {

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -23,10 +23,16 @@ namespace OpenDreamRuntime.Objects {
         }
 
         public ProcState InitProc(DreamThread thread, DreamObject? usr, DreamProcArguments arguments) {
-            if(Deleted){
+            if (Deleted) {
                 throw new Exception("Cannot init proc on a deleted object");
             }
-            return new InitDreamObjectState(thread, this, usr, arguments);
+
+            if (!InitDreamObjectState.Pool.TryPop(out var state)) {
+                state = new InitDreamObjectState(ObjectDefinition.DreamManager, ObjectDefinition.ObjectTree);
+            }
+
+            state.Initialize(thread, this, usr, arguments);
+            return state;
         }
 
         public void Delete(IDreamManager manager) {

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -250,7 +250,7 @@ namespace OpenDreamRuntime.Objects {
             foreach (TreeEntry type in GetAllDescendants(Root)) {
                 int typeId = pathToTypeId[type.Path];
                 DreamTypeJson jsonType = types[typeId];
-                var definition = new DreamObjectDefinition(this, type);
+                var definition = new DreamObjectDefinition(DreamManager, this, type);
 
                 type.ObjectDefinition = definition;
                 type.TreeIndex = treeIndex++;
@@ -318,8 +318,7 @@ namespace OpenDreamRuntime.Objects {
 
         private void LoadProcsFromJson(DreamTypeJson[] types, ProcDefinitionJson[] jsonProcs, List<int> jsonGlobalProcs) {
             Procs = new(jsonProcs.Length);
-            foreach (var proc in jsonProcs)
-            {
+            foreach (var proc in jsonProcs) {
                 Procs.Add(LoadProcJson(types, proc));
             }
 

--- a/OpenDreamRuntime/Procs/AsyncNativeProc.cs
+++ b/OpenDreamRuntime/Procs/AsyncNativeProc.cs
@@ -78,7 +78,7 @@ namespace OpenDreamRuntime.Procs {
 
             public override void Dispose() {
                 base.Dispose();
-                
+
                 _scheduleCancellationToken?.Cancel();
                 _scheduleCancellationToken?.Dispose();
                 _scheduleCancellationToken = null;
@@ -148,7 +148,6 @@ namespace OpenDreamRuntime.Procs {
                         throw _task.Exception;
                     }
 
-                    _scheduleCancellationToken = null;
                     return ProcStatus.Returned;
                 }
 

--- a/OpenDreamRuntime/Procs/AsyncNativeProc.cs
+++ b/OpenDreamRuntime/Procs/AsyncNativeProc.cs
@@ -79,6 +79,7 @@ namespace OpenDreamRuntime.Procs {
             public override void Dispose() {
                 base.Dispose();
 
+                // Cancel the scheduled continuation of this state if there is one
                 _scheduleCancellationToken?.Cancel();
                 _scheduleCancellationToken?.Dispose();
                 _scheduleCancellationToken = null;

--- a/OpenDreamRuntime/Procs/AsyncNativeProc.cs
+++ b/OpenDreamRuntime/Procs/AsyncNativeProc.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using OpenDreamRuntime.Objects;
 using OpenDreamShared.Dream;
@@ -6,28 +7,29 @@ using OpenDreamShared.Dream.Procs;
 
 namespace OpenDreamRuntime.Procs {
     public sealed class AsyncNativeProc : DreamProc {
-        public delegate Task<DreamValue> HandlerFn(State s);
-
         public sealed class State : ProcState {
+            public static readonly Stack<State> Pool = new();
+
             public DreamObject Src;
             public DreamObject Usr;
             public DreamProcArguments Arguments;
 
-            private AsyncNativeProc _proc;
-            public override DreamProc Proc => _proc;
+            private AsyncNativeProc? _proc;
+            public override DreamProc? Proc => _proc;
 
             private Func<State, Task<DreamValue>> _taskFunc;
-            private Task _task;
+            private Task? _task;
+            private CancellationTokenSource? _scheduleCancellationToken;
 
             private ProcState? _callProcNotify;
-            private TaskCompletionSource<DreamValue> _callTcs;
+            private TaskCompletionSource<DreamValue>? _callTcs;
             private DreamValue? _callResult;
 
             private bool _inResume;
 
-            public State(AsyncNativeProc proc, Func<State, Task<DreamValue>> taskFunc, DreamThread thread, DreamObject src, DreamObject usr, DreamProcArguments arguments)
-                : base(thread)
-            {
+            public void Initialize(AsyncNativeProc proc, Func<State, Task<DreamValue>> taskFunc, DreamThread thread, DreamObject src, DreamObject usr, DreamProcArguments arguments) {
+                base.Initialize(thread, true);
+
                 _proc = proc;
                 _taskFunc = taskFunc;
                 Src = src;
@@ -69,16 +71,37 @@ namespace OpenDreamRuntime.Procs {
                 // We don't call `_callTcs.SetResult` here because we're about to be resumed and can do it there.
                 _callResult = value;
             }
+
             public override void Cancel() {
                 _callTcs?.SetCanceled();
+            }
+
+            public override void Dispose() {
+                base.Dispose();
+                
+                _scheduleCancellationToken?.Cancel();
+                _scheduleCancellationToken?.Dispose();
+                _scheduleCancellationToken = null;
+
+                Src = null!;
+                Usr = null!;
+                Arguments = default;
+                _proc = null!;
+                _taskFunc = null!;
+                _task = null;
+                _callProcNotify = null;
+                _callTcs = null!;
+                _callResult = null;
+                _inResume = false;
+
+                Pool.Push(this);
             }
 
             private async Task InternalResumeAsync() {
                 Result = await _taskFunc(this);
             }
 
-            protected override ProcStatus InternalResume()
-            {
+            protected override ProcStatus InternalResume() {
                 _inResume = true;
 
                 // We've just been created, start our task
@@ -97,29 +120,26 @@ namespace OpenDreamRuntime.Procs {
                     }
 
                     IProcScheduler procScheduler = IoCManager.Resolve<IProcScheduler>();
-                    procScheduler.ScheduleAsyncNative(this, _task);
+                    _scheduleCancellationToken = procScheduler.Schedule(this, _task);
                 }
 
-                while (_callProcNotify != null || _callResult != null)
-                {
-                    // We need to call a proc.
-                    if (_callProcNotify != null) {
-                        var callProcNotify = _callProcNotify;
-                        _callProcNotify = null;
+                // We need to call a proc.
+                if (_callProcNotify != null) {
+                    var callProcNotify = _callProcNotify;
+                    _callProcNotify = null;
 
-                        Thread.PushProcState(callProcNotify);
-                        return ProcStatus.Called;
-                    }
+                    Thread.PushProcState(callProcNotify);
+                    return ProcStatus.Called;
+                }
 
-                    // We've just finished calling a proc, notify our task
-                    if (_callResult != null) {
-                        var callTcs = _callTcs;
-                        var callResult = _callResult.Value;
-                        _callTcs = null;
-                        _callResult = null;
+                // We've just finished calling a proc, notify our task
+                if (_callResult != null) {
+                    var callTcs = _callTcs;
+                    var callResult = _callResult.Value;
+                    _callTcs = null;
+                    _callResult = null;
 
-                        callTcs.SetResult(callResult);
-                    }
+                    callTcs.SetResult(callResult);
                 }
 
                 // If the task is finished, we're all done
@@ -128,6 +148,7 @@ namespace OpenDreamRuntime.Procs {
                         throw _task.Exception;
                     }
 
+                    _scheduleCancellationToken = null;
                     return ProcStatus.Returned;
                 }
 
@@ -136,19 +157,18 @@ namespace OpenDreamRuntime.Procs {
                 return Thread.HandleDefer();
             }
 
-            public override void AppendStackFrame(StringBuilder builder)
-            {
+            public override void AppendStackFrame(StringBuilder builder) {
                 if (_proc == null) {
                     builder.Append("<anonymous async proc>");
                     return;
                 }
 
-                builder.Append($"{_proc.Name}");
+                builder.Append($"{_proc}");
             }
         }
 
-        private Dictionary<string, DreamValue> _defaultArgumentValues;
-        private Func<State, Task<DreamValue>> _taskFunc;
+        private readonly Dictionary<string, DreamValue> _defaultArgumentValues;
+        private readonly Func<State, Task<DreamValue>> _taskFunc;
 
         public AsyncNativeProc(DreamPath owningType, string name, DreamProc superProc, List<String> argumentNames, List<DMValueType> argumentTypes, Dictionary<string, DreamValue> defaultArgumentValues, Func<State, Task<DreamValue>> taskFunc, string? verbName, string? verbCategory, string? verbDesc, sbyte? invisibility)
             : base(owningType, name, superProc, ProcAttributes.None, argumentNames, argumentTypes, verbName, verbCategory, verbDesc, invisibility) {
@@ -170,11 +190,21 @@ namespace OpenDreamRuntime.Procs {
                 arguments = new DreamProcArguments(arguments.OrderedArguments, newNamedArguments);
             }
 
-            return new State(this, _taskFunc, thread, src, usr, arguments);
+            if (!State.Pool.TryPop(out var state)) {
+                state = new State();
+            }
+
+            state.Initialize(this, _taskFunc, thread, src, usr, arguments);
+            return state;
         }
 
         public static ProcState CreateAnonymousState(DreamThread thread, Func<State, Task<DreamValue>> taskFunc) {
-            return new State(null, taskFunc, thread, null, null, new DreamProcArguments(null));
+            if (!State.Pool.TryPop(out var state)) {
+                state = new State();
+            }
+
+            state.Initialize(null, taskFunc, thread, null, null, new DreamProcArguments(null));
+            return state;
         }
     }
 }

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -26,8 +26,7 @@ namespace OpenDreamRuntime.Procs {
         private readonly int _maxStackSize;
 
         public DMProc(DreamPath owningType, ProcDefinitionJson json, string? name, IDreamManager dreamManager, IDreamMapManager dreamMapManager, IDreamDebugManager dreamDebugManager, DreamResourceManager dreamResourceManager, IDreamObjectTree objectTree)
-            : base(owningType, name ?? json.Name, null, json.Attributes, GetArgumentNames(json), GetArgumentTypes(json), json.VerbName, json.VerbCategory, json.VerbDesc, json.Invisibility)
-        {
+            : base(owningType, name ?? json.Name, null, json.Attributes, GetArgumentNames(json), GetArgumentTypes(json), json.VerbName, json.VerbCategory, json.VerbDesc, json.Invisibility) {
             Bytecode = json.Bytecode ?? Array.Empty<byte>();
             LocalNames = json.Locals;
             Source = json.Source;
@@ -42,7 +41,12 @@ namespace OpenDreamRuntime.Procs {
         }
 
         public override DMProcState CreateState(DreamThread thread, DreamObject? src, DreamObject? usr, DreamProcArguments arguments) {
-            return new DMProcState(this, thread, _maxStackSize, src, usr, arguments);
+            if (!DMProcState.Pool.TryPop(out var state)) {
+                state = new DMProcState();
+            }
+
+            state.Initialize(this, thread, _maxStackSize, src, usr, arguments);
+            return state;
         }
 
         private static List<string>? GetArgumentNames(ProcDefinitionJson json) {
@@ -69,9 +73,9 @@ namespace OpenDreamRuntime.Procs {
     sealed class DMProcState : ProcState {
         delegate ProcStatus? OpcodeHandler(DMProcState state);
 
-        // TODO: These pools are not returned to if the proc runtimes while _current is null
-        private static ArrayPool<DreamValue> _dreamValuePool = ArrayPool<DreamValue>.Shared;
-        private static ArrayPool<DreamValue> _stackPool = ArrayPool<DreamValue>.Shared;
+        public static readonly Stack<DMProcState> Pool = new();
+
+        private static readonly ArrayPool<DreamValue> _dreamValuePool = ArrayPool<DreamValue>.Create();
 
         #region Opcode Handlers
         //Human readable friendly version, which will be converted to a more efficient lookup at runtime.
@@ -173,7 +177,7 @@ namespace OpenDreamRuntime.Procs {
             {DreamProcOpcode.PushVerbStub, DMOpcodeHandlers.PushVerbStub},
         };
 
-        private static OpcodeHandler?[] _opcodeHandlers = {};
+        private static readonly OpcodeHandler?[] _opcodeHandlers;
         #endregion
 
         public IDreamManager DreamManager => _proc.DreamManager;
@@ -181,8 +185,8 @@ namespace OpenDreamRuntime.Procs {
 
         /// <summary> This stores our 'src' value. May be null!</summary>
         public DreamObject? Instance;
-        public readonly DreamObject? Usr;
-        public readonly int ArgumentCount;
+        public DreamObject? Usr;
+        public int ArgumentCount;
         public string? CurrentSource;
         public int CurrentLine;
         private Stack<IDreamValueEnumerator>? _enumeratorStack;
@@ -192,39 +196,54 @@ namespace OpenDreamRuntime.Procs {
         public int ProgramCounter => _pc;
 
         // Contains both arguments (at index 0) and local vars (at index ArgumentCount)
-        private readonly DreamValue[] _localVariables;
+        private DreamValue[] _localVariables;
 
-        private readonly DMProc _proc;
+        private DMProc _proc;
         public override DMProc Proc => _proc;
 
         public override (string?, int?) SourceLine => (CurrentSource, CurrentLine);
 
-        /// Static initialiser for maintainer friendly OpcodeHandlers to performance friendly _opcodeHandlers
+        /// Static initializer for maintainer friendly OpcodeHandlers to performance friendly _opcodeHandlers
         static DMProcState() {
-            int maxOpcode = 0;
-            foreach(DreamProcOpcode dpo in OpcodeHandlers.Keys) {
-                if(maxOpcode < (int) dpo)
-                    maxOpcode = (int) dpo;
-            }
-            _opcodeHandlers = new OpcodeHandler?[maxOpcode+1];
-            foreach(DreamProcOpcode dpo in OpcodeHandlers.Keys) {
+            int maxOpcode = (int)OpcodeHandlers.Keys.Max();
+
+            _opcodeHandlers = new OpcodeHandler?[maxOpcode + 1];
+            foreach (DreamProcOpcode dpo in OpcodeHandlers.Keys) {
                 _opcodeHandlers[(int) dpo] = OpcodeHandlers[dpo];
             }
         }
-        /// <param name="instance">This is our 'src'.</param>
-        /// <exception cref="Exception">Thrown, at time of writing, when an invalid named arg is given</exception>
-        public DMProcState(DMProc proc, DreamThread thread, int maxStackSize, DreamObject? instance, DreamObject? usr, DreamProcArguments arguments)
-            : base(thread)
-        {
+
+        public DMProcState() { }
+
+        private DMProcState(DMProcState other, DreamThread thread) {
+            if (other._enumeratorStack?.Count > 0) {
+                throw new NotImplementedException();
+            }
+
+            base.Initialize(thread, other.WaitFor);
+            _proc = other._proc;
+            Instance = other.Instance;
+            Usr = other.Usr;
+            ArgumentCount = other.ArgumentCount;
+            CurrentSource = other.CurrentSource;
+            CurrentLine = other.CurrentLine;
+            _pc = other._pc;
+
+            _stack = _dreamValuePool.Rent(other._stack.Length);
+            _localVariables = _dreamValuePool.Rent(other._localVariables.Length);
+            Array.Copy(other._localVariables, _localVariables, other._localVariables.Length);
+        }
+
+        public void Initialize(DMProc proc, DreamThread thread, int maxStackSize, DreamObject? instance, DreamObject? usr, DreamProcArguments arguments) {
+            base.Initialize(thread, (proc.Attributes & ProcAttributes.DisableWaitfor) != ProcAttributes.DisableWaitfor);
             _proc = proc;
-            _stack = _stackPool.Rent(maxStackSize);
             Instance = instance;
             Usr = usr;
-            ArgumentCount = Math.Max(arguments.ArgumentCount, proc.ArgumentNames?.Count ?? 0);
+            ArgumentCount = Math.Max(arguments.ArgumentCount, _proc.ArgumentNames?.Count ?? 0);
+            CurrentSource = _proc.Source;
+            CurrentLine = _proc.Line;
             _localVariables = _dreamValuePool.Rent(256);
-            CurrentSource = proc.Source;
-            CurrentLine = proc.Line;
-            WaitFor = _proc != null ? (_proc.Attributes & ProcAttributes.DisableWaitfor) != ProcAttributes.DisableWaitfor : true;
+            _stack = _dreamValuePool.Rent(maxStackSize);
 
             //TODO: Positional arguments must precede all named arguments, this needs to be enforced somehow
             //Positional arguments
@@ -235,7 +254,7 @@ namespace OpenDreamRuntime.Procs {
             //Named arguments
             if (arguments.NamedArguments != null) {
                 foreach ((string argumentName, DreamValue argumentValue) in arguments.NamedArguments) {
-                    int argumentIndex = proc.ArgumentNames?.IndexOf(argumentName) ?? -1;
+                    int argumentIndex = _proc.ArgumentNames?.IndexOf(argumentName) ?? -1;
                     if (argumentIndex == -1) {
                         throw new Exception($"Invalid argument name \"{argumentName}\"");
                     }
@@ -245,33 +264,8 @@ namespace OpenDreamRuntime.Procs {
             }
         }
 
-        public DMProcState(DMProcState other, DreamThread thread)
-            : base(thread)
-        {
-            if (other.EnumeratorStack.Count > 0) {
-                throw new NotImplementedException();
-            }
-
-            _proc = other._proc;
-            Instance = other.Instance;
-            Usr = other.Usr;
-            ArgumentCount = other.ArgumentCount;
-            CurrentSource = other.CurrentSource;
-            CurrentLine = other.CurrentLine;
-            _pc = other._pc;
-
-            _stack = _stackPool.Rent(other._stack.Length);
-            Array.Copy(other._stack, _stack, _stack.Length);
-
-            _localVariables = _dreamValuePool.Rent(other._localVariables.Length);
-            Array.Copy(other._localVariables, _localVariables, other._localVariables.Length);
-
-            WaitFor = other.WaitFor;
-        }
-
         protected override ProcStatus InternalResume() {
-            if (Instance is not null && Instance.Deleted) {
-                ReturnPools();
+            if (Instance?.Deleted == true) {
                 return ProcStatus.Returned;
             }
 
@@ -283,22 +277,14 @@ namespace OpenDreamRuntime.Procs {
                     throw new Exception($"Attempted to call non-existent Opcode method for opcode 0x{opcode:X2}");
                 ProcStatus? status = handler.Invoke(this);
                 if (status != null) {
-                    if (status == ProcStatus.Returned || status == ProcStatus.Cancelled) {
-                        // TODO: This should be automatic (dispose pattern?)
-                        ReturnPools();
-                    }
-
                     return status.Value;
                 }
             }
 
-            // TODO: This should be automatic (dispose pattern?)
-            ReturnPools();
             return ProcStatus.Returned;
         }
 
-        public override void ReturnedInto(DreamValue value)
-        {
+        public override void ReturnedInto(DreamValue value) {
             Push(value);
         }
 
@@ -325,7 +311,7 @@ namespace OpenDreamRuntime.Procs {
         }
 
         public DreamThread Spawn() {
-            var thread = new DreamThread(this.Proc.ToString());
+            var thread = new DreamThread(Proc.ToString());
 
             var state = new DMProcState(this, thread);
             thread.PushProcState(state);
@@ -333,10 +319,26 @@ namespace OpenDreamRuntime.Procs {
             return thread;
         }
 
-        public void ReturnPools()
-        {
-            _dreamValuePool.Return(_localVariables, true);
-            _stackPool.Return(_stack);
+        public override void Dispose() {
+            base.Dispose();
+
+            Instance = null;
+            Usr = null;
+            ArgumentCount = 0;
+            CurrentSource = null;
+            CurrentLine = 0;
+            _enumeratorStack = null;
+            _pc = 0;
+            _proc = null;
+
+            _dreamValuePool.Return(_stack);
+            _stackIndex = 0;
+            _stack = null;
+
+            _dreamValuePool.Return(_localVariables);
+            _localVariables = null;
+
+            Pool.Push(this);
         }
 
         public Span<DreamValue> GetArguments() {

--- a/OpenDreamRuntime/Procs/InitDreamObject.cs
+++ b/OpenDreamRuntime/Procs/InitDreamObject.cs
@@ -2,10 +2,11 @@ using System.Text;
 using OpenDreamRuntime.Objects;
 
 namespace OpenDreamRuntime.Procs {
-    sealed class InitDreamObjectState : ProcState
-    {
-        [Dependency] private readonly IDreamManager _dreamMan = default!;
-        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
+    sealed class InitDreamObjectState : ProcState {
+        public static readonly Stack<InitDreamObjectState> Pool = new();
+
+        private readonly IDreamManager _dreamMan;
+        private readonly IDreamObjectTree _objectTree;
 
         enum Stage {
             // Need to call the object's (init) proc
@@ -18,13 +19,18 @@ namespace OpenDreamRuntime.Procs {
             Return,
         }
 
-        public InitDreamObjectState(DreamThread thread, DreamObject dreamObject, DreamObject? usr, DreamProcArguments arguments)
-            : base(thread)
-        {
-            IoCManager.InjectDependencies(this);
+        public InitDreamObjectState(IDreamManager dreamManager, IDreamObjectTree objectTree) {
+            _dreamMan = dreamManager;
+            _objectTree = objectTree;
+        }
+
+        public void Initialize(DreamThread thread, DreamObject dreamObject, DreamObject? usr, DreamProcArguments arguments) {
+            base.Initialize(thread, true);
+
             _dreamObject = dreamObject;
             _usr = usr;
             _arguments = arguments;
+            _stage = Stage.Init;
         }
 
         private DreamObject _dreamObject;
@@ -34,13 +40,21 @@ namespace OpenDreamRuntime.Procs {
 
         public override DreamProc? Proc => null;
 
-        public override void AppendStackFrame(StringBuilder builder)
-        {
+        public override void AppendStackFrame(StringBuilder builder) {
             builder.AppendLine($"new {_dreamObject.ObjectDefinition?.Type}");
         }
 
-        protected override ProcStatus InternalResume()
-        {
+        public override void Dispose() {
+            base.Dispose();
+
+            _dreamObject = null!;
+            _usr = null;
+            _arguments = default;
+
+            Pool.Push(this);
+        }
+
+        protected override ProcStatus InternalResume() {
             var src = _dreamObject;
 
             switch_start:

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
@@ -121,7 +121,7 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("Start", DefaultValue = 1, Type = DreamValue.DreamValueType.Float)]
         [DreamProcParameter("End", DefaultValue = 0, Type = DreamValue.DreamValueType.Float)]
         public static async Task<DreamValue> NativeProc_Replace(AsyncNativeProc.State state) {
-            DreamValue haystack = state.Arguments.GetArgument(0, "heystack");
+            DreamValue haystack = state.Arguments.GetArgument(0, "haystack");
             DreamValue replacement = state.Arguments.GetArgument(1, "replacement");
             int start = state.Arguments.GetArgument(2, "Start").GetValueAsInteger();
             int end = state.Arguments.GetArgument(3, "End").GetValueAsInteger();

--- a/OpenDreamRuntime/Procs/NativeProc.cs
+++ b/OpenDreamRuntime/Procs/NativeProc.cs
@@ -30,8 +30,9 @@ namespace OpenDreamRuntime.Procs {
             return (procAttribute.Name, defaultArgumentValues, argumentNames);
         }
 
-        public sealed class State : ProcState
-        {
+        public sealed class State : ProcState {
+            public static readonly Stack<State> Pool = new();
+
             public DreamObject Src;
             public DreamObject Usr;
             public DreamProcArguments Arguments;
@@ -39,30 +40,39 @@ namespace OpenDreamRuntime.Procs {
             private NativeProc _proc;
             public override NativeProc Proc => _proc;
 
-            public State(NativeProc proc, DreamThread thread, DreamObject src, DreamObject usr, DreamProcArguments arguments)
-                : base(thread)
-            {
+            public void Initialize(NativeProc proc, DreamThread thread, DreamObject src, DreamObject usr, DreamProcArguments arguments) {
+                base.Initialize(thread, true);
+
                 _proc = proc;
                 Src = src;
                 Usr = usr;
                 Arguments = arguments;
             }
 
-            protected override ProcStatus InternalResume()
-            {
+            protected override ProcStatus InternalResume() {
                 Result = _proc.Handler.Invoke(Src, Usr, Arguments);
 
                 return ProcStatus.Returned;
             }
 
-            public override void AppendStackFrame(StringBuilder builder)
-            {
+            public override void AppendStackFrame(StringBuilder builder) {
                 if (_proc == null) {
                     builder.Append("<anonymous proc>");
                     return;
                 }
 
                 builder.Append($"{_proc.Name}");
+            }
+
+            public override void Dispose() {
+                base.Dispose();
+
+                Src = null!;
+                Usr = null!;
+                Arguments = default;
+                _proc = null!;
+
+                Pool.Push(this);
             }
         }
 
@@ -89,11 +99,12 @@ namespace OpenDreamRuntime.Procs {
                 arguments = new DreamProcArguments(arguments.OrderedArguments, newNamedArguments);
             }
 
-            return new State(this, thread, src, usr, arguments);
-        }
+            if (!State.Pool.TryPop(out var state)) {
+                state = new State();
+            }
 
-        public static ProcState CreateAnonymousState(DreamThread thread, HandlerFn handler) {
-            return new State(null, thread, null, null, new DreamProcArguments(null));
+            state.Initialize(this, thread, src, usr, arguments);
+            return state;
         }
     }
 }


### PR DESCRIPTION
Every single proc call would create a new `ProcState`. When you've got hundreds of millions of proc calls, this adds up to a lot of memory usage. I made it so finished states could be reused so new ones doesn't need to be made. This cuts about 4GB of memory allocations during Paradise init.

- `ProcState` is now `IDisposable` and has `Dispose()` called when the state is no longer being used.
- `ProcState` now has an `Initialize()` method meant to prepare a state to be used again.
- `DMProcState._dreamValuePool` now uses an ArrayPool that isn't thread-safe for performance reasons. All DM runs on the main thread anyways.

Paradise init before:
![Memory usage](https://user-images.githubusercontent.com/30789242/209453115-138319d0-3aee-424f-b735-9d834ae2acb3.png)
![CPU time](https://user-images.githubusercontent.com/30789242/209453120-9996acd2-7f03-4651-990e-656fb510b28e.png)

after:
![Memory usage](https://user-images.githubusercontent.com/30789242/209453130-d0bd46db-a484-4766-902d-899c5284b553.png)
![CPU time](https://user-images.githubusercontent.com/30789242/209453135-9e6c37ce-d31f-4bd2-aca9-8d40b11cab93.png)
