### PR TITLE
Optimize `HandleInstruction()`

### DIFF
--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -14,7 +14,7 @@ namespace DMCompiler.DM.Visitors {
         internal DMExpression Result { get; private set; }
 
         // NOTE This needs to be turned into a Stack of modes if more complicated scope changes are added in the future
-        public static string _scopeMode;
+        public static string _scopeMode = "normal";
 
         internal DMVisitorExpression(DMObject dmObject, DMProc proc, DreamPath? inferredPath) {
             _dmObject = dmObject;

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -279,7 +279,7 @@ namespace OpenDreamRuntime.Procs {
 
             bool stepping = Thread.StepMode != null;
             while (_pc < _proc.Bytecode.Length) {
-                if (stepping && !_firstResume)
+                if (stepping && !_firstResume) // HandleFirstResume does this for us on the first resume
                     DebugManager.HandleInstruction(this);
                 _firstResume = false;
 

--- a/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
@@ -129,7 +129,11 @@ sealed class DreamDebugManager : IDreamDebugManager {
             Output($"Function breakpoint hit at {state.Proc.OwningType.PathString}::{state.Proc.Name}");
             Stop(state.Thread,
                 new StoppedEvent {Reason = StoppedEvent.ReasonFunctionBreakpoint, HitBreakpointIds = hit});
+            return;
         }
+
+        // Otherwise check for an instruction breakpoint
+        HandleInstruction(state);
     }
 
     public void HandleInstruction(DMProcState state) {
@@ -146,12 +150,12 @@ sealed class DreamDebugManager : IDreamDebugManager {
                 stoppedOnStep = state.Id == whenTop || !state.Thread.InspectStack().Select(p => p.Id).Contains(whenTop);
                 break;
         }
+
         if (stoppedOnStep) {
             state.Thread.StepMode = null;
             Stop(state.Thread, new StoppedEvent {
                 Reason = StoppedEvent.ReasonStep,
             });
-            return;
         }
     }
 


### PR DESCRIPTION
I moved the part of `HandleInstruction()` that handled function breakpoints to a less-often called method. `HandleInstruction()` will also now only be called while stepping is actively happening, since `DreamThread.StepMode` can only change from `null` outside of `InternalResume()`.