### PR TITLE
Remove spawn-in-loop safeguard

### DIFF
--- a/OpenDreamRuntime/Objects/DreamIcon.cs
+++ b/OpenDreamRuntime/Objects/DreamIcon.cs
@@ -363,6 +363,7 @@ public sealed class DreamIconOperationBlendImage : DreamIconOperationBlend {
         }
 
         _blending = blendingIcon.Texture;
+        _blendingDescription = blendingIcon.DMI;
     }
 
     public override void ApplyToFrame(Rgba32[] pixels, int imageSpan, int frame, UIBox2i bounds) {

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -218,10 +218,6 @@ namespace OpenDreamRuntime.Procs {
         public DMProcState() { }
 
         private DMProcState(DMProcState other, DreamThread thread) {
-            if (other._enumeratorStack?.Count > 0) {
-                throw new NotImplementedException();
-            }
-
             base.Initialize(thread, other.WaitFor);
             _proc = other._proc;
             Instance = other.Instance;


### PR DESCRIPTION
I don't see a reason for this safeguard to exist. The only time you'd want to copy the thread's enumerators when spawning is if you want to enumerate them inside that spawn. It isn't possible to even attempt that from DM so I removed the exception. This fixes `/mob/living/say()` in Paradise.

I also fixed an overlooked uninitialized field introduced in a recent icon rework.