### PR TITLE
Make missing `#undef` directives a warning by default

### DIFF
--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -5,7 +5,7 @@
 #pragma FileAlreadyIncluded warning
 #pragma MissingIncludedFile error
 #pragma MisplacedDirective error
-#pragma UndefineMissingDirective error
+#pragma UndefineMissingDirective warning
 #pragma DefinedMissingParen error
 #pragma ErrorDirective error
 #pragma WarningDirective warning


### PR DESCRIPTION
BYOND doesn't care about attempts to undefine nonexistant macros, it doesn't even print any messages about it. I switched it from being an error in OD to a warning.