### PR TITLE
Variadic macro fix

### DIFF
--- a/Content.Tests/DMProject/Tests/Preprocessor/macro_as_arg.dm
+++ b/Content.Tests/DMProject/Tests/Preprocessor/macro_as_arg.dm
@@ -1,31 +1,21 @@
 #define DUMMY(lol) inc_count_and_assert(lol)
-
-#define _GETTER_3(_, _, a, ...) a
-#define TUPLE_GET_3(x) x(_GETTER_3)
-#define GET_MACRO_ARG TUPLE_GET_3
-
+#define YMMUD(lol) dec_count_and_assert(lol)
 #define _GETTER_4(_, _, _, a, ...) a
-#define _GETTER_4_OR_DUMMY(args...) _GETTER_4(##args, DUMMY, DUMMY, DUMMY, DUMMY, DUMMY, DUMMY, DUMMY, DUMMY, DUMMY, DUMMY)
-#define TUPLE_GET_4_OR_DUMMY(x) x(_GETTER_4_OR_DUMMY)
-#define GET_MACRO_OR_DUMMY TUPLE_GET_4_OR_DUMMY
-
-#define DO_THING(thing, thing_arg) do { thing(thing_arg) } while(0)
-
-#define APPLY_ATOM_PROPERTY(_, property) DO_THING(GET_MACRO_OR_DUMMY(property), GET_MACRO_ARG(property))
-
-#define PROP_TEST(x) x("first", DO_THING, 2)
-#define PROP_TEST_2(x) x("first", DO_THING, 2, DUMMY)
+#define _GETTER_4_OR_DUMMY(args...) _GETTER_4(##args DUMMY, DUMMY, DUMMY, DUMMY, DUMMY, DUMMY, DUMMY, DUMMY, DUMMY, DUMMY)
 
 var/i = 0
-
 /proc/inc_count_and_assert(a)
-	if(a == 2)
+ 	if(a == 2)
 		i++
 
+/proc/dec_count_and_assert(a)
+	if(a==2)
+		i--
+
 /proc/RunTest()
-	APPLY_ATOM_PROPERTY(null, PROP_TEST)
-	if(i != 1)
-		CRASH("Test failed at PROP_TEST")
-	APPLY_ATOM_PROPERTY(null, PROP_TEST_2)
-	if(i != 2)
-		CRASH("Test failed at PROP_TEST_2")
+	_GETTER_4_OR_DUMMY(1,2,3)(2)
+	ASSERT(i == 1)
+	_GETTER_4_OR_DUMMY(1,2,3,DUMMY)(2)
+	ASSERT(i == 2)
+	_GETTER_4_OR_DUMMY(1,2,3,YMMUD)(2)
+	ASSERT(i == 1)

--- a/Content.Tests/DMProject/Tests/Preprocessor/macro_as_arg.dm
+++ b/Content.Tests/DMProject/Tests/Preprocessor/macro_as_arg.dm
@@ -1,0 +1,31 @@
+#define DUMMY(lol) inc_count_and_assert(lol)
+
+#define _GETTER_3(_, _, a, ...) a
+#define TUPLE_GET_3(x) x(_GETTER_3)
+#define GET_MACRO_ARG TUPLE_GET_3
+
+#define _GETTER_4(_, _, _, a, ...) a
+#define _GETTER_4_OR_DUMMY(args...) _GETTER_4(##args, DUMMY, DUMMY, DUMMY, DUMMY, DUMMY, DUMMY, DUMMY, DUMMY, DUMMY, DUMMY)
+#define TUPLE_GET_4_OR_DUMMY(x) x(_GETTER_4_OR_DUMMY)
+#define GET_MACRO_OR_DUMMY TUPLE_GET_4_OR_DUMMY
+
+#define DO_THING(thing, thing_arg) do { thing(thing_arg) } while(0)
+
+#define APPLY_ATOM_PROPERTY(_, property) DO_THING(GET_MACRO_OR_DUMMY(property), GET_MACRO_ARG(property))
+
+#define PROP_TEST(x) x("first", DO_THING, 2)
+#define PROP_TEST_2(x) x("first", DO_THING, 2, DUMMY)
+
+var/i = 0
+
+/proc/inc_count_and_assert(a)
+	if(a == 2)
+		i++
+
+/proc/RunTest()
+	APPLY_ATOM_PROPERTY(null, PROP_TEST)
+	if(i != 1)
+		CRASH("Test failed at PROP_TEST")
+	APPLY_ATOM_PROPERTY(null, PROP_TEST_2)
+	if(i != 2)
+		CRASH("Test failed at PROP_TEST_2")

--- a/DMCompiler/Compiler/DMPreprocessor/DMMacro.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMMacro.cs
@@ -94,8 +94,8 @@ namespace DMCompiler.Compiler.DMPreprocessor {
                 } else if (_overflowParameter != null && parameterName == _overflowParameter) {
                     for (int i = _overflowParameterIndex; i < parameters.Count; i++) {
                         expandedTokens.AddRange(parameters[i]);
-                        expandedTokens.Add(new Token(TokenType.DM_Preproc_Punctuator_Comma, ",", Location.Unknown,
-                            null));
+
+                        //expandedTokens.Add(new Token(TokenType.DM_Preproc_Punctuator_Comma, ",", Location.Unknown, null));
                     }
                 } else {
                     if (token.Type == TokenType.DM_Preproc_ParameterStringify) {


### PR DESCRIPTION
Fix `MACRO(args) do_thing(##args)`  getting a bad trailing comma after the args