### PR TITLE
Add support for runtime-created interface elements

### DIFF
--- a/OpenDream.sln.DotSettings
+++ b/OpenDream.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DM/@EntryIndexedValue">DM</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DMF/@EntryIndexedValue">DMF</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DMI/@EntryIndexedValue">DMI</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DMAST/@EntryIndexedValue">DMAST</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>

--- a/OpenDreamClient/DreamClientSystem.cs
+++ b/OpenDreamClient/DreamClientSystem.cs
@@ -14,7 +14,7 @@ namespace OpenDreamClient {
         private void OnPlayerAttached(PlayerAttachSysMessage e) {
             // The active input context gets reset to "common" when a new player is attached
             // So we have to set it again
-            _macroManager.SetActiveMacroSet(_interfaceManager.InterfaceDescriptor.MacroSetDescriptors[0]);
+            _macroManager.SetActiveMacroSet(_interfaceManager.InterfaceDescriptor.MacroSetDescriptors[0].Name);
         }
     }
 }

--- a/OpenDreamClient/Input/DreamCommandSystem.cs
+++ b/OpenDreamClient/Input/DreamCommandSystem.cs
@@ -3,7 +3,7 @@ using OpenDreamClient.Interface;
 using Robust.Shared.Network;
 
 namespace OpenDreamClient.Input {
-    sealed class DreamCommandSystem : SharedDreamCommandSystem {
+    public sealed class DreamCommandSystem : SharedDreamCommandSystem {
         [Dependency] private readonly IDreamInterfaceManager _interfaceManager = default!;
 
         public void RunCommand(string command) {

--- a/OpenDreamClient/Input/DreamMacroManager.cs
+++ b/OpenDreamClient/Input/DreamMacroManager.cs
@@ -1,189 +1,36 @@
-﻿using OpenDreamClient.Interface.Descriptors;
+﻿using OpenDreamClient.Interface;
+using OpenDreamClient.Interface.Descriptors;
 using Robust.Client.Input;
-using Robust.Shared.Input;
-using Robust.Shared.Input.Binding;
-using Key = Robust.Client.Input.Keyboard.Key;
 
 namespace OpenDreamClient.Input {
     sealed class DreamMacroManager : IDreamMacroManager {
+        public Dictionary<string, InterfaceMacroSet> InterfaceMacroSets { get; } = new();
+
         [Dependency] private readonly IInputManager _inputManager = default!;
         [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
 
-        private const string InputContextPrefix = "macroSet_";
-
         public void LoadMacroSets(List<MacroSetDescriptor> macroSets) {
-            IInputContextContainer contexts = _inputManager.Contexts;
+            InterfaceMacroSets.Clear();
 
             foreach (MacroSetDescriptor macroSet in macroSets) {
-                string name = InputContextPrefix + macroSet.Name;
-                if (contexts.Exists(name)) {
-                    contexts.Remove(name);
-                }
-                IInputCmdContext context = contexts.New(name, "common");
-
-                foreach (MacroDescriptor macro in macroSet.Macros) {
-                    BoundKeyFunction function = new BoundKeyFunction(macro.Id);
-                    KeyBindingRegistration binding = CreateMacroBinding(function, macro.Name);
-
-                    if (binding == null)
-                        continue;
-
-                    context.AddFunction(function);
-                    _inputManager.RegisterBinding(in binding);
-                    _inputManager.SetInputCommand(function, InputCmdHandler.FromDelegate(_ => OnMacroPress(macro), _ => OnMacroRelease(macro)));
-                }
+                InterfaceMacroSets.Add(macroSet.Name, new(macroSet, _entitySystemManager, _inputManager));
             }
         }
 
-        public void SetActiveMacroSet(MacroSetDescriptor macroSet) {
-            _inputManager.Contexts.SetActiveContext(InputContextPrefix + macroSet.Name);
-        }
-
-        private void OnMacroPress(MacroDescriptor macro) {
-            if (String.IsNullOrEmpty(macro.Command))
+        public void SetActiveMacroSet(string macroSetName) {
+            if (!InterfaceMacroSets.TryGetValue(macroSetName, out var macroSet)) {
+                Logger.Error($"Attempted to set active macro set to nonexistent set \"{macroSetName}\"");
                 return;
-
-            if (_entitySystemManager.TryGetEntitySystem(out DreamCommandSystem commandSystem)) {
-                if (macro.Name.EndsWith("+REP")) {
-                    commandSystem.StartRepeatingCommand(macro.Command);
-                } else {
-                    commandSystem.RunCommand(macro.Command);
-                }
             }
-        }
 
-        private void OnMacroRelease(MacroDescriptor macro) {
-            if (String.IsNullOrEmpty(macro.Command))
-                return;
-
-            if (_entitySystemManager.TryGetEntitySystem(out DreamCommandSystem commandSystem)) {
-                if (macro.Name.EndsWith("+REP")) {
-                    commandSystem.StopRepeatingCommand(macro.Command);
-                } else if (macro.Name.EndsWith("+UP")) {
-                    commandSystem.RunCommand(macro.Command);
-                }
-            }
-        }
-
-            private KeyBindingRegistration CreateMacroBinding(BoundKeyFunction function, string macroName) {
-            macroName = macroName.Replace("SHIFT+", String.Empty);
-            macroName = macroName.Replace("CTRL+", String.Empty);
-            macroName = macroName.Replace("ALT+", String.Empty);
-            macroName = macroName.Replace("+UP", String.Empty);
-            macroName = macroName.Replace("+REP", String.Empty);
-
-            //TODO: modifiers
-            var key = KeyNameToKey(macroName);
-            if (key == Key.Unknown)
-            {
-                Logger.Warning($"Unknown key: {macroName}");
-                return null;
-            }
-            return new KeyBindingRegistration() {
-                BaseKey = key,
-                Function = function
-            };
-        }
-
-        private static Key KeyNameToKey(string keyName) {
-            return keyName.ToUpper() switch {
-                "A" => Key.A,
-                "B" => Key.B,
-                "C" => Key.C,
-                "D" => Key.D,
-                "E" => Key.E,
-                "F" => Key.F,
-                "G" => Key.G,
-                "H" => Key.H,
-                "I" => Key.I,
-                "J" => Key.J,
-                "K" => Key.K,
-                "L" => Key.L,
-                "M" => Key.M,
-                "N" => Key.N,
-                "O" => Key.O,
-                "P" => Key.P,
-                "Q" => Key.Q,
-                "R" => Key.R,
-                "S" => Key.S,
-                "T" => Key.T,
-                "U" => Key.U,
-                "V" => Key.V,
-                "W" => Key.W,
-                "X" => Key.X,
-                "Y" => Key.Y,
-                "Z" => Key.Z,
-                "0" => Key.Num0,
-                "1" => Key.Num1,
-                "2" => Key.Num2,
-                "3" => Key.Num3,
-                "4" => Key.Num4,
-                "5" => Key.Num5,
-                "6" => Key.Num6,
-                "7" => Key.Num7,
-                "8" => Key.Num8,
-                "9" => Key.Num9,
-                "F1" => Key.F1,
-                "F2" => Key.F2,
-                "F3" => Key.F3,
-                "F4" => Key.F4,
-                "F5" => Key.F5,
-                "F6" => Key.F6,
-                "F7" => Key.F7,
-                "F8" => Key.F8,
-                "F9" => Key.F9,
-                "F10" => Key.F10,
-                "F11" => Key.F11,
-                "F12" => Key.F12,
-                "F13" => Key.F13,
-                "F14" => Key.F14,
-                "F15" => Key.F15,
-                "NUMPAD0" => Key.NumpadNum0,
-                "NUMPAD1" => Key.NumpadNum1,
-                "NUMPAD2" => Key.NumpadNum2,
-                "NUMPAD3" => Key.NumpadNum3,
-                "NUMPAD4" => Key.NumpadNum4,
-                "NUMPAD5" => Key.NumpadNum5,
-                "NUMPAD6" => Key.NumpadNum6,
-                "NUMPAD7" => Key.NumpadNum7,
-                "NUMPAD8" => Key.NumpadNum8,
-                "NUMPAD9" => Key.NumpadNum9,
-                "NORTH" => Key.Up,
-                "SOUTH" => Key.Down,
-                "EAST" => Key.Right,
-                "WEST" => Key.Left,
-                "NORTHWEST" => Key.Home,
-                "SOUTHWEST" => Key.End,
-                "NORTHEAST" => Key.PageUp,
-                "SOUTHEAST" => Key.PageDown,
-                //"CENTER" => Key.Clear,
-                "RETURN" => Key.Return,
-                "ESCAPE" => Key.Escape,
-                "TAB" => Key.Tab,
-                "SPACE" => Key.Space,
-                "BACK" => Key.BackSpace,
-                "INSERT" => Key.Insert,
-                "DELETE" => Key.Delete,
-                "PAUSE" => Key.Pause,
-                //"SNAPSHOT" => Key.PrintScreen,
-                "LWIN" => Key.LSystem,
-                "RWIN" => Key.RSystem,
-                //"APPS" => Key.Apps,
-                "MULTIPLY" => Key.NumpadMultiply,
-                "ADD" => Key.NumpadAdd,
-                "SUBTRACT" => Key.NumpadSubtract,
-                "DIVIDE" => Key.NumpadDivide,
-                //TODO: Right shift/ctrl/alt
-                "SHIFT" => Key.Shift,
-                "CTRL" => Key.Control,
-                "ALT" => Key.Alt,
-                _ => Key.Unknown
-            };
+            macroSet.SetActive();
         }
     }
 
     interface IDreamMacroManager {
+        public Dictionary<string, InterfaceMacroSet> InterfaceMacroSets { get; }
+
         public void LoadMacroSets(List<MacroSetDescriptor> macroSets);
-        public void SetActiveMacroSet(MacroSetDescriptor macroSet);
+        public void SetActiveMacroSet(string macroSetName);
     }
 }

--- a/OpenDreamClient/Interface/BrowsePopup.cs
+++ b/OpenDreamClient/Interface/BrowsePopup.cs
@@ -17,21 +17,20 @@ namespace OpenDreamClient.Interface
             string name,
             Vector2i size,
             IClydeWindow ownerWindow) {
-            WindowDescriptor popupWindowDescriptor = new WindowDescriptor(name, new() {
-                new ControlDescriptorMain() {
-                    Name = "main",
+            WindowDescriptor popupWindowDescriptor = new WindowDescriptor(name,
+                new() {
+                    new ControlDescriptorBrowser {
+                        Name = "browser",
+                        Size = size,
+                        Anchor1 = new Vector2i(0, 0),
+                        Anchor2 = new Vector2i(100, 100)
+                    }
+                }) {
                     Size = size
-                },
-                new ControlDescriptorBrowser() {
-                    Name = "browser",
-                    Size = size,
-                    Anchor1 = new Vector2i(0, 0),
-                    Anchor2 = new Vector2i(100, 100)
-                }
-            });
+                };
 
             WindowElement = new ControlWindow(popupWindowDescriptor);
-            WindowElement.CreateChildControls(IoCManager.Resolve<IDreamInterfaceManager>());
+            WindowElement.CreateChildControls();
 
             _window = WindowElement.CreateWindow();
             _window.StartupLocation = WindowStartupLocation.CenterOwner;

--- a/OpenDreamClient/Interface/Controls/ControlButton.cs
+++ b/OpenDreamClient/Interface/Controls/ControlButton.cs
@@ -29,7 +29,7 @@ namespace OpenDreamClient.Interface.Controls {
             return _button;
         }
 
-        public override void UpdateElementDescriptor() {
+        protected override void UpdateElementDescriptor() {
             base.UpdateElementDescriptor();
 
             ControlDescriptorButton controlDescriptor = (ControlDescriptorButton)ElementDescriptor;

--- a/OpenDreamClient/Interface/Controls/ControlChild.cs
+++ b/OpenDreamClient/Interface/Controls/ControlChild.cs
@@ -23,7 +23,7 @@ namespace OpenDreamClient.Interface.Controls {
             return _grid;
         }
 
-        public override void UpdateElementDescriptor() {
+        protected override void UpdateElementDescriptor() {
             base.UpdateElementDescriptor();
 
             ControlDescriptorChild controlDescriptor = (ControlDescriptorChild)ElementDescriptor;

--- a/OpenDreamClient/Interface/Controls/ControlLabel.cs
+++ b/OpenDreamClient/Interface/Controls/ControlLabel.cs
@@ -18,7 +18,7 @@ namespace OpenDreamClient.Interface.Controls
             return _label;
         }
 
-        public override void UpdateElementDescriptor() {
+        protected override void UpdateElementDescriptor() {
             base.UpdateElementDescriptor();
 
             ControlDescriptorLabel controlDescriptor = (ControlDescriptorLabel)ElementDescriptor;

--- a/OpenDreamClient/Interface/Controls/ControlWindow.cs
+++ b/OpenDreamClient/Interface/Controls/ControlWindow.cs
@@ -1,13 +1,10 @@
-﻿using OpenDreamClient.Input;
-using OpenDreamClient.Interface.Descriptors;
+﻿using OpenDreamClient.Interface.Descriptors;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 
-namespace OpenDreamClient.Interface.Controls
-{
-    public sealed class ControlWindow : InterfaceControl
-    {
+namespace OpenDreamClient.Interface.Controls {
+    public sealed class ControlWindow : InterfaceControl {
         [Dependency] private readonly IUserInterfaceManager _uiMgr = default!;
         [Dependency] private readonly IDreamInterfaceManager _dreamInterface = default!;
 
@@ -15,117 +12,100 @@ namespace OpenDreamClient.Interface.Controls
         // Just like in win32 (which is definitely what this is inspired by let's be real),
         // windows can be embedded into other windows as a way to do nesting.
 
-        public List<InterfaceControl> ChildControls = new();
+        public readonly List<InterfaceControl> ChildControls = new();
 
-        private readonly WindowDescriptor _windowDescriptor;
-        private MenuBar _menu = default!;
+        private WindowDescriptor WindowDescriptor => (ElementDescriptor as WindowDescriptor);
+
+        private Control _menuContainer = default!;
         private LayoutContainer _canvas = default!;
         private readonly List<(OSWindow osWindow, IClydeWindow clydeWindow)> _openWindows = new();
 
-        public ControlWindow(WindowDescriptor windowDescriptor) : base(windowDescriptor.MainControlDescriptor, null)
-        {
+        public ControlWindow(WindowDescriptor windowDescriptor) : base(windowDescriptor, null) {
             IoCManager.InjectDependencies(this);
-
-            _windowDescriptor = windowDescriptor;
         }
 
-        public override void UpdateElementDescriptor()
-        {
+        protected override void UpdateElementDescriptor() {
             // Don't call base.UpdateElementDescriptor();
 
-            var controlDescriptor = (ControlDescriptorMain)ElementDescriptor;
+            _menuContainer.RemoveAllChildren();
+            if (WindowDescriptor.Menu != null) {
+                _dreamInterface.Menus.TryGetValue(WindowDescriptor.Menu,
+                    out InterfaceMenu menu);
 
-            if (controlDescriptor.Menu != null)
-            {
-                _menu.Visible = true;
-
-                InterfaceDescriptor interfaceDescriptor = _dreamInterface.InterfaceDescriptor;
-
-                interfaceDescriptor.MenuDescriptors.TryGetValue(controlDescriptor.Menu,
-                    out MenuDescriptor menuDescriptor);
-                CreateMenu(menuDescriptor);
-            }
-            else
-            {
-                _menu.Visible = false;
+                _menuContainer.AddChild(menu.MenuBar);
+                _menuContainer.Visible = true;
+            } else {
+                _menuContainer.Visible = false;
             }
 
-            foreach (var window in _openWindows)
-            {
-                UpdateWindowAttributes(window, controlDescriptor);
+            foreach (var window in _openWindows) {
+                UpdateWindowAttributes(window);
             }
         }
 
-        public OSWindow CreateWindow()
-        {
+        public OSWindow CreateWindow() {
             OSWindow window = new();
 
             window.Children.Add(UIElement);
-            window.SetWidth = _controlDescriptor.Size?.X ?? 640;
-            window.SetHeight = _controlDescriptor.Size?.Y ?? 440;
-            if(_controlDescriptor.Size?.X == 0)
+            window.SetWidth = ControlDescriptor.Size?.X ?? 640;
+            window.SetHeight = ControlDescriptor.Size?.Y ?? 440;
+            if (ControlDescriptor.Size?.X == 0)
                 window.SetWidth = window.MaxWidth;
-            if(_controlDescriptor.Size?.Y == 0)
+            if (ControlDescriptor.Size?.Y == 0)
                 window.SetHeight = window.MaxHeight;
             window.Closing += _ => { _openWindows.Remove((window, null)); };
 
             _openWindows.Add((window, null));
-            UpdateWindowAttributes((window, null), (ControlDescriptorMain)ElementDescriptor);
+            UpdateWindowAttributes((window, null));
             return window;
         }
 
-        public void RegisterOnClydeWindow(IClydeWindow window)
-        {
+        public void RegisterOnClydeWindow(IClydeWindow window) {
             // todo: listen for closed.
             _openWindows.Add((null, window));
-            UpdateWindowAttributes((null, window), (ControlDescriptorMain)ElementDescriptor);
+            UpdateWindowAttributes((null, window));
         }
 
-        public void UpdateAnchors()
-        {
+        public void UpdateAnchors() {
             var windowSize = Size.GetValueOrDefault();
-            if(windowSize.X == 0)
+            if (windowSize.X == 0)
                 windowSize.X = 640;
-            if(windowSize.Y == 0)
+            if (windowSize.Y == 0)
                 windowSize.Y = 440;
 
-            for(int i = 0; i < ChildControls.Count; i++)
-            {
+            for (int i = 0; i < ChildControls.Count; i++) {
                 InterfaceControl control = ChildControls[i];
                 var element = control.UIElement;
                 var elementPos = control.Pos.GetValueOrDefault();
                 var elementSize = control.Size.GetValueOrDefault();
 
-                if(control.Size?.Y == 0)
-                {
-                    elementSize.Y = (int) (windowSize.Y - elementPos.Y);
-                    if(ChildControls.Count - 1 > i)
-                    {
-                        if(ChildControls[i+1].Pos != null)
-                        {
-                            var nextElementPos = ChildControls[i+1].Pos.GetValueOrDefault();
+                if (control.Size?.Y == 0) {
+                    elementSize.Y = (windowSize.Y - elementPos.Y);
+                    if (ChildControls.Count - 1 > i) {
+                        if (ChildControls[i + 1].Pos != null) {
+                            var nextElementPos = ChildControls[i + 1].Pos.GetValueOrDefault();
                             elementSize.Y = nextElementPos.Y - elementPos.Y;
                         }
                     }
-                    element.SetHeight = (elementSize.Y/windowSize.Y) * _canvas.Height;
+
+                    element.SetHeight = (elementSize.Y / windowSize.Y) * _canvas.Height;
                 }
-                if(control.Size?.X == 0)
-                {
-                    elementSize.X = (int) (windowSize.X - elementPos.X);
-                    if(ChildControls.Count - 1 > i)
-                    {
-                        if(ChildControls[i+1].Pos != null)
-                        {
-                            var nextElementPos = ChildControls[i+1].Pos.GetValueOrDefault();
-                            if(nextElementPos.X < (elementSize.X + elementPos.X) && nextElementPos.Y < (elementSize.Y + elementPos.Y))
+
+                if (control.Size?.X == 0) {
+                    elementSize.X = (windowSize.X - elementPos.X);
+                    if (ChildControls.Count - 1 > i) {
+                        if (ChildControls[i + 1].Pos != null) {
+                            var nextElementPos = ChildControls[i + 1].Pos.GetValueOrDefault();
+                            if (nextElementPos.X < (elementSize.X + elementPos.X) &&
+                                nextElementPos.Y < (elementSize.Y + elementPos.Y))
                                 elementSize.X = nextElementPos.X - elementPos.X;
                         }
                     }
-                    element.SetWidth = (elementSize.X/windowSize.X) * _canvas.Width;
+
+                    element.SetWidth = (elementSize.X / windowSize.X) * _canvas.Width;
                 }
 
-                if (control.Anchor1.HasValue)
-                {
+                if (control.Anchor1.HasValue) {
                     var offset1X = elementPos.X - (windowSize.X * control.Anchor1.Value.X / 100f);
                     var offset1Y = elementPos.Y - (windowSize.Y * control.Anchor1.Value.Y / 100f);
                     var left = (_canvas.Width * control.Anchor1.Value.X / 100) + offset1X;
@@ -133,16 +113,15 @@ namespace OpenDreamClient.Interface.Controls
                     LayoutContainer.SetMarginLeft(element, Math.Max(left, 0));
                     LayoutContainer.SetMarginTop(element, Math.Max(top, 0));
 
-                    if (control.Anchor2.HasValue)
-                    {
-                        if(control.Anchor2.Value.X < control.Anchor1.Value.X || control.Anchor2.Value.Y < control.Anchor1.Value.Y)
+                    if (control.Anchor2.HasValue) {
+                        if (control.Anchor2.Value.X < control.Anchor1.Value.X ||
+                            control.Anchor2.Value.Y < control.Anchor1.Value.Y)
                             Logger.Warning($"Invalid anchor2 value in DMF for element {control.Name}. Ignoring.");
-                        else
-                        {
+                        else {
                             var offset2X = (elementPos.X + elementSize.X) -
-                                        (windowSize.X * control.Anchor2.Value.X / 100);
+                                           (windowSize.X * control.Anchor2.Value.X / 100);
                             var offset2Y = (elementPos.Y + elementSize.Y) -
-                                        (windowSize.Y * control.Anchor2.Value.Y / 100);
+                                           (windowSize.Y * control.Anchor2.Value.Y / 100);
                             var width = (_canvas.Width * control.Anchor2.Value.X / 100) + offset2X - left;
                             var height = (_canvas.Height * control.Anchor2.Value.Y / 100) + offset2Y - top;
                             element.SetWidth = Math.Max(width, 0);
@@ -154,14 +133,11 @@ namespace OpenDreamClient.Interface.Controls
             }
         }
 
-        private void UpdateWindowAttributes(
-            (OSWindow osWindow, IClydeWindow clydeWindow) windowRoot,
-            ControlDescriptorMain descriptor)
-        {
+        private void UpdateWindowAttributes((OSWindow osWindow, IClydeWindow clydeWindow) windowRoot) {
             // TODO: this would probably be cleaner if an OSWindow for MainWindow was available.
             var (osWindow, clydeWindow) = windowRoot;
 
-            var title = descriptor.Title ?? "OpenDream World";
+            var title = WindowDescriptor.Title ?? "OpenDream World";
             if (osWindow != null) osWindow.Title = title;
             else if (clydeWindow != null) clydeWindow.Title = title;
 
@@ -171,70 +147,72 @@ namespace OpenDreamClient.Interface.Controls
             else if (clydeWindow != null)
                 root = _uiMgr.GetWindowRoot(clydeWindow);
 
-            if (root != null)
-            {
-                root.BackgroundColor = descriptor.BackgroundColor;
+            if (root != null) {
+                root.BackgroundColor = WindowDescriptor.BackgroundColor;
             }
         }
 
-        public void CreateChildControls(IDreamInterfaceManager manager)
-        {
-            foreach (ControlDescriptor controlDescriptor in _windowDescriptor.ControlDescriptors)
-            {
-                if (controlDescriptor == _windowDescriptor.MainControlDescriptor) continue;
-
-                InterfaceControl control = controlDescriptor switch
-                {
-                    ControlDescriptorChild => new ControlChild(controlDescriptor, this),
-                    ControlDescriptorInput => new ControlInput(controlDescriptor, this),
-                    ControlDescriptorButton => new ControlButton(controlDescriptor, this),
-                    ControlDescriptorOutput => new ControlOutput(controlDescriptor, this),
-                    ControlDescriptorInfo => new ControlInfo(controlDescriptor, this),
-                    ControlDescriptorMap => new ControlMap(controlDescriptor, this),
-                    ControlDescriptorBrowser => new ControlBrowser(controlDescriptor, this),
-                    ControlDescriptorLabel => new ControlLabel(controlDescriptor, this),
-                    ControlDescriptorGrid => new ControlGrid(controlDescriptor, this),
-                    ControlDescriptorTab => new ControlTab(controlDescriptor, this),
-                    _ => throw new Exception($"Invalid descriptor {controlDescriptor.GetType()}")
-                };
-                // Can't have out-of-order components, so make sure they're ordered properly
-                if(ChildControls.Count > 0) {
-                    var prevPos = ChildControls[ChildControls.Count-1].Pos.GetValueOrDefault();
-                    var curPos = control.Pos.GetValueOrDefault();
-                    if(prevPos.X <= curPos.X && prevPos.Y <= curPos.Y)
-                        ChildControls.Add(control);
-                    else {
-                        Logger.Warning($"Out of order component {control.Name}. Elements should be defined in order of position. Attempting to fix automatically.");
-                        int i = 0;
-                        while(i < ChildControls.Count) {
-                            prevPos = ChildControls[i].Pos.GetValueOrDefault();
-                            if(prevPos.X <= curPos.X && prevPos.Y <= curPos.Y)
-                                i++;
-                            else
-                                break;
-                        }
-                        ChildControls.Insert(i, control);
-                    }
-                } else
-                    ChildControls.Add(control);
-
-                _canvas.Children.Add(control.UIElement);
+        public void CreateChildControls() {
+            foreach (ControlDescriptor controlDescriptor in WindowDescriptor.ControlDescriptors) {
+                AddChild(controlDescriptor);
             }
+        }
+
+        public override void AddChild(ElementDescriptor descriptor) {
+            if (descriptor is not ControlDescriptor controlDescriptor)
+                throw new Exception($"Attempted to add {descriptor} to a window, but it was not a control");
+            if (controlDescriptor is WindowDescriptor)
+                throw new Exception("Cannot add a window to a window");
+
+            InterfaceControl control = controlDescriptor switch {
+                ControlDescriptorChild => new ControlChild(controlDescriptor, this),
+                ControlDescriptorInput => new ControlInput(controlDescriptor, this),
+                ControlDescriptorButton => new ControlButton(controlDescriptor, this),
+                ControlDescriptorOutput => new ControlOutput(controlDescriptor, this),
+                ControlDescriptorInfo => new ControlInfo(controlDescriptor, this),
+                ControlDescriptorMap => new ControlMap(controlDescriptor, this),
+                ControlDescriptorBrowser => new ControlBrowser(controlDescriptor, this),
+                ControlDescriptorLabel => new ControlLabel(controlDescriptor, this),
+                ControlDescriptorGrid => new ControlGrid(controlDescriptor, this),
+                ControlDescriptorTab => new ControlTab(controlDescriptor, this),
+                _ => throw new Exception($"Invalid descriptor {controlDescriptor.GetType()}")
+            };
+
+            // Can't have out-of-order components, so make sure they're ordered properly
+            if (ChildControls.Count > 0) {
+                var prevPos = ChildControls[^1].Pos.GetValueOrDefault();
+                var curPos = control.Pos.GetValueOrDefault();
+                if (prevPos.X <= curPos.X && prevPos.Y <= curPos.Y)
+                    ChildControls.Add(control);
+                else {
+                    Logger.Warning(
+                        $"Out of order component {control.Name}. Elements should be defined in order of position. Attempting to fix automatically.");
+                    int i = 0;
+                    while (i < ChildControls.Count) {
+                        prevPos = ChildControls[i].Pos.GetValueOrDefault();
+                        if (prevPos.X <= curPos.X && prevPos.Y <= curPos.Y)
+                            i++;
+                        else
+                            break;
+                    }
+
+                    ChildControls.Insert(i, control);
+                }
+            } else
+                ChildControls.Add(control);
+
+            _canvas.Children.Add(control.UIElement);
         }
 
         // Because of how windows are not always real windows,
         // UIControl contains the *contents* of the window, not the actual OS window itself.
-        protected override Control CreateUIElement()
-        {
-            var container = new BoxContainer
-            {
+        protected override Control CreateUIElement() {
+            var container = new BoxContainer {
                 RectClipContent = true,
                 Orientation = BoxContainer.LayoutOrientation.Vertical,
-                Children =
-                {
-                    (_menu = new MenuBar { Margin = new Thickness(4, 0)}),
-                    (_canvas = new LayoutContainer
-                    {
+                Children = {
+                    (_menuContainer = new Control { Margin = new Thickness(4, 0)}),
+                    (_canvas = new LayoutContainer {
                         InheritChildMeasure = false,
                         VerticalExpand = true
                     })
@@ -246,80 +224,8 @@ namespace OpenDreamClient.Interface.Controls
             return container;
         }
 
-        private void CanvasOnResized()
-        {
+        private void CanvasOnResized() {
             UpdateAnchors();
-        }
-
-        private class MenuNode {
-            public MenuElementDescriptor Data;
-            public List<MenuNode> Children = new();
-
-            public MenuNode(MenuElementDescriptor myData) {
-                this.Data = myData;
-            }
-
-            public MenuBar.MenuEntry GetMenuEntry() {
-                string name = Data.Name;
-                if (name.StartsWith("&"))
-                    name = name[1..]; //TODO: First character in name becomes a selection shortcut
-
-                if(Children.Count > 0) {
-                    MenuBar.SubMenu result = new MenuBar.SubMenu();
-                    result.Text = name;
-                    foreach(MenuNode child in Children)
-                        result.Entries.Add(child.GetMenuEntry());
-
-                    return result;
-                } else if(!String.IsNullOrEmpty(name)) {
-                    MenuBar.MenuButton result = new MenuBar.MenuButton();
-                    result.Text = name;
-                    //result.IsCheckable = data.CanCheck;
-                    if (!String.IsNullOrEmpty(Data.Command))
-                        result.OnPressed += () => { EntitySystem.Get<DreamCommandSystem>().RunCommand(Data.Command); };
-                    return result;
-                } else
-                    return new MenuBar.MenuSeparator();
-            }
-        }
-        private void CreateMenu(MenuDescriptor menuDescriptor) {
-            _menu.Menus.Clear();
-            if (menuDescriptor == null) return;
-            List<MenuNode> menuTree = new();
-            Dictionary<string, MenuNode> treeQuickLookup = new();
-
-            foreach (MenuElementDescriptor elementDescriptor in menuDescriptor.Elements) {
-                if (elementDescriptor.Category == null) {
-                    MenuNode topLevelMenuItem = new(elementDescriptor);
-                    treeQuickLookup.Add(elementDescriptor.Name, topLevelMenuItem);
-                    menuTree.Add(topLevelMenuItem);
-                } else {
-                    if (!treeQuickLookup.ContainsKey(elementDescriptor.Category)) {
-                        //if category is set but the parent element doesn't exist, create it
-                        MenuElementDescriptor parentMenuItem = new MenuElementDescriptor();
-                        parentMenuItem.Name = elementDescriptor.Category;
-                        MenuNode topLevelMenuItem = new(parentMenuItem);
-                        treeQuickLookup.Add(parentMenuItem.Name, topLevelMenuItem);
-                        menuTree.Add(topLevelMenuItem);
-                    }
-                    //now add this as a child
-                    MenuNode childMenuItem = new MenuNode(elementDescriptor);
-                    treeQuickLookup[elementDescriptor.Category].Children.Add(childMenuItem);
-                    treeQuickLookup.Add(elementDescriptor.Name, childMenuItem);
-                }
-            }
-
-            foreach (MenuNode topLevelMenuItem in menuTree) {
-                MenuBar.Menu menu = new MenuBar.Menu();
-                menu.Title = topLevelMenuItem.Data.Name;
-                if (menu.Title?.StartsWith("&") ?? false)
-                    menu.Title = menu.Title[1..]; //TODO: First character in name becomes a selection shortcut
-
-                _menu.Menus.Add(menu);
-                //visit each node in the tree, populating the menu from that
-                foreach (MenuNode child in topLevelMenuItem.Children)
-                    menu.Entries.Add(child.GetMenuEntry());
-            }
         }
     }
 }

--- a/OpenDreamClient/Interface/Controls/InterfaceControl.cs
+++ b/OpenDreamClient/Interface/Controls/InterfaceControl.cs
@@ -4,23 +4,21 @@ using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 
-namespace OpenDreamClient.Interface.Controls
-{
-    public abstract class InterfaceControl : InterfaceElement
-    {
-        public Control UIElement { get; private set; }
-        public bool IsDefault { get => _controlDescriptor.IsDefault; }
-        public Vector2i? Size { get => _controlDescriptor.Size; }
-        public Vector2i? Pos { get => _controlDescriptor.Pos; }
-        public Vector2i? Anchor1 { get => _controlDescriptor.Anchor1; }
-        public Vector2i? Anchor2 { get => _controlDescriptor.Anchor2; }
+namespace OpenDreamClient.Interface.Controls {
+    public abstract class InterfaceControl : InterfaceElement {
+        public readonly Control UIElement;
+        public bool IsDefault => ControlDescriptor.IsDefault;
+        public Vector2i? Size => ControlDescriptor.Size;
+        public Vector2i? Pos => ControlDescriptor.Pos;
+        public Vector2i? Anchor1 => ControlDescriptor.Anchor1;
+        public Vector2i? Anchor2 => ControlDescriptor.Anchor2;
 
-        protected ControlDescriptor _controlDescriptor { get => ElementDescriptor as ControlDescriptor; }
-        protected ControlWindow _window;
+        protected ControlDescriptor ControlDescriptor => ElementDescriptor as ControlDescriptor;
+
+        private readonly ControlWindow _window;
 
         [SuppressMessage("ReSharper", "VirtualMemberCallInConstructor")]
-        public InterfaceControl(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor)
-        {
+        protected InterfaceControl(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor) {
             IoCManager.InjectDependencies(this);
 
             _window = window;
@@ -31,21 +29,19 @@ namespace OpenDreamClient.Interface.Controls
 
         protected abstract Control CreateUIElement();
 
+        protected override void UpdateElementDescriptor() {
+            UIElement.Name = ControlDescriptor.Name;
 
-        public override void UpdateElementDescriptor()
-        {
-            UIElement.Name = _controlDescriptor.Name;
-
-            var pos = _controlDescriptor.Pos.GetValueOrDefault();
+            var pos = ControlDescriptor.Pos.GetValueOrDefault();
             LayoutContainer.SetMarginLeft(UIElement, pos.X);
             LayoutContainer.SetMarginTop(UIElement, pos.Y);
 
-            if (_controlDescriptor.Size is { } size)
+            if (ControlDescriptor.Size is { } size)
                 UIElement.SetSize = size;
 
             _window?.UpdateAnchors();
 
-            if (_controlDescriptor.BackgroundColor is { } bgColor)
+            if (ControlDescriptor.BackgroundColor is { } bgColor)
             {
                 var styleBox = new StyleBoxFlat { BackgroundColor = bgColor };
 
@@ -57,7 +53,7 @@ namespace OpenDreamClient.Interface.Controls
                 }
             }
 
-            UIElement.Visible = _controlDescriptor.IsVisible;
+            UIElement.Visible = ControlDescriptor.IsVisible;
             // TODO: enablement
             //UIControl.IsEnabled = !_controlDescriptor.IsDisabled;
         }

--- a/OpenDreamClient/Interface/Descriptors/InterfaceDescriptor.cs
+++ b/OpenDreamClient/Interface/Descriptors/InterfaceDescriptor.cs
@@ -1,11 +1,14 @@
-﻿namespace OpenDreamClient.Interface.Descriptors;
+﻿using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown.Mapping;
+
+namespace OpenDreamClient.Interface.Descriptors;
 
 public sealed class InterfaceDescriptor {
-    public List<WindowDescriptor> WindowDescriptors;
-    public List<MacroSetDescriptor> MacroSetDescriptors;
-    public Dictionary<string, MenuDescriptor> MenuDescriptors;
+    public readonly List<WindowDescriptor> WindowDescriptors;
+    public readonly List<MacroSetDescriptor> MacroSetDescriptors;
+    public readonly List<MenuDescriptor> MenuDescriptors;
 
-    public InterfaceDescriptor(List<WindowDescriptor> windowDescriptors, List<MacroSetDescriptor> macroSetDescriptors, Dictionary<string, MenuDescriptor> menuDescriptors) {
+    public InterfaceDescriptor(List<WindowDescriptor> windowDescriptors, List<MacroSetDescriptor> macroSetDescriptors, List<MenuDescriptor> menuDescriptors) {
         WindowDescriptors = windowDescriptors;
         MacroSetDescriptors = macroSetDescriptors;
         MenuDescriptors = menuDescriptors;
@@ -18,4 +21,12 @@ public class ElementDescriptor {
     public string Type;
     [DataField("name")]
     public string Name;
+
+    public virtual ElementDescriptor CreateChildDescriptor(ISerializationManager serializationManager, MappingDataNode attributes) {
+        throw new InvalidOperationException($"{this} cannot create a child descriptor");
+    }
+
+    public override string ToString() {
+        return $"{GetType().Name}(Type={Type},Name={Name})";
+    }
 }

--- a/OpenDreamClient/Interface/Descriptors/MacroDescriptors.cs
+++ b/OpenDreamClient/Interface/Descriptors/MacroDescriptors.cs
@@ -1,12 +1,20 @@
-﻿namespace OpenDreamClient.Interface.Descriptors;
+﻿using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown.Mapping;
 
-public sealed class MacroSetDescriptor {
-    public string Name;
-    public List<MacroDescriptor> Macros;
+namespace OpenDreamClient.Interface.Descriptors;
 
-    public MacroSetDescriptor(string name, List<MacroDescriptor> macros) {
+public sealed class MacroSetDescriptor : ElementDescriptor {
+    public readonly List<MacroDescriptor> Macros = new();
+
+    public MacroSetDescriptor(string name) {
         Name = name;
-        Macros = macros;
+    }
+
+    public override MacroDescriptor CreateChildDescriptor(ISerializationManager serializationManager, MappingDataNode attributes) {
+        var macro = serializationManager.Read<MacroDescriptor>(attributes);
+
+        Macros.Add(macro);
+        return macro;
     }
 }
 

--- a/OpenDreamClient/Interface/Descriptors/MenuDescriptors.cs
+++ b/OpenDreamClient/Interface/Descriptors/MenuDescriptors.cs
@@ -1,12 +1,20 @@
-﻿namespace OpenDreamClient.Interface.Descriptors;
+﻿using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown.Mapping;
 
-public sealed class MenuDescriptor {
-    public string Name;
-    public List<MenuElementDescriptor> Elements;
+namespace OpenDreamClient.Interface.Descriptors;
 
-    public MenuDescriptor(string name, List<MenuElementDescriptor> elements) {
+public sealed class MenuDescriptor : ElementDescriptor {
+    public readonly List<MenuElementDescriptor> Elements = new();
+
+    public MenuDescriptor(string name) {
         Name = name;
-        Elements = elements;
+    }
+
+    public override MenuElementDescriptor CreateChildDescriptor(ISerializationManager serializationManager, MappingDataNode attributes) {
+        var menuElement = serializationManager.Read<MenuElementDescriptor>(attributes);
+
+        Elements.Add(menuElement);
+        return menuElement;
     }
 }
 
@@ -17,4 +25,9 @@ public sealed class MenuElementDescriptor : ElementDescriptor {
     public string Category;
     [DataField("can-check")]
     public bool CanCheck;
+
+    // Menu elements can have other menu elements as children
+    public override MenuElementDescriptor CreateChildDescriptor(ISerializationManager serializationManager, MappingDataNode attributes) {
+        return serializationManager.Read<MenuElementDescriptor>(attributes);
+    }
 }

--- a/OpenDreamClient/Interface/DummyDreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DummyDreamInterfaceManager.cs
@@ -2,15 +2,14 @@ using OpenDreamClient.Interface.Controls;
 using OpenDreamClient.Interface.Descriptors;
 using Robust.Shared.Timing;
 
-namespace OpenDreamClient.Interface
-{
+namespace OpenDreamClient.Interface {
     /// <summary>
     /// Used in unit testing to run a headless client.
     /// </summary>
-    public sealed class DummyDreamInterfaceManager : IDreamInterfaceManager
-    {
+    public sealed class DummyDreamInterfaceManager : IDreamInterfaceManager {
         public (string, string, string)[] AvailableVerbs { get; }
         public Dictionary<string, ControlWindow> Windows { get; }
+        public Dictionary<string, InterfaceMenu> Menus { get; }
         public InterfaceDescriptor InterfaceDescriptor { get; }
 
         public void Initialize()

--- a/OpenDreamClient/Interface/InterfaceElement.cs
+++ b/OpenDreamClient/Interface/InterfaceElement.cs
@@ -2,21 +2,19 @@
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Markdown.Mapping;
 
-namespace OpenDreamClient.Interface
-{
+namespace OpenDreamClient.Interface {
     [Virtual]
     public class InterfaceElement {
         public string Type => ElementDescriptor.Type;
         public string Name => ElementDescriptor.Name;
 
-        protected ElementDescriptor ElementDescriptor;
+        public ElementDescriptor ElementDescriptor;
 
-        public InterfaceElement(ElementDescriptor elementDescriptor) {
+        protected InterfaceElement(ElementDescriptor elementDescriptor) {
             ElementDescriptor = elementDescriptor;
         }
 
-        public void PopulateElementDescriptor(MappingDataNode node, ISerializationManager serializationManager)
-        {
+        public void PopulateElementDescriptor(MappingDataNode node, ISerializationManager serializationManager) {
             MappingDataNode original = (MappingDataNode)serializationManager.WriteValue(ElementDescriptor.GetType(), ElementDescriptor);
             foreach (var key in node.Keys) {
                 original.Remove(key);
@@ -27,8 +25,12 @@ namespace OpenDreamClient.Interface
             UpdateElementDescriptor();
         }
 
-        public virtual void UpdateElementDescriptor() {
+        protected virtual void UpdateElementDescriptor() {
 
+        }
+
+        public virtual void AddChild(ElementDescriptor descriptor) {
+            throw new InvalidOperationException($"{this} cannot add a child");
         }
 
         public virtual void Shutdown() {

--- a/OpenDreamClient/Interface/InterfaceMacro.cs
+++ b/OpenDreamClient/Interface/InterfaceMacro.cs
@@ -64,7 +64,7 @@ public sealed class InterfaceMacro : InterfaceElement {
 
         inputContext.AddFunction(function);
         inputManager.RegisterBinding(in binding);
-        inputManager.SetInputCommand(function, InputCmdHandler.FromDelegate(OnMacroPress, OnMacroRelease));
+        inputManager.SetInputCommand(function, InputCmdHandler.FromDelegate(OnMacroPress, OnMacroRelease, outsidePrediction: false));
     }
 
     private void OnMacroPress([CanBeNull] ICommonSession session) {

--- a/OpenDreamClient/Interface/InterfaceMacro.cs
+++ b/OpenDreamClient/Interface/InterfaceMacro.cs
@@ -1,0 +1,211 @@
+﻿using JetBrains.Annotations;
+using OpenDreamClient.Input;
+using OpenDreamClient.Interface.Descriptors;
+using Robust.Client.Input;
+using Robust.Shared.Input;
+using Robust.Shared.Input.Binding;
+using Robust.Shared.Players;
+using Key = Robust.Client.Input.Keyboard.Key;
+
+namespace OpenDreamClient.Interface;
+
+public sealed class InterfaceMacroSet : InterfaceElement {
+    public readonly Dictionary<string, InterfaceMacro> Macros = new();
+
+    private const string InputContextPrefix = "macroSet_";
+
+    private readonly IInputManager _inputManager;
+    private readonly IEntitySystemManager _entitySystemManager;
+    private readonly IInputCmdContext _inputContext;
+
+    public InterfaceMacroSet(MacroSetDescriptor descriptor, IEntitySystemManager entitySystemManager, IInputManager inputManager) : base(descriptor) {
+        _inputManager = inputManager;
+        _entitySystemManager = entitySystemManager;
+
+        var inputContextName = $"{InputContextPrefix}{Name}";
+        if (inputManager.Contexts.Exists(inputContextName)) {
+            inputManager.Contexts.Remove(inputContextName);
+        }
+
+        _inputContext = inputManager.Contexts.New(inputContextName, "common");
+        foreach (MacroDescriptor macro in descriptor.Macros) {
+            AddChild(macro);
+        }
+    }
+
+    public override void AddChild(ElementDescriptor descriptor) {
+        if (descriptor is not MacroDescriptor macroDescriptor)
+            throw new ArgumentException($"Attempted to add a {descriptor} to a macro set", nameof(descriptor));
+
+        Macros.Add(macroDescriptor.Name, new InterfaceMacro(macroDescriptor, _entitySystemManager, _inputManager, _inputContext));
+    }
+
+    public void SetActive() {
+        _inputManager.Contexts.SetActiveContext($"{InputContextPrefix}{Name}");
+    }
+}
+
+public sealed class InterfaceMacro : InterfaceElement {
+    public string Id => MacroDescriptor.Id;
+    public string Command => MacroDescriptor.Id;
+
+    private MacroDescriptor MacroDescriptor => (ElementDescriptor as MacroDescriptor);
+
+    private readonly IEntitySystemManager _entitySystemManager;
+
+    public InterfaceMacro(MacroDescriptor descriptor, IEntitySystemManager entitySystemManager, IInputManager inputManager, IInputCmdContext inputContext) : base(descriptor) {
+        _entitySystemManager = entitySystemManager;
+
+        BoundKeyFunction function = new BoundKeyFunction(Id);
+        KeyBindingRegistration binding = CreateMacroBinding(function, Name);
+
+        if (binding == null)
+            return;
+
+        inputContext.AddFunction(function);
+        inputManager.RegisterBinding(in binding);
+        inputManager.SetInputCommand(function, InputCmdHandler.FromDelegate(OnMacroPress, OnMacroRelease));
+    }
+
+    private void OnMacroPress([CanBeNull] ICommonSession session) {
+        if (String.IsNullOrEmpty(Command))
+            return;
+
+        if (_entitySystemManager.TryGetEntitySystem(out DreamCommandSystem commandSystem)) {
+            if (Name.EndsWith("+REP")) {
+                commandSystem.StartRepeatingCommand(Command);
+            } else {
+                commandSystem.RunCommand(Command);
+            }
+        }
+    }
+
+    private void OnMacroRelease([CanBeNull] ICommonSession session) {
+        if (String.IsNullOrEmpty(Command))
+            return;
+
+        if (_entitySystemManager.TryGetEntitySystem(out DreamCommandSystem commandSystem)) {
+            if (Name.EndsWith("+REP")) {
+                commandSystem.StopRepeatingCommand(Command);
+            } else if (Name.EndsWith("+UP")) {
+                commandSystem.RunCommand(Command);
+            }
+        }
+    }
+
+    private static KeyBindingRegistration CreateMacroBinding(BoundKeyFunction function, string macroName) {
+            macroName = macroName.Replace("SHIFT+", String.Empty);
+            macroName = macroName.Replace("CTRL+", String.Empty);
+            macroName = macroName.Replace("ALT+", String.Empty);
+            macroName = macroName.Replace("+UP", String.Empty);
+            macroName = macroName.Replace("+REP", String.Empty);
+
+            //TODO: modifiers
+            var key = KeyNameToKey(macroName);
+            if (key == Key.Unknown) {
+                Logger.Warning($"Unknown key: {macroName}");
+                return null;
+            }
+
+            return new KeyBindingRegistration() {
+                BaseKey = key,
+                Function = function
+            };
+        }
+
+        private static Key KeyNameToKey(string keyName) {
+            return keyName.ToUpper() switch {
+                "A" => Key.A,
+                "B" => Key.B,
+                "C" => Key.C,
+                "D" => Key.D,
+                "E" => Key.E,
+                "F" => Key.F,
+                "G" => Key.G,
+                "H" => Key.H,
+                "I" => Key.I,
+                "J" => Key.J,
+                "K" => Key.K,
+                "L" => Key.L,
+                "M" => Key.M,
+                "N" => Key.N,
+                "O" => Key.O,
+                "P" => Key.P,
+                "Q" => Key.Q,
+                "R" => Key.R,
+                "S" => Key.S,
+                "T" => Key.T,
+                "U" => Key.U,
+                "V" => Key.V,
+                "W" => Key.W,
+                "X" => Key.X,
+                "Y" => Key.Y,
+                "Z" => Key.Z,
+                "0" => Key.Num0,
+                "1" => Key.Num1,
+                "2" => Key.Num2,
+                "3" => Key.Num3,
+                "4" => Key.Num4,
+                "5" => Key.Num5,
+                "6" => Key.Num6,
+                "7" => Key.Num7,
+                "8" => Key.Num8,
+                "9" => Key.Num9,
+                "F1" => Key.F1,
+                "F2" => Key.F2,
+                "F3" => Key.F3,
+                "F4" => Key.F4,
+                "F5" => Key.F5,
+                "F6" => Key.F6,
+                "F7" => Key.F7,
+                "F8" => Key.F8,
+                "F9" => Key.F9,
+                "F10" => Key.F10,
+                "F11" => Key.F11,
+                "F12" => Key.F12,
+                "F13" => Key.F13,
+                "F14" => Key.F14,
+                "F15" => Key.F15,
+                "NUMPAD0" => Key.NumpadNum0,
+                "NUMPAD1" => Key.NumpadNum1,
+                "NUMPAD2" => Key.NumpadNum2,
+                "NUMPAD3" => Key.NumpadNum3,
+                "NUMPAD4" => Key.NumpadNum4,
+                "NUMPAD5" => Key.NumpadNum5,
+                "NUMPAD6" => Key.NumpadNum6,
+                "NUMPAD7" => Key.NumpadNum7,
+                "NUMPAD8" => Key.NumpadNum8,
+                "NUMPAD9" => Key.NumpadNum9,
+                "NORTH" => Key.Up,
+                "SOUTH" => Key.Down,
+                "EAST" => Key.Right,
+                "WEST" => Key.Left,
+                "NORTHWEST" => Key.Home,
+                "SOUTHWEST" => Key.End,
+                "NORTHEAST" => Key.PageUp,
+                "SOUTHEAST" => Key.PageDown,
+                //"CENTER" => Key.Clear,
+                "RETURN" => Key.Return,
+                "ESCAPE" => Key.Escape,
+                "TAB" => Key.Tab,
+                "SPACE" => Key.Space,
+                "BACK" => Key.BackSpace,
+                "INSERT" => Key.Insert,
+                "DELETE" => Key.Delete,
+                "PAUSE" => Key.Pause,
+                //"SNAPSHOT" => Key.PrintScreen,
+                "LWIN" => Key.LSystem,
+                "RWIN" => Key.RSystem,
+                //"APPS" => Key.Apps,
+                "MULTIPLY" => Key.NumpadMultiply,
+                "ADD" => Key.NumpadAdd,
+                "SUBTRACT" => Key.NumpadSubtract,
+                "DIVIDE" => Key.NumpadDivide,
+                //TODO: Right shift/ctrl/alt
+                "SHIFT" => Key.Shift,
+                "CTRL" => Key.Control,
+                "ALT" => Key.Alt,
+                _ => Key.Unknown
+            };
+        }
+}

--- a/OpenDreamClient/Interface/InterfaceMenu.cs
+++ b/OpenDreamClient/Interface/InterfaceMenu.cs
@@ -1,0 +1,127 @@
+﻿using OpenDreamClient.Input;
+using OpenDreamClient.Interface.Descriptors;
+using Robust.Client.UserInterface.Controls;
+
+namespace OpenDreamClient.Interface;
+
+public sealed class InterfaceMenu : InterfaceElement {
+    public readonly Dictionary<string, MenuElement> MenuElements = new();
+    public readonly MenuBar MenuBar;
+
+    private readonly bool _pauseMenuCreation;
+
+    public InterfaceMenu(MenuDescriptor descriptor) : base(descriptor) {
+        MenuBar = new MenuBar {Margin = new Thickness(4, 0)};
+
+        _pauseMenuCreation = true;
+        foreach (MenuElementDescriptor menuElement in descriptor.Elements) {
+            AddChild(menuElement);
+        }
+
+        _pauseMenuCreation = false;
+        CreateMenu();
+    }
+
+    public override void AddChild(ElementDescriptor descriptor) {
+        if (descriptor is not MenuElementDescriptor elementDescriptor)
+            throw new ArgumentException($"Attempted to add a {descriptor} to a menu", nameof(descriptor));
+
+        MenuElement element;
+        if (elementDescriptor.Category == null) {
+            element = new(elementDescriptor, this);
+        } else {
+            if (!MenuElements.TryGetValue(elementDescriptor.Category, out var parentMenu)) {
+                //if category is set but the parent element doesn't exist, create it
+                var parentMenuDescriptor = new MenuElementDescriptor() {
+                    Name = elementDescriptor.Category
+                };
+
+                parentMenu = new(parentMenuDescriptor, this);
+                MenuElements.Add(parentMenu.Name, parentMenu);
+            }
+
+            //now add this as a child
+            element = new MenuElement(elementDescriptor, this);
+            parentMenu.Children.Add(element);
+        }
+
+        MenuElements.Add(element.Name, element);
+        CreateMenu(); // Update the menu to include the new child
+    }
+
+    private void CreateMenu() {
+        if (_pauseMenuCreation)
+            return;
+
+        MenuBar.Menus.Clear();
+
+        foreach (MenuElement menuElement in MenuElements.Values) {
+            if (menuElement.Category != null) // We only want the root-level menus here
+                continue;
+
+            MenuBar.Menu menu = new() {
+                Title = menuElement.Name
+            };
+
+            if (menu.Title?.StartsWith("&") ?? false)
+                menu.Title = menu.Title[1..]; //TODO: First character in name becomes a selection shortcut
+
+            MenuBar.Menus.Add(menu);
+            //visit each node in the tree, populating the menu from that
+            foreach (MenuElement child in menuElement.Children)
+                menu.Entries.Add(child.CreateMenuEntry());
+        }
+    }
+
+    public sealed class MenuElement : InterfaceElement {
+        public readonly List<MenuElement> Children = new();
+
+        private MenuElementDescriptor MenuElementDescriptor => (ElementDescriptor as MenuElementDescriptor);
+        public string Category => MenuElementDescriptor.Category;
+        public string Command => MenuElementDescriptor.Command;
+
+        private readonly InterfaceMenu _menu;
+
+        public MenuElement(MenuElementDescriptor data, InterfaceMenu menu) : base(data) {
+            _menu = menu;
+        }
+
+        public MenuBar.MenuEntry CreateMenuEntry() {
+            string text = Name;
+            if (text.StartsWith("&"))
+                text = text[1..]; //TODO: First character in name becomes a selection shortcut
+
+            if(Children.Count > 0) {
+                MenuBar.SubMenu subMenu = new() {
+                    Text = text
+                };
+
+                foreach(MenuElement child in Children)
+                    subMenu.Entries.Add(child.CreateMenuEntry());
+
+                return subMenu;
+            }
+
+            if (String.IsNullOrEmpty(text))
+                return new MenuBar.MenuSeparator();
+
+            MenuBar.MenuButton menuButton = new() {
+                Text = text
+            };
+
+            //result.IsCheckable = MenuElementDescriptor.CanCheck;
+            if (!String.IsNullOrEmpty(Command))
+                menuButton.OnPressed += () => { EntitySystem.Get<DreamCommandSystem>().RunCommand(Command); };
+            return menuButton;
+        }
+
+        public override void AddChild(ElementDescriptor descriptor) {
+            // Set the child's category to this element
+            // TODO: The "parent" and "category" attributes seem to be treated differently in BYOND; not the same thing.
+            ((Descriptors.MenuElementDescriptor) descriptor).Category = MenuElementDescriptor.Name;
+
+            // Pass this on to the parent menu
+            _menu.AddChild(descriptor);
+        }
+    }
+}

--- a/OpenDreamClient/Interface/InterfaceMenu.cs
+++ b/OpenDreamClient/Interface/InterfaceMenu.cs
@@ -11,7 +11,7 @@ public sealed class InterfaceMenu : InterfaceElement {
     private readonly bool _pauseMenuCreation;
 
     public InterfaceMenu(MenuDescriptor descriptor) : base(descriptor) {
-        MenuBar = new MenuBar {Margin = new Thickness(4, 0)};
+        MenuBar = new MenuBar();
 
         _pauseMenuCreation = true;
         foreach (MenuElementDescriptor menuElement in descriptor.Elements) {


### PR DESCRIPTION
This adds support for `winset()`s that create new interface elements at runtime (macros, controls, and menus).

Fixes #759