### PR TITLE
Fix json encoding (`json_encode()`) of special characters

### DIFF
--- a/OpenDreamShared/Network/Messages/MsgOutput.cs
+++ b/OpenDreamShared/Network/Messages/MsgOutput.cs
@@ -2,25 +2,21 @@
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
-namespace OpenDreamShared.Network.Messages
-{
-    public sealed class MsgOutput : NetMessage
-    {
+namespace OpenDreamShared.Network.Messages {
+    public sealed class MsgOutput : NetMessage {
         public override MsgGroups MsgGroup => MsgGroups.EntityEvent;
 
         public string Control;
         public string Value;
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
-        {
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer) {
             Value = buffer.ReadString();
             Control = buffer.ReadString();
             if (Control == string.Empty)
                 Control = null;
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
-        {
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer) {
             buffer.Write(Value);
             buffer.Write(Control ?? string.Empty);
         }


### PR DESCRIPTION
OpenDream would encode things like `json_encode("\"")` as `"\u0022"`, instead of the `"\""` that BYOND does. This fixes that.

This also runs `HttpUtility.JavaScriptStringEncode()` on a browser's ` << output()` before executing it in JavaScript to more properly escape its special characters.