### PR TITLE
Dont cache DreamList's ObjectDefinition

### DIFF
--- a/OpenDream.sln.DotSettings
+++ b/OpenDream.sln.DotSettings
@@ -5,8 +5,10 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=BYOND/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cmptext/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=copytext/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Debuggee/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fcopy/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=flist/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=isarea/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=isfile/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=isinf/@EntryIndexedValue">True</s:Boolean>
@@ -24,6 +26,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=replacetext/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=savefile/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Savefiles/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=splittext/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=typesof/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=waitfor/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=winset/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -35,7 +35,6 @@ namespace OpenDreamRuntime {
         // Global state that may not really (really really) belong here
         public List<DreamValue> Globals { get; set; } = new();
         public IReadOnlyList<string> GlobalNames { get; private set; } = new List<string>();
-        public DreamList WorldContentsList { get; private set; }
         public Dictionary<DreamObject, DreamList> AreaContents { get; set; } = new();
         public Dictionary<DreamObject, int> ReferenceIDs { get; set; } = new();
         public List<DreamObject> Mobs { get; set; } = new();
@@ -110,7 +109,6 @@ namespace OpenDreamRuntime {
             DreamProcNative.SetupNativeProcs(_objectTree);
 
             _dreamMapManager.Initialize();
-            WorldContentsList = DreamList.Create();
             WorldInstance = _objectTree.CreateObject(_objectTree.World);
 
             // Call /world/<init>. This is an IMPLEMENTATION DETAIL and non-DMStandard should NOT be run here.

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectArea.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectArea.cs
@@ -1,5 +1,4 @@
 ﻿using OpenDreamRuntime.Procs;
-using OpenDreamShared.Dream;
 
 namespace OpenDreamRuntime.Objects.MetaObjects {
     sealed class DreamMetaObjectArea : IDreamMetaObject {
@@ -15,7 +14,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         }
 
         public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
-            DreamList contents = DreamList.Create();
+            DreamList contents = _objectTree.CreateList();
 
             contents.ValueAssigned += (_, _, value) => {
                 if (!value.TryGetValueAsDreamObjectOfType(_objectTree.Turf, out DreamObject turf))

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -30,7 +30,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             // TODO: Create a special list to prevent this needless list creation
             List<int>? objectVerbs = dreamObject.ObjectDefinition.Verbs;
             if (objectVerbs != null) {
-                DreamList verbsList = DreamList.Create(objectVerbs.Count);
+                DreamList verbsList = _objectTree.CreateList(objectVerbs.Count);
 
                 foreach (int verbId in objectVerbs) {
                     DreamProc verb = _objectTree.Procs[verbId];
@@ -41,7 +41,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 dreamObject.SetVariableValue("verbs", new DreamValue(verbsList));
             }
 
-            _filterLists[dreamObject] = new DreamFilterList(dreamObject);
+            _filterLists[dreamObject] = new DreamFilterList(_objectTree.List.ObjectDefinition, dreamObject);
 
             ParentType?.OnObjectCreated(dreamObject, creationArguments);
         }
@@ -154,7 +154,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
                     DreamList overlayList;
                     if (!value.TryGetValueAsDreamList(out overlayList)) {
-                        overlayList = DreamList.Create();
+                        overlayList = _objectTree.CreateList();
                     }
 
                     overlayList.ValueAssigned += OverlayValueAssigned;
@@ -173,7 +173,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
                     DreamList underlayList;
                     if (!value.TryGetValueAsDreamList(out underlayList)) {
-                        underlayList = DreamList.Create();
+                        underlayList = _objectTree.CreateList();
                     }
 
                     underlayList.ValueAssigned += UnderlayValueAssigned;

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
@@ -71,7 +71,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
                     DreamList screenList;
                     if (!value.TryGetValueAsDreamList(out screenList)) {
-                        screenList = DreamList.Create();
+                        screenList = _objectTree.CreateList();
                     }
 
                     screenList.ValueAssigned += ScreenValueAssigned;
@@ -88,7 +88,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
                     DreamList imageList;
                     if (!value.TryGetValueAsDreamList(out imageList)) {
-                        imageList = DreamList.Create();
+                        imageList = _objectTree.CreateList();
                     }
 
                     dreamObject.SetVariableValue(varName, new DreamValue(imageList));
@@ -139,7 +139,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 case "connection":
                     return new DreamValue("seeker");
                 case "vars": // /client has this too!
-                    return new DreamValue(DreamListVars.Create(dreamObject));
+                    return new DreamValue(new DreamListVars(_objectTree.List.ObjectDefinition, dreamObject));
                 default:
                     return ParentType?.OnVariableGet(dreamObject, varName, value) ?? value;
             }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectDatum.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectDatum.cs
@@ -41,7 +41,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             return varName switch {
                 "type" => new DreamValue(dreamObject.ObjectDefinition.TreeEntry),
                 "parent_type" => new DreamValue(dreamObject.ObjectDefinition.TreeEntry.ParentEntry),
-                "vars" => new DreamValue(DreamListVars.Create(dreamObject)),
+                "vars" => new DreamValue(new DreamListVars(_objectTree.List.ObjectDefinition, dreamObject)),
                 _ => ParentType?.OnVariableGet(dreamObject, varName, value) ?? value
             };
         }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectList.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectList.cs
@@ -35,7 +35,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
                             for (int j = 0; j < size; j++) {
                                 if (argIndex < dimensions - 1) {
-                                    DreamList newList = DreamList.Create();
+                                    DreamList newList = _objectTree.CreateList();
 
                                     list.AddValue(new DreamValue(newList));
                                     newLists[i * size + j] = newList;

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMovable.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMovable.cs
@@ -117,7 +117,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     return new(coordinate);
                 }
                 case "contents": {
-                    DreamList contents = DreamList.Create();
+                    DreamList contents = _objectTree.CreateList();
                     EntityUid entity = _atomManager.GetMovableEntity(dreamObject);
 
                     if (_entityManager.TryGetComponent<TransformComponent>(entity, out var transform)) {
@@ -135,7 +135,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 }
                 case "locs": {
                     // Unimplemented; just return a list containing src.loc
-                    DreamList locs = DreamList.Create();
+                    DreamList locs = _objectTree.CreateList();
                     locs.AddValue(dreamObject.GetVariable("loc"));
 
                     return new DreamValue(locs);
@@ -150,7 +150,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 return;
 
             ScreenLocation screenLocation;
-            if (screenLocationValue.TryGetValueAsString(out string screenLocationString)) {
+            if (screenLocationValue.TryGetValueAsString(out string? screenLocationString)) {
                 screenLocation = new ScreenLocation(screenLocationString);
             } else {
                 screenLocation = new ScreenLocation(0, 0, 0, 0);

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectTurf.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectTurf.cs
@@ -8,6 +8,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
         [Dependency] private readonly IAtomManager _atomManager = default!;
         [Dependency] private readonly IDreamMapManager _dreamMapManager = default!;
+        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
         [Dependency] private readonly IEntityManager _entityManager = default!;
         [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
         private readonly EntityLookupSystem _entityLookup;
@@ -46,7 +47,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     (Vector2i pos, DreamMapManager.Level level) = _dreamMapManager.GetTurfPosition(dreamObject);
 
                     HashSet<EntityUid> entities = _entityLookup.GetEntitiesIntersecting(level.Grid.Owner, pos, LookupFlags.Uncontained);
-                    DreamList contents = DreamList.Create(entities.Count);
+                    DreamList contents = _objectTree.CreateList(entities.Count);
                     foreach (EntityUid movableEntity in entities) {
                         if (!_transformQuery.TryGetComponent(movableEntity, out var transform))
                             continue;

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectWorld.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectWorld.cs
@@ -14,6 +14,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public IDreamMetaObject? ParentType { get; set; }
 
         [Dependency] private readonly IDreamManager _dreamManager = default!;
+        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
         [Dependency] private readonly IServerNetManager _netManager = default!;
         [Dependency] private readonly DreamResourceManager _dreamRscMan = default!;
         [Dependency] private readonly IDreamMapManager _dreamMapManager = default!;
@@ -113,7 +114,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public DreamValue OnVariableGet(DreamObject dreamObject, string varName, DreamValue value) {
             switch (varName) {
                 case "contents":
-                    return new DreamValue(new WorldContentsList(_dreamMapManager));
+                    return new DreamValue(new WorldContentsList(_objectTree.List.ObjectDefinition, _dreamMapManager));
                 case "process":
                     return new DreamValue(Environment.ProcessId);
                 case "tick_lag":
@@ -177,7 +178,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     }
                 }
                 case "vars":
-                    return new DreamValue(DreamListVars.Create(dreamObject));
+                    return new DreamValue(new DreamListVars(_objectTree.List.ObjectDefinition, dreamObject));
                 default:
                     return ParentType?.OnVariableGet(dreamObject, varName, value) ?? value;
             }

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -31,7 +31,7 @@ namespace OpenDreamRuntime.Procs {
 
         public static ProcStatus? CreateList(DMProcState state) {
             int size = state.ReadInt();
-            var list = DreamList.Create(size);
+            var list = state.Proc.ObjectTree.CreateList(size);
 
             foreach (DreamValue value in state.PopCount(size)) {
                 list.AddValue(value);
@@ -43,7 +43,7 @@ namespace OpenDreamRuntime.Procs {
 
         public static ProcStatus? CreateAssociativeList(DMProcState state) {
             int size = state.ReadInt();
-            var list = DreamList.Create(size);
+            var list = state.Proc.ObjectTree.CreateList(size);
 
             ReadOnlySpan<DreamValue> popped = state.PopCount(size * 2);
             for (int i = 0; i < popped.Length; i += 2) {
@@ -553,9 +553,8 @@ namespace OpenDreamRuntime.Procs {
             return null;
         }
 
-        public static ProcStatus? PushGlobalVars(DMProcState state)
-        {
-            state.Push(new DreamValue(DreamGlobalVars.Create()));
+        public static ProcStatus? PushGlobalVars(DMProcState state) {
+            state.Push(new DreamValue(new DreamGlobalVars(state.Proc.ObjectTree.List.ObjectDefinition)));
             return null;
         }
         #endregion Values
@@ -687,7 +686,7 @@ namespace OpenDreamRuntime.Procs {
             DreamValue first = state.Pop();
 
             if (first.TryGetValueAsDreamList(out DreamList list)) {
-                DreamList newList = DreamList.Create();
+                DreamList newList = state.Proc.ObjectTree.CreateList();
 
                 if (second.TryGetValueAsDreamList(out DreamList secondList)) {
                     int len = list.GetLength();
@@ -810,7 +809,7 @@ namespace OpenDreamRuntime.Procs {
             DreamValue second = state.Pop();
             DreamValue first = state.Pop();
 
-            state.Push(BitXorValues(first, second));
+            state.Push(BitXorValues(state.Proc.ObjectTree, first, second));
             return null;
         }
 
@@ -818,7 +817,7 @@ namespace OpenDreamRuntime.Procs {
             DreamValue second = state.Pop();
             DMReference reference = state.ReadReference();
             DreamValue first = state.GetReferenceValue(reference, peek: true);
-            DreamValue result = BitXorValues(first, second);
+            DreamValue result = BitXorValues(state.Proc.ObjectTree, first, second);
 
             state.AssignReference(reference, result);
             state.Push(result);
@@ -2067,9 +2066,9 @@ namespace OpenDreamRuntime.Procs {
             }
         }
 
-        private static DreamValue BitXorValues(DreamValue first, DreamValue second) {
-            if (first.TryGetValueAsDreamList(out DreamList list)) {
-                DreamList newList = DreamList.Create();
+        private static DreamValue BitXorValues(IDreamObjectTree objectTree, DreamValue first, DreamValue second) {
+            if (first.TryGetValueAsDreamList(out var list)) {
+                DreamList newList = objectTree.CreateList();
                 List<DreamValue> values;
 
                 if (second.TryGetValueAsDreamList(out DreamList secondList)) {

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -528,7 +528,7 @@ namespace OpenDreamRuntime.Procs {
                 case DMReference.Type.Argument: return _localVariables[reference.Index];
                 case DMReference.Type.Local: return _localVariables[ArgumentCount + reference.Index];
                 case DMReference.Type.Args: {
-                    DreamList argsList = DreamList.Create(ArgumentCount);
+                    DreamList argsList = Proc.ObjectTree.CreateList(ArgumentCount);
 
                     for (int i = 0; i < ArgumentCount; i++) {
                         argsList.AddValue(_localVariables[i]);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
@@ -33,7 +33,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 instance.SetVariable("index", new DreamValue(match.Index + 1));
                 instance.SetVariable("match", new DreamValue(match.Value));
                 if (match.Groups.Count > 0) {
-                    DreamList groupList = DreamList.Create(match.Groups.Count);
+                    DreamList groupList = DreamProcNativeRoot.ObjectTree.CreateList(match.Groups.Count);
 
                     for (int i = 1; i < match.Groups.Count; i++) {
                         groupList.AddValue(new DreamValue(match.Groups[i].Value));

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
@@ -3,17 +3,14 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using OpenDreamRuntime.Objects;
 
-namespace OpenDreamRuntime.Procs.Native
-{
-    internal static class DreamProcNativeWorld
-    {
+namespace OpenDreamRuntime.Procs.Native {
+    internal static class DreamProcNativeWorld {
         [DreamProc("Export")]
         [DreamProcParameter("Addr", Type = DreamValue.DreamValueType.String)]
         [DreamProcParameter("File", Type = DreamValue.DreamValueType.DreamObject)]
         [DreamProcParameter("Persist", Type = DreamValue.DreamValueType.Float, DefaultValue = 0)]
         [DreamProcParameter("Clients", Type = DreamValue.DreamValueType.DreamObject)]
-        public static async Task<DreamValue> NativeProc_Export(AsyncNativeProc.State state)
-        {
+        public static async Task<DreamValue> NativeProc_Export(AsyncNativeProc.State state) {
             var addr = state.Arguments.GetArgument(0, "Addr").Stringify();
 
             if (!Uri.TryCreate(addr, UriKind.RelativeOrAbsolute, out var uri))
@@ -26,9 +23,8 @@ namespace OpenDreamRuntime.Procs.Native
             var client = new HttpClient();
             var response = await client.GetAsync(uri);
 
-            var list = DreamList.Create();
-            foreach (var header in response.Headers)
-            {
+            var list = DreamProcNativeRoot.ObjectTree.CreateList();
+            foreach (var header in response.Headers) {
                 // TODO: How to handle headers with multiple values?
                 list.SetValue(new DreamValue(header.Key), new DreamValue(header.Value.First()));
             }


### PR DESCRIPTION
`DreamList` would cache its ObjectDefinition to prevent an IoC resolve every time it was created. This led to an incorrect value in situations where the object tree was reset, such as in unit tests.

This changes it so that you create lists through `IDreamObjectTree.CreateList()` instead, always using an up-to-date ObjectDefinition.