### PR TITLE
Several verb fixes

### DIFF
--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -5,7 +5,7 @@
 	var/text = null
 	var/desc = null
 	var/suffix = null as opendream_unimplemented
-	var/list/verbs = list()
+	var/list/verbs = null
 
 	var/list/contents = list()
 	var/list/overlays = list()

--- a/DMCompiler/DMStandard/Types/Client.dm
+++ b/DMCompiler/DMStandard/Types/Client.dm
@@ -1,5 +1,5 @@
 ﻿/client
-	var/list/verbs = list()
+	var/list/verbs = null
 	var/list/screen = list()
 	var/list/images = list() as opendream_unimplemented
 	var/list/vars

--- a/OpenDreamClient/Input/DreamCommandSystem.cs
+++ b/OpenDreamClient/Input/DreamCommandSystem.cs
@@ -30,12 +30,8 @@ namespace OpenDreamClient.Input {
                     break;
 
                 default: {
-                    if (split.Length > 1)
-                    {
-                        Logger.ErrorS("opendream.commands", "Verb argument parsing is not implemented yet.");
-                        return;
-                    }
-
+                    // Send the entire command to the server.
+                    // It has more info about argument types so it can parse it better than we can.
                     RaiseNetworkEvent(new CommandEvent(command));
                     break;
                 }

--- a/OpenDreamClient/Interface/Controls/ControlInfo.cs
+++ b/OpenDreamClient/Interface/Controls/ControlInfo.cs
@@ -56,18 +56,18 @@ namespace OpenDreamClient.Interface.Controls {
         public void RefreshVerbs() {
             _grid.Children.Clear();
 
-            foreach ((string verbType, string verbName, string verbCategory) in _dreamInterface.AvailableVerbs) {
+            foreach ((string verbName, string verbId, string verbCategory) in _dreamInterface.AvailableVerbs) {
                 if (verbCategory != PanelName)
                     continue;
 
                 InterfaceButton verbButton = new InterfaceButton() {
                     Margin = new Thickness(2),
                     MinWidth = 100,
-                    Text = verbName == string.Empty ? verbType : verbName
+                    Text = verbName
                 };
 
                 verbButton.OnPressed += _ => {
-                    EntitySystem.Get<DreamCommandSystem>().RunCommand(verbType);
+                    EntitySystem.Get<DreamCommandSystem>().RunCommand(verbId);
                 };
 
                 _grid.Children.Add(verbButton);

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -109,6 +109,10 @@ namespace OpenDreamClient.Interface {
 
         private void RxUpdateAvailableVerbs(MsgUpdateAvailableVerbs message) {
             AvailableVerbs = message.AvailableVerbs;
+
+            // Verbs are displayed alphabetically with uppercase coming first
+            Array.Sort(AvailableVerbs, (a, b) => String.CompareOrdinal(a.Item1, b.Item1));
+
             foreach (var verb in AvailableVerbs) {
                 // Verb category
                 if (verb.Item3 != string.Empty && !DefaultInfo.HasVerbPanel(verb.Item3)) {

--- a/OpenDreamClient/Interface/InterfaceMacro.cs
+++ b/OpenDreamClient/Interface/InterfaceMacro.cs
@@ -59,7 +59,7 @@ public sealed class InterfaceMacro : InterfaceElement {
         _entitySystemManager = entitySystemManager;
 
         BoundKeyFunction function = new BoundKeyFunction($"{contextName}_{Id}");
-        KeyBindingRegistration binding = CreateMacroBinding(function, Name);
+        KeyBindingRegistration binding = CreateMacroBinding(function, Name.ToUpperInvariant());
 
         if (binding == null)
             return;

--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using System.Web;
 using OpenDreamRuntime.Objects;
+using OpenDreamRuntime.Objects.MetaObjects;
 using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Procs.Native;
 using OpenDreamRuntime.Resources;
@@ -17,8 +18,8 @@ namespace OpenDreamRuntime
         [Dependency] private readonly IAtomManager _atomManager = default!;
         [Dependency] private readonly DreamResourceManager _resourceManager = default!;
 
-        [ViewVariables] private Dictionary<string, DreamProc> _availableVerbs = new();
-        [ViewVariables] private Dictionary<string, List<string>> _statPanels = new();
+        [ViewVariables] private readonly Dictionary<string, (DreamObject Src, DreamProc Verb)> _availableVerbs = new();
+        [ViewVariables] private readonly Dictionary<string, List<string>> _statPanels = new();
         [ViewVariables] private bool _currentlyUpdatingStat;
         [ViewVariables] public IPlayerSession Session { get; }
 
@@ -28,7 +29,7 @@ namespace OpenDreamRuntime
 
         [ViewVariables] private string _outputStatPanel;
         [ViewVariables] private string _selectedStatPanel;
-        [ViewVariables] private Dictionary<int, Action<DreamValue>> _promptEvents = new();
+        [ViewVariables] private readonly Dictionary<int, Action<DreamValue>> _promptEvents = new();
         [ViewVariables] private int _nextPromptEvent = 1;
 
         public string SelectedStatPanel {
@@ -67,8 +68,7 @@ namespace OpenDreamRuntime
             }
         }
 
-        public DreamConnection(IPlayerSession session)
-        {
+        public DreamConnection(IPlayerSession session) {
             IoCManager.InjectDependencies(this);
 
             Session = session;
@@ -76,20 +76,27 @@ namespace OpenDreamRuntime
 
         public void UpdateAvailableVerbs() {
             _availableVerbs.Clear();
-            List<(string, string, string)>? verbs = null;
+            var verbs = new List<(string, string, string)>();
 
-            if (MobDreamObject != null) {
-                List<DreamValue> mobVerbPaths = MobDreamObject.GetVariable("verbs").MustGetValueAsDreamList().GetValues();
-                verbs = new List<(string, string, string)>(mobVerbPaths.Count);
-                foreach (DreamValue mobVerb in mobVerbPaths) {
+            void AddVerbs(DreamObject src, IEnumerable<DreamValue> adding) {
+                foreach (DreamValue mobVerb in adding) {
                     if (!mobVerb.TryGetValueAsProc(out var proc))
                         continue;
 
-                    _availableVerbs.Add(proc.Name, proc);
+                    string verbName = proc.VerbName ?? proc.Name;
+                    string verbId = verbName.ToLowerInvariant().Replace(" ", "-"); // Case-insensitive, dashes instead of spaces
+                    if (_availableVerbs.ContainsKey(verbId)) {
+                        // BYOND will actually show the user two verbs with different capitalization/dashes, but they will both execute the same verb.
+                        // We make a warning and ignore the latter ones instead.
+                        Logger.Warning($"User \"{Session.Name}\" has multiple verb commands named \"{verbId}\", ignoring all but the first");
+                        continue;
+                    }
+
+                    _availableVerbs.Add(verbId, (src, proc));
 
                     // Don't send hidden verbs. Names starting with "." count as hidden.
                     if ((proc.Attributes & ProcAttributes.Hidden) == ProcAttributes.Hidden ||
-                        (proc.VerbName != null && proc.VerbName[0] == '.')) {
+                        verbName.StartsWith('.')) {
                         continue;
                     }
 
@@ -97,17 +104,22 @@ namespace OpenDreamRuntime
                     // Explicitly null category is hidden from verb panels, "" category becomes the default_verb_category
                     if (category == string.Empty) {
                         // But if default_verb_category is null, we hide it from the verb panel
-                        category = ClientDreamObject.GetVariable("default_verb_category").TryGetValueAsString(out var value) ? value : null;
+                        ClientDreamObject.GetVariable("default_verb_category").TryGetValueAsString(out category);
                     }
 
-                    // No set name is serialized as an empty string and the last element will be used
                     // Null category is serialized as an empty string and treated as hidden
-                    verbs.Add((proc.Name, proc.VerbName ?? string.Empty, category ?? string.Empty));
+                    verbs.Add((verbName, verbId, category ?? String.Empty));
                 }
             }
 
+            AddVerbs(ClientDreamObject, DreamMetaObjectClient.VerbLists[ClientDreamObject].GetValues());
+
+            if (MobDreamObject != null) {
+                AddVerbs(MobDreamObject, DreamMetaObjectAtom.VerbLists[MobDreamObject].GetValues());
+            }
+
             var msg = new MsgUpdateAvailableVerbs() {
-                AvailableVerbs = verbs?.ToArray() ?? Array.Empty<(string, string, string)>()
+                AvailableVerbs = verbs.ToArray()
             };
 
             Session.ConnectedClient.SendMessage(msg);
@@ -242,8 +254,12 @@ namespace OpenDreamRuntime
             Session.ConnectedClient.SendMessage(msg);
         }
 
-        public void HandleCommand(string command)
-        {
+        public void HandleCommand(string fullCommand) {
+            // TODO: Arguments are a little more complicated than "split by spaces"
+            // e.g. strings can be passed
+            string[] args = fullCommand.Split(' ');
+            string command = args[0].ToLowerInvariant().Replace(" ", "-"); // Case-insensitive, dashes instead of spaces
+
             switch (command) {
                 //TODO: Maybe move these verbs to DM code?
                 case ".north": ClientDreamObject.SpawnProc("North"); break;
@@ -257,21 +273,37 @@ namespace OpenDreamRuntime
                 case ".center": ClientDreamObject.SpawnProc("Center"); break;
 
                 default: {
-                    if (_availableVerbs.TryGetValue(command, out DreamProc verb)) {
-                        DreamThread.Run(command, async (state) => {
+                    if (_availableVerbs.TryGetValue(command, out var value)) {
+                        (DreamObject verbSrc, DreamProc verb) = value;
+
+                        DreamThread.Run(fullCommand, async (state) => {
                             Dictionary<String, DreamValue> arguments = new();
 
                             // TODO: this should probably be done on the client, shouldn't it?
-                            for (int i = 0; i < (verb.ArgumentNames?.Count ?? 0); i++) {
-                                String argumentName = verb.ArgumentNames[i];
-                                DMValueType argumentType = verb.ArgumentTypes[i];
-                                DreamValue value = await Prompt(argumentType, title: String.Empty, // No settable title for verbs
-                                    argumentName, defaultValue: String.Empty); // No default value for verbs
+                            if (args.Length == 1) { // No args given; prompt the client for them
+                                for (int i = 0; i < (verb.ArgumentNames?.Count ?? 0); i++) {
+                                    String argumentName = verb.ArgumentNames[i];
+                                    DMValueType argumentType = verb.ArgumentTypes[i];
+                                    DreamValue value = await Prompt(argumentType, title: String.Empty, // No settable title for verbs
+                                        argumentName, defaultValue: String.Empty); // No default value for verbs
 
-                                arguments.Add(argumentName, value);
+                                    arguments.Add(argumentName, value);
+                                }
+                            } else { // Attempt to parse the given arguments
+                                for (int i = 0; i < (verb.ArgumentNames?.Count ?? 0); i++) {
+                                    String argumentName = verb.ArgumentNames[i];
+                                    DMValueType argumentType = verb.ArgumentTypes[i];
+
+                                    if (argumentType == DMValueType.Text) {
+                                        arguments.Add(argumentName, new(args[i+1]));
+                                    } else {
+                                        Logger.Error($"Parsing verb args of type {argumentType} is unimplemented; ignoring command ({fullCommand})");
+                                        return DreamValue.Null;
+                                    }
+                                }
                             }
 
-                            await state.Call(verb, MobDreamObject, MobDreamObject, new DreamProcArguments(new(), arguments));
+                            await state.Call(verb, verbSrc, MobDreamObject, new DreamProcArguments(new(), arguments));
                             return DreamValue.Null;
                         });
                     }

--- a/OpenDreamRuntime/Input/DreamCommandSystem.cs
+++ b/OpenDreamRuntime/Input/DreamCommandSystem.cs
@@ -35,8 +35,7 @@ namespace OpenDreamRuntime.Input {
             _repeatingCommands.Remove(tuple);
         }
 
-        private void RunCommand(string command, IPlayerSession session)
-        {
+        private void RunCommand(string command, IPlayerSession session) {
             var connection = _dreamManager.GetConnectionBySession(session);
             connection.HandleCommand(command);
         }

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using OpenDreamRuntime.Objects.MetaObjects;
-using OpenDreamRuntime.Procs;
 using OpenDreamShared.Dream;
 using Robust.Shared.Serialization.Manager;
 
@@ -292,6 +291,63 @@ namespace OpenDreamRuntime.Objects {
             } else {
                 throw new Exception($"Invalid var index {key}");
             }
+        }
+    }
+
+    // verbs list
+    // Keeps track of an atom's or client's verbs
+    public sealed class VerbsList : DreamList {
+        private readonly List<DreamProc> _verbs = new();
+
+        public VerbsList(IDreamObjectTree objectTree, DreamObject dreamObject) : base(objectTree.List.ObjectDefinition, 0) {
+            List<int>? verbs = dreamObject.ObjectDefinition.Verbs;
+            if (verbs == null)
+                return;
+
+            _verbs.EnsureCapacity(verbs.Count);
+            foreach (int verbId in verbs) {
+                _verbs.Add(objectTree.Procs[verbId]);
+            }
+        }
+
+        public override DreamValue GetValue(DreamValue key) {
+            if (!key.TryGetValueAsInteger(out var index))
+                throw new Exception($"Invalid index into verbs list: {key}");
+            if (index < 1 || index > _verbs.Count)
+                throw new Exception($"Out of bounds index on verbs list: {index}");
+
+            return new DreamValue(_verbs[index - 1]);
+        }
+
+        public override List<DreamValue> GetValues() {
+            List<DreamValue> values = new(_verbs.Count);
+
+            foreach (DreamProc verb in _verbs)
+                values.Add(new(verb));
+
+            return values;
+        }
+
+        public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
+            throw new Exception("Cannot set the values of a verbs list");
+        }
+
+        public override void AddValue(DreamValue value) {
+            if (!value.TryGetValueAsProc(out var verb))
+                throw new Exception($"Cannot add {value} to verbs list");
+
+            _verbs.Add(verb);
+        }
+
+        public override void Cut(int start = 1, int end = 0) {
+            int verbCount = _verbs.Count + 1;
+            if (end == 0 || end > verbCount) end = verbCount;
+
+            _verbs.RemoveRange(start - 1, end - start);
+        }
+
+        public override int GetLength() {
+            return _verbs.Count;
         }
     }
 

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -9,7 +9,8 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public bool ShouldCallNew => true;
         public IDreamMetaObject? ParentType { get; set; }
 
-        [Dependency] private readonly IDreamManager _dreamManager = default!;
+        public static readonly Dictionary<DreamObject, VerbsList> VerbLists = new();
+
         [Dependency] private readonly DreamResourceManager _resourceManager = default!;
         [Dependency] private readonly IDreamMapManager _mapManager = default!;
         [Dependency] private readonly IDreamObjectTree _objectTree = default!;
@@ -27,26 +28,14 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 _mapManager.AllAtoms.Add(dreamObject);
             }
 
-            // TODO: Create a special list to prevent this needless list creation
-            List<int>? objectVerbs = dreamObject.ObjectDefinition.Verbs;
-            if (objectVerbs != null) {
-                DreamList verbsList = _objectTree.CreateList(objectVerbs.Count);
-
-                foreach (int verbId in objectVerbs) {
-                    DreamProc verb = _objectTree.Procs[verbId];
-
-                    verbsList.AddValue(new DreamValue(verb));
-                }
-
-                dreamObject.SetVariableValue("verbs", new DreamValue(verbsList));
-            }
-
+            VerbLists[dreamObject] = new VerbsList(_objectTree, dreamObject);
             _filterLists[dreamObject] = new DreamFilterList(_objectTree.List.ObjectDefinition, dreamObject);
 
             ParentType?.OnObjectCreated(dreamObject, creationArguments);
         }
 
         public void OnObjectDeleted(DreamObject dreamObject) {
+            VerbLists.Remove(dreamObject);
             _filterLists.Remove(dreamObject);
 
             _atomManager.DeleteMovableEntity(dreamObject);
@@ -133,8 +122,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                         appearance.Direction = (AtomDirection)dir;
                     });
                     break;
-                case "transform":
-                {
+                case "transform":  {
                     _atomManager.UpdateAppearance(dreamObject, appearance => {
                         float[] matrixArray = value.TryGetValueAsDreamObjectOfType(_objectTree.Matrix, out var matrix)
                             ? DreamMetaObjectMatrix.MatrixToTransformFloatArray(matrix)
@@ -182,6 +170,21 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     dreamObject.SetVariableValue(varName, new DreamValue(underlayList));
                     break;
                 }
+                case "verbs": {
+                    VerbsList verbsList = VerbLists[dreamObject];
+
+                    verbsList.Cut();
+
+                    if (value.TryGetValueAsDreamList(out var valueList)) {
+                        foreach (DreamValue verbValue in valueList.GetValues()) {
+                            verbsList.AddValue(verbValue);
+                        }
+                    } else if (value != DreamValue.Null) {
+                        verbsList.AddValue(value);
+                    }
+
+                    break;
+                }
                 case "filters": {
                     DreamFilterList filterList = _filterLists[dreamObject];
 
@@ -209,6 +212,8 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     matrix.InitSpawn(new DreamProcArguments(new() { value }));
 
                     return new DreamValue(matrix);
+                case "verbs":
+                    return new DreamValue(VerbLists[dreamObject]);
                 case "filters":
                     return new DreamValue(_filterLists[dreamObject]);
                 default:

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
@@ -9,6 +9,8 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public bool ShouldCallNew => true;
         public IDreamMetaObject? ParentType { get; set; }
 
+        public static readonly Dictionary<DreamObject, VerbsList> VerbLists = new();
+
         private readonly ServerScreenOverlaySystem? _screenOverlaySystem;
         private readonly Dictionary<DreamList, DreamObject> _screenListToClient = new();
 
@@ -25,6 +27,8 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
             ParentType?.OnObjectCreated(dreamObject, creationArguments);
 
+            VerbLists.Add(dreamObject, new VerbsList(_objectTree, dreamObject));
+
             _dreamManager.Clients.Add(dreamObject);
 
             ClientPerspective perspective = (ClientPerspective)dreamObject.GetVariable("perspective").GetValueAsInteger();
@@ -35,6 +39,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
         public void OnObjectDeleted(DreamObject dreamObject) {
             ParentType?.OnObjectDeleted(dreamObject);
+            VerbLists.Remove(dreamObject);
             _dreamManager.Clients.Remove(dreamObject);
         }
 
@@ -138,6 +143,8 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 }
                 case "connection":
                     return new DreamValue("seeker");
+                case "verbs":
+                    return new DreamValue(VerbLists[dreamObject]);
                 case "vars": // /client has this too!
                     return new DreamValue(new DreamListVars(_objectTree.List.ObjectDefinition, dreamObject));
                 default:

--- a/OpenDreamShared/Network/Messages/MsgUpdateAvailableVerbs.cs
+++ b/OpenDreamShared/Network/Messages/MsgUpdateAvailableVerbs.cs
@@ -1,36 +1,28 @@
-using System;
-using System.Collections.Generic;
 using Lidgren.Network;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
-namespace OpenDreamShared.Network.Messages
-{
-    public sealed class MsgUpdateAvailableVerbs : NetMessage
-    {
+namespace OpenDreamShared.Network.Messages {
+    public sealed class MsgUpdateAvailableVerbs : NetMessage {
         public override MsgGroups MsgGroup => MsgGroups.EntityEvent;
 
-        public (string, string, string)[] AvailableVerbs;
+        public (string Name, string Id, string Category)[] AvailableVerbs;
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
-        {
+        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer) {
             var count = buffer.ReadVariableInt32();
             (string, string, string)[] verbs = new (string, string, string)[count];
 
-            for (var i = 0; i < count; i++)
-            {
+            for (var i = 0; i < count; i++) {
                 verbs[i] = (buffer.ReadString(), buffer.ReadString(), buffer.ReadString());
             }
 
             AvailableVerbs = verbs;
         }
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
-        {
+        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer) {
             buffer.WriteVariableInt32(AvailableVerbs.Length);
 
-            foreach (var verb in AvailableVerbs)
-            {
+            foreach (var verb in AvailableVerbs) {
                 buffer.Write(verb.Item1);
                 buffer.Write(verb.Item2);
                 buffer.Write(verb.Item3);


### PR DESCRIPTION
Several little things surrounding verbs and macros have been fixed
* /client verbs can now be used
* Verb commands are now space and case-insensitive
* Lowercase macros work now
* Display verbs alphabetically on the client

This combined with #1041 will be everything needed to get unmodified Paradise/SS13 controls working.