### PR TITLE
Fix a bug with DreamFilters

### DIFF
--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -367,6 +367,8 @@ namespace OpenDreamRuntime.Objects {
             if (!value.TryGetValueAsDreamObjectOfType(_objectTree.Filter, out var filterObject))
                 throw new Exception($"Cannot add {value} to filter list");
 
+            //This is dynamic to prevent the compiler from optimising the SerializationManager.CreateCopy() call to the DreamFilter type
+            //so we can preserve the subclass information. Setting it to DreamFilter instead will cause filter parameters to stop working.
             dynamic filter = DreamMetaObjectFilter.DreamObjectToFilter[filterObject];
             DreamFilter copy = _serializationManager.CreateCopy(filter, notNullableOverride: true); // Adding a filter creates a copy
 

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -367,7 +367,7 @@ namespace OpenDreamRuntime.Objects {
             if (!value.TryGetValueAsDreamObjectOfType(_objectTree.Filter, out var filterObject))
                 throw new Exception($"Cannot add {value} to filter list");
 
-            DreamFilter filter = DreamMetaObjectFilter.DreamObjectToFilter[filterObject];
+            dynamic filter = DreamMetaObjectFilter.DreamObjectToFilter[filterObject];
             DreamFilter copy = _serializationManager.CreateCopy(filter, notNullableOverride: true); // Adding a filter creates a copy
 
             DreamMetaObjectFilter.FilterAttachedTo[copy] = this;


### PR DESCRIPTION
DreamFilters were losing their type information because a compile time optimisation was replacing the serialisation manager's `CreateCopy()` with a static typed `CreateCopy<DreamFilter>()`. 

This just forces it to be dynamic, allowing filter parameters to work again.