### PR TITLE
Give message prompts a multi-line text editor

### DIFF
--- a/OpenDreamClient/Interface/Prompts/InputWindow.cs
+++ b/OpenDreamClient/Interface/Prompts/InputWindow.cs
@@ -1,13 +1,13 @@
 ﻿using OpenDreamShared.Dream.Procs;
 using Robust.Client.UserInterface;
 
-namespace OpenDreamClient.Interface.Prompts
-{
+namespace OpenDreamClient.Interface.Prompts {
     [Virtual]
     class InputWindow : PromptWindow {
-        public InputWindow(int promptId, String title, String message, String defaultValue, bool canCancel) : base(promptId, title, message) {
+        protected InputWindow(int promptId, String title, String message, String defaultValue, bool canCancel) : base(
+            promptId, title, message) {
             CreateButton("Ok", true);
-            if (canCancel) CreateButton("Cancel", false);;
+            if (canCancel) CreateButton("Cancel", false);
         }
 
         protected void SetPromptControl(Control promptControl, bool grabKeyboard = true) {
@@ -26,4 +26,5 @@ namespace OpenDreamClient.Interface.Prompts
         protected virtual void OkButtonClicked() {
             throw new NotImplementedException();
         }
-    }}
+    }
+}

--- a/OpenDreamClient/Interface/Prompts/MessagePrompt.cs
+++ b/OpenDreamClient/Interface/Prompts/MessagePrompt.cs
@@ -1,30 +1,26 @@
 ﻿using OpenDreamShared.Dream.Procs;
-using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Utility;
 
-namespace OpenDreamClient.Interface.Prompts
-{
+namespace OpenDreamClient.Interface.Prompts {
     sealed class MessagePrompt : InputWindow {
-        private readonly LineEdit _lineEdit;
+        private readonly TextEdit _textEdit;
 
         public MessagePrompt(int promptId, String title, String message, String defaultValue, bool canCancel) : base(
             promptId, title, message, defaultValue, canCancel) {
-            // TODO: Switch this to a proper multi-line edit.
-            _lineEdit = new LineEdit {
-                MinHeight = 100,
-                MaxWidth = 500,
-                MaxHeight = 400,
-                //AcceptsReturn = true,
-                //VerticalScrollBarVisibility = ScrollBarVisibility.Visible,
-                //HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
-                Text = defaultValue,
+            _textEdit = new TextEdit {
+                TextRope = new Rope.Leaf(defaultValue),
+
+                // Select all the text by default
+                CursorPosition = new TextEdit.CursorPos(defaultValue.Length, TextEdit.LineBreakBias.Bottom),
+                SelectionStart = new TextEdit.CursorPos(0, TextEdit.LineBreakBias.Bottom)
             };
 
-            SetPromptControl(_lineEdit);
+            SetPromptControl(_textEdit);
         }
 
         protected override void OkButtonClicked() {
-            FinishPrompt(DMValueType.Message, _lineEdit.Text);
+            FinishPrompt(DMValueType.Message, Rope.Collapse(_textEdit.TextRope));
         }
     }
 }


### PR DESCRIPTION
Message prompts lost the ability to edit multiple lines of text during the switch to RobustToolbox due to RT not having a control capable of doing it. Now it does, so I switched it from using a `LineEdit` to a `TextEdit`.