### PR TITLE
Implements color matrices, allows `/atom.color` to be set with one

### DIFF
--- a/Content.IntegrationTests/DMProject/code.dm
+++ b/Content.IntegrationTests/DMProject/code.dm
@@ -62,8 +62,19 @@
 		CRASH("Using a non-/turf Center for range() did not work correctly.")
 	del(timmy)
 
+/proc/test_color_matrix()
+	var/r = "#de000000"
+	var/g = "#00ad0000"
+	var/b = "#0000be00"
+	var/a = "#000000ef" // deadbeef my beloved
+	var/mob/M = new
+	M.color = list(r,g,b,a)
+	if(M.color != "#deadbe")
+		CRASH("Color matrix transformation in rgba() value didn't work correctly, color is '[json_encode(M.color)]' instead.")
+
 /world/New()
 	..()
 	test_world_init()
 	test_range()
+	test_color_matrix()
 	world.log << "IntegrationTests successful, /world/New() exiting..."

--- a/Content.IntegrationTests/DMProject/code.dm
+++ b/Content.IntegrationTests/DMProject/code.dm
@@ -71,6 +71,10 @@
 	M.color = list(r,g,b,a)
 	if(M.color != "#deadbe")
 		CRASH("Color matrix transformation in rgba() value didn't work correctly, color is '[json_encode(M.color)]' instead.")
+	M.color = null
+	M.filters += filter(type="color",color=list(r,g,b,a))
+	if(M.filters.len < 1)
+		CRASH("Using a color filter created using filter() was not successful.")
 
 /world/New()
 	..()

--- a/Content.Tests/DummyDreamMapManager.cs
+++ b/Content.Tests/DummyDreamMapManager.cs
@@ -31,7 +31,7 @@ namespace Content.Tests {
 
         public void SetTurfAppearance(DreamObject turf, IconAppearance appearance) { }
 
-        public IconAppearance GetTurfAppearance(DreamObject turf) {
+        public IconAppearance MustGetTurfAppearance(DreamObject turf) {
             return new IconAppearance();
         }
 
@@ -42,6 +42,11 @@ namespace Content.Tests {
 
         public IDreamMapManager.Cell GetCellFromTurf(DreamObject turf) {
             throw null;
+        }
+
+        public bool TryGetTurfAppearance(DreamObject turf, out IconAppearance appearance) {
+            appearance = MustGetTurfAppearance(turf);
+            return true;
         }
 
         public bool TryGetTurfAt(Vector2i pos, int z, out DreamObject turf) {

--- a/Content.Tests/DummyDreamMapManager.cs
+++ b/Content.Tests/DummyDreamMapManager.cs
@@ -35,6 +35,11 @@ namespace Content.Tests {
             return new IconAppearance();
         }
 
+        public bool TryGetTurfAppearance(DreamObject turf, out IconAppearance appearance) {
+            appearance = MustGetTurfAppearance(turf);
+            return true;
+        }
+
         public bool TryGetCellFromTransform(TransformComponent transform, [NotNullWhen(true)] out IDreamMapManager.Cell? cell) {
             cell = null;
             return false;
@@ -42,11 +47,6 @@ namespace Content.Tests {
 
         public IDreamMapManager.Cell GetCellFromTurf(DreamObject turf) {
             throw null;
-        }
-
-        public bool TryGetTurfAppearance(DreamObject turf, out IconAppearance appearance) {
-            appearance = MustGetTurfAppearance(turf);
-            return true;
         }
 
         public bool TryGetTurfAt(Vector2i pos, int z, out DreamObject turf) {

--- a/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
+++ b/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
@@ -112,8 +112,20 @@ namespace OpenDreamClient.Rendering {
                     case DreamFilterBlur blur:
                         instance.SetParameter("size", blur.Size);
                         break;
-                    case DreamFilterColor color:
+                    case DreamFilterColor color: {
+                        //Since SWSL doesn't support 4x5 matrices, we need to get a bit silly.
+                        instance.SetParameter("colorMatrix", new Matrix4(
+                            color.Color.c11, color.Color.c12, color.Color.c13, color.Color.c14,
+                            color.Color.c21, color.Color.c22, color.Color.c23, color.Color.c24,
+                            color.Color.c31, color.Color.c32, color.Color.c33, color.Color.c34,
+                            color.Color.c41, color.Color.c42, color.Color.c43, color.Color.c44
+                            ));
+                        instance.SetParameter("offsetVector", new Vector4(
+                            color.Color.c51, color.Color.c52, color.Color.c53, color.Color.c54
+                            ));
+                        //TODO: Support the alternative colour mappings.
                         break;
+                    }
                     case DreamFilterDisplace displace:
                         break;
                     case DreamFilterDropShadow dropShadow:

--- a/OpenDreamClient/Rendering/DreamIcon.cs
+++ b/OpenDreamClient/Rendering/DreamIcon.cs
@@ -186,7 +186,7 @@ namespace OpenDreamClient.Rendering {
 
             AtlasTexture frame = CurrentFrame;
             if (frame != null) {
-                handle.DrawTexture(frame, position, Appearance.Color);
+                handle.DrawTexture(frame, position, Appearance.Color); // TODO: Does not consider ColorMatrix
             }
 
             foreach (DreamIcon overlay in Overlays) {

--- a/OpenDreamClient/Rendering/DreamIcon.cs
+++ b/OpenDreamClient/Rendering/DreamIcon.cs
@@ -4,9 +4,11 @@ using OpenDreamClient.Resources.ResourceTypes;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Resources;
 using Robust.Client.Graphics;
+using Robust.Shared.Player;
 
 namespace OpenDreamClient.Rendering {
     sealed class DreamIcon {
+
         public delegate void SizeChangedEventHandler();
 
         public List<DreamIcon> Overlays { get; } = new();
@@ -186,7 +188,7 @@ namespace OpenDreamClient.Rendering {
 
             AtlasTexture frame = CurrentFrame;
             if (frame != null) {
-                handle.DrawTexture(frame, position, Appearance.Color); // TODO: Does not consider ColorMatrix
+                handle.DrawTexture(frame, position, Appearance.Color); // TODO: Does not consider SillyColorFilter
             }
 
             foreach (DreamIcon overlay in Overlays) {

--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -210,7 +210,7 @@ namespace OpenDreamRuntime {
 
         public IconAppearance? MustGetAppearance(DreamObject atom);
 
-        public bool TryGetAppearance(DreamObject atom, out IconAppearance? appearance);
+        public bool TryGetAppearance(DreamObject atom, [NotNullWhen(true)] out IconAppearance? appearance);
         public void UpdateAppearance(DreamObject atom, Action<IconAppearance> update);
         public void AnimateAppearance(DreamObject atom, TimeSpan duration, Action<IconAppearance> animate);
         public IconAppearance CreateAppearanceFromAtom(DreamObject atom);

--- a/OpenDreamRuntime/DreamMapManager.cs
+++ b/OpenDreamRuntime/DreamMapManager.cs
@@ -180,7 +180,7 @@ namespace OpenDreamRuntime {
             level.QueuedTileUpdates[pos] = new Tile(turfId);
         }
 
-        public IconAppearance GetTurfAppearance(DreamObject turf) {
+        private uint GetAppearanceIDForTurf(DreamObject turf) {
             (Vector2i pos, Level level) = _turfToTilePos[turf];
 
             if (!level.QueuedTileUpdates.TryGetValue(pos, out var tile)) {
@@ -188,7 +188,16 @@ namespace OpenDreamRuntime {
             }
 
             uint appearanceId = (uint)tile.TypeId - 1;
-            return _appearanceSystem.GetAppearance(appearanceId);
+            return appearanceId;
+        }
+
+        public IconAppearance MustGetTurfAppearance(DreamObject turf) {
+
+            return _appearanceSystem.MustGetAppearance(GetAppearanceIDForTurf(turf));
+        }
+
+        public bool TryGetTurfAppearance(DreamObject turf, [NotNullWhen(true)] out IconAppearance? appearance) {
+            return _appearanceSystem.TryGetAppearance(GetAppearanceIDForTurf(turf), out appearance);
         }
 
         public Cell GetCellFromTurf(DreamObject turf) {
@@ -398,7 +407,8 @@ namespace OpenDreamRuntime {
 
         public void SetTurf(DreamObject turf, DreamObjectDefinition type, DreamProcArguments creationArguments);
         public void SetTurfAppearance(DreamObject turf, IconAppearance appearance);
-        public IconAppearance GetTurfAppearance(DreamObject turf);
+        public IconAppearance MustGetTurfAppearance(DreamObject turf);
+        public bool TryGetTurfAppearance(DreamObject turf, out IconAppearance? appearance);
         public Cell GetCellFromTurf(DreamObject turf);
         public bool TryGetCellFromTransform(TransformComponent transform, [NotNullWhen(true)] out Cell? cell);
         public bool TryGetTurfAt(Vector2i pos, int z, [NotNullWhen(true)] out DreamObject? turf);

--- a/OpenDreamRuntime/DreamMapManager.cs
+++ b/OpenDreamRuntime/DreamMapManager.cs
@@ -192,7 +192,6 @@ namespace OpenDreamRuntime {
         }
 
         public IconAppearance MustGetTurfAppearance(DreamObject turf) {
-
             return _appearanceSystem.MustGetAppearance(GetAppearanceIDForTurf(turf));
         }
 
@@ -408,7 +407,7 @@ namespace OpenDreamRuntime {
         public void SetTurf(DreamObject turf, DreamObjectDefinition type, DreamProcArguments creationArguments);
         public void SetTurfAppearance(DreamObject turf, IconAppearance appearance);
         public IconAppearance MustGetTurfAppearance(DreamObject turf);
-        public bool TryGetTurfAppearance(DreamObject turf, out IconAppearance? appearance);
+        public bool TryGetTurfAppearance(DreamObject turf, [NotNullWhen(true)] out IconAppearance? appearance);
         public Cell GetCellFromTurf(DreamObject turf);
         public bool TryGetCellFromTransform(TransformComponent transform, [NotNullWhen(true)] out Cell? cell);
         public bool TryGetTurfAt(Vector2i pos, int z, [NotNullWhen(true)] out DreamObject? turf);

--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -680,7 +680,7 @@ namespace OpenDreamRuntime {
     }
 
     [TypeSerializer]
-    public sealed class DreamValueColorMatrixSerializer : ITypeReader<ColorMatrix, DreamValueDataNode> {
+    public sealed class DreamValueColorMatrixSerializer : ITypeReader<ColorMatrix, DreamValueDataNode>, ITypeCopyCreator<ColorMatrix> {
         public ColorMatrix Read(ISerializationManager serializationManager,
             DreamValueDataNode node,
             IDependencyCollection dependencies,
@@ -708,6 +708,12 @@ namespace OpenDreamRuntime {
                 return new ValidatedValueNode(node);
             //TODO: Improve validation
             return new ErrorNode(node, $"Value {node.Value} is not a color matrix");
+        }
+
+        public ColorMatrix CreateCopy(ISerializationManager serializationManager, ColorMatrix source,
+           SerializationHookContext hookCtx,
+           ISerializationContext? context = null) {
+            return new(source);
         }
     }
     #endregion Serialization

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -439,7 +439,7 @@ namespace OpenDreamRuntime.Objects {
         }
 
         private IconAppearance GetAppearance() {
-            IconAppearance? appearance = _atomManager.GetAppearance(_atom);
+            IconAppearance? appearance = _atomManager.MustGetAppearance(_atom);
             if (appearance == null)
                 throw new Exception("Atom has no appearance");
 

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -430,13 +430,12 @@ namespace OpenDreamRuntime.Objects {
 
             DreamMetaObjectFilter.FilterAttachedTo[copy] = this;
             _atomManager.UpdateAppearance(_atom, appearance => {
-                if(appearance.Matrix is not null) { // If this appearance already has a color matrix (and therefore a color filter somewhere)
+                // If this appearance already has a color filter (from /atom.color)
+                if(copy is DreamFilterColor && appearance.SillyColorFilter is not null) {
                     // This is to support an edge case where an atom's .color var has been set to a matrix, and then it also gets a color filter.
                     // In BYOND, this apparently causes a crash or something, depending on the order.
                     // Lets just... try to support it though, huh? :^)
-                    appearance.RemoveColorFilter();
-                    appearance.Matrix = null;
-                    appearance.Color = Color.White; // NOTE: Not sure if parity
+                    appearance.SillyColorFilter = null;
                 }
                 appearance.Filters.Add(copy);
             });

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -430,6 +430,14 @@ namespace OpenDreamRuntime.Objects {
 
             DreamMetaObjectFilter.FilterAttachedTo[copy] = this;
             _atomManager.UpdateAppearance(_atom, appearance => {
+                if(appearance.Matrix is not null) { // If this appearance already has a color matrix (and therefore a color filter somewhere)
+                    // This is to support an edge case where an atom's .color var has been set to a matrix, and then it also gets a color filter.
+                    // In BYOND, this apparently causes a crash or something, depending on the order.
+                    // Lets just... try to support it though, huh? :^)
+                    appearance.RemoveColorFilter();
+                    appearance.Matrix = null;
+                    appearance.Color = Color.White; // NOTE: Not sure if parity
+                }
                 appearance.Filters.Add(copy);
             });
         }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -4,6 +4,7 @@ using OpenDreamRuntime.Rendering;
 using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
 using Robust.Shared.Utility;
+using System.Diagnostics;
 
 namespace OpenDreamRuntime.Objects.MetaObjects {
     sealed class DreamMetaObjectAtom : IDreamMetaObject {
@@ -116,12 +117,11 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     if(value.TryGetValueAsDreamList(out var list)) {
                         if(DreamProcNativeHelpers.TryParseColorMatrix(list, out var matrix)) {
                             _atomManager.UpdateAppearance(dreamObject, appearance => {
-                                appearance.SetColor(matrix);
+                                appearance.SetColor(in matrix);
                             });
                             break;
-                        } else {
-                            throw new ArgumentException("Invalid /list provided to /atom.color - it is not a color matrix");
                         }
+                        throw new ArgumentException("Invalid /list provided to /atom.color - it is not a color matrix");
                     }
 
                     value.TryGetValueAsString(out var colorString);
@@ -242,14 +242,15 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                         }
                         return DreamValue.Null; //idek
                     }
-                    if(appearance.Matrix is not null) {
+                    if(appearance!.SillyColorFilter is not null) {
                         var matrixList = _objectTree.CreateList(20);
-                        foreach (float entry in appearance.Matrix.Value.GetValues())
+                        foreach (float entry in appearance.SillyColorFilter.Color.GetValues())
                             matrixList.AddValue(new DreamValue(entry));
                         return new DreamValue(matrixList);
                     }
-                    if (appearance.Color == Color.White)
+                    if (appearance.Color == Color.White) {
                         return DreamValue.Null;
+                    }
                     return new DreamValue(appearance.Color.ToHexNoAlpha().ToLower()); // BYOND quirk, does not return the alpha channel for some reason.
                 default:
                     return ParentType?.OnVariableGet(dreamObject, varName, value) ?? value;

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -135,7 +135,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                                 for (var i = 0; i < listArray.Count && i < 5; ++i) {
                                     var listValue = listArray[i];
                                     if(listValue.TryGetValueAsString(out var RGBString)) {
-                                        if(ColorHelpers.TryParseColor(RGBString, out var color)) {
+                                        if(ColorHelpers.TryParseColor(RGBString, out var color, defaultAlpha: "00")) {
                                             newMatrix.SetRow(i, color);
                                         }
                                     }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -242,7 +242,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                         }
                         return DreamValue.Null; //idek
                     }
-                    if(appearance!.SillyColorFilter is not null) {
+                    if(appearance.SillyColorFilter is not null) {
                         var matrixList = _objectTree.CreateList(20);
                         foreach (float entry in appearance.SillyColorFilter.Color.GetValues())
                             matrixList.AddValue(new DreamValue(entry));

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -1,4 +1,5 @@
 using OpenDreamRuntime.Procs;
+using OpenDreamRuntime.Procs.Native;
 using OpenDreamRuntime.Rendering;
 using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
@@ -113,39 +114,13 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     break;
                 case "color":
                     if(value.TryGetValueAsDreamList(out var list)) {
-                        /*
-                            This is being used to define a ColorMatrix.
-                            Possible correct arguments include:
-                            list(rr,rg,rb, gr,gg,gb, br,bg,bb)
-                            list(rr,rg,rb, gr,gg,gb, br,bg,bb, cr,cg,cb)
-                            list(rr,rg,rb,ra, gr,gg,gb,ga, br,bg,bb,ba, ar,ag,ab,aa)
-                            list(rr,rg,rb,ra, gr,gg,gb,ga, br,bg,bb,ba, ar,ag,ab,aa, cr,cg,cb,ca)
-                            list(rgb() or null, rgb() or null, rgb() or null, rgb() or null, rgb() or null) // In this case any of the null ones are just their identity row
-                        */
-                        switch(list.GetLength()) {
-                            case 0:
-                                break; // Back off into the "reset the color var" behaviour that the string|null stuff has, below
-                            case 1: // 1 to 5 is the rgb() string spam
-                            case 2:
-                            case 3:
-                            case 4: 
-                            case 5: 
-                                var newMatrix = ColorMatrix.Identity;
-                                var listArray = list.GetValues();
-                                for (var i = 0; i < listArray.Count && i < 5; ++i) {
-                                    var listValue = listArray[i];
-                                    if(listValue.TryGetValueAsString(out var RGBString)) {
-                                        if(ColorHelpers.TryParseColor(RGBString, out var color, defaultAlpha: "00")) {
-                                            newMatrix.SetRow(i, color);
-                                        }
-                                    }
-                                }
-                                _atomManager.UpdateAppearance(dreamObject, appearance => {
-                                    appearance.SetColor(newMatrix);
-                                });
-                                return;
-                            default:
-                                throw new ArgumentException("Incorrect /list provided for /atom.color");
+                        if(DreamProcNativeHelpers.TryParseColorMatrix(list, out var matrix)) {
+                            _atomManager.UpdateAppearance(dreamObject, appearance => {
+                                appearance.SetColor(matrix);
+                            });
+                            break;
+                        } else {
+                            throw new ArgumentException("Invalid /list provided to /atom.color - it is not a color matrix");
                         }
                     }
 

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -258,8 +258,15 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 case "filters":
                     return new DreamValue(_filterLists[dreamObject]);
                 case "color":
-                    if(!_atomManager.TryGetAppearance(dreamObject, out IconAppearance? appearance))
-                        return DreamValue.Null;
+                    if(!_atomManager.TryGetAppearance(dreamObject, out IconAppearance? appearance)) {
+                        //This is here to avoid infinite loops, since the lazy-init of appearances
+                        // (that would occur if we tried to just invoke MustGetAppearance())
+                        //requires accessing the color var.
+                        if (dreamObject.ObjectDefinition.TryGetVariable("color",out var colorValue)) {
+                            return colorValue;
+                        }
+                        return DreamValue.Null; //idek
+                    }
                     if(appearance.Matrix is not null) {
                         var matrixList = _objectTree.CreateList(20);
                         foreach (float entry in appearance.Matrix.Value.GetValues())

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
@@ -172,7 +172,7 @@ internal static class DreamProcNativeHelpers {
             switch (list.GetLength()) {
                 case 0:
                     return true; // Just return the identity matrix. NOTE: Not sure if *exactly* parity.
-                case 1: // 0 to 5 is the rgb() string spam: 
+                case 1: // 0 to 5 is the rgb() string spam:
                 case 2: // list(rgb() or null, rgb() or null, rgb() or null, rgb() or null, rgb() or null)
                 case 3:
                 case 4:
@@ -216,7 +216,7 @@ internal static class DreamProcNativeHelpers {
                         matrix.SetRow(row, listArray[offset].MustGetValueAsFloat(),
                                            listArray[offset + 1].MustGetValueAsFloat(),
                                            listArray[offset + 2].MustGetValueAsFloat(),
-                                           listArray[offset + 2].MustGetValueAsFloat());
+                                           listArray[offset + 3].MustGetValueAsFloat());
                     }
                     return true;
                 case 20: // list(rr, rg, rb, ra, gr, gg, gb, ga, br, bg, bb, ba, ar, ag, ab, aa, cr, cg, cb, ca)
@@ -225,7 +225,7 @@ internal static class DreamProcNativeHelpers {
                         matrix.SetRow(row, listArray[offset].MustGetValueAsFloat(),
                                            listArray[offset + 1].MustGetValueAsFloat(),
                                            listArray[offset + 2].MustGetValueAsFloat(),
-                                           listArray[offset + 2].MustGetValueAsFloat());
+                                           listArray[offset + 3].MustGetValueAsFloat());
                     }
                     return true;
                 default:

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -504,7 +504,7 @@ namespace OpenDreamRuntime.Procs.Native {
             }
 
             DreamFilter? filter = serializationManager.Read(filterType, attributes) as DreamFilter;
-            if (filter == null)
+            if (filter is null)
                 throw new Exception($"Failed to create filter of type {filterType}");
 
             DreamObject filterObject = ObjectTree.CreateObject(ObjectTree.Filter);

--- a/OpenDreamRuntime/Rendering/DMISpriteComponent.cs
+++ b/OpenDreamRuntime/Rendering/DMISpriteComponent.cs
@@ -16,7 +16,7 @@ namespace OpenDreamRuntime.Rendering {
         private ScreenLocation? _screenLocation;
 
         [ViewVariables]
-        public IconAppearance? Appearance => (_appearanceId != null) ? EntitySystem.Get<ServerAppearanceSystem>().GetAppearance(_appearanceId.Value) : null;
+        public IconAppearance? Appearance => (_appearanceId != null) ? EntitySystem.Get<ServerAppearanceSystem>().MustGetAppearance(_appearanceId.Value) : null;
 
         private uint? _appearanceId;
 

--- a/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
+++ b/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
@@ -3,6 +3,7 @@ using OpenDreamShared.Dream;
 using Robust.Server.Player;
 using Robust.Shared.Enums;
 using SharedAppearanceSystem = OpenDreamShared.Rendering.SharedAppearanceSystem;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenDreamRuntime.Rendering {
     sealed class ServerAppearanceSystem : SharedAppearanceSystem {
@@ -45,8 +46,12 @@ namespace OpenDreamRuntime.Rendering {
             return null;
         }
 
-        public IconAppearance GetAppearance(uint appearanceId) {
+        public IconAppearance MustGetAppearance(uint appearanceId) {
             return _idToAppearance[appearanceId];
+        }
+
+        public bool TryGetAppearance(uint appearanceId, [NotNullWhen(true)] out IconAppearance? appearance) {
+            return _idToAppearance.TryGetValue(appearanceId, out appearance);
         }
 
         public void Animate(EntityUid entity, IconAppearance targetAppearance, TimeSpan duration) {

--- a/OpenDreamShared/Dream/ColorHelpers.cs
+++ b/OpenDreamShared/Dream/ColorHelpers.cs
@@ -36,7 +36,7 @@ namespace OpenDreamShared.Dream
 
                     color = new string('#', 1) + new string(color[1], 2) + new string(color[2], 2) + new string(color[3], 2) + alphaComponent;
                 } else if (color.Length == 7) { //Missing alpha
-                    color += "ff";
+                    color += defaultAlpha;
                 }
 
                 colorOut = Color.FromHex(color, Color.White);

--- a/OpenDreamShared/Dream/ColorMatrix.cs
+++ b/OpenDreamShared/Dream/ColorMatrix.cs
@@ -1,0 +1,162 @@
+﻿using Robust.Shared.Maths;
+using Robust.Shared.Physics.Dynamics.Joints;
+using Robust.Shared.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace OpenDreamShared.Dream {
+    /// <summary>
+    /// Holds the 5x4 matrix data necessary to encapsulate a color matrix: https://www.byond.com/docs/ref/#/{notes}/color-matrix
+    /// </summary>
+    /// <remarks>
+    /// This is going to be one of those structs that gets, absolutely destroyed by the fact <br/>
+    /// that fixed arrays are """"""unsafe"""""" in this language.
+    /// </remarks>
+    [Serializable, NetSerializable, StructLayout(LayoutKind.Sequential)]
+    public struct ColorMatrix {
+
+        public float c11;
+        public float c12;
+        public float c13;
+        public float c14;
+
+        public float c21;
+        public float c22;
+        public float c23;
+        public float c24;
+
+        public float c31;
+        public float c32;
+        public float c33;
+        public float c34;
+
+        public float c41;
+        public float c42;
+        public float c43;
+        public float c44;
+
+        public float c51;
+        public float c52;
+        public float c53;
+        public float c54;
+
+        public ColorMatrix(float m11, float m12, float m13, float m14,
+                         float m21, float m22, float m23, float m24,
+                         float m31, float m32, float m33, float m34,
+                         float m41, float m42, float m43, float m44,
+                         float m51, float m52, float m53, float m54) {
+            c11 = m11;
+            c12 = m12;
+            c13 = m13;
+            c14 = m14;
+
+            c21 = m21;
+            c22 = m22;
+            c23 = m23;
+            c24 = m24;
+
+            c31 = m31;
+            c32 = m32;
+            c33 = m33;
+            c34 = m34;
+
+            c41 = m41;
+            c42 = m42;
+            c43 = m43;
+            c44 = m44;
+
+            c51 = m51;
+            c52 = m52;
+            c53 = m53;
+            c54 = m54;
+        }
+
+        public static ColorMatrix Identity =>
+            new ColorMatrix(1F, 0F, 0F, 0F,
+                            0F, 1F, 0F, 0F,
+                            0F, 0F, 1F, 0F,
+                            0F, 0F, 0F, 1F,
+                            0F, 0F, 0F, 0F);
+
+        public void SetRow(int row, in Color color) {
+            switch(row) {
+                case 0:
+                    c11 = color.R;
+                    c12 = color.G;
+                    c13 = color.B;
+                    c14 = color.A;
+                    break;
+                case 1:
+                    c21 = color.R;
+                    c22 = color.G;
+                    c23 = color.B;
+                    c24 = color.A;
+                    break;
+                case 2:
+                    c31 = color.R;
+                    c32 = color.G;
+                    c33 = color.B;
+                    c34 = color.A;
+                    break;
+                case 3:
+                    c41 = color.R;
+                    c42 = color.G;
+                    c43 = color.B;
+                    c44 = color.A;
+                    break;
+                case 4:
+                    c51 = color.R;
+                    c52 = color.G;
+                    c53 = color.B;
+                    c54 = color.A;
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Gets the diagonal values in this matrix. Used for detecting whether this matrix is convertible into a Color.
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<float> GetDiagonal() {
+            yield return c11;
+            yield return c22;
+            yield return c33;
+            yield return c44;
+            yield break;
+        }
+
+        /// <summary>
+        /// Returns all of the values in this struct, in order.
+        /// </summary>
+        public IEnumerable<float> GetValues() {
+            yield return c11;
+            yield return c12;
+            yield return c13;
+            yield return c14;
+
+            yield return c21;
+            yield return c22;
+            yield return c23;
+            yield return c24;
+
+            yield return c31;
+            yield return c32;
+            yield return c33;
+            yield return c34;
+
+            yield return c41;
+            yield return c42;
+            yield return c43;
+            yield return c44;
+
+            yield return c51;
+            yield return c52;
+            yield return c53;
+            yield return c54;
+            yield break;
+        }
+    }
+}

--- a/OpenDreamShared/Dream/ColorMatrix.cs
+++ b/OpenDreamShared/Dream/ColorMatrix.cs
@@ -75,6 +75,35 @@ namespace OpenDreamShared.Dream {
             c54 = m54;
         }
 
+        public ColorMatrix(in ColorMatrix cloned) {
+            //I have never, ever missed the "pointer to member access" goofball operator from C++
+            //until this exact, debilitating moment
+            c11 = cloned.c11;
+            c12 = cloned.c12;
+            c13 = cloned.c13;
+            c14 = cloned.c14;
+
+            c21 = cloned.c21;
+            c22 = cloned.c22;
+            c23 = cloned.c23;
+            c24 = cloned.c24;
+
+            c31 = cloned.c31;
+            c32 = cloned.c32;
+            c33 = cloned.c33;
+            c34 = cloned.c34;
+
+            c41 = cloned.c41;
+            c42 = cloned.c42;
+            c43 = cloned.c43;
+            c44 = cloned.c44;
+
+            c51 = cloned.c51;
+            c52 = cloned.c52;
+            c53 = cloned.c53;
+            c54 = cloned.c54;
+        }
+
         /// <summary>
         /// Constructs a ColorMatrix that is equivalent to the given color, during transformations.
         /// </summary>

--- a/OpenDreamShared/Dream/ColorMatrix.cs
+++ b/OpenDreamShared/Dream/ColorMatrix.cs
@@ -3,6 +3,7 @@ using Robust.Shared.Physics.Dynamics.Joints;
 using Robust.Shared.Serialization;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -74,6 +75,21 @@ namespace OpenDreamShared.Dream {
             c54 = m54;
         }
 
+        /// <summary>
+        /// Constructs a ColorMatrix that is equivalent to the given color, during transformations.
+        /// </summary>
+        /// <remarks>Note: This constructor assumes that floats are zero-initialized.</remarks>
+        /// <param name="basicColor"></param>
+        public ColorMatrix(in Color basicColor) {
+            c11 = basicColor.R;
+
+            c22 = basicColor.G;
+
+            c33 = basicColor.B;
+
+            c44 = basicColor.A;
+        }
+
         public static ColorMatrix Identity =>
             new ColorMatrix(1F, 0F, 0F, 0F,
                             0F, 1F, 0F, 0F,
@@ -82,37 +98,44 @@ namespace OpenDreamShared.Dream {
                             0F, 0F, 0F, 0F);
 
         public void SetRow(int row, in Color color) {
+            SetRow(row, color.R, color.G, color.B, color.A);
+        }
+
+        public void SetRow(int row, float r, float g, float b, float a) {
             switch(row) {
                 case 0:
-                    c11 = color.R;
-                    c12 = color.G;
-                    c13 = color.B;
-                    c14 = color.A;
+                    c11 = r;
+                    c12 = g;
+                    c13 = b;
+                    c14 = a;
                     break;
                 case 1:
-                    c21 = color.R;
-                    c22 = color.G;
-                    c23 = color.B;
-                    c24 = color.A;
+                    c21 = r;
+                    c22 = g;
+                    c23 = b;
+                    c24 = a;
                     break;
                 case 2:
-                    c31 = color.R;
-                    c32 = color.G;
-                    c33 = color.B;
-                    c34 = color.A;
+                    c31 = r;
+                    c32 = g;
+                    c33 = b;
+                    c34 = a;
                     break;
                 case 3:
-                    c41 = color.R;
-                    c42 = color.G;
-                    c43 = color.B;
-                    c44 = color.A;
+                    c41 = r;
+                    c42 = g;
+                    c43 = b;
+                    c44 = a;
                     break;
                 case 4:
-                    c51 = color.R;
-                    c52 = color.G;
-                    c53 = color.B;
-                    c54 = color.A;
+                    c51 = r;
+                    c52 = g;
+                    c53 = b;
+                    c54 = a;
                     break;
+                default:
+                    //Should be an UnreachableException but it's verbotten or something by the sandboxer
+                    throw new Exception($"Cannot access {row}th row of a 5x4 matrix");
             }
         }
 

--- a/OpenDreamShared/Dream/ColorMatrix.cs
+++ b/OpenDreamShared/Dream/ColorMatrix.cs
@@ -8,207 +8,206 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 
-namespace OpenDreamShared.Dream {
+namespace OpenDreamShared.Dream;
+/// <summary>
+/// Holds the 5x4 matrix data necessary to encapsulate a color matrix: https://www.byond.com/docs/ref/#/{notes}/color-matrix
+/// </summary>
+/// <remarks>
+/// This is going to be one of those structs that gets, absolutely destroyed by the fact <br/>
+/// that fixed arrays are """"""unsafe"""""" in this language.
+/// </remarks>
+[Serializable, NetSerializable, StructLayout(LayoutKind.Sequential)]
+public struct ColorMatrix {
+
+    public float c11;
+    public float c12;
+    public float c13;
+    public float c14;
+
+    public float c21;
+    public float c22;
+    public float c23;
+    public float c24;
+
+    public float c31;
+    public float c32;
+    public float c33;
+    public float c34;
+
+    public float c41;
+    public float c42;
+    public float c43;
+    public float c44;
+
+    public float c51;
+    public float c52;
+    public float c53;
+    public float c54;
+
+    public ColorMatrix(float m11, float m12, float m13, float m14,
+                        float m21, float m22, float m23, float m24,
+                        float m31, float m32, float m33, float m34,
+                        float m41, float m42, float m43, float m44,
+                        float m51, float m52, float m53, float m54) {
+        c11 = m11;
+        c12 = m12;
+        c13 = m13;
+        c14 = m14;
+
+        c21 = m21;
+        c22 = m22;
+        c23 = m23;
+        c24 = m24;
+
+        c31 = m31;
+        c32 = m32;
+        c33 = m33;
+        c34 = m34;
+
+        c41 = m41;
+        c42 = m42;
+        c43 = m43;
+        c44 = m44;
+
+        c51 = m51;
+        c52 = m52;
+        c53 = m53;
+        c54 = m54;
+    }
+
+    public ColorMatrix(in ColorMatrix cloned) {
+        //I have never, ever missed the "pointer to member access" goofball operator from C++
+        //until this exact, debilitating moment
+        c11 = cloned.c11;
+        c12 = cloned.c12;
+        c13 = cloned.c13;
+        c14 = cloned.c14;
+
+        c21 = cloned.c21;
+        c22 = cloned.c22;
+        c23 = cloned.c23;
+        c24 = cloned.c24;
+
+        c31 = cloned.c31;
+        c32 = cloned.c32;
+        c33 = cloned.c33;
+        c34 = cloned.c34;
+
+        c41 = cloned.c41;
+        c42 = cloned.c42;
+        c43 = cloned.c43;
+        c44 = cloned.c44;
+
+        c51 = cloned.c51;
+        c52 = cloned.c52;
+        c53 = cloned.c53;
+        c54 = cloned.c54;
+    }
+
     /// <summary>
-    /// Holds the 5x4 matrix data necessary to encapsulate a color matrix: https://www.byond.com/docs/ref/#/{notes}/color-matrix
+    /// Constructs a ColorMatrix that is equivalent to the given color, during transformations.
     /// </summary>
-    /// <remarks>
-    /// This is going to be one of those structs that gets, absolutely destroyed by the fact <br/>
-    /// that fixed arrays are """"""unsafe"""""" in this language.
-    /// </remarks>
-    [Serializable, NetSerializable, StructLayout(LayoutKind.Sequential)]
-    public struct ColorMatrix {
+    /// <remarks>Note: This constructor assumes that floats are zero-initialized.</remarks>
+    /// <param name="basicColor"></param>
+    public ColorMatrix(in Color basicColor) {
+        c11 = basicColor.R;
 
-        public float c11;
-        public float c12;
-        public float c13;
-        public float c14;
+        c22 = basicColor.G;
 
-        public float c21;
-        public float c22;
-        public float c23;
-        public float c24;
+        c33 = basicColor.B;
 
-        public float c31;
-        public float c32;
-        public float c33;
-        public float c34;
+        c44 = basicColor.A;
+    }
 
-        public float c41;
-        public float c42;
-        public float c43;
-        public float c44;
+    public static ColorMatrix Identity =>
+        new ColorMatrix(1F, 0F, 0F, 0F,
+                        0F, 1F, 0F, 0F,
+                        0F, 0F, 1F, 0F,
+                        0F, 0F, 0F, 1F,
+                        0F, 0F, 0F, 0F);
 
-        public float c51;
-        public float c52;
-        public float c53;
-        public float c54;
+    public void SetRow(int row, in Color color) {
+        SetRow(row, color.R, color.G, color.B, color.A);
+    }
 
-        public ColorMatrix(float m11, float m12, float m13, float m14,
-                         float m21, float m22, float m23, float m24,
-                         float m31, float m32, float m33, float m34,
-                         float m41, float m42, float m43, float m44,
-                         float m51, float m52, float m53, float m54) {
-            c11 = m11;
-            c12 = m12;
-            c13 = m13;
-            c14 = m14;
-
-            c21 = m21;
-            c22 = m22;
-            c23 = m23;
-            c24 = m24;
-
-            c31 = m31;
-            c32 = m32;
-            c33 = m33;
-            c34 = m34;
-
-            c41 = m41;
-            c42 = m42;
-            c43 = m43;
-            c44 = m44;
-
-            c51 = m51;
-            c52 = m52;
-            c53 = m53;
-            c54 = m54;
+    public void SetRow(int row, float r, float g, float b, float a) {
+        switch(row) {
+            case 0:
+                c11 = r;
+                c12 = g;
+                c13 = b;
+                c14 = a;
+                break;
+            case 1:
+                c21 = r;
+                c22 = g;
+                c23 = b;
+                c24 = a;
+                break;
+            case 2:
+                c31 = r;
+                c32 = g;
+                c33 = b;
+                c34 = a;
+                break;
+            case 3:
+                c41 = r;
+                c42 = g;
+                c43 = b;
+                c44 = a;
+                break;
+            case 4:
+                c51 = r;
+                c52 = g;
+                c53 = b;
+                c54 = a;
+                break;
+            default:
+                //Should be an UnreachableException but it's verbotten or something by the sandboxer
+                throw new Exception($"Cannot access {row}th row of a 5x4 matrix");
         }
+    }
 
-        public ColorMatrix(in ColorMatrix cloned) {
-            //I have never, ever missed the "pointer to member access" goofball operator from C++
-            //until this exact, debilitating moment
-            c11 = cloned.c11;
-            c12 = cloned.c12;
-            c13 = cloned.c13;
-            c14 = cloned.c14;
+    /// <summary>
+    /// Gets the diagonal values in this matrix. Used for detecting whether this matrix is convertible into a Color.
+    /// </summary>
+    /// <returns></returns>
+    public IEnumerable<float> GetDiagonal() {
+        yield return c11;
+        yield return c22;
+        yield return c33;
+        yield return c44;
+        yield break;
+    }
 
-            c21 = cloned.c21;
-            c22 = cloned.c22;
-            c23 = cloned.c23;
-            c24 = cloned.c24;
+    /// <summary>
+    /// Returns all of the values in this struct, in order.
+    /// </summary>
+    public IEnumerable<float> GetValues() {
+        yield return c11;
+        yield return c12;
+        yield return c13;
+        yield return c14;
 
-            c31 = cloned.c31;
-            c32 = cloned.c32;
-            c33 = cloned.c33;
-            c34 = cloned.c34;
+        yield return c21;
+        yield return c22;
+        yield return c23;
+        yield return c24;
 
-            c41 = cloned.c41;
-            c42 = cloned.c42;
-            c43 = cloned.c43;
-            c44 = cloned.c44;
+        yield return c31;
+        yield return c32;
+        yield return c33;
+        yield return c34;
 
-            c51 = cloned.c51;
-            c52 = cloned.c52;
-            c53 = cloned.c53;
-            c54 = cloned.c54;
-        }
+        yield return c41;
+        yield return c42;
+        yield return c43;
+        yield return c44;
 
-        /// <summary>
-        /// Constructs a ColorMatrix that is equivalent to the given color, during transformations.
-        /// </summary>
-        /// <remarks>Note: This constructor assumes that floats are zero-initialized.</remarks>
-        /// <param name="basicColor"></param>
-        public ColorMatrix(in Color basicColor) {
-            c11 = basicColor.R;
-
-            c22 = basicColor.G;
-
-            c33 = basicColor.B;
-
-            c44 = basicColor.A;
-        }
-
-        public static ColorMatrix Identity =>
-            new ColorMatrix(1F, 0F, 0F, 0F,
-                            0F, 1F, 0F, 0F,
-                            0F, 0F, 1F, 0F,
-                            0F, 0F, 0F, 1F,
-                            0F, 0F, 0F, 0F);
-
-        public void SetRow(int row, in Color color) {
-            SetRow(row, color.R, color.G, color.B, color.A);
-        }
-
-        public void SetRow(int row, float r, float g, float b, float a) {
-            switch(row) {
-                case 0:
-                    c11 = r;
-                    c12 = g;
-                    c13 = b;
-                    c14 = a;
-                    break;
-                case 1:
-                    c21 = r;
-                    c22 = g;
-                    c23 = b;
-                    c24 = a;
-                    break;
-                case 2:
-                    c31 = r;
-                    c32 = g;
-                    c33 = b;
-                    c34 = a;
-                    break;
-                case 3:
-                    c41 = r;
-                    c42 = g;
-                    c43 = b;
-                    c44 = a;
-                    break;
-                case 4:
-                    c51 = r;
-                    c52 = g;
-                    c53 = b;
-                    c54 = a;
-                    break;
-                default:
-                    //Should be an UnreachableException but it's verbotten or something by the sandboxer
-                    throw new Exception($"Cannot access {row}th row of a 5x4 matrix");
-            }
-        }
-
-        /// <summary>
-        /// Gets the diagonal values in this matrix. Used for detecting whether this matrix is convertible into a Color.
-        /// </summary>
-        /// <returns></returns>
-        public IEnumerable<float> GetDiagonal() {
-            yield return c11;
-            yield return c22;
-            yield return c33;
-            yield return c44;
-            yield break;
-        }
-
-        /// <summary>
-        /// Returns all of the values in this struct, in order.
-        /// </summary>
-        public IEnumerable<float> GetValues() {
-            yield return c11;
-            yield return c12;
-            yield return c13;
-            yield return c14;
-
-            yield return c21;
-            yield return c22;
-            yield return c23;
-            yield return c24;
-
-            yield return c31;
-            yield return c32;
-            yield return c33;
-            yield return c34;
-
-            yield return c41;
-            yield return c42;
-            yield return c43;
-            yield return c44;
-
-            yield return c51;
-            yield return c52;
-            yield return c53;
-            yield return c54;
-            yield break;
-        }
+        yield return c51;
+        yield return c52;
+        yield return c53;
+        yield return c54;
+        yield break;
     }
 }

--- a/OpenDreamShared/Dream/DreamFilter.cs
+++ b/OpenDreamShared/Dream/DreamFilter.cs
@@ -74,7 +74,7 @@ public sealed record DreamFilterBlur : DreamFilter {
 
 [Serializable, NetSerializable]
 public sealed record DreamFilterColor : DreamFilter {
-    //[ViewVariables, DataField("color", required: true)] public object Color; // Color matrix TODO
+    [ViewVariables, DataField("color", required: true)] public ColorMatrix Color;
     [ViewVariables, DataField("space")] public float Space; // Default is FILTER_COLOR_RGB = 0
 }
 

--- a/OpenDreamShared/Dream/IconAppearance.cs
+++ b/OpenDreamShared/Dream/IconAppearance.cs
@@ -180,6 +180,7 @@ namespace OpenDreamShared.Dream {
             var newFilter = new DreamFilterColor(); // Am I like... doing this right?
             newFilter.Color = matrix;
             newFilter.Space = 0; // TODO: Support color mappings that aren't RGB.
+            newFilter.FilterType = "color";
             Filters.Add(newFilter);
         }
     }

--- a/OpenDreamShared/Dream/IconAppearance.cs
+++ b/OpenDreamShared/Dream/IconAppearance.cs
@@ -109,7 +109,7 @@ namespace OpenDreamShared.Dream {
             return maybeColor is not null;
         }
 
-        private void RemoveColorFilter() {
+        public void RemoveColorFilter() {
             for (int i = 0; i < Filters.Count; i++) {
                 if (Filters[i] is DreamFilterColor) {
                     Filters.RemoveAt(i);

--- a/OpenDreamShared/Dream/IconAppearance.cs
+++ b/OpenDreamShared/Dream/IconAppearance.cs
@@ -14,12 +14,16 @@ namespace OpenDreamShared.Dream {
         [ViewVariables] public AtomDirection Direction;
         [ViewVariables] public Vector2i PixelOffset;
         [ViewVariables] public Color Color = Color.White;
-        /// <remarks>
+        /// <summary>
         /// An appearance can gain a color matrix filter by two possible forces: <br/>
         /// 1. the /atom.color var is modified. <br/>
         /// 2. the /atom.filters var gets a new filter of type "color". <br/>
         /// DM crashes in some circumstances of this but we, as an extension :^), should try not to. <br/>
         /// So, this exists as a way for the appearance to remember whether it's coloured by .color, specifically.
+        /// </summary>
+        /// <remarks>
+        /// The reason we don't just take the slow path and always use this filter is not just for optimization,<br/>
+        /// it's also for parity! See <see cref="TryRepresentMatrixAsRGBAColor(in ColorMatrix, out Color?)"/> for more.
         /// </remarks>
         [ViewVariables] public DreamFilterColor? SillyColorFilter;
         [ViewVariables] public float Layer;
@@ -105,15 +109,18 @@ namespace OpenDreamShared.Dream {
             // The R G B A values need to be bounded [0,1] for a color conversion to work;
             // anything higher implies trying to render "superblue" or something.
             float diagonalSum = 0f;
-            foreach(float diagonalValue in matrix.GetDiagonal()) {
+            foreach (float diagonalValue in matrix.GetDiagonal()) {
                 if (diagonalValue < 0 || diagonalValue > 1)
                     return false;
                 diagonalSum += diagonalValue;
             }
             // and then all of the other values need to be zero, including the offset vector.
             float sum = 0f;
-            foreach(float value in matrix.GetValues())
+            foreach (float value in matrix.GetValues()) {
+                if (value < 0f) // To avoid situations like negatives and positives cancelling out this checksum.
+                    return false;
                 sum += value;
+            }
             if (sum - diagonalSum == 0) // PREEETTY sure I can trust the floating-point math here. Not 100% though
                 maybeColor = new Color(matrix.c11, matrix.c22, matrix.c33, matrix.c44);
             return maybeColor is not null;

--- a/Resources/Prototypes/Shaders/dreamshaders.yml
+++ b/Resources/Prototypes/Shaders/dreamshaders.yml
@@ -29,7 +29,7 @@
   kind: source
   path: "/Shaders/colormatrix.swsl"
   params:
-    colorMatrix: 0 #FIXME: actually reasonable default arguments
+    colorMatrix: 1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1
     offsetVector: 0,0,0,0
 
 #unimplemented shaders point to empty.swsl and do nothing

--- a/Resources/Prototypes/Shaders/dreamshaders.yml
+++ b/Resources/Prototypes/Shaders/dreamshaders.yml
@@ -1,3 +1,8 @@
+# NOTE:
+# Due to how this data is later serialized and accessed by the filter() native proc,
+# the ID of the shader must be the exact same as the BYOND string literal of the filter it correlates to.
+# i.e. filter(type="color"...) must correlate to a shader with id: color
+# This may later change (comment written Feb 13 '23) but, uh, watch out for that.
 
 - type: shader
   id: outline
@@ -18,6 +23,14 @@
   path: "/Shaders/blur.swsl"
   params:
     size: 1
+
+- type: shader
+  id: color
+  kind: source
+  path: "/Shaders/colormatrix.swsl"
+  params:
+    colorMatrix: 0 #FIXME: actually reasonable default arguments
+    offsetVector: 0,0,0,0
 
 #unimplemented shaders point to empty.swsl and do nothing
 
@@ -50,14 +63,6 @@
     size: 1    
     offset: 0
     alpha: 0
-
-- type: shader
-  id: color
-  kind: source
-  path: "/Shaders/empty.swsl"
-  params:
-    color: 0
-    space: 1    
 
 - type: shader
   id: displace

--- a/Resources/Shaders/colormatrix.swsl
+++ b/Resources/Shaders/colormatrix.swsl
@@ -6,22 +6,28 @@
 uniform lowp mat4 colorMatrix;
 uniform lowp vec4 offsetVector; // The final row of the 4x5 matrix it kinda is
 void fragment() {
-    lowp vec3 oldColor = COLOR.rgb; // Dorky micro-optimization, since the math lets us skip on saving one of them
-    COLOR.r =   oldColor.r * colorMatrix[0].x + 
-                oldColor.g * colorMatrix[0].y + 
-                oldColor.b * colorMatrix[0].z + 
-                COLOR.a * colorMatrix[0].w;
-    COLOR.g =   oldColor.r * colorMatrix[1].x + 
-                oldColor.g * colorMatrix[1].y + 
-                oldColor.b * colorMatrix[1].z + 
-                COLOR.a * colorMatrix[1].w;
-    COLOR.b =   oldColor.r * colorMatrix[2].x + 
-                oldColor.g * colorMatrix[2].y + 
-                oldColor.b * colorMatrix[2].z + 
-                COLOR.a * colorMatrix[2].w;
-    COLOR.a =   oldColor.r * colorMatrix[3].x + 
-                oldColor.g * colorMatrix[3].y + 
-                oldColor.b * colorMatrix[3].z + 
-                COLOR.a * colorMatrix[3].w;
+    highp vec4 oldColor = zTexture(UV);
+	//Even though mat4s are supposed to be COLUMN first,
+	//Clyde has done something devilish, and swapped it back via a transpose
+	//so this is actually row-first.
+    COLOR[0] =  oldColor[0] * colorMatrix[0][0] + 
+                oldColor[1] * colorMatrix[1][0] + 
+                oldColor[2] * colorMatrix[2][0] + 
+                oldColor[3] * colorMatrix[3][0];
+				
+    COLOR[1] =  oldColor[0] * colorMatrix[0][1] + 
+                oldColor[1] * colorMatrix[1][1] + 
+                oldColor[2] * colorMatrix[2][1] + 
+                oldColor[3] * colorMatrix[3][1];
+				
+    COLOR[2] =  oldColor[0] * colorMatrix[0][2] + 
+                oldColor[1] * colorMatrix[1][2] + 
+                oldColor[2] * colorMatrix[2][2] + 
+                oldColor[3] * colorMatrix[3][2];
+				
+    COLOR[3] =  oldColor[0] * colorMatrix[0][3] + 
+                oldColor[1] * colorMatrix[1][3] + 
+                oldColor[2] * colorMatrix[2][3] + 
+                oldColor[3] * colorMatrix[3][3];
     COLOR = COLOR + offsetVector;
 }

--- a/Resources/Shaders/colormatrix.swsl
+++ b/Resources/Shaders/colormatrix.swsl
@@ -1,0 +1,27 @@
+//This is for handling transformations
+//caused by DM colour matrices: https://secure.byond.com/docs/ref/#/{notes}/color-matrix
+//In general, our code should try to avoid using this shader, in favour of the 'modulate' Color parameter available in some RT/Clyde drawing routines.
+//This should only be used for color transformations that can only be expressed as the linear algebra nonsense featured below.
+
+uniform lowp mat4 colorMatrix;
+uniform lowp vec4 offsetVector; // The final row of the 4x5 matrix it kinda is
+void fragment() {
+    lowp vec3 oldColor = COLOR.rgb; // Dorky micro-optimization, since the math lets us skip on saving one of them
+    COLOR.r =   oldColor.r * colorMatrix[0].x + 
+                oldColor.g * colorMatrix[0].y + 
+                oldColor.b * colorMatrix[0].z + 
+                COLOR.a * colorMatrix[0].w;
+    COLOR.g =   oldColor.r * colorMatrix[1].x + 
+                oldColor.g * colorMatrix[1].y + 
+                oldColor.b * colorMatrix[1].z + 
+                COLOR.a * colorMatrix[1].w;
+    COLOR.b =   oldColor.r * colorMatrix[2].x + 
+                oldColor.g * colorMatrix[2].y + 
+                oldColor.b * colorMatrix[2].z + 
+                COLOR.a * colorMatrix[2].w;
+    COLOR.a =   oldColor.r * colorMatrix[3].x + 
+                oldColor.g * colorMatrix[3].y + 
+                oldColor.b * colorMatrix[3].z + 
+                COLOR.a * colorMatrix[3].w;
+    COLOR = COLOR + offsetVector;
+}

--- a/Resources/Shaders/colormatrix.swsl
+++ b/Resources/Shaders/colormatrix.swsl
@@ -7,27 +7,24 @@ uniform lowp mat4 colorMatrix;
 uniform lowp vec4 offsetVector; // The final row of the 4x5 matrix it kinda is
 void fragment() {
     highp vec4 oldColor = zTexture(UV);
-	//Even though mat4s are supposed to be COLUMN first,
-	//Clyde has done something devilish, and swapped it back via a transpose
-	//so this is actually row-first.
     COLOR[0] =  oldColor[0] * colorMatrix[0][0] + 
-                oldColor[1] * colorMatrix[1][0] + 
-                oldColor[2] * colorMatrix[2][0] + 
-                oldColor[3] * colorMatrix[3][0];
+                oldColor[1] * colorMatrix[0][1] + 
+                oldColor[2] * colorMatrix[0][2] + 
+                oldColor[3] * colorMatrix[0][3];
 				
-    COLOR[1] =  oldColor[0] * colorMatrix[0][1] + 
+    COLOR[1] =  oldColor[0] * colorMatrix[1][0] + 
                 oldColor[1] * colorMatrix[1][1] + 
-                oldColor[2] * colorMatrix[2][1] + 
-                oldColor[3] * colorMatrix[3][1];
+                oldColor[2] * colorMatrix[1][2] + 
+                oldColor[3] * colorMatrix[1][3];
 				
-    COLOR[2] =  oldColor[0] * colorMatrix[0][2] + 
-                oldColor[1] * colorMatrix[1][2] + 
+    COLOR[2] =  oldColor[0] * colorMatrix[2][0] + 
+                oldColor[1] * colorMatrix[2][1] + 
                 oldColor[2] * colorMatrix[2][2] + 
-                oldColor[3] * colorMatrix[3][2];
+                oldColor[3] * colorMatrix[2][3];
 				
-    COLOR[3] =  oldColor[0] * colorMatrix[0][3] + 
-                oldColor[1] * colorMatrix[1][3] + 
-                oldColor[2] * colorMatrix[2][3] + 
+    COLOR[3] =  oldColor[0] * colorMatrix[3][0] + 
+                oldColor[1] * colorMatrix[3][1] + 
+                oldColor[2] * colorMatrix[3][2] + 
                 oldColor[3] * colorMatrix[3][3];
     COLOR = COLOR + offsetVector;
 }

--- a/Resources/Shaders/colormatrix.swsl
+++ b/Resources/Shaders/colormatrix.swsl
@@ -3,10 +3,12 @@
 //In general, our code should try to avoid using this shader, in favour of the 'modulate' Color parameter available in some RT/Clyde drawing routines.
 //This should only be used for color transformations that can only be expressed as the linear algebra nonsense featured below.
 
+blend_mode none; // Assuming that Wix's inclusion of this ends up in RT, here
+
 uniform lowp mat4 colorMatrix;
 uniform lowp vec4 offsetVector; // The final row of the 4x5 matrix it kinda is
 void fragment() {
-    highp vec4 oldColor = zTexture(UV);
+    highp vec4 oldColor = zToSrgb(zTexture(UV)); // TODO: It'd be easier and more precise if we avoided this color-space conversion.
     COLOR[0] =  oldColor[0] * colorMatrix[0][0] + 
                 oldColor[1] * colorMatrix[0][1] + 
                 oldColor[2] * colorMatrix[0][2] + 
@@ -26,5 +28,5 @@ void fragment() {
                 oldColor[1] * colorMatrix[3][1] + 
                 oldColor[2] * colorMatrix[3][2] + 
                 oldColor[3] * colorMatrix[3][3];
-    COLOR = COLOR + offsetVector;
+    COLOR = zFromSrgb(COLOR + offsetVector);
 }

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -8,6 +8,9 @@
 /mob
 	icon = 'icons/mob.dmi'
 	icon_state = "mob"
+	name = "Square Man"
+	desc = "Such a beautiful smile."
+	gender = MALE
 
 	New()
 		..()
@@ -90,7 +93,7 @@
 			src.filters = null
 			usr << "Filters cleared"
 		else
-			var/selected = input("Pick a filter", "Choose a filter to apply (with demo settings)", null) as null|anything in list("outline", "greyscale", "blur", "outline/grey", "grey/outline", "all")
+			var/selected = input("Pick a filter", "Choose a filter to apply (with demo settings)", null) as null|anything in list("outline", "greyscale", "blur", "outline/grey", "grey/outline", "color", "all")
 			if(isnull(selected))
 				src.filters = null
 				usr << "No filter selected, filters cleared"
@@ -105,20 +108,14 @@
 					src.filters = list(filter(type="outline", size=1, color=rgb(255,0,0)), filter(type="greyscale"))
 				if("grey/outline")
 					src.filters = list(filter(type="greyscale"), filter(type="outline", size=1, color=rgb(255,0,0)))
+				if("color")
+					usr << "[usr], you fool! You have activated my evil attack!"
+					var/list/M = list("#ff0000","#000000","#00ff00")	
+					src.color = M
+					usr << json_encode(src.color)
 				if("all")
 					src.filters = list(filter(type="greyscale"), filter(type="outline", size=1, color=rgb(255,0,0)), filter(type="blur", size=2))
 			usr << "Applied [selected] filter"
-	
-	verb/test_color()
-		set category = "Test"
-		//unit matrix: list(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1, 0,0,0,0)
-		var/list/noRed = list(0,0,0,0, 0,2,0,0, 0,0,2,0, 0,0,0,1, 0,0,0,0)
-		var/list/noBlue = list(2,0,0,0, 0,2,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0)
-		src.color = noRed
-		src.filters = filter(type="color",noBlue)
-		usr << "Applied silly colours:"
-		usr << json_encode(src.color)
-		usr << json_encode(src.filters)
 
 /mob/Stat()
 	if (statpanel("Status"))

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -108,6 +108,17 @@
 				if("all")
 					src.filters = list(filter(type="greyscale"), filter(type="outline", size=1, color=rgb(255,0,0)), filter(type="blur", size=2))
 			usr << "Applied [selected] filter"
+	
+	verb/test_color()
+		set category = "Test"
+		//unit matrix: list(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1, 0,0,0,0)
+		var/list/noRed = list(0,0,0,0, 0,2,0,0, 0,0,2,0, 0,0,0,1, 0,0,0,0)
+		var/list/noBlue = list(2,0,0,0, 0,2,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0)
+		src.color = noRed
+		src.filters = filter(type="color",noBlue)
+		usr << "Applied silly colours:"
+		usr << json_encode(src.color)
+		usr << json_encode(src.filters)
 
 /mob/Stat()
 	if (statpanel("Status"))

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -110,7 +110,7 @@
 					src.filters = list(filter(type="greyscale"), filter(type="outline", size=1, color=rgb(255,0,0)))
 				if("color")
 					usr << "[usr], you fool! You have activated my evil attack!"
-					var/list/M = list("#ff0000","#000000","#00ff00")	
+					var/list/M = list("#de0000","#000000","#00ad00")	
 					src.color = M
 					usr << json_encode(src.color)
 				if("all")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29939414/219305315-8138ab6b-c6b7-47bc-99f1-d01d0fe8a066.png)

## Summary
This was supposed to be me doing something very simple to dip my toes into the graphics side of this project, but lucky for me, this has been a total trap. After a few days of losing my mind, here's something that only works with novel RT code.

## Changelog
- Setting `/atom.color` to a color matrix now works.
- The color filter (instantiated by `filter(type="color",..)` now works.