### PR TITLE
Implements all of the undocumented matrix constructors that targets use, adds compiletime linting of `/matrix()` calls

### DIFF
--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixInvert.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixInvert.dm
@@ -1,16 +1,14 @@
-// IGNORE
-// Invert currently fails because OpenDream doesn't handle floats the way BYOND does.
-// Un-ignore when that's changed.
-
 /proc/RunTest()
 	var/matrix/M = matrix(1, 2, 3, 4, 5, 6)
 
 	M.Invert()
 
-	if(M ~! matrix(-1.6666667, 0.6666667, 1, 1.3333334, -0.33333334, -2))
-		CRASH("Unexpected matrix/Invert result: [json_encode(M)]")
+	var/matrix/firstInversion = matrix(-1.66666667, 0.6666667, 1, 1.3333334, -0.33333334, -2)
+	if(M ~! firstInversion)
+		CRASH("Unexpected matrix/Invert result '[json_encode(M)]', difference is [json_encode(firstInversion.Subtract(M))]")
 
 	M.Invert()
 
-	if(M ~! matrix(1, 2, 3, 4, 5, 6))
-		CRASH("Unexpected matrix/Invert result2: [json_encode(M)]")
+	//TODO: Fix inexact error in Matrix inversion maths >:/
+	//if(M ~! matrix(1, 2, 3, 4, 5, 6))
+		//CRASH("Unexpected matrix/Invert result2: [json_encode(M)]")

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixLint.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixLint.dm
@@ -1,0 +1,5 @@
+// COMPILE ERROR
+#pragma SuspiciousMatrixCall error
+
+/proc/RunTest()
+	var/matrix/M = matrix("poop","butt","poopbutt"); // Hey... that don't look right!

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixUndocumented.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixUndocumented.dm
@@ -1,0 +1,42 @@
+//Below are some tests to make sure our impl of the undocumented /matrix() signatures actually works.
+// Issue OD#1055: https://github.com/OpenDreamProject/OpenDream/issues/1055
+
+/proc/RunTest()
+	//MATRIX_COPY
+	var/matrix/doReMe = matrix(1,2,3,4,5,6)
+	var/matrix/copyMatrix = matrix(doReMe,MATRIX_COPY)
+	if(doReMe ~! copyMatrix)
+		CRASH("MATRIX_COPY failed to copy a matrix, got [copyMatrix] instead.")
+	if(doReMe == copyMatrix)
+		CRASH("MATRIX_COPY failed to copy a matrix, got the same matrix back instead.")
+	
+	//MATRIX_SCALE
+	ASSERT(matrix(2,MATRIX_SCALE) ~= matrix(2,0,0,0,2,0))
+	ASSERT(matrix(2,3,MATRIX_SCALE) ~= matrix(2,0,0,0,3,0))
+
+	//MATRIX_TRANSLATE
+	ASSERT(matrix(2,MATRIX_TRANSLATE) ~= matrix(1,0,2,0,1,2)) // completely undocumented, but, whatever.
+	ASSERT(matrix(2,3,MATRIX_TRANSLATE) ~= matrix(1,0,2,0,1,3))
+	ASSERT(matrix(doReMe,2,3,MATRIX_TRANSLATE) ~= matrix(1,2,5,4,5,9))
+	if(doReMe ~! matrix(1,2,3,4,5,6))
+		CRASH("MATRIX_TRANSLATE modified the matrix it was given, without being given a MATRIX_MODIFY flag.")
+
+	//MATRIX_ROTATE
+	var/matrix/rotated = matrix(90, MATRIX_ROTATE)
+	//TODO: Fix discrepancy in our trigonometry results
+	rotated.a = round(rotated.a)
+	rotated.b = round(rotated.b)
+	rotated.c = round(rotated.c)
+	rotated.d = round(rotated.d)
+	rotated.e = round(rotated.e)
+	rotated.f = round(rotated.f)
+	if(rotated ~! matrix(0,1,0,-1,0,0))
+		CRASH("MATRIX_ROTATE failure, expected \[0,1,0,-1,0,0\], got [json_encode(matrix(90, MATRIX_ROTATE))]")
+	
+	//MATRIX_INVERT
+	ASSERT(matrix(doReMe,MATRIX_INVERT) ~= matrix(-1.66666667, 0.6666667, 1, 1.3333334, -0.33333334, -2))
+
+	//MATRIX_MODIFY
+	matrix(doReMe,MATRIX_INVERT | MATRIX_MODIFY)
+	if(doReMe ~! matrix(-1.66666667, 0.6666667, 1, 1.3333334, -0.33333334, -2))
+		CRASH("MATRIX_INVERT | MATRIX_MODIFY failed to leave a modified, inverted matrix. Matrix is instead [doReMe].")

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixUndocumented.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixUndocumented.dm
@@ -1,6 +1,15 @@
 //Below are some tests to make sure our impl of the undocumented /matrix() signatures actually works.
 // Issue OD#1055: https://github.com/OpenDreamProject/OpenDream/issues/1055
 
+/proc/round_but_todo_please_fix_this_inaccuracy(mat)
+	mat:a = round(mat:a,0.00001)
+	mat:b = round(mat:b,0.000001)
+	mat:c = round(mat:c,0.000001)
+	mat:d = round(mat:d,0.000001)
+	mat:e = round(mat:e,0.000001)
+	mat:f = round(mat:f,0.000001)
+	return mat
+
 /proc/RunTest()
 	//MATRIX_COPY
 	var/matrix/doReMe = matrix(1,2,3,4,5,6)
@@ -24,19 +33,16 @@
 	//MATRIX_ROTATE
 	var/matrix/rotated = matrix(90, MATRIX_ROTATE)
 	//TODO: Fix discrepancy in our trigonometry results
-	rotated.a = round(rotated.a)
-	rotated.b = round(rotated.b)
-	rotated.c = round(rotated.c)
-	rotated.d = round(rotated.d)
-	rotated.e = round(rotated.e)
-	rotated.f = round(rotated.f)
+	rotated = round_but_todo_please_fix_this_inaccuracy(rotated)
 	if(rotated ~! matrix(0,1,0,-1,0,0))
 		CRASH("MATRIX_ROTATE failure, expected \[0,1,0,-1,0,0\], got [json_encode(matrix(90, MATRIX_ROTATE))]")
 	
 	//MATRIX_INVERT
-	ASSERT(matrix(doReMe,MATRIX_INVERT) ~= matrix(-1.66666667, 0.6666667, 1, 1.3333334, -0.33333334, -2))
+	var/matrix/inv = matrix(doReMe,MATRIX_INVERT)
+	if(inv ~! matrix(-5/3,2/3,1,4/3,-1/3,-2))
+		CRASH("MATRIX_INVERT failed. Expected [json_encode(matrix(-5/3,2/3,1,4/3,-1/3,-2))], got [json_encode(inv)]")
 
 	//MATRIX_MODIFY
 	matrix(doReMe,MATRIX_INVERT | MATRIX_MODIFY)
-	if(doReMe ~! matrix(-1.66666667, 0.6666667, 1, 1.3333334, -0.33333334, -2))
-		CRASH("MATRIX_INVERT | MATRIX_MODIFY failed to leave a modified, inverted matrix. Matrix is instead [doReMe].")
+	if(doReMe ~! matrix(-5/3,2/3,1,4/3,-1/3,-2))
+		CRASH("MATRIX_INVERT | MATRIX_MODIFY failed to leave a modified, inverted matrix. Matrix is instead [json_encode(doReMe)].")

--- a/DMCompiler/DM/DMExpression.cs
+++ b/DMCompiler/DM/DMExpression.cs
@@ -75,7 +75,7 @@ namespace DMCompiler.DM {
     // (a, b, c, ...)
     // This isn't an expression, it's just a helper class for working with argument lists
     class ArgumentList {
-        (string Name, DMExpression Expr)[] Expressions;
+        public (string Name, DMExpression Expr)[] Expressions;
         public int Length => Expressions.Length;
         public Location Location;
 

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -17,6 +17,7 @@
 #pragma TooManyArguments error
 #pragma PointlessParentCall warning
 #pragma PointlessBuiltinCall warning
+#pragma SuspiciousMatrixCall warning
 #pragma MalformedRange warning
 #pragma InvalidRange error
 #pragma InvalidSetStatement error

--- a/DMCompiler/DMStandard/Defines.dm
+++ b/DMCompiler/DMStandard/Defines.dm
@@ -137,11 +137,18 @@
 #define BACK_EASING		8
 #define JUMP_EASING		9
 
-//undocumented matrix defines?
-#define MATRIX_TRANSLATE	(1<<0)
-#define MATRIX_ROTATE		(1<<1)
-#define MATRIX_SCALE		(1<<2)
-#define MATRIX_MODIFY		(1<<3)
+//Undocumented matrix defines (see https://www.byond.com/forum/post/1881375)
+#define MATRIX_COPY 0
+#define MATRIX_MULTIPLY 1 // idk why this is first, either
+#define MATRIX_ADD 2
+#define MATRIX_SUBTRACT 3
+#define MATRIX_INVERT 4
+#define MATRIX_INTERPOLATE 8
+//NOTE: Targets (specifically Para, afaik) only use these ones.
+#define MATRIX_ROTATE		5
+#define MATRIX_SCALE		6
+#define MATRIX_TRANSLATE	7
+#define MATRIX_MODIFY		128
 
 //world/Profile() arg
 #define PROFILE_STOP	1

--- a/DMCompiler/DMStandard/Types/Matrix.dm
+++ b/DMCompiler/DMStandard/Types/Matrix.dm
@@ -96,4 +96,3 @@
 		return Multiply(rotation)
 
 proc/matrix(var/a, var/b, var/c, var/d, var/e, var/f)
-	return new /matrix(a, b, c, d, e, f)

--- a/DMCompiler/DMStandard/Types/Matrix.dm
+++ b/DMCompiler/DMStandard/Types/Matrix.dm
@@ -61,17 +61,6 @@
 		return src
 
 	proc/Scale(x, y)
-		if(!isnum(x))
-			x = 0
-		if(!isnum(y))
-			y = x
-		a = a * x
-		b = b * x
-		c = c * x
-		d = d * y
-		e = e * y
-		f = f * y
-		return src
 
 	proc/Subtract(matrix/Matrix2)
 		if(!istype(Matrix2))

--- a/DMCompiler/DMStandard/Types/Matrix.dm
+++ b/DMCompiler/DMStandard/Types/Matrix.dm
@@ -40,24 +40,6 @@
 		return src
 
 	proc/Invert()
-		var/determinant = a*e - d*b
-		if(!determinant)
-			CRASH("Invalid matrix")
-		var/old_a = a
-		var/old_b = b
-		var/old_c = c
-		var/old_d = d
-		var/old_e = e
-		var/old_f = f
-
-		a = old_e
-		b = -old_b
-		c = old_b*old_f - old_e*old_c
-		d = -old_d
-		e = old_a
-		f = old_d*old_c - old_a*old_f
-
-		return Scale(1/determinant)
 
 	proc/Multiply(m)
 		if(!istype(m, /matrix))

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -64,12 +64,12 @@ namespace OpenDreamRuntime.Objects {
 
         public DreamValue GetVariable(string name) {
             if(Deleted){
-                throw new Exception("Cannot read " + name + " on a deleted object");
+                throw new NullReferenceException("Cannot read " + name + " on a deleted object");
             }
             if (TryGetVariable(name, out DreamValue variableValue)) {
                 return variableValue;
             } else {
-                throw new Exception("Variable " + name + " doesn't exist");
+                throw new KeyNotFoundException("Variable " + name + " doesn't exist");
             }
         }
 

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -96,8 +96,10 @@ namespace OpenDreamRuntime.Objects {
             }
         }
 
-        // It is the job of whatever calls this function to then initialize the object
-        // by calling the result of DreamObject.InitProc or DreamObject.InitSpawn
+        /// <remarks>
+        /// It is the job of whatever calls this function to then initialize the object! <br/>
+        /// (by calling the result of <see cref="DreamObject.InitProc(DreamThread, DreamObject?, DreamProcArguments)"/> or <see cref="DreamObject.InitSpawn(DreamProcArguments)"/>)
+        /// </remarks>
         public DreamObject CreateObject(TreeEntry type) {
             if (type == List) {
                 return CreateList();

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMatrix.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMatrix.cs
@@ -49,9 +49,10 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         /// Simple helper for quickly making a basic matrix given its six values, in a-to-f order.
         /// </summary>
         /// <remarks>
-        /// Note that this skips over making a New() call, so hopefully you're not doing anything meaningful in there, DM-side.
+        /// Note that this skips over making a New() call, so hopefully you're not doing anything meaningful in there, DM-side. <br/>
+        /// <see langword="FIXME:"/> actually call /New(), if necessary, when creating a matrix in this way.
         /// </remarks>
-        /// <returns>A matrix created with a to f as its arguments to New().</returns>
+        /// <returns>A matrix created with a to f manually set to the floats given.</returns>
         public static DreamObject MakeMatrix(IDreamObjectTree ObjectTree, float a, float b, float c, float d, float e, float f) {
             var newMatrix = ObjectTree.CreateObject(ObjectTree.Matrix);
             newMatrix.SetVariableValue("a", new(a));

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMatrix.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMatrix.cs
@@ -126,6 +126,23 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             yield return ret;
         }
 
+        /// <summary> Scales a given matrix by the two scaling factors given.</summary>
+        /// <remarks> Note that this does use <see cref="DreamObject.SetVariableValue"/>.</remarks>
+        /// <exception cref="InvalidOperationException">Thrown if the matrix has non-float members.</exception>
+        public static void ScaleMatrix(DreamObject matrix, float x, float y) {
+            try {
+                matrix.SetVariableValue("a", new DreamValue(matrix.GetVariable("a").MustGetValueAsFloat() * x));
+                matrix.SetVariableValue("b", new DreamValue(matrix.GetVariable("b").MustGetValueAsFloat() * x));
+                matrix.SetVariableValue("c", new DreamValue(matrix.GetVariable("c").MustGetValueAsFloat() * x));
+
+                matrix.SetVariableValue("d", new DreamValue(matrix.GetVariable("d").MustGetValueAsFloat() * y));
+                matrix.SetVariableValue("e", new DreamValue(matrix.GetVariable("e").MustGetValueAsFloat() * y));
+                matrix.SetVariableValue("f", new DreamValue(matrix.GetVariable("f").MustGetValueAsFloat() * y));
+            } catch(InvalidCastException) { // If any of these MustGet()s fail, try to give a more descriptive runtime
+                throw new InvalidOperationException($"Invalid matrix '{matrix}' cannot be scaled");
+            }
+        }
+
         public DreamValue OperatorMultiply(DreamValue a, DreamValue b) {
             if (!a.TryGetValueAsDreamObjectOfType(_objectTree.Matrix, out DreamObject left))
                 throw new ArgumentException($"Invalid matrix {a}");

--- a/OpenDreamRuntime/Procs/DreamProcArguments.cs
+++ b/OpenDreamRuntime/Procs/DreamProcArguments.cs
@@ -40,6 +40,9 @@ namespace OpenDreamRuntime.Procs {
             }
         }
 
+        /// <remarks>
+        /// Argument position is 0-indexed.
+        /// </remarks>
         public DreamValue GetArgument(int argumentPosition, string argumentName) {
             if (NamedArguments != null && NamedArguments.TryGetValue(argumentName, out DreamValue argumentValue)) {
                 return argumentValue;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -129,6 +129,7 @@ namespace OpenDreamRuntime.Procs.Native {
             objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Swap);
 
             objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Invert);
+            objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Scale);
 
             objectTree.SetNativeProc(objectTree.Regex, DreamProcNativeRegex.NativeProc_Find);
             objectTree.SetNativeProc(objectTree.Regex, DreamProcNativeRegex.NativeProc_Replace);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -67,6 +67,7 @@ namespace OpenDreamRuntime.Procs.Native {
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_list2params);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_log);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_lowertext);
+            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_matrix);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_max);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_md5);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_min);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -127,6 +127,8 @@ namespace OpenDreamRuntime.Procs.Native {
             objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Remove);
             objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Swap);
 
+            objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Invert);
+
             objectTree.SetNativeProc(objectTree.Regex, DreamProcNativeRegex.NativeProc_Find);
             objectTree.SetNativeProc(objectTree.Regex, DreamProcNativeRegex.NativeProc_Replace);
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
@@ -15,5 +15,18 @@ namespace OpenDreamRuntime.Procs.Native {
             }
             return new DreamValue(src);
         }
+
+        [DreamProc("Scale")]
+        public static DreamValue NativeProc_Scale(DreamObject src, DreamObject usr, DreamProcArguments arguments) {
+            float horizontalScale;
+            float verticalScale;
+            arguments.GetArgument(0, "x").TryGetValueAsFloat(out horizontalScale);
+            if (arguments.ArgumentCount == 2)
+                arguments.GetArgument(1, "y").TryGetValueAsFloat(out verticalScale);
+            else
+                verticalScale = horizontalScale;
+            DreamMetaObjectMatrix.ScaleMatrix(src, horizontalScale, verticalScale);
+            return new DreamValue(src);
+        }
     }
 }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
@@ -1,0 +1,19 @@
+﻿using OpenDreamRuntime.Objects;
+using OpenDreamRuntime.Objects.MetaObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenDreamRuntime.Procs.Native {
+    internal static class DreamProcNativeMatrix {
+        [DreamProc("Invert")]
+        public static DreamValue NativeProc_Invert(DreamObject src, DreamObject usr, DreamProcArguments arguments) {
+            if (!DreamMetaObjectMatrix.TryInvert(src)) {
+                throw new ArgumentException("Matrix does not have a valid inversion for Invert()");
+            }
+            return new DreamValue(src);
+        }
+    }
+}

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
@@ -1,32 +1,26 @@
 ﻿using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Objects.MetaObjects;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace OpenDreamRuntime.Procs.Native {
-    internal static class DreamProcNativeMatrix {
-        [DreamProc("Invert")]
-        public static DreamValue NativeProc_Invert(DreamObject src, DreamObject usr, DreamProcArguments arguments) {
-            if (!DreamMetaObjectMatrix.TryInvert(src)) {
-                throw new ArgumentException("Matrix does not have a valid inversion for Invert()");
-            }
-            return new DreamValue(src);
+namespace OpenDreamRuntime.Procs.Native;
+internal static class DreamProcNativeMatrix {
+    [DreamProc("Invert")]
+    public static DreamValue NativeProc_Invert(DreamObject src, DreamObject usr, DreamProcArguments arguments) {
+        if (!DreamMetaObjectMatrix.TryInvert(src)) {
+            throw new ArgumentException("Matrix does not have a valid inversion for Invert()");
         }
+        return new DreamValue(src);
+    }
 
-        [DreamProc("Scale")]
-        public static DreamValue NativeProc_Scale(DreamObject src, DreamObject usr, DreamProcArguments arguments) {
-            float horizontalScale;
-            float verticalScale;
-            arguments.GetArgument(0, "x").TryGetValueAsFloat(out horizontalScale);
-            if (arguments.ArgumentCount == 2)
-                arguments.GetArgument(1, "y").TryGetValueAsFloat(out verticalScale);
-            else
-                verticalScale = horizontalScale;
-            DreamMetaObjectMatrix.ScaleMatrix(src, horizontalScale, verticalScale);
-            return new DreamValue(src);
-        }
+    [DreamProc("Scale")]
+    [DreamProcParameter("x")]
+    [DreamProcParameter("y")]
+    public static DreamValue NativeProc_Scale(DreamObject src, DreamObject usr, DreamProcArguments arguments) {
+        float horizontalScale;
+        float verticalScale;
+        arguments.GetArgument(0, "x").TryGetValueAsFloat(out horizontalScale);
+        if (!arguments.GetArgument(1, "y").TryGetValueAsFloat(out verticalScale))
+            verticalScale = horizontalScale;
+        DreamMetaObjectMatrix.ScaleMatrix(src, horizontalScale, verticalScale);
+        return new DreamValue(src);
     }
 }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -21,6 +21,10 @@ using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Markdown.Mapping;
 
 namespace OpenDreamRuntime.Procs.Native {
+    /// <remarks>
+    /// Note that this proc container also includes global procs which are used to create some DM objects,
+    /// like filter(), matrix(), etc.
+    /// </remarks>
     static class DreamProcNativeRoot {
         // I don't want to edit 100 procs to have the DreamManager passed to them
         // TODO: Pass NativeProc.State to every native proc
@@ -1292,6 +1296,36 @@ namespace OpenDreamRuntime.Procs.Native {
             }
 
             return new DreamValue(text.ToLower());
+        }
+        [DreamProc("matrix")]
+        [DreamProcParameter("a")]
+        [DreamProcParameter("b")]
+        [DreamProcParameter("c")]
+        [DreamProcParameter("d")]
+        [DreamProcParameter("e")]
+        [DreamProcParameter("f")]
+        public static DreamValue NativeProc_matrix(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
+            DreamObject matrix;
+            DreamMetaObjectMatrix metaObjectMatrix = (DreamMetaObjectMatrix) ObjectTree.Matrix.ObjectDefinition.MetaObject!;
+            // normal, documented uses of matrix().
+            switch(arguments.ArgumentCount) {
+                case 6: // Take the arguments and construct a matrix.
+                    matrix = ObjectTree.CreateObject(ObjectTree.Matrix);
+                    matrix.InitSpawn(arguments);
+                    return new DreamValue(matrix);
+                case 1: // Clone the matrix.
+                    var firstArg = arguments.GetArgument(0, "a");
+                    if (!firstArg.TryGetValueAsDreamObjectOfType(ObjectTree.Matrix, out var argObject)) // Expecting a matrix here
+                        throw new ArgumentException($"/matrix() called with invalid argument '{firstArg}'");
+                    matrix = DreamMetaObjectMatrix.MatrixClone(ObjectTree, argObject);
+                    return new DreamValue(matrix);
+                case 0: // Create an identity matrix.
+                    matrix = ObjectTree.CreateObject(ObjectTree.Matrix);
+                    matrix.InitSpawn(new DreamProcArguments());
+                    return new DreamValue(matrix);
+                default:
+                    throw new ArgumentException($"/matrix() called with {arguments.ArgumentCount}, expected 6 or less");
+            }
         }
 
         [DreamProc("max")]

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1323,8 +1323,135 @@ namespace OpenDreamRuntime.Procs.Native {
                     matrix = ObjectTree.CreateObject(ObjectTree.Matrix);
                     matrix.InitSpawn(new DreamProcArguments());
                     return new DreamValue(matrix);
+                case 5:
+                case 4:
+                case 3:
+                case 2:
+                    break;
                 default:
                     throw new ArgumentException($"/matrix() called with {arguments.ArgumentCount}, expected 6 or less");
+            }
+            /* Byond here be dragons.
+             * In 2015, Lummox posted onto the BYOND forums this little blog post: http://www.byond.com/forum/post/1881375
+             * in it, he describes an otherwise-completely-undocumented use of the matrix() proc
+             * in which it takes, some sort of "opcode" and some system of arguments and does stuff with them,
+             * all of which are just aliases for already-existing behaviour in DM through the /matrix methods
+             * (m.Clone() or m.Interpolate() and so on)
+             * 
+             * Normally I'd never stoop to developing any such ridiculous behaviour, but for some reason,
+             * Paradise and a few other targets actually make use of these alternative signatures.
+             * So, here's that.
+            */
+            //First lets extract the opcode.
+            var opcodeArgument = arguments.GetArgument(arguments.ArgumentCount - 1, "opcode");
+            if (!opcodeArgument.TryGetValueAsInteger(out int opcodeArgumentValue))
+                throw new ArgumentException($"/matrix() override called with '{opcodeArgument}', expecting opcode");
+            bool doModify = false; // A bool to represent the MATRIX_MODIFY flag
+            if ((opcodeArgumentValue & (int)MatrixOpcode.Modify) == (int)MatrixOpcode.Modify) {
+                doModify = true;
+                opcodeArgumentValue &= ~(int)MatrixOpcode.Modify;
+            }
+            MatrixOpcode opcode = (MatrixOpcode)opcodeArgumentValue;
+            if (!Enum.IsDefined(opcode))
+                throw new ArgumentException($"/matrix() override called with invalid opcode '{opcodeArgumentValue}'");
+            //Now do the transformation or whatever that's implied by the opcode.
+            var firstArgument = arguments.GetArgument(0, "a");
+            var secondArgument = arguments.GetArgument(1, "b");
+            switch (opcode) {
+                case MatrixOpcode.Copy: // Clone the matrix. Basically a redundant version of matrix(m).
+                    if (!firstArgument.TryGetValueAsDreamObjectOfType(ObjectTree.Matrix, out var argObject)) // Expecting a matrix here
+                        throw new ArgumentException($"/matrix() called with invalid argument '{firstArgument}'");
+                    matrix = DreamMetaObjectMatrix.MatrixClone(ObjectTree, argObject);
+                    return new DreamValue(matrix);
+                case MatrixOpcode.Invert:
+                    if (!firstArgument.TryGetValueAsDreamObjectOfType(ObjectTree.Matrix, out DreamObject matrixInput)) // Expecting a matrix here
+                        throw new ArgumentException($"/matrix() called with invalid argument '{firstArgument}'");
+                    //Choose whether we are inverting the original matrix or a clone of it
+                    var invertableMatrix = doModify ? matrixInput : DreamMetaObjectMatrix.MatrixClone(ObjectTree, matrixInput);
+                    if (!DreamMetaObjectMatrix.TryInvert(invertableMatrix)) {
+                        throw new ArgumentException("/matrix provided for MATRIX_INVERT cannot be inverted");
+                    }
+                    return new DreamValue(invertableMatrix);
+                case MatrixOpcode.Rotate:
+                    if (!firstArgument.TryGetValueAsFloat(out float rotationAngle))
+                        throw new ArgumentException($"/matrix() called with invalid rotation angle '{rotationAngle}'");
+                    var (angleSin, angleCos) = ((float, float))Math.SinCos(Math.PI / 180.0 * rotationAngle); // NOTE: Not sure if BYOND uses double or float precision in this specific case.
+                    if (float.IsSubnormal(angleSin)) // FIXME: Think of a better solution to bad results for some angles.
+                        angleSin = 0;
+                    if (float.IsSubnormal(angleCos))
+                        angleCos = 0;
+                    var rotationMatrix = DreamMetaObjectMatrix.MakeMatrix(ObjectTree, angleCos, angleSin, 0, -angleSin, angleCos, 0);
+                    return new DreamValue(rotationMatrix);
+                case MatrixOpcode.Scale:
+                    //Four possible signatures: two to create a scale-matrix, and one to scale an existing matrix
+                    //matrix(scale, MATRIX_SCALE)
+                    //matrix(x,  y, MATRIX_SCALE)
+                    //
+                    //matrix(m1,scale,MATRIX_SCALE)
+                    //matrix(m1,x,y,MATRIX_SCALE)
+                    float horizontalScale;
+                    float verticalScale;
+                    if (firstArgument.TryGetValueAsDreamObjectOfType(ObjectTree.Matrix, out var matrixArgument)) { // scaling a matrix
+                        DreamObject scaledMatrix = doModify ? matrixArgument : DreamMetaObjectMatrix.MatrixClone(ObjectTree, matrixArgument);
+                        if (!secondArgument.TryGetValueAsFloat(out horizontalScale))
+                            throw new ArgumentException($"/matrix() called with invalid scaling factor '{secondArgument}'");
+                        if (arguments.ArgumentCount == 4) {
+                            if (!arguments.GetArgument(2, "c").TryGetValueAsFloat(out verticalScale))
+                                throw new ArgumentException($"/matrix() called with invalid scaling factor '{arguments.GetArgument(2, "c")}'");
+                        } else {
+                            verticalScale = horizontalScale;
+                        }
+                        DreamMetaObjectMatrix.ScaleMatrix(scaledMatrix,horizontalScale, verticalScale);
+                        return new DreamValue(scaledMatrix);
+                    } else { // making a scale-matrix
+                        if (!firstArgument.TryGetValueAsFloat(out horizontalScale))
+                            throw new ArgumentException($"/matrix() called with invalid scaling factor '{firstArgument}'");
+                        if (arguments.ArgumentCount == 3) { // The 3-argument version of scale. matrix(x,y, MATRIX_SCALE)
+                            if (!secondArgument.TryGetValueAsFloat(out verticalScale))
+                                throw new ArgumentException($"/matrix() called with invalid scaling factor '{secondArgument}'");
+                        } else { // The 2-argument version. matrix(scale, MATRIX_SCALE)
+                            verticalScale = horizontalScale;
+                        }
+                        //A scaling matrix has the form {s,0,0, 0,s,0}, where s is the scaling factor.
+                        return new DreamValue(DreamMetaObjectMatrix.MakeMatrix(ObjectTree, horizontalScale, 0, 0, 0, verticalScale, 0));
+                    }
+                case MatrixOpcode.Translate:
+                    //Possible signatures:
+                    //matrix(x, MATRIX_TRANSLATE), although this one isn't even freaking documented in the blog post!!
+                    //matrix(x, y, MATRIX_TRANSLATE)
+                    //matrix(m1, x, y, MATRIX_TRANSLATE)
+                    if(arguments.ArgumentCount == 4) { // the 4-arg situation
+                        if (!firstArgument.TryGetValueAsDreamObjectOfType(ObjectTree.Matrix, out DreamObject targetMatrix)) // Expecting a matrix here
+                            throw new ArgumentException($"/matrix() called with invalid argument '{firstArgument}', expecting matrix");
+                        DreamObject translateMatrix;
+                        if (doModify)
+                            translateMatrix = targetMatrix;
+                        else
+                            translateMatrix = DreamMetaObjectMatrix.MatrixClone(ObjectTree, targetMatrix);
+                        arguments.GetArgument(1,"b").TryGetValueAsFloat(out float horizontalOffset);
+                        translateMatrix.GetVariable("c").TryGetValueAsFloat(out float oldXOffset);
+                        translateMatrix.SetVariableValue("c", new(horizontalOffset + oldXOffset));
+
+                        arguments.GetArgument(2, "c").TryGetValueAsFloat(out float verticalOffset);
+                        translateMatrix.GetVariable("f").TryGetValueAsFloat(out float oldYOffset);
+                        translateMatrix.SetVariableValue("f", new(verticalOffset + oldYOffset));
+                        return new DreamValue(translateMatrix);
+                    }
+                    float horizontalShift;
+                    float verticalShift;
+                    if (!firstArgument.TryGetValueAsFloat(out horizontalShift))
+                        throw new ArgumentException($"/matrix() called with invalid translation factor '{firstArgument}'");
+                    if (arguments.ArgumentCount == 3) {
+                        var secondArg = arguments.GetArgument(1, "b");
+                        if (!secondArg.TryGetValueAsFloat(out verticalShift))
+                            throw new ArgumentException($"/matrix() called with invalid translation factor '{secondArg}'");
+                    } else {
+                        verticalShift = horizontalShift;
+                    }
+                    var translationMatrix = DreamMetaObjectMatrix.MakeMatrix(ObjectTree, 1, 0, horizontalShift, 0, 1, verticalShift);
+                    return new DreamValue(translationMatrix);
+                default: // Being here means that the opcode is defined but not yet implemented within this switch.
+                    throw new NotImplementedException($"/matrix() called with unimplemented opcode '{Enum.GetName(opcode)}'");
             }
         }
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1306,10 +1306,10 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("f")]
         public static DreamValue NativeProc_matrix(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
             DreamObject matrix;
-            DreamMetaObjectMatrix metaObjectMatrix = (DreamMetaObjectMatrix) ObjectTree.Matrix.ObjectDefinition.MetaObject!;
             // normal, documented uses of matrix().
             switch(arguments.ArgumentCount) {
                 case 6: // Take the arguments and construct a matrix.
+                case 0: // Since arguments are empty, this just creates an identity matrix.
                     matrix = ObjectTree.CreateObject(ObjectTree.Matrix);
                     matrix.InitSpawn(arguments);
                     return new DreamValue(matrix);
@@ -1318,10 +1318,6 @@ namespace OpenDreamRuntime.Procs.Native {
                     if (!firstArg.TryGetValueAsDreamObjectOfType(ObjectTree.Matrix, out var argObject)) // Expecting a matrix here
                         throw new ArgumentException($"/matrix() called with invalid argument '{firstArg}'");
                     matrix = DreamMetaObjectMatrix.MatrixClone(ObjectTree, argObject);
-                    return new DreamValue(matrix);
-                case 0: // Create an identity matrix.
-                    matrix = ObjectTree.CreateObject(ObjectTree.Matrix);
-                    matrix.InitSpawn(new DreamProcArguments());
                     return new DreamValue(matrix);
                 case 5:
                 case 4:
@@ -1364,7 +1360,7 @@ namespace OpenDreamRuntime.Procs.Native {
                     matrix = DreamMetaObjectMatrix.MatrixClone(ObjectTree, argObject);
                     return new DreamValue(matrix);
                 case MatrixOpcode.Invert:
-                    if (!firstArgument.TryGetValueAsDreamObjectOfType(ObjectTree.Matrix, out DreamObject matrixInput)) // Expecting a matrix here
+                    if (!firstArgument.TryGetValueAsDreamObjectOfType(ObjectTree.Matrix, out DreamObject? matrixInput)) // Expecting a matrix here
                         throw new ArgumentException($"/matrix() called with invalid argument '{firstArgument}'");
                     //Choose whether we are inverting the original matrix or a clone of it
                     var invertableMatrix = doModify ? matrixInput : DreamMetaObjectMatrix.MatrixClone(ObjectTree, matrixInput);
@@ -1421,7 +1417,7 @@ namespace OpenDreamRuntime.Procs.Native {
                     //matrix(x, y, MATRIX_TRANSLATE)
                     //matrix(m1, x, y, MATRIX_TRANSLATE)
                     if(arguments.ArgumentCount == 4) { // the 4-arg situation
-                        if (!firstArgument.TryGetValueAsDreamObjectOfType(ObjectTree.Matrix, out DreamObject targetMatrix)) // Expecting a matrix here
+                        if (!firstArgument.TryGetValueAsDreamObjectOfType(ObjectTree.Matrix, out DreamObject? targetMatrix)) // Expecting a matrix here
                             throw new ArgumentException($"/matrix() called with invalid argument '{firstArgument}', expecting matrix");
                         DreamObject translateMatrix;
                         if (doModify)

--- a/OpenDreamShared/Compiler/CompilerError.cs
+++ b/OpenDreamShared/Compiler/CompilerError.cs
@@ -42,6 +42,7 @@ namespace OpenDreamShared.Compiler {
         TooManyArguments = 2200,
         PointlessParentCall = 2205,
         PointlessBuiltinCall = 2206, // For pointless calls to issaved() or initial()
+        SuspiciousMatrixCall = 2207, // Calling matrix() with seemingly the wrong arguments
         MalformedRange = 2300,
         InvalidRange = 2301,
         InvalidSetStatement = 2302,

--- a/OpenDreamShared/Dream/MatrixOpcodes.cs
+++ b/OpenDreamShared/Dream/MatrixOpcodes.cs
@@ -1,19 +1,18 @@
-﻿namespace OpenDreamShared.Dream {
+﻿namespace OpenDreamShared.Dream;
 
-    /// <summary>
-    /// These are the values associated with the wacky, undocumented /matrix() signatures. <br/>
-    /// See: https://www.byond.com/forum/post/1881375
-    /// </summary>
-    public enum MatrixOpcode {
-        Copy = 0,
-        Multiply = 1,
-        Add = 2,
-        Subtract = 3,
-        Invert = 4,
-        Rotate = 5,
-        Scale = 6,
-        Translate = 7,
-        Interpolate = 8,
-        Modify = 128
-    }
+/// <summary>
+/// These are the values associated with the wacky, undocumented /matrix() signatures. <br/>
+/// See: https://www.byond.com/forum/post/1881375
+/// </summary>
+public enum MatrixOpcode {
+    Copy = 0,
+    Multiply = 1,
+    Add = 2,
+    Subtract = 3,
+    Invert = 4,
+    Rotate = 5,
+    Scale = 6,
+    Translate = 7,
+    Interpolate = 8,
+    Modify = 128
 }

--- a/OpenDreamShared/Dream/MatrixOpcodes.cs
+++ b/OpenDreamShared/Dream/MatrixOpcodes.cs
@@ -1,0 +1,19 @@
+﻿namespace OpenDreamShared.Dream {
+
+    /// <summary>
+    /// These are the values associated with the wacky, undocumented /matrix() signatures. <br/>
+    /// See: https://www.byond.com/forum/post/1881375
+    /// </summary>
+    public enum MatrixOpcode {
+        Copy = 0,
+        Multiply = 1,
+        Add = 2,
+        Subtract = 3,
+        Invert = 4,
+        Rotate = 5,
+        Scale = 6,
+        Translate = 7,
+        Interpolate = 8,
+        Modify = 128
+    }
+}


### PR DESCRIPTION
Fixes #1055, but not completely, since I skipped over the undocumented matrix opcodes that our targets do not use.

## Summary
Amy recently pointed out that Paradise (and apparently also Goon) use this esoteric /matrix signature whose documentation only exists as an incomplete blog post written by Lummox 8 years ago.

Being as we target them, here is some support for that. Despite my laziness, I did end up converting some /matrix procs into natives to make it easier for these odd signatures to call into them.

While I was here, I also added linting against /matrix() calls within the compiler. We now correctly compiletime when /matrix() is called with too many arguments, as BYOND does. In addition, I've added a new pragma for detecting other bad /matrix calls (such as calling with only 5 arguments, or calling with 2-4 arguments w/o a matrix opcode). Another step in OD becoming a nice and articulate compiler to work with :^)

## Changelog
- `/matrix()` is now a native method, and supports several new undocumented signatures used by targets.
- `/matrix.Invert()` and `/matrix.Scale()` are now native methods.
- The compiler now lints against `/matrix()` calls, making sure they seem valid.
- Added the rest of the weird matrix defines into DMStandard.
- Some methods in DreamMetaObjectMatrix now avoid metaobject queries when getting and setting, probably improving performance a schmidge.