### PR TITLE
Remove outdated try/catch unimplemented-warning

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -1366,11 +1366,6 @@ namespace DMCompiler.Compiler.DM {
                     tryBody = new DMASTProcBlockInner(loc,statement);
                 }
 
-                if (_unimplementedWarnings)
-                {
-                    Warning("Exceptions in 'try/catch' blocks are currently not caught");
-                }
-
                 Newline();
                 Consume(TokenType.DM_Catch, "Expected catch");
                 Whitespace();


### PR DESCRIPTION
This is no longer relevant now that we support try/catch