### PR TITLE
Some enumeration fixes

### DIFF
--- a/Content.Tests/DMProject/Tests/Loop/For.dm
+++ b/Content.Tests/DMProject/Tests/Loop/For.dm
@@ -9,6 +9,21 @@
 		counter++
 	ASSERT(counter == 3)
 
+	var/i = -1
+	for(i in 1 to 0) // An end bound lower than the start bound should not assign to i
+		continue
+	ASSERT(i == -1)
+
+	i = -1
+	for(i in list()) // This should though!
+		continue
+	ASSERT(i == null)
+
+	i = -1
+	for(i in list(1)) // Even ends up being null if the list isn't empty
+		continue
+	ASSERT(i == null)
+
 	counter = 0
 	var/j = 1
 	for(,j <= 3,j++)

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -179,10 +179,8 @@ namespace OpenDreamRuntime.Procs {
             IDreamValueEnumerator enumerator = state.EnumeratorStack.Peek();
             DMReference reference = state.ReadReference();
             int jumpToIfFailure = state.ReadInt();
-            bool successfulEnumeration = enumerator.MoveNext();
 
-            state.AssignReference(reference, enumerator.Current);
-            if (!successfulEnumeration)
+            if (!enumerator.Enumerate(state, reference))
                 state.Jump(jumpToIfFailure);
 
             return null;


### PR DESCRIPTION
Turns out the `for (i in 1 to 3)` variation of a for loop will leave `i` as `3` after the loop is finished (or unchanged if the end bound is lower than the start bound).

This differs from `for (i in list(...))` which will leave `i` as `null` after it's finished. IDreamValueEnumerator is now responsible for assigning the DMReference to account for this difference.