### PR TITLE
Show C# stack traces in DM errors again

### DIFF
--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -87,20 +87,28 @@ namespace OpenDreamRuntime {
     }
 
     [Virtual]
-    class DMRuntime : Exception {
+    class DMThrowException : Exception {
         public readonly DreamValue Value;
-        public DMRuntime(string message)
-            : base(message) {
-            Value = new DreamValue(message);
+
+        public DMThrowException(DreamValue value) : base(GetRuntimeMessage(value)) {
+            Value = value;
         }
 
-        public DMRuntime(DreamValue value) : base($"'throw' thrown ({value})") {
-            Value = value;
+        private static string GetRuntimeMessage(DreamValue value) {
+            string? name;
+
+            value.TryGetValueAsDreamObject(out var dreamObject);
+            if (dreamObject?.TryGetVariable("name", out var nameVar) == true) {
+                name = nameVar.TryGetValueAsString(out name) ? name : String.Empty;
+            } else {
+                name = String.Empty;
+            }
+
+            return name;
         }
     }
 
-    sealed class DMCrashRuntime : DMRuntime {
-        public DMCrashRuntime(string message) : base(message) { }
+    sealed class DMCrashRuntime : DMThrowException {
         public DMCrashRuntime(DreamValue value) : base(value) { }
     }
 
@@ -134,11 +142,11 @@ namespace OpenDreamRuntime {
         public abstract ProcStatus Resume();
 
         /// <summary>
-        /// Returns wether or not the proc is currently in a try catch block.
+        /// Returns whether or not the proc is currently in a try catch block.
         /// </summary>
         public virtual bool IsCatching() => false;
 
-        public virtual void CatchException(DreamValue value) {
+        public virtual void CatchException(Exception exception) {
             throw new InvalidOperationException(
                 $"Called {nameof(CatchException)} on a {nameof(ProcState)} that isn't catching!");
         }
@@ -206,13 +214,14 @@ namespace OpenDreamRuntime {
             try {
                 CurrentlyExecuting.Value!.Push(this);
                 while (_current != null) {
-                    bool TryCatchException(DreamValue value) {
+                    bool TryCatchException(Exception exception) {
                         if (!_stack.Any(x => x.IsCatching())) return false;
 
                         while (!_current.IsCatching()) {
                             PopProcState();
                         }
-                        _current.CatchException(value);
+
+                        _current.CatchException(exception);
                         return true;
                     }
 
@@ -223,7 +232,7 @@ namespace OpenDreamRuntime {
                     } catch (DMCrashRuntime dmCrashRuntime) {
                         //skip one level on the call stack because crash is being treated as an actual proc
                         PopProcState();
-                        if (TryCatchException(dmCrashRuntime.Value)) continue;
+                        if (TryCatchException(dmCrashRuntime)) continue;
                         HandleException(dmCrashRuntime);
                         status = ProcStatus.Returned;
                     } catch (DMError dmError) {
@@ -231,10 +240,8 @@ namespace OpenDreamRuntime {
                         HandleException(dmError);
                         status = ProcStatus.Cancelled;
                     } catch (Exception exception) {
-                        //dmruntime and system exceptions are handled the same (?)
-                        var dmRuntime = exception as DMRuntime ?? new DMRuntime(exception.Message);
-                        if (TryCatchException(dmRuntime.Value)) continue;
-                        HandleException(dmRuntime);
+                        if (TryCatchException(exception)) continue;
+                        HandleException(exception);
                         status = ProcStatus.Returned;
                     }
 

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -90,6 +90,7 @@ namespace OpenDreamRuntime.Objects {
             if(Deleted){
                 throw new Exception("Cannot try to get variable on a deleted object");
             }
+
             if ((_variables?.TryGetValue(name, out variableValue) is true) || ObjectDefinition.Variables.TryGetValue(name, out variableValue)) {
                 if (ObjectDefinition.MetaObject != null) variableValue = ObjectDefinition.MetaObject.OnVariableGet(this, name, variableValue);
 

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1456,11 +1456,7 @@ namespace OpenDreamRuntime.Procs {
         public static ProcStatus? Throw(DMProcState state) {
             DreamValue value = state.Pop();
 
-            if (value.TryGetValueAsDreamObjectOfType(state.Proc.ObjectTree.Exception, out DreamObject exception)) {
-                throw new DMRuntime($"'throw' thrown ({exception.GetVariable("name").GetValueAsString()})");
-            }
-
-            throw new DMRuntime(value);
+            throw new DMThrowException(value);
         }
 
         public static ProcStatus? Try(DMProcState state) {

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -295,11 +295,11 @@ namespace OpenDreamRuntime.Procs {
                 ProcStatus? status;
                 try {
                     status = handler.Invoke(this);
-                } catch (DMRuntime ce) {
+                } catch (Exception e) {
                     if (!IsCatching())
                         throw;
 
-                    CatchException(ce.Value);
+                    CatchException(e);
                     continue;
                 }
 
@@ -358,13 +358,20 @@ namespace OpenDreamRuntime.Procs {
 
         public override bool IsCatching() => _catchPosition.Count > 0;
 
-        public override void CatchException(DreamValue value) {
+        public override void CatchException(Exception exception) {
             if (!IsCatching())
-                base.CatchException(value);
+                base.CatchException(exception);
 
             Jump(_catchPosition.Pop());
             var varIdx = _catchVarIndex.Pop();
             if (varIdx != NoTryCatchVar) {
+                DreamValue value;
+
+                if (exception is DMThrowException throwException)
+                    value = throwException.Value;
+                else
+                    value = new DreamValue(exception.Message); // TODO: Probably need to create an /exception
+
                 _localVariables[varIdx] = value;
             }
         }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -304,12 +304,9 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProc("CRASH")]
         [DreamProcParameter("msg", Type = DreamValueType.String)]
         public static DreamValue NativeProc_CRASH(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
-            if (arguments.GetArgument(0, "msg").TryGetValueAsString(out var message))
-            {
-                throw new DMCrashRuntime(message);
-            }
+            arguments.GetArgument(0, "msg").TryGetValueAsString(out var message);
 
-            throw new DMCrashRuntime("");
+            throw new DMCrashRuntime(new DreamValue(message ?? String.Empty));
         }
 
         [DreamProc("fcopy")]
@@ -2080,20 +2077,20 @@ namespace OpenDreamRuntime.Procs.Native {
                 return new DreamValue(0);
             }
             StringInfo textStringInfo = new StringInfo(text);
-            
+
             if(start < 0) {
                 start = Math.Max(start + textStringInfo.LengthInTextElements + 1, 1);
             }
 
             int result = 0;
-            
+
             TextElementEnumerator needlesElementEnumerator = StringInfo.GetTextElementEnumerator(needles);
             TextElementEnumerator textElementEnumerator = StringInfo.GetTextElementEnumerator(text, start - 1);
 
             while(textElementEnumerator.MoveNext()) {
                 bool found = false;
                 needlesElementEnumerator.Reset();
-                
+
                 //lol O(N*M)
                 while (needlesElementEnumerator.MoveNext()) {
                     if (textElementEnumerator.Current.Equals(needlesElementEnumerator.Current)) {


### PR DESCRIPTION
The implementation of try/catch brought a change that made C# stack traces no longer show in DM errors. This makes `DMRuntime` (now `DMThrowException`) used only in `throw ...` statements so that the original C# exception can otherwise be kept throughout.