### PR TITLE
Demote `#pragma EmptyBlock` to `notice`

### DIFF
--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -22,4 +22,4 @@
 #pragma InvalidSetStatement error
 
 //3000-3999
-#pragma EmptyBlock warning
+#pragma EmptyBlock notice


### PR DESCRIPTION
Targets are full of these and it just creates warning spam.