### PR TITLE
Fix null arguments to clamp

### DIFF
--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -222,6 +222,8 @@ namespace OpenDreamRuntime.Procs.Native {
                 return new DreamValue(tmp);
             } else if (value.TryGetValueAsFloat(out float floatVal)) {
                 return new DreamValue(Math.Clamp(floatVal, lVal, hVal));
+            } else if (value == DreamValue.Null) {
+                return new DreamValue(Math.Clamp(0.0, lVal, hVal));
             } else {
                 throw new Exception("Clamp expects a number or list");
             }


### PR DESCRIPTION
`TryGetValueAsFloat` returns false for an argument of `DreamValue.Null`, so clamp fails instead of coercing null -> `0.0` like in DM. This fixes that.

An alternative approach would be to special-case `this == Null` in `TryGetValueAsFloat`, but that feels messy and unpredictable.