### PR TITLE
Fix negating null values

### DIFF
--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1057,6 +1057,7 @@ namespace OpenDreamRuntime.Procs {
 
             switch (value.Type) {
                 case DreamValue.DreamValueType.Float: state.Push(new DreamValue(-value.GetValueAsFloat())); break;
+                case DreamValue.DreamValueType.DreamObject when value == DreamValue.Null: state.Push(new DreamValue(0.0f)); break;
                 default: throw new Exception("Invalid negate operation on " + value);
             }
 


### PR DESCRIPTION
`TryGetValueAsFloat` returns false for an argument of `DreamValue.Null`, so negation fails instead of coercing null -> `0.0` like in DM. This fixes that.

An alternative approach would be to special-case `this == Null` in `TryGetValueAsFloat`, but that feels messy and unpredictable.