### PR TITLE
Fix `flist()` on nonexistent dirs

### DIFF
--- a/Content.Tests/DMProject/Tests/Builtins/flist.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/flist.dm
@@ -3,5 +3,5 @@
 
 /proc/RunTest()
 	// Assert that a nonexistent dir returns an empty list
-	var/list/L = flist("./woiguowejsiojioeh") // If you create this dir, I'll kill you
+	var/list/L = flist("woiguowejsiojioeh/") // If you create this dir, I'll kill you
 	ASSERT(islist(L) && L.len == 0)

--- a/Content.Tests/DMProject/Tests/Builtins/flist.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/flist.dm
@@ -1,0 +1,7 @@
+
+// TODO: Test that it lists files in a dir correctly. Right now we only test flist() on a nonexistent dir
+
+/proc/RunTest()
+	// Assert that a nonexistent dir returns an empty list
+	var/list/L = flist("./woiguowejsiojioeh") // If you create this dir, I'll kill you
+	ASSERT(islist(L) && L.len == 0)

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -640,9 +640,13 @@ namespace OpenDreamRuntime.Procs.Native {
             }
 
             var resourceManager = IoCManager.Resolve<DreamResourceManager>();
-            var listing = resourceManager.EnumerateListing(path);
-            DreamList list = ObjectTree.CreateList(listing);
-            return new DreamValue(list);
+            try {
+                var listing = resourceManager.EnumerateListing(path);
+                DreamList list = ObjectTree.CreateList(listing);
+                return new DreamValue(list);
+            } catch (DirectoryNotFoundException) {
+                return new DreamValue(ObjectTree.CreateList()); // empty list
+            }
         }
 
         [DreamProc("floor")]


### PR DESCRIPTION
Closes #1088 

At first I considered just checking if the dir exists first, but then I realized most flist() calls will presumably be for existing dirs, so that's added unnecessary overhead to every call whereas try/catch only adds overhead on calls for nonexistent dirs.