### PR TITLE
Stub `regex.Find_char()`

### DIFF
--- a/DMCompiler/DMStandard/Types/Regex.dm
+++ b/DMCompiler/DMStandard/Types/Regex.dm
@@ -20,6 +20,10 @@
 			src.flags = flags
 
 	proc/Find(haystack, Start = 1, End = 0)
+
+	proc/Find_char(haystack, Start = 1, End = 0)
+		set opendream_unimplemented = TRUE
+
 	proc/Replace(haystack, replacement, Start = 1, End = 0)
 
 	proc/Replace_char(haystack, replacement, Start = 1, End = 0)


### PR DESCRIPTION
It's documented in the unicode notice for `regex.Find()`: https://www.byond.com/docs/ref/#/regex/proc/Find