### PR TITLE
Rewrite `block()` builtin in C#

### DIFF
--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -11,6 +11,7 @@ proc/arccos(X)
 proc/arcsin(X)
 proc/arctan(A)
 proc/ascii2text(N)
+proc/block(var/atom/Start, var/atom/End)
 proc/ceil(A)
 proc/ckey(Key)
 proc/ckeyEx(Text)
@@ -146,22 +147,6 @@ proc/winset(player, control_id, params)
 proc/replacetextEx_char(Haystack, Needle, Replacement, Start = 1, End = 0)
 	set opendream_unimplemented = TRUE
 	return Haystack
-
-proc/block(var/atom/Start, var/atom/End)
-	var/list/atoms = list()
-
-	var/startX = min(Start.x, End.x)
-	var/startY = min(Start.y, End.y)
-	var/startZ = min(Start.z, End.z)
-	var/endX = max(Start.x, End.x)
-	var/endY = max(Start.y, End.y)
-	var/endZ = max(Start.z, End.z)
-	for (var/z=startZ; z<=endZ; z++)
-		for (var/y=startY; y<=endY; y++)
-			for (var/x=startX; x<=endX; x++)
-				atoms.Add(locate(x, y, z))
-
-	return atoms
 
 /proc/step(atom/movable/Ref, var/Dir, var/Speed=0)
 	//TODO: Speed = step_size if Speed is 0

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -16,6 +16,7 @@ namespace OpenDreamRuntime.Procs.Native {
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_arcsin);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_arctan);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ascii2text);
+            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_block);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ceil);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ckey);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ckeyEx);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -160,6 +160,46 @@ namespace OpenDreamRuntime.Procs.Native {
             return new DreamValue(Convert.ToChar(asciiValue).ToString());
         }
 
+        [DreamProc("block")]
+        [DreamProcParameter("Start", Type = DreamValueType.DreamObject)]
+        [DreamProcParameter("End", Type = DreamValueType.DreamObject)]
+        public static DreamValue NativeProc_block(DreamObject? instance, DreamObject? usr, DreamProcArguments arguments) {
+            if (!arguments.GetArgument(0, "Start").TryGetValueAsDreamObjectOfType(ObjectTree.Atom, out var start))
+                return new DreamValue(ObjectTree.CreateList());
+            if (!arguments.GetArgument(1, "End").TryGetValueAsDreamObjectOfType(ObjectTree.Atom, out var end))
+                return new DreamValue(ObjectTree.CreateList());
+
+            start.GetVariable("x").TryGetValueAsInteger(out var x1);
+            start.GetVariable("y").TryGetValueAsInteger(out var y1);
+            start.GetVariable("z").TryGetValueAsInteger(out var z1);
+
+            end.GetVariable("x").TryGetValueAsInteger(out var x2);
+            end.GetVariable("y").TryGetValueAsInteger(out var y2);
+            end.GetVariable("z").TryGetValueAsInteger(out var z2);
+
+            int startX = Math.Min(x1, x2);
+            int startY = Math.Min(y1, y2);
+            int startZ = Math.Min(z1, z2);
+            int endX = Math.Max(x1, x2);
+            int endY = Math.Max(y1, y2);
+            int endZ = Math.Max(z1, z2);
+
+            DreamList turfs = ObjectTree.CreateList((endX - startX + 1) * (endY - startY + 1) * (endZ - startZ + 1));
+
+            // Collected in z-y-x order
+            for (int z = startZ; z <= endZ; z++) {
+                for (int y = startY; y <= endY; y++) {
+                    for (int x = startX; x <= endX; x++) {
+                        MapManager.TryGetTurfAt((x, y), z, out var turf);
+
+                        turfs.AddValue(new DreamValue(turf));
+                    }
+                }
+            }
+
+            return new DreamValue(turfs);
+        }
+
         [DreamProc("ceil")]
         [DreamProcParameter("A", Type = DreamValueType.Float)]
         public static DreamValue NativeProc_ceil(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -164,9 +164,9 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("Start", Type = DreamValueType.DreamObject)]
         [DreamProcParameter("End", Type = DreamValueType.DreamObject)]
         public static DreamValue NativeProc_block(DreamObject? instance, DreamObject? usr, DreamProcArguments arguments) {
-            if (!arguments.GetArgument(0, "Start").TryGetValueAsDreamObjectOfType(ObjectTree.Atom, out var start))
+            if (!arguments.GetArgument(0, "Start").TryGetValueAsDreamObjectOfType(ObjectTree.Turf, out var start))
                 return new DreamValue(ObjectTree.CreateList());
-            if (!arguments.GetArgument(1, "End").TryGetValueAsDreamObjectOfType(ObjectTree.Atom, out var end))
+            if (!arguments.GetArgument(1, "End").TryGetValueAsDreamObjectOfType(ObjectTree.Turf, out var end))
                 return new DreamValue(ObjectTree.CreateList());
 
             start.GetVariable("x").TryGetValueAsInteger(out var x1);
@@ -714,7 +714,7 @@ namespace OpenDreamRuntime.Procs.Native {
             }
             return new DreamValue(0);
         }
-        
+
         [DreamProc("get_dir")]
         [DreamProcParameter("Loc1", Type = DreamValueType.DreamObject)]
         [DreamProcParameter("Loc2", Type = DreamValueType.DreamObject)]
@@ -751,7 +751,7 @@ namespace OpenDreamRuntime.Procs.Native {
 
             return new DreamValue(direction);
         }
-        
+
         [DreamProc("get_step")]
         [DreamProcParameter("Ref", Type = DreamValueType.DreamObject)]
         [DreamProcParameter("Dir", Type = DreamValueType.Float)]


### PR DESCRIPTION
Rewrites the `block()` builtin as a native proc

Performance before:
![image](https://user-images.githubusercontent.com/30789242/225778745-cc416323-d73b-4c91-b7d1-5c16e9815049.png)

After:
![image](https://user-images.githubusercontent.com/30789242/225778787-d7afb345-d55a-44b0-9f6b-81b33addfc13.png)