### PR TITLE
Show the `CRASH()` message in the exception

### DIFF
--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -108,8 +108,8 @@ namespace OpenDreamRuntime {
         }
     }
 
-    sealed class DMCrashRuntime : DMThrowException {
-        public DMCrashRuntime(DreamValue value) : base(value) { }
+    sealed class DMCrashRuntime : Exception {
+        public DMCrashRuntime(string message) : base(message) { }
     }
 
     /// <summary>

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -349,7 +349,7 @@ namespace OpenDreamRuntime.Procs.Native {
         public static DreamValue NativeProc_CRASH(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
             arguments.GetArgument(0, "msg").TryGetValueAsString(out var message);
 
-            throw new DMCrashRuntime(new DreamValue(message ?? String.Empty));
+            throw new DMCrashRuntime(message ?? String.Empty);
         }
 
         [DreamProc("fcopy")]


### PR DESCRIPTION
This was lost somewhere in the middle of adding try/catch support. Now it shows again.