### PR TITLE
Add turn() "support" for icons

### DIFF
--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -181,6 +181,10 @@ proc/replacetextEx_char(Haystack, Needle, Replacement, Start = 1, End = 0)
 		var/matrix/copy = new(Dir)
 		return copy.Turn(Angle)
 
+	if (istype(Dir, /icon))
+		var/icon/copy = new(Dir)
+		return copy.Turn(Angle)
+
 	var/dirAngle = 0
 
 	switch (Dir)


### PR DESCRIPTION
Allows the `turn()` proc to call the (stubbed/unimplemented) `icon.Turn()` proc, as in BYOND.