### PR TITLE
Fix incorrect Entered/Exited code

### DIFF
--- a/DMCompiler/DMStandard/Types/Atoms/Movable.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/Movable.dm
@@ -37,20 +37,18 @@
 			var/area/newarea = NewLoc.loc
 			loc = NewLoc
 
-			// First, call Exited() on the old location
+			// First, call Exited() on the old area
 			if (newarea != oldarea)
 				oldarea.Exited(src, loc)
 
-			// Second, call Exited() and Uncrossed() on the old turf and its contents
+			// Second, call Exited() on the old turf and Uncrossed() on its contents
 			oldloc.Exited(src, loc)
 			for (var/atom/movable/uncrossed in oldloc)
-				uncrossed.Exited(src, loc)
 				uncrossed.Uncrossed(src)
 
-			// Third, call Entered() and Crossed() on the new turf and its contents
+			// Third, call Entered() on the new turf and Crossed() on its contents
 			loc.Entered(src, oldloc)
 			for (var/atom/movable/crossed in loc)
-				crossed.Entered(src, oldloc)
 				crossed.Crossed(src)
 
 			// Fourth, call Entered() on the new area


### PR DESCRIPTION
This code called Entered and Exited on *all the contents of an entered turf,* which is incorrect and led to problems. It should only call Crossed/Uncrossed instead.