### PR TITLE
Fix `in` operators on non-enumerable arguments

### DIFF
--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -85,8 +85,8 @@ namespace OpenDreamRuntime.Procs {
                     ? new DreamValueArrayEnumerator(values)
                     : new FilteredDreamValueArrayEnumerator(values, filterType);
             }
-
-            throw new Exception($"Value {value} is not a {objectTree.List}, {objectTree.Atom}, {objectTree.World}, or null");
+            // BYOND ignores all floats, strings, types, etc. here and just doesn't run the loop.
+            return new DreamValueArrayEnumerator(Array.Empty<DreamValue>());
         }
 
         public static ProcStatus? CreateListEnumerator(DMProcState state) {
@@ -420,7 +420,8 @@ namespace OpenDreamRuntime.Procs {
                     if (listObject.IsSubtypeOf(state.Proc.ObjectTree.Atom) || listObject.IsSubtypeOf(state.Proc.ObjectTree.World)) {
                         list = listObject.GetVariable("contents").GetValueAsDreamList();
                     } else {
-                        throw new Exception($"Value {listObject} is not a {state.Proc.ObjectTree.List}, {state.Proc.ObjectTree.Atom}, or {state.Proc.ObjectTree.World}");
+                        // BYOND ignores all floats, strings, types, etc. here and just doesn't run the loop.
+                        state.Push(new DreamValue(0));
                     }
                 }
 


### PR DESCRIPTION
In BYOND, loops like `for (var/i in null)` do nothing. This was already implemented. However, loops like `for (var/i in 0)`, `for (var/i in 1)`, `for(var/i in "foo")`, and `for(var/i in /datum)` also just skip the loop; OD will error instead. The same goes for the boolean `in` operator with `"foo" in null`, `"foo" in "foobar"`, `"foo" in 0`, `"foo" in /datum`, etc.

Some code in SS13 relies on patterns like `for (var/i in return_results_or_FALSE())`, so I'm emulating the BYOND functionality here. I suppose this could be made into an optional warning or something somehow, but that's above my skill level.