### PR TITLE
Fix null reference exception debugger crashes

### DIFF
--- a/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
@@ -498,7 +498,7 @@ sealed class DreamDebugManager : IDreamDebugManager {
 
     private void HandleRequestThreads(DebugAdapterClient client, RequestThreads reqThreads) {
         var threads = new List<Thread>();
-        foreach (var thread in InspectThreads().Distinct()) {
+        foreach (var thread in InspectThreads().Distinct().Where(x => x != null)) {
             threads.Add(new Thread(thread.Id, thread.Name));
         }
         if (!threads.Any()) {
@@ -567,7 +567,7 @@ sealed class DreamDebugManager : IDreamDebugManager {
     }
 
     private void HandleRequestStackTrace(DebugAdapterClient client, RequestStackTrace reqStackTrace) {
-        var thread = InspectThreads().FirstOrDefault(t => t.Id == reqStackTrace.Arguments.ThreadId);
+        var thread = InspectThreads().FirstOrDefault(t => t?.Id == reqStackTrace.Arguments.ThreadId);
         if (thread is null) {
             reqStackTrace.RespondError(client, $"No thread with ID {reqStackTrace.Arguments.ThreadId}");
             return;


### PR DESCRIPTION
I encountered some crashes due to null DreamThreads in the list returned from InspectThreads and figured I'd PR a quick fix for it. CC @SpaceManiac to see if this is a sane solution or if it happened due to a configuration issue, user error, etc. in the first place, since I don't really know what I'm doing here.