### PR TITLE
Reorder +UP/+REP replacement in keybinds

### DIFF
--- a/OpenDreamClient/Interface/InterfaceMacro.cs
+++ b/OpenDreamClient/Interface/InterfaceMacro.cs
@@ -107,11 +107,11 @@ public sealed class InterfaceMacro : InterfaceElement {
     }
 
     private static KeyBindingRegistration CreateMacroBinding(BoundKeyFunction function, string macroName) {
+        macroName = macroName.Replace("+UP", String.Empty);
+        macroName = macroName.Replace("+REP", String.Empty);
         macroName = macroName.Replace("SHIFT+", String.Empty);
         macroName = macroName.Replace("CTRL+", String.Empty);
         macroName = macroName.Replace("ALT+", String.Empty);
-        macroName = macroName.Replace("+UP", String.Empty);
-        macroName = macroName.Replace("+REP", String.Empty);
 
         //TODO: modifiers
         var key = KeyNameToKey(macroName);


### PR DESCRIPTION
+UP and +REP are now replaced prior to SHIFT+, CTRL+, etc. This means that `SHIFT+UP` will properly become `SHIFT` with a `+UP` modifier, rather than `UP` (which is nonexistent) with a `SHIFT+` modifier.