### PR TITLE
Fix jointext for string values

### DIFF
--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -258,9 +258,11 @@ proc/step_rand(atom/movable/Ref, Speed=0)
 	return Ref.Move(target, get_dir(Ref, target))
 
 proc/jointext(list/List, Glue, Start = 1, End = 0)
-	if (isnull(List)) CRASH("Invalid list")
-
-	return List.Join(Glue, Start, End)
+	if(islist(List))
+		return List.Join(Glue, Start, End)
+	if(istext(List))
+		return List
+	CRASH("jointext was passed a non-list, non-text value")
 
 proc/lentext(T)
 	return length(T)


### PR DESCRIPTION
In BYOND, `jointext(string, *)` just returns the string passed to the function entirely unmodified, ignoring any further arguments (as far as I can tell, anyway). This PR replicates that as well as raises an error for passing something that isn't a string or list, like `jointext(12, null)`, just like in BYOND.