### PR TITLE
Create a special list tracking turf contents

### DIFF
--- a/Content.Tests/DummyDreamMapManager.cs
+++ b/Content.Tests/DummyDreamMapManager.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using OpenDreamRuntime;
 using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Procs;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Json;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Maths;
 
 namespace Content.Tests {
@@ -28,12 +30,21 @@ namespace Content.Tests {
             return new IconAppearance();
         }
 
+        public bool TryGetCellFromTransform(TransformComponent transform, [NotNullWhen(true)] out IDreamMapManager.Cell? cell) {
+            cell = null;
+            return false;
+        }
+
+        public IDreamMapManager.Cell GetCellFromTurf(DreamObject turf) {
+            throw null;
+        }
+
         public bool TryGetTurfAt(Vector2i pos, int z, out DreamObject turf) {
             turf = null;
             return false;
         }
 
-        public (Vector2i Pos, DreamMapManager.Level Level) GetTurfPosition(DreamObject turf) {
+        public (Vector2i Pos, IDreamMapManager.Level Level) GetTurfPosition(DreamObject turf) {
             return (Vector2i.Zero, null);
         }
 

--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -7,7 +7,7 @@
 	var/suffix = null as opendream_unimplemented
 	var/list/verbs = null
 
-	var/list/contents = list()
+	var/list/contents = null
 	var/list/overlays = list()
 	var/list/underlays = list()
 	var/atom/loc

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -485,4 +485,59 @@ namespace OpenDreamRuntime.Objects {
             return _mapManager.AllAtoms.Count;
         }
     }
+
+    // turf.contents list
+    public sealed class TurfContentsList : DreamList {
+        private readonly IDreamObjectTree _objectTree;
+        private readonly IDreamMapManager.Cell _cell;
+
+        public TurfContentsList(DreamObjectDefinition listDef, IDreamObjectTree objectTree, IDreamMapManager.Cell cell) : base(listDef, 0) {
+            _objectTree = objectTree;
+            _cell = cell;
+        }
+
+        public override DreamValue GetValue(DreamValue key) {
+            if (!key.TryGetValueAsInteger(out var index))
+                throw new Exception($"Invalid index into turf contents list: {key}");
+            if (index < 1 || index > _cell.Movables.Count)
+                throw new Exception($"Out of bounds index on turf contents list: {index}");
+
+            return new DreamValue(_cell.Movables[index - 1]);
+        }
+
+        // TODO: This would preferably be an IEnumerable<> method. Probably as part of #985.
+        public override List<DreamValue> GetValues() {
+            List<DreamValue> values = new(_cell.Movables.Count);
+
+            foreach (var movable in _cell.Movables) {
+                values.Add(new(movable));
+            }
+
+            return values;
+        }
+
+        public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
+            throw new Exception("Cannot set an index of turf contents list");
+        }
+
+        public override void AddValue(DreamValue value) {
+            if (!value.TryGetValueAsDreamObjectOfType(_objectTree.Movable, out var movable))
+                throw new Exception($"Cannot add {value} to turf contents");
+
+            movable.SetVariable("loc", new(_cell.Turf));
+        }
+
+        public override void Cut(int start = 1, int end = 0) {
+            int movableCount = _cell.Movables.Count + 1;
+            if (end == 0 || end > movableCount) end = movableCount;
+
+            for (int i = start - 1; i < end - 1; i++) {
+                _cell.Movables[i].SetVariable("loc", DreamValue.Null);
+            }
+        }
+
+        public override int GetLength() {
+            return _cell.Movables.Count;
+        }
+    }
 }

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -531,8 +531,8 @@ namespace OpenDreamRuntime.Objects {
             int movableCount = _cell.Movables.Count + 1;
             if (end == 0 || end > movableCount) end = movableCount;
 
-            for (int i = start - 1; i < end - 1; i++) {
-                _cell.Movables[i].SetVariable("loc", DreamValue.Null);
+            for (int i = start; i < end; i++) {
+                _cell.Movables[i - 1].SetVariable("loc", DreamValue.Null);
             }
         }
 

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectArea.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectArea.cs
@@ -20,7 +20,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 if (!value.TryGetValueAsDreamObjectOfType(_objectTree.Turf, out DreamObject turf))
                     return;
 
-                (Vector2i pos, DreamMapManager.Level level) = _dreamMapManager.GetTurfPosition(turf);
+                (Vector2i pos, IDreamMapManager.Level level) = _dreamMapManager.GetTurfPosition(turf);
                 level.SetArea(pos, dreamObject);
             };
 

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMovable.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMovable.cs
@@ -58,11 +58,20 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 }
                 case "loc": {
                     EntityUid entity = _atomManager.GetMovableEntity(dreamObject);
+                    if (!_entityManager.TryGetComponent(entity, out TransformComponent? transform))
+                        return;
+
+                    if (_dreamMapManager.TryGetCellFromTransform(transform, out var oldMapCell)) {
+                        oldMapCell.Movables.Remove(dreamObject);
+                    }
 
                     if (value.TryGetValueAsDreamObjectOfType(_objectTree.Turf, out var turfLoc)) {
-                        (Vector2i pos, DreamMapManager.Level level) = _dreamMapManager.GetTurfPosition(turfLoc);
+                        (Vector2i pos, IDreamMapManager.Level level) = _dreamMapManager.GetTurfPosition(turfLoc);
                         _transformSystem.SetParent(entity, level.Grid.Owner);
                         _transformSystem.SetWorldPosition(entity, pos);
+
+                        var newMapCell = _dreamMapManager.GetCellFromTurf(turfLoc);
+                        newMapCell.Movables.Add(dreamObject);
                     } else if (value.TryGetValueAsDreamObjectOfType(_objectTree.Movable, out var movableLoc)) {
                         EntityUid locEntity = _atomManager.GetMovableEntity(movableLoc);
                         _transformSystem.SetParent(entity, locEntity);
@@ -85,7 +94,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     break;
                 }
                 case "desc": {
-                    value.TryGetValueAsString(out string desc);
+                    value.TryGetValueAsString(out string? desc);
                     EntityUid entity = _atomManager.GetMovableEntity(dreamObject);
                     if (!_entityManager.TryGetComponent(entity, out MetaDataComponent? metaData))
                         break;

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectTurf.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectTurf.cs
@@ -8,17 +8,11 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
         [Dependency] private readonly IAtomManager _atomManager = default!;
         [Dependency] private readonly IDreamMapManager _dreamMapManager = default!;
-        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
-        [Dependency] private readonly IEntityManager _entityManager = default!;
-        [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
-        private readonly EntityLookupSystem _entityLookup;
-        private readonly EntityQuery<TransformComponent> _transformQuery;
+
+        public static readonly Dictionary<DreamObject, TurfContentsList> TurfContentsLists = new();
 
         public DreamMetaObjectTurf() {
             IoCManager.InjectDependencies(this);
-
-            _entityLookup = _entitySystemManager.GetEntitySystem<EntityLookupSystem>();
-            _transformQuery = _entityManager.GetEntityQuery<TransformComponent>();
         }
 
         public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
@@ -28,43 +22,42 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             _dreamMapManager.SetTurfAppearance(dreamObject, turfAppearance);
         }
 
+        public void OnVariableSet(DreamObject dreamObject, string varName, DreamValue value, DreamValue oldValue) {
+            ParentType?.OnVariableSet(dreamObject, varName, value, oldValue);
+
+            switch (varName) {
+                case "contents": {
+                    TurfContentsList contentsList = TurfContentsLists[dreamObject];
+
+                    contentsList.Cut();
+
+                    if (value.TryGetValueAsDreamList(out var valueList)) {
+                        foreach (DreamValue contentValue in valueList.GetValues()) {
+                            contentsList.AddValue(contentValue);
+                        }
+                    }
+
+                    break;
+                }
+            }
+        }
+
         public DreamValue OnVariableGet(DreamObject dreamObject, string varName, DreamValue value) {
             switch (varName) {
                 case "x":
                 case "y":
                 case "z": {
-                    (Vector2i pos, DreamMapManager.Level level) = _dreamMapManager.GetTurfPosition(dreamObject);
+                    (Vector2i pos, IDreamMapManager.Level level) = _dreamMapManager.GetTurfPosition(dreamObject);
 
                     int coord = varName == "x" ? pos.X :
                                 varName == "y" ? pos.Y :
                                 level.Z;
                     return new(coord);
                 }
-                case "loc": {
+                case "loc":
                     return new(_dreamMapManager.GetAreaAt(dreamObject));
-                }
-                case "contents": {
-                    (Vector2i pos, DreamMapManager.Level level) = _dreamMapManager.GetTurfPosition(dreamObject);
-
-                    HashSet<EntityUid> entities = _entityLookup.GetEntitiesIntersecting(level.Grid.Owner, pos, LookupFlags.Uncontained);
-                    DreamList contents = _objectTree.CreateList(entities.Count);
-                    foreach (EntityUid movableEntity in entities) {
-                        if (!_transformQuery.TryGetComponent(movableEntity, out var transform))
-                            continue;
-
-                        // Entities on neighboring tiles seem to be caught as well
-                        if (transform.WorldPosition != pos)
-                            continue;
-                        if (transform.ParentUid != level.Grid.Owner)
-                            continue;
-                        if (!_atomManager.TryGetMovableFromEntity(movableEntity, out var movable))
-                            continue;
-
-                        contents.AddValue(new(movable));
-                    }
-
-                    return new(contents);
-                }
+                case "contents":
+                    return new(TurfContentsLists[dreamObject]);
                 default:
                     return ParentType?.OnVariableGet(dreamObject, varName, value) ?? value;
             }


### PR DESCRIPTION
The /movables in a map cell are now tracked. `/turf.contents` is now a special list that uses that to prevent the need to do an entity lookup every time it's used.

Closes #1067