### PR TITLE
Rewrite `turn()`, `/matrix.Turn`, and `/matrix.Multiply` builtins in C# 

### DIFF
--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixMultiply.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixMultiply.dm
@@ -7,7 +7,7 @@
 	if(M ~! matrix(39, 54, 78, 54, 75, 108))
 		CRASH("Unexpected matrix/Multiply result: [json_encode(M)]")
 
-	M.multiply(null) // Doesn't do anything
+	M.Multiply(null) // Doesn't do anything
 	if(M ~! matrix(39, 54, 78, 54, 75, 108))
 		CRASH("Unexpected matrix/Multiply(null) result: [json_encode(M)]")
 
@@ -19,4 +19,4 @@
 
 	M.Multiply("a")
 	if(M ~! matrix(0, 0, 0, 0, 0, 0))
-		CRASH("Unexpected matrix/Multiply("a") result: [json_encode(M)]")
+		CRASH("Unexpected matrix/Multiply(\"a\") result: [json_encode(M)]")

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixMultiply.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixMultiply.dm
@@ -6,4 +6,4 @@
 	M.Multiply(N)
 
 	if(M ~! matrix(39, 54, 78, 54, 75, 108))
-		CRASH("Unexpected matrix/Multiply result")
+		CRASH("Unexpected matrix/Multiply result: [json_encode(M)]")

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixMultiply.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixMultiply.dm
@@ -4,6 +4,19 @@
 	var/matrix/N = matrix(7, 8, 9, 10, 11, 12)
 
 	M.Multiply(N)
-
 	if(M ~! matrix(39, 54, 78, 54, 75, 108))
 		CRASH("Unexpected matrix/Multiply result: [json_encode(M)]")
+
+	M.multiply(null) // Doesn't do anything
+	if(M ~! matrix(39, 54, 78, 54, 75, 108))
+		CRASH("Unexpected matrix/Multiply(null) result: [json_encode(M)]")
+
+	M = matrix(1, 1, 1, 1, 1, 1)
+
+	M.Multiply(2)
+	if(M ~! matrix(2, 2, 2, 2, 2, 2))
+		CRASH("Unexpected matrix/Multiply(2) result: [json_encode(M)]")
+
+	M.Multiply("a")
+	if(M ~! matrix(0, 0, 0, 0, 0, 0))
+		CRASH("Unexpected matrix/Multiply("a") result: [json_encode(M)]")

--- a/Content.Tests/DMProject/Tests/Builtins/turn.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/turn.dm
@@ -1,5 +1,5 @@
 ﻿/proc/RunTest()
-	// Note byond goes counter clockwise (why)
+	// Note byond goes counterclockwise (why)
 
 	// Make sure it returns right
 	ASSERT(turn(EAST, 0) == EAST)

--- a/Content.Tests/DMProject/Tests/Builtins/turn.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/turn.dm
@@ -1,5 +1,8 @@
 ﻿/proc/RunTest()
-	// Note byond goes counterclockwise (why)
+	// Note byond goes counterclockwise (why) (unlike every other turn proc also)
+
+	// Handle the testable invalid case
+	ASSERT(turn(0, 0) == 0)
 
 	// Make sure it returns right
 	ASSERT(turn(EAST, 0) == EAST)

--- a/DMCompiler/DMStandard/Types/Matrix.dm
+++ b/DMCompiler/DMStandard/Types/Matrix.dm
@@ -77,5 +77,7 @@
 		c += x
 		f += y
 
+	proc/Turn(angle)
+
 
 proc/matrix(var/a, var/b, var/c, var/d, var/e, var/f)

--- a/DMCompiler/DMStandard/Types/Matrix.dm
+++ b/DMCompiler/DMStandard/Types/Matrix.dm
@@ -77,11 +77,5 @@
 		c += x
 		f += y
 
-	proc/Turn(angle)
-		var/angleCos = cos(angle)
-		var/angleSin = sin(angle)
-		var/matrix/rotation = new(angleCos, angleSin, 0, -angleSin, angleCos, 0)
-
-		return Multiply(rotation)
 
 proc/matrix(var/a, var/b, var/c, var/d, var/e, var/f)

--- a/DMCompiler/DMStandard/Types/Matrix.dm
+++ b/DMCompiler/DMStandard/Types/Matrix.dm
@@ -42,23 +42,6 @@
 	proc/Invert()
 
 	proc/Multiply(m)
-		if(!istype(m, /matrix))
-			return Scale(m)
-		var/matrix/n = m
-		var/old_a = a
-		var/old_b = b
-		var/old_c = c
-		var/old_d = d
-		var/old_e = e
-		var/old_f = f
-
-		a = old_a*n.a + old_d*n.b
-		b = old_b*n.a + old_e*n.b
-		c = old_c*n.a + old_f*n.b + n.c
-		d = old_a*n.d + old_d*n.e
-		e = old_b*n.d + old_e*n.e
-		f = old_c*n.d + old_f*n.e + n.f
-		return src
 
 	proc/Scale(x, y)
 

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -109,6 +109,7 @@ proc/text2path(T)
 proc/time2text(timestamp, format)
 proc/trimtext(Text)
 proc/trunc(n)
+proc/turn(Dir, Angle)
 proc/typesof(Item1)
 proc/uppertext(T)
 proc/url_decode(UrlText)
@@ -176,50 +177,6 @@ proc/replacetextEx_char(Haystack, Needle, Replacement, Start = 1, End = 0)
 /proc/walk_away(Ref,Trg,Max=5,Lag=0,Speed=0)
 	set opendream_unimplemented = TRUE
 	CRASH("/walk_away() is not implemented")
-
-/proc/turn(Dir, Angle)
-	if (istype(Dir, /matrix))
-		var/matrix/copy = new(Dir)
-		return copy.Turn(Angle)
-
-	if (istype(Dir, /icon))
-		var/icon/copy = new(Dir)
-		return copy.Turn(Angle)
-
-	var/dirAngle = 0
-
-	switch (Dir)
-		if (EAST) dirAngle = 0
-		if (NORTHEAST) dirAngle = 45
-		if (NORTH) dirAngle = 90
-		if (NORTHWEST) dirAngle = 135
-		if (WEST) dirAngle = 180
-		if (SOUTHWEST) dirAngle = 225
-		if (SOUTH) dirAngle = 270
-		if (SOUTHEAST) dirAngle = 315
-		else
-			if (Angle != 0)
-				return pick(NORTH, SOUTH, EAST, WEST, NORTHEAST, SOUTHEAST, SOUTHWEST, NORTHWEST)
-			else if (!isnum(Dir))
-				CRASH("Invalid Dir \"[json_encode(Dir)]\"")
-			else
-				return Dir
-
-	dirAngle += trunc(Angle/45) * 45
-
-	dirAngle = dirAngle % 360
-	if(dirAngle < 0)
-		dirAngle = 360 + dirAngle
-
-	switch (dirAngle)
-		if (45) return NORTHEAST
-		if (90) return NORTH
-		if (135) return NORTHWEST
-		if (180) return WEST
-		if (225) return SOUTHWEST
-		if (270) return SOUTH
-		if (315) return SOUTHEAST
-		else return EAST
 
 proc/get_dist(atom/Loc1, atom/Loc2)
 	if (!istype(Loc1) || !istype(Loc2)) return 127

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectIcon.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectIcon.cs
@@ -72,4 +72,16 @@ sealed class DreamMetaObjectIcon : IDreamMetaObject {
         ObjectToDreamIcon.Add(icon, dreamIcon);
         return dreamIcon;
     }
+
+    public static DreamObject CloneIcon(IDreamObjectTree ObjectTree, DreamObject icon) {
+        // var newIcon = ObjectTree.CreateObject(icon.ObjectDefinition.TreeEntry);
+        // newIcon.InitSpawn(new Procs.DreamProcArguments(args));
+        //TODO: actually clone the icon
+        return icon;
+    }
+
+    public static DreamIcon TurnIcon(DreamIcon icon, float angle) {
+        //TODO: actually rotate the icon clockwise x degrees
+        return icon;
+    }
 }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMatrix.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMatrix.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 namespace OpenDreamRuntime.Objects.MetaObjects {
     sealed class DreamMetaObjectMatrix : IDreamMetaObject {
         public static readonly float[] IdentityMatrixArray = {1f, 0f, 0f, 0f, 1f, 0f};
-        public static readonly float[] ZeroMatrixArray = {0f, 0f, 0f, 0f, 0f, 0f};
 
         public bool ShouldCallNew => true;
         public IDreamMetaObject? ParentType { get; set; }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -9,6 +9,7 @@ namespace OpenDreamRuntime.Procs.Native {
             DreamProcNativeRoot.MapManager = IoCManager.Resolve<IDreamMapManager>();
             DreamProcNativeRoot.ObjectTree = objectTree;
 
+            DreamProcNativeIcon.ObjectTree = objectTree;
             DreamProcNativeMatrix.ObjectTree = objectTree;
 
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_abs);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -116,6 +116,7 @@ namespace OpenDreamRuntime.Procs.Native {
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_time2text);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_trimtext);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_trunc);
+            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_turn);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_typesof);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_uppertext);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_url_decode);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -9,6 +9,8 @@ namespace OpenDreamRuntime.Procs.Native {
             DreamProcNativeRoot.MapManager = IoCManager.Resolve<IDreamMapManager>();
             DreamProcNativeRoot.ObjectTree = objectTree;
 
+            DreamProcNativeMatrix.ObjectTree = objectTree;
+
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_abs);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_alert);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_animate);
@@ -138,7 +140,9 @@ namespace OpenDreamRuntime.Procs.Native {
             objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Swap);
 
             objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Invert);
+            objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Multiply);
             objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Scale);
+            objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Turn);
 
             objectTree.SetNativeProc(objectTree.Regex, DreamProcNativeRegex.NativeProc_Find);
             objectTree.SetNativeProc(objectTree.Regex, DreamProcNativeRegex.NativeProc_Replace);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
@@ -3,9 +3,12 @@ using OpenDreamRuntime.Objects.MetaObjects;
 using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
 using BlendType = OpenDreamRuntime.Objects.DreamIconOperationBlend.BlendType;
+using DreamValueType = OpenDreamRuntime.DreamValue.DreamValueType;
 
 namespace OpenDreamRuntime.Procs.Native {
     static class DreamProcNativeIcon {
+        public static IDreamObjectTree ObjectTree;
+
         [DreamProc("Width")]
         public static DreamValue NativeProc_Width(DreamObject instance, DreamObject usr, DreamProcArguments arguments) {
             DreamIcon dreamIconObject = DreamMetaObjectIcon.ObjectToDreamIcon[instance];
@@ -93,6 +96,23 @@ namespace OpenDreamRuntime.Procs.Native {
             iconObj.Width = width;
             iconObj.Height = height;
             return DreamValue.Null;
+        }
+
+        [DreamProc("Turn")]
+        [DreamProcParameter("angle", Type = DreamValueType.Float)]
+        public static DreamValue NativeProc_Turn(DreamObject src, DreamObject usr, DreamProcArguments arguments) {
+            DreamValue angleArg = arguments.GetArgument(0, "angle");
+            if (!angleArg.TryGetValueAsFloat(out float angle)) {
+                return new DreamValue(src); // Defaults to input on invalid angle
+            }
+            return _NativeProc_TurnInternal(src, usr, angle);
+        }
+
+        /// <summary> Turns a given icon a given amount of degrees clockwise. </summary>
+        /// <returns> Returns a new icon which has been rotated </returns>
+        public static DreamValue _NativeProc_TurnInternal(DreamObject src, DreamObject usr, float angle) {
+            DreamIcon dreamIconObject = DreamMetaObjectIcon.ObjectToDreamIcon[src];
+            return new DreamValue(DreamMetaObjectIcon.TurnIcon(dreamIconObject, angle));
         }
     }
 }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
@@ -31,8 +31,9 @@ internal static class DreamProcNativeMatrix {
         if (possibleMatrix.Equals(DreamValue.Null)) {
             return new DreamValue(src);
         }
-        // Give up and return the zero matrix on invalid input
-        return new DreamValue(DreamMetaObjectMatrix.MakeMatrix(ObjectTree, DreamMetaObjectMatrix.ZeroMatrixArray));
+        // Give up and turn the input into the zero matrix on invalid input
+        DreamMetaObjectMatrix.ScaleMatrix(src, 0, 0);
+        return new DreamValue(src);
     }
 
     [DreamProc("Scale")]

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
@@ -61,8 +61,11 @@ internal static class DreamProcNativeMatrix {
     /// <summary> Turns a given matrix a given amount of degrees clockwise. </summary>
     /// <returns> Returns a new matrix which has been rotated </returns>
     public static DreamValue _NativeProc_TurnInternal(DreamObject src, DreamObject usr, float angle) {
-        float angleSin = MathF.Sin(angle);
-        float angleCos = MathF.Cos(angle);
+        var (angleSin, angleCos) = ((float, float))Math.SinCos(Angle.FromDegrees(angle));
+        if (float.IsSubnormal(angleSin)) // FIXME: Think of a better solution to bad results for some angles.
+            angleSin = 0;
+        if (float.IsSubnormal(angleCos))
+            angleCos = 0;
 
         DreamObject rotationMatrix = DreamMetaObjectMatrix.MakeMatrix(ObjectTree,angleCos, angleSin, 0, -angleSin, angleCos, 0);
         DreamMetaObjectMatrix.MultiplyMatrix(src, rotationMatrix);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
@@ -62,7 +62,7 @@ internal static class DreamProcNativeMatrix {
     /// <summary> Turns a given matrix a given amount of degrees clockwise. </summary>
     /// <returns> Returns a new matrix which has been rotated </returns>
     public static DreamValue _NativeProc_TurnInternal(DreamObject src, DreamObject usr, float angle) {
-        var (angleSin, angleCos) = ((float, float))Math.SinCos(Angle.FromDegrees(angle));
+        var (angleSin, angleCos) = ((float, float))Math.SinCos(Math.PI / 180.0 * angle);
         if (float.IsSubnormal(angleSin)) // FIXME: Think of a better solution to bad results for some angles.
             angleSin = 0;
         if (float.IsSubnormal(angleCos))

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
@@ -1,14 +1,38 @@
 ﻿using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Objects.MetaObjects;
+using DreamValueType = OpenDreamRuntime.DreamValue.DreamValueType;
 
 namespace OpenDreamRuntime.Procs.Native;
 internal static class DreamProcNativeMatrix {
+    public static IDreamObjectTree ObjectTree;
+
     [DreamProc("Invert")]
     public static DreamValue NativeProc_Invert(DreamObject src, DreamObject usr, DreamProcArguments arguments) {
         if (!DreamMetaObjectMatrix.TryInvert(src)) {
             throw new ArgumentException("Matrix does not have a valid inversion for Invert()");
         }
         return new DreamValue(src);
+    }
+
+    [DreamProc("Multiply")]
+    [DreamProcParameter("Matrix2")] // or "n"
+    public static DreamValue NativeProc_Multiply(DreamObject src, DreamObject usr, DreamProcArguments arguments) {
+        DreamValue possibleMatrix = arguments.GetArgument(0, "Matrix2");
+        if (possibleMatrix.TryGetValueAsDreamObjectOfType(ObjectTree.Matrix, out var matrixArg)) {
+            DreamMetaObjectMatrix.MultiplyMatrix(src, matrixArg);
+            return new DreamValue(src);
+        }
+        // The other valid call is with a number "n"
+        if (possibleMatrix.TryGetValueAsFloat(out float n)) {
+            DreamMetaObjectMatrix.ScaleMatrix(src, n, n);
+            return new DreamValue(src);
+        }
+        // Special case: If null was passed, return src
+        if (possibleMatrix.Equals(DreamValue.Null)) {
+            return new DreamValue(src);
+        }
+        // Give up and return the zero matrix on invalid input
+        return new DreamValue(DreamMetaObjectMatrix.MakeMatrix(ObjectTree, DreamMetaObjectMatrix.ZeroMatrixArray));
     }
 
     [DreamProc("Scale")]
@@ -22,5 +46,28 @@ internal static class DreamProcNativeMatrix {
             verticalScale = horizontalScale;
         DreamMetaObjectMatrix.ScaleMatrix(src, horizontalScale, verticalScale);
         return new DreamValue(src);
+    }
+
+    [DreamProc("Turn")]
+    [DreamProcParameter("angle", Type = DreamValueType.Float)]
+    public static DreamValue NativeProc_Turn(DreamObject src, DreamObject usr, DreamProcArguments arguments) {
+        DreamValue angleArg = arguments.GetArgument(0, "angle");
+        if (!angleArg.TryGetValueAsFloat(out float angle)) {
+            return new DreamValue(src); // Defaults to input on invalid angle
+        }
+        return _NativeProc_TurnInternal(src, usr, angle);
+    }
+
+    /// <summary> Turns a given matrix a given amount of degrees clockwise. </summary>
+    /// <returns> Returns a new matrix which has been rotated </returns>
+    public static DreamValue _NativeProc_TurnInternal(DreamObject src, DreamObject usr, float angle) {
+        float angleCos = MathF.Cos(angle);
+        float angleSin = MathF.Sin(angle);
+
+        DreamObject clonedMatrix = DreamMetaObjectMatrix.MatrixClone(ObjectTree, src);
+        DreamObject rotationMatrix = DreamMetaObjectMatrix.MakeMatrix(ObjectTree,angleCos, angleSin, 0, -angleSin, angleCos, 0);
+        DreamMetaObjectMatrix.MultiplyMatrix(clonedMatrix, rotationMatrix);
+
+        return new DreamValue(clonedMatrix);
     }
 }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
@@ -15,7 +15,7 @@ internal static class DreamProcNativeMatrix {
     }
 
     [DreamProc("Multiply")]
-    [DreamProcParameter("Matrix2")] // or "n"
+    [DreamProcParameter("Matrix2", Type = DreamValueType.DreamObject | DreamValueType.Float)] // or "n"
     public static DreamValue NativeProc_Multiply(DreamObject src, DreamObject usr, DreamProcArguments arguments) {
         DreamValue possibleMatrix = arguments.GetArgument(0, "Matrix2");
         if (possibleMatrix.TryGetValueAsDreamObjectOfType(ObjectTree.Matrix, out var matrixArg)) {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeMatrix.cs
@@ -61,13 +61,12 @@ internal static class DreamProcNativeMatrix {
     /// <summary> Turns a given matrix a given amount of degrees clockwise. </summary>
     /// <returns> Returns a new matrix which has been rotated </returns>
     public static DreamValue _NativeProc_TurnInternal(DreamObject src, DreamObject usr, float angle) {
-        float angleCos = MathF.Cos(angle);
         float angleSin = MathF.Sin(angle);
+        float angleCos = MathF.Cos(angle);
 
-        DreamObject clonedMatrix = DreamMetaObjectMatrix.MatrixClone(ObjectTree, src);
         DreamObject rotationMatrix = DreamMetaObjectMatrix.MakeMatrix(ObjectTree,angleCos, angleSin, 0, -angleSin, angleCos, 0);
-        DreamMetaObjectMatrix.MultiplyMatrix(clonedMatrix, rotationMatrix);
+        DreamMetaObjectMatrix.MultiplyMatrix(src, rotationMatrix);
 
-        return new DreamValue(clonedMatrix);
+        return new DreamValue(src);
     }
 }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2726,21 +2726,16 @@ namespace OpenDreamRuntime.Procs.Native {
             DreamValue dirArg = arguments.GetArgument(0, "dir");
             DreamValue angleArg = arguments.GetArgument(1, "angle");
 
-            if (dirArg.TryGetValueAsDreamObjectOfType(ObjectTree.Matrix, out var matrix)) {
-                DreamValue matrixCopy = new DreamValue(matrix);
-/*
- * 	if (istype(Dir, /matrix))
-		var/matrix/copy = new(Dir)
-		return copy.Turn(Angle)
- */
-
-
-            }
             // Handle an invalid angle, defaults to 0
             if (!angleArg.TryGetValueAsFloat(out float angle)) {
                 angle = 0;
-
             }
+
+            // If Dir is actually a matrix, call /matrix.Turn
+            if (dirArg.TryGetValueAsDreamObjectOfType(ObjectTree.Matrix, out var matrix)) {
+                return DreamProcNativeMatrix._NativeProc_TurnInternal(matrix, usr, angle);
+            }
+
             if (!dirArg.TryGetValueAsInteger(out int possibleDir)) {
                 throw new ArgumentException($"Invalid Dir for Turn: \"{dirArg.ToString()}\"");
             }
@@ -2785,7 +2780,7 @@ namespace OpenDreamRuntime.Procs.Native {
                     315 => AtomDirection.Southeast,
                     _ => AtomDirection.East
             };
-            return new DreamValue(toReturn);
+            return new DreamValue((int)toReturn);
         }
 
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2719,6 +2719,8 @@ namespace OpenDreamRuntime.Procs.Native {
             return new DreamValue(0);
         }
 
+        /// <summary> Global turn() proc </summary>
+        /// <remarks> Take note that this turn proc is a counterclockwise rotation unlike the rest </remarks>
         [DreamProc("turn")]
         [DreamProcParameter("Dir", Type = DreamValueType.Float)]
         [DreamProcParameter("Angle", Type = DreamValueType.Float)]
@@ -2733,7 +2735,9 @@ namespace OpenDreamRuntime.Procs.Native {
 
             // If Dir is actually a matrix, call /matrix.Turn
             if (dirArg.TryGetValueAsDreamObjectOfType(ObjectTree.Matrix, out var matrix)) {
-                return DreamProcNativeMatrix._NativeProc_TurnInternal(matrix, usr, angle);
+                // Clone matrix here since it's specified to return a new one
+                DreamObject clonedMatrix = DreamMetaObjectMatrix.MatrixClone(ObjectTree, matrix);
+                return DreamProcNativeMatrix._NativeProc_TurnInternal(clonedMatrix, usr, angle);
             }
 
             if (!dirArg.TryGetValueAsInteger(out int possibleDir)) {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1447,7 +1447,7 @@ namespace OpenDreamRuntime.Procs.Native {
              * in which it takes, some sort of "opcode" and some system of arguments and does stuff with them,
              * all of which are just aliases for already-existing behaviour in DM through the /matrix methods
              * (m.Clone() or m.Interpolate() and so on)
-             * 
+             *
              * Normally I'd never stoop to developing any such ridiculous behaviour, but for some reason,
              * Paradise and a few other targets actually make use of these alternative signatures.
              * So, here's that.
@@ -1485,7 +1485,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 case MatrixOpcode.Rotate:
                     if (!firstArgument.TryGetValueAsFloat(out float rotationAngle))
                         throw new ArgumentException($"/matrix() called with invalid rotation angle '{rotationAngle}'");
-                    var (angleSin, angleCos) = ((float, float))Math.SinCos(Angle.FromDegrees(rotationAngle)); // NOTE: Not sure if BYOND uses double or float precision in this specific case.
+                    var (angleSin, angleCos) = ((float, float))Math.SinCos(Math.PI / 180.0 * rotationAngle); // NOTE: Not sure if BYOND uses double or float precision in this specific case.
                     if (float.IsSubnormal(angleSin)) // FIXME: Think of a better solution to bad results for some angles.
                         angleSin = 0;
                     if (float.IsSubnormal(angleCos))

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2748,15 +2748,16 @@ namespace OpenDreamRuntime.Procs.Native {
             }
 
             if (!dirArg.TryGetValueAsInteger(out int possibleDir)) {
-                throw new ArgumentException($"Invalid Dir for Turn: \"{dirArg.ToString()}\"");
+                possibleDir = 0; // Mark as invalid dir
             }
 
-            if (!Enum.IsDefined(typeof(AtomDirection), possibleDir)) { // Invalid dir
-                // If Dir is invalid and angle is 0, Dir is returned
+            // Is the dir invalid (includes zero)?
+            if (possibleDir == 0) {
+                // If Dir is invalid and angle is zero, 0 is returned
                 if (angle == 0) {
-                    return dirArg;
+                    return new DreamValue(0);
                 }
-                // Otherwise, a random direction
+                // Otherwise, it returns a random direction
                 var allDirs = Enum.GetValues(typeof(AtomDirection));
                 return (DreamValue)(allDirs.GetValue(DreamManager.Random.Next(allDirs.Length)) ?? AtomDirection.North);
             }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2733,6 +2733,13 @@ namespace OpenDreamRuntime.Procs.Native {
                 angle = 0;
             }
 
+            // If Dir is actually an icon, call /icon.Turn
+            if (dirArg.TryGetValueAsDreamObjectOfType(ObjectTree.Icon, out var icon)) {
+                // Clone icon here since it's specified to return a new one
+                DreamObject clonedIcon = DreamMetaObjectIcon.CloneIcon(ObjectTree, icon);
+                return DreamProcNativeIcon._NativeProc_TurnInternal(clonedIcon, usr, angle);
+            }
+
             // If Dir is actually a matrix, call /matrix.Turn
             if (dirArg.TryGetValueAsDreamObjectOfType(ObjectTree.Matrix, out var matrix)) {
                 // Clone matrix here since it's specified to return a new one
@@ -2786,9 +2793,6 @@ namespace OpenDreamRuntime.Procs.Native {
             };
             return new DreamValue((int)toReturn);
         }
-
-
-
 
         [DreamProc("typesof")]
         [DreamProcParameter("Item1", Type = DreamValueType.DreamType | DreamValueType.DreamObject | DreamValueType.ProcStub | DreamValueType.VerbStub)]

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1485,7 +1485,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 case MatrixOpcode.Rotate:
                     if (!firstArgument.TryGetValueAsFloat(out float rotationAngle))
                         throw new ArgumentException($"/matrix() called with invalid rotation angle '{rotationAngle}'");
-                    var (angleSin, angleCos) = ((float, float))Math.SinCos(Math.PI / 180.0 * rotationAngle); // NOTE: Not sure if BYOND uses double or float precision in this specific case.
+                    var (angleSin, angleCos) = ((float, float))Math.SinCos(Angle.FromDegrees(rotationAngle)); // NOTE: Not sure if BYOND uses double or float precision in this specific case.
                     if (float.IsSubnormal(angleSin)) // FIXME: Think of a better solution to bad results for some angles.
                         angleSin = 0;
                     if (float.IsSubnormal(angleCos))

--- a/OpenDreamShared/Dream/AtomDirection.cs
+++ b/OpenDreamShared/Dream/AtomDirection.cs
@@ -2,7 +2,7 @@
 using System;
 
 namespace OpenDreamShared.Dream {
-    [Serializable, NetSerializable]
+    [Serializable, NetSerializable, Flags]
     public enum AtomDirection {
         None = 0,
 


### PR DESCRIPTION
This rewrites three procs that were previously written in DM to be written in C#.

## Reasoning

This is mainly done for performance reasons, but also comes with many other benefits including more comprehensive debugging, better failure modes, access to actual types, and all the various goodies.

Builds off work done in #1064
See self-review for more annotations on specific code sections.
Dev testing and unit tests all passed.


## Performance comparisons (Release):
| Impl  | Operation (800,000 loops) | Time |
| ------------- | ------------- | ------------- |
| DM | Matrix.Multiply | 77ds |
| C# | Matrix.Multiply | 65ds |

**15.6%** increase in perf 
| Impl  | Operation (800,000 loops) | Time |
| ------------- | ------------- | ------------- |
| DM | Matrix.Turn | 80ds |
| C# | Matrix.Turn | 49ds |

**38.75%** increase in perf
| Impl  | Operation (10,000,000 loops) | Time |
| ------------- | ------------- | ------------- |
| DM | /proc/turn() | 101ds |
| C# | /proc/turn() | 44ds |

**56.43%** increase in perf

<details>
<summary>Test Code (borrowed from a unit test):</summary>
<pre>
/proc/one()
	var/matrix/M = matrix(1, 2, 3, 4, 5, 6)
	var/matrix/N = matrix(7, 8, 9, 10, 11, 12)
	M.Multiply(N)
	if(M ~! matrix(39, 54, 78, 54, 75, 108))
		CRASH("Unexpected matrix/Multiply result: [json_encode(M)]")
/proc/two()
	var/matrix/M = matrix(1, 2, 3, 4, 5, 6)
	M.Turn(90)
	if(M ~! matrix(4, 5, 6, -1, -2, -3))
		CRASH("Unexpected matrix/Turn result: [json_encode(M)]")
/proc/three()
	var/x = pick(NORTH, SOUTH, EAST, WEST, NORTHEAST, SOUTHEAST, SOUTHWEST, NORTHWEST)
	some_global = turn(x, pick(45, 1, 39, 90, -90, 20, 40, 10, -3))
</pre>
</details>

