### PR TITLE
Optimize `in world` loops for `/area`s and `/turf`s

### DIFF
--- a/Content.Tests/DummyDreamMapManager.cs
+++ b/Content.Tests/DummyDreamMapManager.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.InteropServices.JavaScript;
 using OpenDreamRuntime;
 using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Procs;
@@ -11,6 +14,8 @@ namespace Content.Tests {
         public Vector2i Size => Vector2i.Zero;
         public int Levels => 0;
         public List<DreamObject> AllAtoms { get; } = new();
+        public IEnumerable<DreamObject> AllAreas { get; } = Array.Empty<DreamObject>();
+        public IEnumerable<DreamObject> AllTurfs { get; } = Array.Empty<DreamObject>();
 
         public void Initialize() { }
 

--- a/OpenDreamRuntime/DreamMapManager.cs
+++ b/OpenDreamRuntime/DreamMapManager.cs
@@ -58,6 +58,8 @@ namespace OpenDreamRuntime {
         public Vector2i Size { get; private set; }
         public int Levels => _levels.Count;
         public List<DreamObject> AllAtoms { get; } = new();
+        public IEnumerable<DreamObject> AllAreas => _areas.Values;
+        public IEnumerable<DreamObject> AllTurfs => _turfToTilePos.Keys; // Hijack this dictionary
 
         private readonly List<Level> _levels = new();
         private readonly Dictionary<DreamObject, (Vector2i Pos, Level Level)> _turfToTilePos = new();
@@ -357,6 +359,8 @@ namespace OpenDreamRuntime {
         public Vector2i Size { get; }
         public int Levels { get; }
         public List<DreamObject> AllAtoms { get; }
+        public IEnumerable<DreamObject> AllAreas { get; }
+        public IEnumerable<DreamObject> AllTurfs { get; }
 
         public void Initialize();
         public void LoadAreasAndTurfs(List<DreamMapJson> maps);

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -69,6 +69,13 @@ namespace OpenDreamRuntime.Procs {
                     if (dreamObject.IsSubtypeOf(objectTree.Atom)) {
                         list = dreamObject.GetVariable("contents").GetValueAsDreamList();
                     } else if (dreamObject.IsSubtypeOf(objectTree.World)) {
+                        // Use a different enumerator for /area and /turf that only enumerates those rather than all atoms
+                        if (filterType?.ObjectDefinition.IsSubtypeOf(objectTree.Area) == true) {
+                            return new DreamObjectEnumerator(mapManager.AllAreas, filterType);
+                        } else if (filterType?.ObjectDefinition.IsSubtypeOf(objectTree.Turf) == true) {
+                            return new DreamObjectEnumerator(mapManager.AllTurfs, filterType);
+                        }
+
                         return new WorldContentsEnumerator(mapManager, filterType);
                     }
                 }


### PR DESCRIPTION
Large speedup for `for (var/area/A in world)` and `for (var/turf/T in world)` loops by enumerating a list containing only those types of atoms rather than all atoms.

Does as suggested in #327, though not for all atom types.