### PR TITLE
Speed up `/atom` and `/atom/movable` init times

### DIFF
--- a/DMCompiler/DMStandard/Types/Atoms/Movable.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/Movable.dm
@@ -2,7 +2,7 @@
 	var/screen_loc
 
 	var/animate_movement = FORWARD_STEPS as opendream_unimplemented
-	var/list/locs = list() as opendream_unimplemented
+	var/list/locs = null as opendream_unimplemented
 	var/glide_size as opendream_unimplemented
 	var/step_size as opendream_unimplemented
 	var/bound_x as opendream_unimplemented

--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -5,11 +5,15 @@
 	var/text = null
 	var/desc = null
 	var/suffix = null as opendream_unimplemented
-	var/list/verbs = null
 
+	// The initialization/usage of these lists is handled internally by the runtime
+	var/list/verbs = null
 	var/list/contents = null
 	var/list/overlays = null
 	var/list/underlays = null
+	var/list/vis_locs = null as opendream_unimplemented
+    var/list/vis_contents = null as opendream_unimplemented
+
 	var/atom/loc
 	var/dir = SOUTH
 	var/x = 0
@@ -54,8 +58,6 @@
 	var/mouse_over_pointer as opendream_unimplemented
 	var/render_target as opendream_unimplemented
 	var/vis_flags as opendream_unimplemented
-	var/list/vis_locs = list() as opendream_unimplemented
-	var/list/vis_contents = list() as opendream_unimplemented
 
 	proc/Click(location, control, params)
 

--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -12,7 +12,7 @@
 	var/list/overlays = null
 	var/list/underlays = null
 	var/list/vis_locs = null as opendream_unimplemented
-    var/list/vis_contents = null as opendream_unimplemented
+	var/list/vis_contents = null as opendream_unimplemented
 
 	var/atom/loc
 	var/dir = SOUTH

--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -7,9 +7,9 @@
 	var/suffix = null as opendream_unimplemented
 	var/list/verbs = null
 
-	var/list/contents = list()
-	var/list/overlays = list()
-	var/list/underlays = list()
+	var/list/contents = null
+	var/list/overlays = null
+	var/list/underlays = null
 	var/atom/loc
 	var/dir = SOUTH
 	var/x = 0

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -31,6 +31,12 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             VerbLists[dreamObject] = new VerbsList(_objectTree, dreamObject);
             _filterLists[dreamObject] = new DreamFilterList(_objectTree.List.ObjectDefinition, dreamObject);
 
+            // TODO: These should use their own special list types
+            dreamObject.SetVariable("overlays", new(_objectTree.CreateList()));
+            dreamObject.SetVariable("underlays", new(_objectTree.CreateList()));
+            dreamObject.SetVariableValue("vis_locs", new(_objectTree.CreateList()));
+            dreamObject.SetVariableValue("vis_contents", new(_objectTree.CreateList()));
+
             ParentType?.OnObjectCreated(dreamObject, creationArguments);
         }
 
@@ -133,15 +139,14 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     break;
                 }
                 case "overlays": {
-                    if (oldValue.TryGetValueAsDreamList(out DreamList oldList)) {
+                    if (oldValue.TryGetValueAsDreamList(out var oldList)) {
                         oldList.Cut();
                         oldList.ValueAssigned -= OverlayValueAssigned;
                         oldList.BeforeValueRemoved -= OverlayBeforeValueRemoved;
                         _atomManager.OverlaysListToAtom.Remove(oldList);
                     }
 
-                    DreamList overlayList;
-                    if (!value.TryGetValueAsDreamList(out overlayList)) {
+                    if (!value.TryGetValueAsDreamList(out var overlayList)) {
                         overlayList = _objectTree.CreateList();
                     }
 
@@ -152,15 +157,14 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     break;
                 }
                 case "underlays": {
-                    if (oldValue.TryGetValueAsDreamList(out DreamList oldList)) {
+                    if (oldValue.TryGetValueAsDreamList(out var oldList)) {
                         oldList.Cut();
                         oldList.ValueAssigned -= UnderlayValueAssigned;
                         oldList.BeforeValueRemoved -= UnderlayBeforeValueRemoved;
                         _atomManager.UnderlaysListToAtom.Remove(oldList);
                     }
 
-                    DreamList underlayList;
-                    if (!value.TryGetValueAsDreamList(out underlayList)) {
+                    if (!value.TryGetValueAsDreamList(out var underlayList)) {
                         underlayList = _objectTree.CreateList();
                     }
 


### PR DESCRIPTION
Speed up `/atom/proc/<init>` and `/atom/movable/proc/<init>` by setting the built-in list vars inside their meta objects.