### PR TITLE
Fix inferred paths in appends and lint for suspicious `list += new`

### DIFF
--- a/Content.Tests/DMProject/Tests/List/SuspiciousListNew.dm
+++ b/Content.Tests/DMProject/Tests/List/SuspiciousListNew.dm
@@ -1,0 +1,6 @@
+// COMPILE ERROR
+// Test that the pragma works
+#pragma SuspiciousListNew error
+/proc/RunTest()
+	var/list/L = list()
+	L += new

--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -268,7 +268,10 @@ namespace DMCompiler.DM.Visitors {
 
         public void VisitAppend(DMASTAppend append) {
             var lhs = DMExpression.Create(_dmObject, _proc, append.A, _inferredPath);
-            var rhs = DMExpression.Create(_dmObject, _proc, append.B, _inferredPath);
+            var rhs = DMExpression.Create(_dmObject, _proc, append.B, lhs.Path);
+            if (lhs.Path == DreamPath.List && rhs is NewPath) {
+                DMCompiler.Emit(WarningCode.SuspiciousListNew, rhs.Location, "Appending \"new\" to a list is ambiguous");
+            }
             Result = new Expressions.Append(append.Location, lhs, rhs);
         }
 

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -26,3 +26,4 @@
 
 //3000-3999
 #pragma EmptyBlock notice
+#pragma SuspiciousListNew warning

--- a/OpenDreamShared/Compiler/CompilerError.cs
+++ b/OpenDreamShared/Compiler/CompilerError.cs
@@ -50,6 +50,7 @@ namespace OpenDreamShared.Compiler {
         DanglingVarType = 2401, // For types inferred by a particular var definition and nowhere else, that ends up not existing (not forced-fatal because BYOND doesn't always error)
         // 3000 - 3999 are reserved for stylistic configuration.
         EmptyBlock = 3100,
+        SuspiciousListNew = 3200,
 
         // 4000 - 4999 are reserved for runtime configuration. (TODO: Runtime doesn't know about configs yet!)
     }


### PR DESCRIPTION
Closes #1126 

The inferred path behavior now matches `VisitAssign()`.