### PR TITLE
Add Trident/7.0 to browser's user agent

### DIFF
--- a/OpenDreamClient/EntryPoint.cs
+++ b/OpenDreamClient/EntryPoint.cs
@@ -21,7 +21,7 @@ namespace OpenDreamClient {
         private readonly IDreamResourceManager _dreamResource = default!;
 
         private const string UserAgent =
-            "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729) ";
+            "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729)";
 
         public override void PreInit()
         {

--- a/OpenDreamClient/EntryPoint.cs
+++ b/OpenDreamClient/EntryPoint.cs
@@ -23,11 +23,9 @@ namespace OpenDreamClient {
         private const string UserAgent =
             "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729)";
 
-        public override void PreInit()
-        {
+        public override void PreInit() {
             var config = IoCManager.Resolve<IConfigurationManager>();
-            if (config.GetCVar(OpenDreamCVars.SpoofIEUserAgent))
-            {
+            if (config.GetCVar(OpenDreamCVars.SpoofIEUserAgent)) {
                 config.OverrideDefault(WCVars.WebUserAgentOverride, UserAgent);
             }
         }

--- a/OpenDreamClient/EntryPoint.cs
+++ b/OpenDreamClient/EntryPoint.cs
@@ -6,6 +6,7 @@ using OpenDreamClient.Resources;
 using OpenDreamClient.States;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
+using Robust.Client.WebView;
 using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
@@ -17,6 +18,14 @@ namespace OpenDreamClient {
         private readonly IDreamInterfaceManager _dreamInterface = default!;
         [Dependency]
         private readonly IDreamResourceManager _dreamResource = default!;
+
+        private const string UserAgent =
+            "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729; Tablet PC 2.0; Zoom 3.6.0) ";
+
+        public override void PreInit()
+        {
+            IoCManager.Resolve<IConfigurationManager>().OverrideDefault(WCVars.WebUserAgentOverride, UserAgent);
+        }
 
         public override void Init() {
             IoCManager.Resolve<IConfigurationManager>().OverrideDefault(CVars.NetPredict, false);

--- a/OpenDreamClient/EntryPoint.cs
+++ b/OpenDreamClient/EntryPoint.cs
@@ -4,6 +4,7 @@ using OpenDreamClient.Interface;
 using OpenDreamClient.Rendering;
 using OpenDreamClient.Resources;
 using OpenDreamClient.States;
+using OpenDreamShared;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Client.WebView;
@@ -24,7 +25,11 @@ namespace OpenDreamClient {
 
         public override void PreInit()
         {
-            IoCManager.Resolve<IConfigurationManager>().OverrideDefault(WCVars.WebUserAgentOverride, UserAgent);
+            var config = IoCManager.Resolve<IConfigurationManager>();
+            if (config.GetCVar(OpenDreamCVars.SpoofIEUserAgent))
+            {
+                config.OverrideDefault(WCVars.WebUserAgentOverride, UserAgent);
+            }
         }
 
         public override void Init() {

--- a/OpenDreamClient/EntryPoint.cs
+++ b/OpenDreamClient/EntryPoint.cs
@@ -21,7 +21,7 @@ namespace OpenDreamClient {
         private readonly IDreamResourceManager _dreamResource = default!;
 
         private const string UserAgent =
-            "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729; Tablet PC 2.0; Zoom 3.6.0) ";
+            "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729) ";
 
         public override void PreInit()
         {

--- a/OpenDreamShared/OpenDreamCVars.cs
+++ b/OpenDreamShared/OpenDreamCVars.cs
@@ -15,5 +15,8 @@ namespace OpenDreamShared {
 
         public static readonly CVarDef<int> DebugAdapterLaunched =
             CVarDef.Create("opendream.debug_adapter_launched", 0, CVar.SERVERONLY);
+
+        public static readonly CVarDef<bool> SpoofIEUserAgent =
+            CVarDef.Create("opendream.spoof_ie_user_agent", true, CVar.CLIENTONLY);
     }
 }


### PR DESCRIPTION
Fixes #1023
Copies the one that @wixoaGit gave as an example on the issue.

User agent being shown in the logs:
```
[INFO] web.cef: CEF Version: 102.0.5005.63
[DEBG] web.cef: CEF command line: "C:\Projects\OpenDream\bin\Content.Client\OpenDreamClient.exe" --browser-subprocess-path="C:\Projects\OpenDream\bin\Content.Client\Robust.Client.WebView.exe" --no-sandbox --user-agent="Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6
.2; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729; Tablet PC 2.0; Zoom 3.6.0) " --lang=en-US --log-file="C:\Projects\OpenDream\bin\Content.Client\debug.log" --resources-dir-path="C:\Projects\OpenDream\bin\Content.
Client\runtimes\win-x64\native\cef_resources" --locales-dir-path="C:\Projects\OpenDream\bin\Content.Client\runtimes\win-x64\native\cef_resources\locales" --remote-debugging-port=9222 --disable-features=CalculateNativeWinOcclusion,WinUseBrowserSpellChecker --no-zygot
e --disable-threaded-scrolling=1 --disable-features=TouchpadAndWheelScrollLatching,AsyncWheelEvents
```