### PR TITLE
Embedded `winset`

### DIFF
--- a/OpenDreamClient/Interface/Controls/ControlBrowser.cs
+++ b/OpenDreamClient/Interface/Controls/ControlBrowser.cs
@@ -80,7 +80,19 @@ namespace OpenDreamClient.Interface.Controls
                 context.DoCancel();
 
                 if (newUri.Host == "winset") { // Embedded winset. Ex: usr << browse("<a href=\"byond://winset?command=.quit\">Quit</a>", "window=quitbutton")
-                    _interfaceManager.WinSet(null, newUri.Query.Substring(1)); // Strip the question mark
+                    // Strip the question mark out before parsing
+                    var queryParams = HttpUtility.ParseQueryString(newUri.Query.Substring(1));
+
+                    // We need to extract the control element (if one was included)
+                    string? element = queryParams.Get("element");
+                    queryParams.Remove("element");
+
+                    // Reassemble the query params without element then convert to winset syntax
+                    var query = queryParams.ToString();
+                    query = query!.Replace('&', ';');
+
+                    // We can finally call winset
+                    _interfaceManager.WinSet(element, query);
                     return;
                 }
 

--- a/OpenDreamClient/Interface/Controls/ControlBrowser.cs
+++ b/OpenDreamClient/Interface/Controls/ControlBrowser.cs
@@ -89,7 +89,7 @@ namespace OpenDreamClient.Interface.Controls
 
                     // Reassemble the query params without element then convert to winset syntax
                     var query = queryParams.ToString();
-                    query = query!.Replace('&', ';');
+                    query = query!.Replace('&', ';'); // TODO: More robust parsing
 
                     // We can finally call winset
                     _interfaceManager.WinSet(element, query);

--- a/OpenDreamClient/Interface/Controls/ControlBrowser.cs
+++ b/OpenDreamClient/Interface/Controls/ControlBrowser.cs
@@ -32,6 +32,7 @@ namespace OpenDreamClient.Interface.Controls
 
         [Dependency] private readonly IResourceManager _resourceManager = default!;
         [Dependency] private readonly IClientNetManager _netManager = default!;
+        [Dependency] private readonly IDreamInterfaceManager _interfaceManager = default!;
         [Dependency] private readonly IDreamResourceManager _dreamResource = default!;
 
         private ISawmill _sawmill = Logger.GetSawmill("opendream.browser");
@@ -77,6 +78,11 @@ namespace OpenDreamClient.Interface.Controls
 
             if (newUri.Scheme == "byond" || (newUri.AbsolutePath == oldUri.AbsolutePath && newUri.Query != String.Empty)) {
                 context.DoCancel();
+
+                if (newUri.Host == "winset") { // Embedded winset. Ex: usr << browse("<a href=\"byond://winset?command=.quit\">Quit</a>", "window=quitbutton")
+                    _interfaceManager.WinSet(null, newUri.Query.Substring(1)); // Strip the question mark
+                    return;
+                }
 
                 var msg = new MsgTopic() { Query = newUri.Query };
                 _netManager.ClientSendMessage(msg);


### PR DESCRIPTION
Fixes #1125 

TG's usage won't work until https://github.com/OpenDreamProject/OpenDream/pull/1121 is also merged.

Tested it with the following tossed in a verb (requires the other aforementioned PR to work):
`usr << browse("<a href=\"byond://winset?size=100x10&command=.quit\">Quit</a>", "window=quitbutton")`