### PR TITLE
"Implement" `call_ext()`

### DIFF
--- a/DMCompiler/Compiler/DM/DMLexer.cs
+++ b/DMCompiler/Compiler/DM/DMLexer.cs
@@ -56,6 +56,7 @@ namespace DMCompiler.Compiler.DM {
             { "as", TokenType.DM_As },
             { "set", TokenType.DM_Set },
             { "call", TokenType.DM_Call },
+            { "call_ext", TokenType.DM_Call},
             { "spawn", TokenType.DM_Spawn },
             { "goto", TokenType.DM_Goto },
             { "step", TokenType.DM_Step },


### PR DESCRIPTION
We're in that weird transitionary 514 -> 515 period where supporting both functionalities is somewhat desirable.

In the future we need to properly separate these before ~~goonstation~~ some SS13 codebase manages to rely on the distinction