### PR TITLE
Fixes a few cases where invalid appearance sources had differing behavior

### DIFF
--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -314,7 +314,8 @@ namespace OpenDreamRuntime {
             if (_resourceManager.TryLoadIcon(value, out var iconResource)) {
                 appearance.Icon = iconResource.Id;
             } else if (value != DreamValue.Null) {
-                throw new Exception($"Cannot create an appearance from {value}");
+                // Return a default appearance, but log a warning about it
+                Logger.Warning($"Attempted to create an appearance from {value}. This is invalid and a default appearance was created instead.");
             }
 
             return appearance;

--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -293,32 +293,37 @@ namespace OpenDreamRuntime {
             _appearanceSystem.Animate(GetMovableEntity(atom), appearance, duration);
         }
 
-        public IconAppearance CreateAppearanceFrom(DreamValue value) {
+        public bool TryCreateAppearanceFrom(DreamValue value, [NotNullWhen(true)] out IconAppearance? appearance) {
             if (value.TryGetValueAsAppearance(out var copyFromAppearance)) {
-                return new(copyFromAppearance);
+                appearance = new(copyFromAppearance);
+                return true;
             }
 
             if (value.TryGetValueAsDreamObjectOfType(_objectTree.Image, out var copyFromImage)) {
-                return new(DreamMetaObjectImage.ObjectToAppearance[copyFromImage]);
+                appearance = new(DreamMetaObjectImage.ObjectToAppearance[copyFromImage]);
+                return true;
             }
 
             if (value.TryGetValueAsType(out var copyFromType)) {
-                return CreateAppearanceFromDefinition(copyFromType.ObjectDefinition);
+                appearance = CreateAppearanceFromDefinition(copyFromType.ObjectDefinition);
+                return true;
             }
 
             if (value.TryGetValueAsDreamObjectOfType(_objectTree.Atom, out var copyFromAtom)) {
-                return CreateAppearanceFromAtom(copyFromAtom);
+                appearance = CreateAppearanceFromAtom(copyFromAtom);
+                return true;
             }
 
-            var appearance = new IconAppearance();
             if (_resourceManager.TryLoadIcon(value, out var iconResource)) {
-                appearance.Icon = iconResource.Id;
-            } else if (value != DreamValue.Null) {
-                // Return a default appearance, but log a warning about it
-                Logger.Warning($"Attempted to create an appearance from {value}. This is invalid and a default appearance was created instead.");
+                appearance = new IconAppearance() {
+                    Icon = iconResource.Id
+                };
+
+                return true;
             }
 
-            return appearance;
+            appearance = null;
+            return false;
         }
 
         public IconAppearance CreateAppearanceFromAtom(DreamObject atom) {
@@ -411,7 +416,7 @@ namespace OpenDreamRuntime {
         public bool TryGetAppearance(DreamObject atom, [NotNullWhen(true)] out IconAppearance? appearance);
         public void UpdateAppearance(DreamObject atom, Action<IconAppearance> update);
         public void AnimateAppearance(DreamObject atom, TimeSpan duration, Action<IconAppearance> animate);
-        public IconAppearance CreateAppearanceFrom(DreamValue value);
+        public bool TryCreateAppearanceFrom(DreamValue value, [NotNullWhen(true)] out IconAppearance? appearance);
         public IconAppearance CreateAppearanceFromAtom(DreamObject atom);
         public IconAppearance CreateAppearanceFromDefinition(DreamObjectDefinition def);
     }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -187,8 +187,10 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 overlay = new IconAppearance() {
                     IconState = iconState
                 };
+            } else if (_atomManager.TryCreateAppearanceFrom(value, out var overlayAppearance)) {
+                overlay = overlayAppearance;
             } else {
-                overlay = _atomManager.CreateAppearanceFrom(value);
+                return new IconAppearance(); // Not a valid overlay, use a default appearance
             }
 
             if (overlay.Icon == null) {

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectImage.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectImage.cs
@@ -30,7 +30,12 @@ sealed class DreamMetaObjectImage : IDreamMetaObject {
         ParentType?.OnObjectCreated(dreamObject, creationArguments);
 
         DreamValue icon = creationArguments.GetArgument(0, "icon");
-        IconAppearance appearance = _atomManager.CreateAppearanceFrom(icon);
+        if (!_atomManager.TryCreateAppearanceFrom(icon, out var appearance)) {
+            // Use a default appearance, but log a warning about it if icon wasn't null
+            appearance = new IconAppearance();
+            if (icon != DreamValue.Null)
+                Logger.Warning($"Attempted to create an /image from {icon}. This is invalid and a default image was created instead.");
+        }
 
         int argIndex = 1;
         DreamValue loc = creationArguments.GetArgument(1, "loc");
@@ -59,7 +64,8 @@ sealed class DreamMetaObjectImage : IDreamMetaObject {
     public void OnVariableSet(DreamObject dreamObject, string varName, DreamValue value, DreamValue oldValue) {
         switch (varName) {
             case "appearance":
-                var newAppearance = _atomManager.CreateAppearanceFrom(value);
+                if (!_atomManager.TryCreateAppearanceFrom(value, out var newAppearance))
+                    return; // Ignore attempts to set an invalid appearance
 
                 ObjectToAppearance[dreamObject] = newAppearance;
                 break;


### PR DESCRIPTION
`new /image(new /datum)` creates a default image

`atom.appearance = null` and `image.appearance = null` is ignored

`atom.overlays |= new /datum` appears to do nothing, but still adds an entry to the list. Meaning it's probably an empty appearance.