### PR TITLE
Null out deleted DreamObjects before comparing DreamValues

### DIFF
--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -451,9 +451,16 @@ namespace OpenDreamRuntime {
         public override bool Equals(object? obj) => obj is DreamValue other && Equals(other);
 
         public bool Equals(DreamValue other) {
+            // Ensure deleted DreamObjects are made null
+            if ((_refValue as DreamObject)?.Deleted == true)
+                _refValue = null;
+            if ((other._refValue as DreamObject)?.Deleted == true)
+                other._refValue = null;
+
             if (Type != other.Type) return false;
             if (Type == DreamValueType.Float) return _floatValue == other._floatValue;
             if (_refValue == null) return other._refValue == null;
+
             return _refValue.Equals(other._refValue);
         }
 


### PR DESCRIPTION
DreamValue wasn't treating deleted DreamObjects as null when checking their equality.

This would lead to the following code example giving `0` instead of `1`:
```
var/list/L = list(new /datum)
del L[1]
world.log << (null in L)
```