### PR TITLE
Remove associated values from list when removing the key

### DIFF
--- a/Content.Tests/DMProject/Tests/List/RemoveKey.dm
+++ b/Content.Tests/DMProject/Tests/List/RemoveKey.dm
@@ -1,0 +1,6 @@
+﻿/proc/RunTest()
+	var/list/L = list("foo" = "bar")
+
+	// Removing the key should remove the associated value as well
+	L -= "foo"
+	ASSERT(L["foo"] == null)

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -91,6 +91,7 @@ namespace OpenDreamRuntime.Objects {
             if (valueIndex != -1) {
                 BeforeValueRemoved?.Invoke(this, new DreamValue(valueIndex), _values[valueIndex]);
 
+                _associativeValues?.Remove(value);
                 _values.RemoveAt(valueIndex);
             }
         }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectList.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectList.cs
@@ -125,7 +125,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public DreamValue OperatorRemove(DreamValue a, DreamValue b) {
             DreamList list = a.MustGetValueAsDreamList();
 
-            if (b.TryGetValueAsDreamList(out DreamList bList)) {
+            if (b.TryGetValueAsDreamList(out var bList)) {
                 DreamValue[] values = bList.GetValues().ToArray();
 
                 foreach (DreamValue value in values) {


### PR DESCRIPTION
Removing a key from a list using `-=` wouldn't remove the value associated with it if one existed.