### PR TITLE
Fix margin on DMF buttons

### DIFF
--- a/OpenDreamClient/Interface/Controls/ControlButton.cs
+++ b/OpenDreamClient/Interface/Controls/ControlButton.cs
@@ -4,16 +4,7 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 
 namespace OpenDreamClient.Interface.Controls {
-    sealed class InterfaceButton : Button
-    {
-        public InterfaceButton()
-        {
-            Label.Margin = new Thickness(6, 0, 6, 2);
-        }
-    }
-
-    sealed class ControlButton : InterfaceControl
-    {
+    sealed class ControlButton : InterfaceControl {
         public const string StyleClassDMFButton = "DMFbutton";
 
         private Button _button;
@@ -21,10 +12,13 @@ namespace OpenDreamClient.Interface.Controls {
         public ControlButton(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor, window) { }
 
         protected override Control CreateUIElement() {
-            _button = new InterfaceButton();
+            _button = new Button() {
+                ClipText = true
+            };
+
             _button.OnPressed += OnButtonClick;
-            _button.ClipText = true;
-            _button.Label.AddStyleClass("DMFbutton");
+            _button.Label.Margin = new Thickness(0, -3, 0, 0);
+            _button.Label.AddStyleClass(StyleClassDMFButton);
 
             return _button;
         }

--- a/OpenDreamClient/Interface/Controls/ControlInfo.cs
+++ b/OpenDreamClient/Interface/Controls/ControlInfo.cs
@@ -60,12 +60,13 @@ namespace OpenDreamClient.Interface.Controls {
                 if (verbCategory != PanelName)
                     continue;
 
-                InterfaceButton verbButton = new InterfaceButton() {
+                Button verbButton = new Button() {
                     Margin = new Thickness(2),
                     MinWidth = 100,
                     Text = verbName
                 };
 
+                verbButton.Label.Margin = new Thickness(6, 0, 6, 2);
                 verbButton.OnPressed += _ => {
                     EntitySystem.Get<DreamCommandSystem>().RunCommand(verbId);
                 };


### PR DESCRIPTION
The margin on buttons was causing some clipping issues on smaller sizes.

OpenDream before:
![image](https://user-images.githubusercontent.com/30789242/232265502-ab0fbda9-c85f-4092-a09c-03505f5b6a38.png)

OpenDream after:
![image](https://user-images.githubusercontent.com/30789242/232265469-84655245-49e0-4896-974b-1100e5e3b02c.png)

BYOND:
![image](https://user-images.githubusercontent.com/30789242/232265512-34c6f343-afb6-4128-9a50-ff98a6034896.png)
