### PR TITLE
Add profiler groups to dream overlay

### DIFF
--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -47,7 +47,7 @@ sealed class DreamViewOverlay : Overlay {
     private Stack<RendererMetaData> _rendererMetaDataRental = new();
     private Stack<RendererMetaData> _rendererMetaDataToReturn = new();
     private Matrix3 _flipMatrix;
-    private const LookupFlags Flags = LookupFlags.Approximate | LookupFlags.Dynamic | LookupFlags.Static | LookupFlags.Sundries | LookupFlags.Contained;
+    private const LookupFlags Flags = LookupFlags.Approximate | LookupFlags.Uncontained;
 
     public DreamViewOverlay() {
         IoCManager.InjectDependencies(this);

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -47,7 +47,7 @@ sealed class DreamViewOverlay : Overlay {
     private Stack<RendererMetaData> _rendererMetaDataRental = new();
     private Stack<RendererMetaData> _rendererMetaDataToReturn = new();
     private Matrix3 _flipMatrix;
-    private const LookupFlags Flags = LookupFlags.Approximate | LookupFlags.Uncontained;
+    private const LookupFlags MapLookupFlags = LookupFlags.Approximate | LookupFlags.Uncontained;
 
     public DreamViewOverlay() {
         IoCManager.InjectDependencies(this);
@@ -129,7 +129,7 @@ sealed class DreamViewOverlay : Overlay {
         using (_prof.Group("lookup")) {
             //TODO use a sprite tree.
             //the scaling is to attempt to prevent pop-in, by rendering sprites that are *just* offscreen
-            entities = _lookupSystem.GetEntitiesIntersecting(args.MapId, screenArea.Scale(1.2f), Flags);
+            entities = _lookupSystem.GetEntitiesIntersecting(args.MapId, screenArea.Scale(1.2f), MapLookupFlags);
         }
 
         List<RendererMetaData> sprites = new(entities.Count + 1);


### PR DESCRIPTION
Makes it easier to get an overview of which parts of the rendering is slow. Also changes the lookup flags to use approximate lookups, seeing as lookup area is already arbitrarily scaled up.

![OpenDreamClient_oMR5riM9mM](https://user-images.githubusercontent.com/60421075/232377992-1e8977c3-55f3-4889-a4c0-209c8084ae53.png)
