### PR TITLE
Fix a bug with overlay dir inheritance

### DIFF
--- a/OpenDreamClient/Rendering/DreamIcon.cs
+++ b/OpenDreamClient/Rendering/DreamIcon.cs
@@ -66,7 +66,7 @@ namespace OpenDreamClient.Rendering {
             ClientAppearanceSystem appearanceSystem = EntitySystem.Get<ClientAppearanceSystem>();
 
             appearanceSystem.LoadAppearance(appearanceId.Value, appearance => {
-                if (parentDir != null) {
+                if (parentDir != null && appearance.InheritsDirection) {
                     appearance = new IconAppearance(appearance) {
                         Direction = parentDir.Value
                     };

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectImage.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectImage.cs
@@ -39,7 +39,7 @@ sealed class DreamMetaObjectImage : IDreamMetaObject {
 
         int argIndex = 1;
         DreamValue loc = creationArguments.GetArgument(1, "loc");
-        if (loc.Type != DreamValue.DreamValueType.String) { // If it's a string, it's actually icon_state and not loc
+        if (loc.Type == DreamValue.DreamValueType.DreamObject) { // If it's not a DreamObject, it's actually icon_state and not loc
             dreamObject.SetVariableValue("loc", loc);
             argIndex = 2;
         }
@@ -50,6 +50,12 @@ sealed class DreamMetaObjectImage : IDreamMetaObject {
                 continue;
 
             _atomManager.SetAppearanceVar(appearance, argName, arg);
+            if (argName == "dir") {
+                // If a dir is explicitly given in the constructor then overlays using this won't use their owner's dir
+                // Setting dir after construction does not affect this
+                // This is undocumented and I hate it
+                appearance.InheritsDirection = false;
+            }
         }
 
         ObjectToAppearance.Add(dreamObject, appearance);
@@ -66,6 +72,10 @@ sealed class DreamMetaObjectImage : IDreamMetaObject {
             case "appearance":
                 if (!_atomManager.TryCreateAppearanceFrom(value, out var newAppearance))
                     return; // Ignore attempts to set an invalid appearance
+
+                // The dir does not get changed
+                var oldDir = ObjectToAppearance[dreamObject].Direction;
+                newAppearance.Direction = oldDir;
 
                 ObjectToAppearance[dreamObject] = newAppearance;
                 break;

--- a/OpenDreamShared/Dream/IconAppearance.cs
+++ b/OpenDreamShared/Dream/IconAppearance.cs
@@ -12,6 +12,7 @@ namespace OpenDreamShared.Dream {
         [ViewVariables] public int? Icon;
         [ViewVariables] [CanBeNull] public string IconState;
         [ViewVariables] public AtomDirection Direction = AtomDirection.South;
+        [ViewVariables] public bool InheritsDirection = true; // Inherits direction when used as an overlay
         [ViewVariables] public Vector2i PixelOffset;
         [ViewVariables] public Color Color = Color.White;
         [ViewVariables] public byte Alpha = 255;
@@ -50,6 +51,7 @@ namespace OpenDreamShared.Dream {
             Icon = appearance.Icon;
             IconState = appearance.IconState;
             Direction = appearance.Direction;
+            InheritsDirection = appearance.InheritsDirection;
             PixelOffset = appearance.PixelOffset;
             Color = appearance.Color;
             Alpha = appearance.Alpha;
@@ -80,6 +82,7 @@ namespace OpenDreamShared.Dream {
             if (appearance.Icon != Icon) return false;
             if (appearance.IconState != IconState) return false;
             if (appearance.Direction != Direction) return false;
+            if (appearance.InheritsDirection != InheritsDirection) return false;
             if (appearance.PixelOffset != PixelOffset) return false;
             if (appearance.Color != Color) return false;
             if (appearance.Alpha != Alpha) return false;
@@ -150,6 +153,7 @@ namespace OpenDreamShared.Dream {
             hashCode.Add(Icon);
             hashCode.Add(IconState);
             hashCode.Add(Direction);
+            hashCode.Add(InheritsDirection);
             hashCode.Add(PixelOffset);
             hashCode.Add(Color);
             hashCode.Add(ColorMatrix);


### PR DESCRIPTION
`/image` has this undocumented "feature" where setting the dir in the constructor (but not afterwards) will force overlays to have that direction, rather than inheriting a direction from their owner. I also fixed a bug in `/image.appearance = value`, the image's `dir` is supposed to stay as it is.

Fixes many overlays in Nebula. I don't see any changes on Paradise but it probably has an effect in a more niche use somewhere.