### PR TITLE
Optimize `del()`

### DIFF
--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -9,6 +9,13 @@ using Robust.Shared.Map;
 
 namespace OpenDreamRuntime {
     internal sealed class AtomManager : IAtomManager {
+        public List<DreamObject> Areas { get; } = new();
+        public List<DreamObject> Turfs { get; } = new();
+        public List<DreamObject> Movables { get; } = new();
+        public List<DreamObject> Objects { get; } = new();
+        public List<DreamObject> Mobs { get; } = new();
+        public int AtomCount => Areas.Count + Turfs.Count + Movables.Count + Objects.Count + Mobs.Count;
+
         //TODO: Maybe turn these into a special DreamList, similar to DreamListVars?
         public Dictionary<DreamList, DreamObject> OverlaysListToAtom { get; } = new();
         public Dictionary<DreamList, DreamObject> UnderlaysListToAtom { get; } = new();
@@ -23,6 +30,29 @@ namespace OpenDreamRuntime {
         private readonly Dictionary<EntityUid, DreamObject> _entityToAtom = new();
 
         private ServerAppearanceSystem? _appearanceSystem;
+
+        public DreamObject GetAtom(int index) {
+            if (index < Areas.Count)
+                return Areas[index];
+
+            index -= Areas.Count;
+            if (index < Turfs.Count)
+                return Turfs[index];
+
+            index -= Turfs.Count;
+            if (index < Movables.Count)
+                return Movables[index];
+
+            index -= Movables.Count;
+            if (index < Objects.Count)
+                return Objects[index];
+
+            index -= Objects.Count;
+            if (index < Mobs.Count)
+                return Mobs[index];
+
+            throw new IndexOutOfRangeException($"Cannot get atom at index {index}. There are only {AtomCount} atoms.");
+        }
 
         public EntityUid CreateMovableEntity(DreamObject atom) {
             if (_atomToEntity.TryGetValue(atom, out var entity))
@@ -397,8 +427,17 @@ namespace OpenDreamRuntime {
     }
 
     public interface IAtomManager {
+        public List<DreamObject> Areas { get; }
+        public List<DreamObject> Turfs { get; }
+        public List<DreamObject> Movables { get; }
+        public List<DreamObject> Objects { get; }
+        public List<DreamObject> Mobs { get; }
+        public int AtomCount { get; }
+
         public Dictionary<DreamList, DreamObject> OverlaysListToAtom { get; }
         public Dictionary<DreamList, DreamObject> UnderlaysListToAtom { get; }
+
+        public DreamObject GetAtom(int index);
 
         public EntityUid CreateMovableEntity(DreamObject movable);
         public EntityUid GetMovableEntity(DreamObject movable);

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -4,11 +4,9 @@ using System.Text.Json;
 using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Objects.MetaObjects;
 using OpenDreamRuntime.Procs;
-using OpenDreamRuntime.Procs.DebugAdapter;
 using OpenDreamRuntime.Procs.Native;
 using OpenDreamRuntime.Resources;
 using OpenDreamShared;
-using OpenDreamShared.Dream;
 using OpenDreamShared.Json;
 using Robust.Server;
 using Robust.Server.Player;
@@ -37,9 +35,8 @@ namespace OpenDreamRuntime {
         public IReadOnlyList<string> GlobalNames { get; private set; } = new List<string>();
         public Dictionary<DreamObject, DreamList> AreaContents { get; set; } = new();
         public Dictionary<DreamObject, int> ReferenceIDs { get; set; } = new();
-        public List<DreamObject> Mobs { get; set; } = new();
-        public List<DreamObject> Clients { get; set; } = new();
-        public List<DreamObject> Datums { get; set; } = new();
+        public HashSet<DreamObject> Clients { get; set; } = new();
+        public HashSet<DreamObject> Datums { get; set; } = new();
         public Random Random { get; set; } = new();
         public Dictionary<string, List<DreamObject>> Tags { get; set; } = new();
 
@@ -149,6 +146,7 @@ namespace OpenDreamRuntime {
             _objectTree.SetMetaObject(_objectTree.Area, new DreamMetaObjectArea());
             _objectTree.SetMetaObject(_objectTree.Turf, new DreamMetaObjectTurf());
             _objectTree.SetMetaObject(_objectTree.Movable, new DreamMetaObjectMovable());
+            _objectTree.SetMetaObject(_objectTree.Obj, new DreamMetaObjectObj());
             _objectTree.SetMetaObject(_objectTree.Mob, new DreamMetaObjectMob());
             _objectTree.SetMetaObject(_objectTree.Image, new DreamMetaObjectImage());
             _objectTree.SetMetaObject(_objectTree.Icon, new DreamMetaObjectIcon());

--- a/OpenDreamRuntime/DreamMapManager.cs
+++ b/OpenDreamRuntime/DreamMapManager.cs
@@ -26,9 +26,6 @@ namespace OpenDreamRuntime {
 
         public Vector2i Size { get; private set; }
         public int Levels => _levels.Count;
-        public List<DreamObject> AllAtoms { get; } = new();
-        public IEnumerable<DreamObject> AllAreas => _areas.Values;
-        public IEnumerable<DreamObject> AllTurfs => _turfToTilePos.Keys; // Hijack this dictionary
 
         private readonly List<Level> _levels = new();
         private readonly Dictionary<DreamObject, (Vector2i Pos, Level Level)> _turfToTilePos = new();
@@ -37,8 +34,6 @@ namespace OpenDreamRuntime {
         private IDreamObjectTree.TreeEntry _defaultTurf;
 
         public void Initialize() {
-            AllAtoms.Clear();
-
             _appearanceSystem = _entitySystemManager.GetEntitySystem<ServerAppearanceSystem>();
             _transformSystem = _entitySystemManager.GetEntitySystem<TransformSystem>();
 
@@ -118,11 +113,9 @@ namespace OpenDreamRuntime {
 
             // Also call New() on all /area not in the grid.
             // This may call New() a SECOND TIME. This is intentional.
-            foreach (var thing in AllAtoms) {
-                if (thing.IsSubtypeOf(_objectTree.Area)) {
-                    if (seenAreas.Add(thing)) {
-                        thing.SpawnProc("New");
-                    }
+            foreach (var thing in _atomManager.Areas) {
+                if (seenAreas.Add(thing)) {
+                    thing.SpawnProc("New");
                 }
             }
 
@@ -153,7 +146,7 @@ namespace OpenDreamRuntime {
                 _turfToTilePos.Add(cell.Turf, (pos, level));
                 // Only add the /turf to .contents when it's created.
                 cell.Area.GetVariable("contents").GetValueAsDreamList().AddValue(new(cell.Turf));
-                AllAtoms.Add(cell.Turf);
+                _atomManager.Turfs.Add(cell.Turf);
                 DreamMetaObjectTurf.TurfContentsLists.Add(cell.Turf, new TurfContentsList(_objectTree.List.ObjectDefinition, _objectTree, cell));
             }
 
@@ -399,9 +392,6 @@ namespace OpenDreamRuntime {
 
         public Vector2i Size { get; }
         public int Levels { get; }
-        public List<DreamObject> AllAtoms { get; }
-        public IEnumerable<DreamObject> AllAreas { get; }
-        public IEnumerable<DreamObject> AllTurfs { get; }
 
         public void Initialize();
         public void LoadAreasAndTurfs(List<DreamMapJson> maps);

--- a/OpenDreamRuntime/IDreamManager.cs
+++ b/OpenDreamRuntime/IDreamManager.cs
@@ -19,9 +19,8 @@ namespace OpenDreamRuntime {
         public IReadOnlyList<string> GlobalNames { get; }
         public Dictionary<DreamObject, DreamList> AreaContents { get; set; }
         public Dictionary<DreamObject, int> ReferenceIDs { get; set; }
-        public List<DreamObject> Mobs { get; set; }
-        public List<DreamObject> Clients { get; set; }
-        public List<DreamObject> Datums { get; set; }
+        public HashSet<DreamObject> Clients { get; set; }
+        public HashSet<DreamObject> Datums { get; set; }
         public Random Random { get; set; }
         public Dictionary<string, List<DreamObject>> Tags { get; set; }
         IEnumerable<DreamConnection> Connections { get; }

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -451,19 +451,19 @@ namespace OpenDreamRuntime.Objects {
     // world.contents list
     // Operates on a list of all atoms
     public sealed class WorldContentsList : DreamList {
-        private readonly IDreamMapManager _mapManager;
+        private readonly IAtomManager _atomManager;
 
-        public WorldContentsList(DreamObjectDefinition listDef, IDreamMapManager mapManager) : base(listDef, 0) {
-            _mapManager = mapManager;
+        public WorldContentsList(DreamObjectDefinition listDef, IAtomManager atomManager) : base(listDef, 0) {
+            _atomManager = atomManager;
         }
 
         public override DreamValue GetValue(DreamValue key) {
             if (!key.TryGetValueAsInteger(out var index))
                 throw new Exception($"Invalid index into world contents list: {key}");
-            if (index < 1 || index > _mapManager.AllAtoms.Count)
+            if (index < 1 || index > _atomManager.AtomCount)
                 throw new Exception($"Out of bounds index on world contents list: {index}");
 
-            return new DreamValue(_mapManager.AllAtoms[index - 1]);
+            return new DreamValue(_atomManager.GetAtom(index - 1));
         }
 
         public override List<DreamValue> GetValues() {
@@ -483,7 +483,7 @@ namespace OpenDreamRuntime.Objects {
         }
 
         public override int GetLength() {
-            return _mapManager.AllAtoms.Count;
+            return _atomManager.AtomCount;
         }
     }
 

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -41,6 +41,7 @@ namespace OpenDreamRuntime.Objects {
         private Dictionary<DreamPath, TreeEntry> _pathToType = new();
         private Dictionary<string, int> _globalProcIds;
 
+        [Dependency] private readonly IAtomManager _atomManager = default!;
         [Dependency] private readonly IDreamManager _dreamManager = default!;
         [Dependency] private readonly IDreamMapManager _dreamMapManager = default!;
         [Dependency] private readonly IDreamDebugManager _dreamDebugManager = default!;
@@ -50,7 +51,7 @@ namespace OpenDreamRuntime.Objects {
             Strings = json.Strings;
 
             if (json.GlobalInitProc is ProcDefinitionJson initProcDef) {
-                GlobalInitProc = new DMProc(DreamPath.Root, initProcDef, "<global init>", _dreamManager, _dreamMapManager, _dreamDebugManager, _dreamResourceManager, this);
+                GlobalInitProc = new DMProc(DreamPath.Root, initProcDef, "<global init>", _dreamManager, _atomManager, _dreamMapManager, _dreamDebugManager, _dreamResourceManager, this);
             } else {
                 GlobalInitProc = null;
             }
@@ -325,7 +326,7 @@ namespace OpenDreamRuntime.Objects {
         public DreamProc LoadProcJson(DreamTypeJson[] types, ProcDefinitionJson procDefinition) {
             DreamPath owningType = new DreamPath(types[procDefinition.OwningTypeId].Path);
             return new DMProc(owningType, procDefinition, null, _dreamManager,
-                _dreamMapManager, _dreamDebugManager, _dreamResourceManager, this);
+                _atomManager, _dreamMapManager, _dreamDebugManager, _dreamResourceManager, this);
         }
 
         private void LoadProcsFromJson(DreamTypeJson[] types, ProcDefinitionJson[] jsonProcs, List<int> jsonGlobalProcs) {

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectArea.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectArea.cs
@@ -1,10 +1,12 @@
 ﻿using OpenDreamRuntime.Procs;
+using Robust.Shared.Utility;
 
 namespace OpenDreamRuntime.Objects.MetaObjects {
     sealed class DreamMetaObjectArea : IDreamMetaObject {
         public bool ShouldCallNew => true;
         public IDreamMetaObject? ParentType { get; set; }
 
+        [Dependency] private readonly IAtomManager _atomManager = default!;
         [Dependency] private readonly IDreamManager _dreamManager = default!;
         [Dependency] private readonly IDreamObjectTree _objectTree = default!;
         [Dependency] private readonly IDreamMapManager _dreamMapManager = default!;
@@ -24,13 +26,16 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 level.SetArea(pos, dreamObject);
             };
 
+            _atomManager.Areas.Add(dreamObject);
             _dreamManager.AreaContents.Add(dreamObject, contents);
 
             ParentType?.OnObjectCreated(dreamObject, creationArguments);
         }
 
         public void OnObjectDeleted(DreamObject dreamObject) {
+            _atomManager.Areas.RemoveSwap(_atomManager.Areas.IndexOf(dreamObject));
             _dreamManager.AreaContents.Remove(dreamObject);
+
             ParentType?.OnObjectDeleted(dreamObject);
         }
 

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -23,11 +23,6 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         }
 
         public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
-            // Turfs can be new()ed multiple times, so let DreamMapManager handle it.
-            if (!dreamObject.IsSubtypeOf(_objectTree.Turf)) {
-                _mapManager.AllAtoms.Add(dreamObject);
-            }
-
             VerbLists[dreamObject] = new VerbsList(_objectTree, dreamObject);
             _filterLists[dreamObject] = new DreamFilterList(_objectTree.List.ObjectDefinition, dreamObject);
 
@@ -45,12 +40,6 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             _filterLists.Remove(dreamObject);
 
             _atomManager.DeleteMovableEntity(dreamObject);
-
-            // Replace our world.contents spot with the last so this doesn't mess with enumerators
-            // Results in a different order than BYOND, but nothing about our order resembles BYOND at all right now
-            // TODO: Handle this placing atoms earlier than an enumerator's index
-            int worldContentsIndex = _mapManager.AllAtoms.IndexOf(dreamObject);
-            _mapManager.AllAtoms.RemoveSwap(worldContentsIndex);
 
             _atomManager.OverlaysListToAtom.Remove(dreamObject.GetVariable("overlays").GetValueAsDreamList());
             _atomManager.UnderlaysListToAtom.Remove(dreamObject.GetVariable("underlays").GetValueAsDreamList());

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMob.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMob.cs
@@ -1,7 +1,7 @@
 ﻿using OpenDreamRuntime.Procs;
-using OpenDreamShared.Dream;
 using Robust.Server.Player;
 using OpenDreamShared.Rendering;
+using Robust.Shared.Utility;
 
 namespace OpenDreamRuntime.Objects.MetaObjects {
     sealed class DreamMetaObjectMob : IDreamMetaObject {
@@ -13,13 +13,16 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly IEntityManager _entityManager = default!;
         [Dependency] private readonly IAtomManager _atomManager = default!;
+
         public DreamMetaObjectMob() {
             IoCManager.InjectDependencies(this);
         }
 
         public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
+            _atomManager.Mobs.Add(dreamObject);
+
             ParentType?.OnObjectCreated(dreamObject, creationArguments);
-            _dreamManager.Mobs.Add(dreamObject);
+
             EntityUid entity = _atomManager.GetMovableEntity(dreamObject);
             DreamMobSightComponent mobSightComponent = _entityManager.AddComponent<DreamMobSightComponent>(entity);
             dreamObject.TryGetVariable("see_invisible", out DreamValue seeVis);
@@ -27,8 +30,9 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         }
 
         public void OnObjectDeleted(DreamObject dreamObject) {
+            _atomManager.Mobs.RemoveSwap(_atomManager.Mobs.IndexOf(dreamObject));
+
             ParentType?.OnObjectDeleted(dreamObject);
-            _dreamManager.Mobs.Remove(dreamObject);
         }
 
         public void OnVariableSet(DreamObject dreamObject, string varName, DreamValue value, DreamValue oldValue) {

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMovable.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMovable.cs
@@ -3,6 +3,7 @@ using OpenDreamRuntime.Rendering;
 using OpenDreamShared.Dream;
 using Robust.Server.GameObjects;
 using Robust.Shared.Map;
+using Robust.Shared.Utility;
 
 namespace OpenDreamRuntime.Objects.MetaObjects {
     [Virtual]
@@ -26,6 +27,9 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         }
 
         public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
+            if (dreamObject.ObjectDefinition == _objectTree.Movable.ObjectDefinition)
+                _atomManager.Movables.Add(dreamObject);
+
             _atomManager.CreateMovableEntity(dreamObject); // TODO: Should probably be moved to earlier in init; before even <init> is called.
 
             ParentType?.OnObjectCreated(dreamObject, creationArguments);
@@ -37,6 +41,13 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
             DreamValue screenLocationValue = dreamObject.GetVariable("screen_loc");
             if (screenLocationValue != DreamValue.Null) UpdateScreenLocation(dreamObject, screenLocationValue);
+        }
+
+        public void OnObjectDeleted(DreamObject dreamObject) {
+            if (dreamObject.ObjectDefinition == _objectTree.Movable.ObjectDefinition)
+                _atomManager.Movables.RemoveSwap(_atomManager.Movables.IndexOf(dreamObject));
+
+            ParentType?.OnObjectDeleted(dreamObject);
         }
 
         public void OnVariableSet(DreamObject dreamObject, string varName, DreamValue value, DreamValue oldValue) {

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectObj.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectObj.cs
@@ -1,0 +1,27 @@
+﻿using OpenDreamRuntime.Procs;
+using Robust.Shared.Utility;
+
+namespace OpenDreamRuntime.Objects.MetaObjects {
+    sealed class DreamMetaObjectObj : IDreamMetaObject {
+        public bool ShouldCallNew => true;
+        public IDreamMetaObject? ParentType { get; set; }
+
+        [Dependency] private readonly IAtomManager _atomManager = default!;
+
+        public DreamMetaObjectObj() {
+            IoCManager.InjectDependencies(this);
+        }
+
+        public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
+            _atomManager.Objects.Add(dreamObject);
+
+            ParentType?.OnObjectCreated(dreamObject, creationArguments);
+        }
+
+        public void OnObjectDeleted(DreamObject dreamObject) {
+            _atomManager.Objects.RemoveSwap(_atomManager.Objects.IndexOf(dreamObject));
+
+            ParentType?.OnObjectDeleted(dreamObject);
+        }
+    }
+}

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectWorld.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectWorld.cs
@@ -13,6 +13,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public bool ShouldCallNew => false; // Gets called manually later
         public IDreamMetaObject? ParentType { get; set; }
 
+        [Dependency] private readonly IAtomManager _atomManager = default!;
         [Dependency] private readonly IDreamManager _dreamManager = default!;
         [Dependency] private readonly IDreamObjectTree _objectTree = default!;
         [Dependency] private readonly IServerNetManager _netManager = default!;
@@ -114,7 +115,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public DreamValue OnVariableGet(DreamObject dreamObject, string varName, DreamValue value) {
             switch (varName) {
                 case "contents":
-                    return new DreamValue(new WorldContentsList(_objectTree.List.ObjectDefinition, _dreamMapManager));
+                    return new DreamValue(new WorldContentsList(_objectTree.List.ObjectDefinition, _atomManager));
                 case "process":
                     return new DreamValue(Environment.ProcessId);
                 case "tick_lag":

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -17,6 +17,7 @@ namespace OpenDreamRuntime.Procs {
         public int Line { get; }
         public IReadOnlyList<LocalVariableJson> LocalNames { get; }
 
+        public readonly IAtomManager AtomManager;
         public readonly IDreamManager DreamManager;
         public readonly IDreamMapManager DreamMapManager;
         public readonly IDreamDebugManager DreamDebugManager;
@@ -25,7 +26,7 @@ namespace OpenDreamRuntime.Procs {
 
         private readonly int _maxStackSize;
 
-        public DMProc(DreamPath owningType, ProcDefinitionJson json, string? name, IDreamManager dreamManager, IDreamMapManager dreamMapManager, IDreamDebugManager dreamDebugManager, DreamResourceManager dreamResourceManager, IDreamObjectTree objectTree)
+        public DMProc(DreamPath owningType, ProcDefinitionJson json, string? name, IDreamManager dreamManager, IAtomManager atomManager, IDreamMapManager dreamMapManager, IDreamDebugManager dreamDebugManager, DreamResourceManager dreamResourceManager, IDreamObjectTree objectTree)
             : base(owningType, name ?? json.Name, null, json.Attributes, GetArgumentNames(json), GetArgumentTypes(json), json.VerbName, json.VerbCategory, json.VerbDesc, json.Invisibility) {
             Bytecode = json.Bytecode ?? Array.Empty<byte>();
             LocalNames = json.Locals;
@@ -33,6 +34,7 @@ namespace OpenDreamRuntime.Procs {
             Line = json.Line;
             _maxStackSize = json.MaxStackSize;
 
+            AtomManager = atomManager;
             DreamManager = dreamManager;
             DreamMapManager = dreamMapManager;
             DreamDebugManager = dreamDebugManager;

--- a/OpenDreamRuntime/Procs/DreamEnumerators.cs
+++ b/OpenDreamRuntime/Procs/DreamEnumerators.cs
@@ -115,24 +115,24 @@ namespace OpenDreamRuntime.Procs {
     /// <code>for (var/obj/item/I in world)</code>
     /// </summary>
     sealed class WorldContentsEnumerator : IDreamValueEnumerator {
-        private readonly IDreamMapManager _mapManager;
+        private readonly IAtomManager _atomManager;
         private readonly IDreamObjectTree.TreeEntry? _filterType;
         private int _current = -1;
 
-        public WorldContentsEnumerator(IDreamMapManager mapManager, IDreamObjectTree.TreeEntry? filterType) {
-            _mapManager = mapManager;
+        public WorldContentsEnumerator(IAtomManager atomManager, IDreamObjectTree.TreeEntry? filterType) {
+            _atomManager = atomManager;
             _filterType = filterType;
         }
 
         public bool Enumerate(DMProcState state, DMReference reference) {
             do {
                 _current++;
-                if (_current >= _mapManager.AllAtoms.Count) {
+                if (_current >= _atomManager.AtomCount) {
                     state.AssignReference(reference, DreamValue.Null);
                     return false;
                 }
 
-                DreamObject atom = _mapManager.AllAtoms[_current];
+                DreamObject atom = _atomManager.GetAtom(_current);
                 if (_filterType == null || atom.IsSubtypeOf(_filterType)) {
                     state.AssignReference(reference, new DreamValue(atom));
                     return true;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -4,6 +4,7 @@ using OpenDreamRuntime.Resources;
 namespace OpenDreamRuntime.Procs.Native {
     static class DreamProcNative {
         public static void SetupNativeProcs(IDreamObjectTree objectTree) {
+            DreamProcNativeRoot.AtomManager = IoCManager.Resolve<IAtomManager>();
             DreamProcNativeRoot.DreamManager = IoCManager.Resolve<IDreamManager>();
             DreamProcNativeRoot.ResourceManager = IoCManager.Resolve<DreamResourceManager>();
             DreamProcNativeRoot.MapManager = IoCManager.Resolve<IDreamMapManager>();

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -28,6 +28,7 @@ namespace OpenDreamRuntime.Procs.Native {
     static class DreamProcNativeRoot {
         // I don't want to edit 100 procs to have the DreamManager passed to them
         // TODO: Pass NativeProc.State to every native proc
+        public static IAtomManager AtomManager;
         public static IDreamManager DreamManager;
         public static DreamResourceManager ResourceManager;
         public static IDreamMapManager MapManager;
@@ -1816,7 +1817,7 @@ namespace OpenDreamRuntime.Procs.Native {
             int centerX = center.GetVariable("x").GetValueAsInteger();
             int centerY = center.GetVariable("y").GetValueAsInteger();
 
-            foreach (DreamObject mob in DreamManager.Mobs) {
+            foreach (DreamObject mob in AtomManager.Mobs) {
                 int mobX = mob.GetVariable("x").GetValueAsInteger();
                 int mobY = mob.GetVariable("y").GetValueAsInteger();
 
@@ -2906,7 +2907,7 @@ namespace OpenDreamRuntime.Procs.Native {
             int centerX = center.GetVariable("x").MustGetValueAsInteger();
             int centerY = center.GetVariable("y").MustGetValueAsInteger();
 
-            foreach (DreamObject mob in DreamManager.Mobs) {
+            foreach (DreamObject mob in AtomManager.Mobs) {
                 int mobX = mob.GetVariable("x").MustGetValueAsInteger();
                 int mobY = mob.GetVariable("y").MustGetValueAsInteger();
 


### PR DESCRIPTION
I split up the `AllAtoms` list into a different list for each type of atom (`/area`, `/turf`, `/atom/movable`, `/obj`, and `/mob`). This speeds up the `IndexOf()` that happens every time an atom is deleted.

I also turned the `Datums` list into a hash set to speed up the removal when a datum is deleted.

Resolves #387 by implementing the idea.

This intends to fix the runaway garbage subsystem queue problem that happens after running a server for multiple hours.
![image](https://user-images.githubusercontent.com/30789242/232663046-e654ed57-b501-4701-8ba4-3bd7936db841.png)