### PR TITLE
Fix `turn()` with an invalid first arg

### DIFF
--- a/Content.Tests/DMProject/Tests/Builtins/turn.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/turn.dm
@@ -51,3 +51,10 @@
 	ASSERT(turn(WEST, -22) == WEST)
 	ASSERT(turn(WEST, -44) == WEST)
 	ASSERT(turn(WEST, -75) == NORTHWEST)
+
+	// An invalid first arg but valid second arg should give a random direction
+	// It's a little hard to test for randomness here, so just verify it's within the range of valid directions
+	var/shouldBeRandomDir = turn(0, 90)
+	ASSERT(shouldBeRandomDir >= 1 && shouldBeRandomDir <= 10)
+	shouldBeRandomDir = turn("NORTH", 90)
+	ASSERT(shouldBeRandomDir >= 1 && shouldBeRandomDir <= 10)


### PR DESCRIPTION
It was attempting to cast an int to a DreamValue directly. I also fixed a bug where it could return 0.

This was triggered by this code in Paradise, which is probably another bug in itself that needs looked into (`dir` was 0):
```
/obj/structure/disposalpipe/segment/Initialize(mapload)
	. = ..()
	if(icon_state == "pipe-s")
		dpdir = dir | turn(dir, 180)
	else
		dpdir = dir | turn(dir, -90)
	update()
```