### PR TITLE
Use IDs when creating DreamResource refs

### DIFF
--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -213,7 +213,7 @@ namespace OpenDreamRuntime {
                 case "icon":
                     if (appearance.Icon == null)
                         return DreamValue.Null;
-                    if (!_resourceManager.TryGetResource(appearance.Icon.Value, out var iconResource))
+                    if (!_resourceManager.TryLoadResource(appearance.Icon.Value, out var iconResource))
                         return DreamValue.Null;
 
                     return new(iconResource);

--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -213,8 +213,9 @@ namespace OpenDreamRuntime {
                 case "icon":
                     if (appearance.Icon == null)
                         return DreamValue.Null;
+                    if (!_resourceManager.TryGetResource(appearance.Icon.Value, out var iconResource))
+                        return DreamValue.Null;
 
-                    var iconResource = _resourceManager.GetResource(appearance.Icon.Value);
                     return new(iconResource);
                 case "icon_state":
                     if (appearance.IconState == null)

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -260,7 +260,7 @@ namespace OpenDreamRuntime {
                         ? new DreamValue(_objectTree.Types[refId])
                         : DreamValue.Null;
                 case RefType.DreamResource:
-                    if (!_dreamResourceManager.TryGetResource(refId, out var resource))
+                    if (!_dreamResourceManager.TryLoadResource(refId, out var resource))
                         return DreamValue.Null;
 
                     return new DreamValue(resource);

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -216,8 +216,8 @@ namespace OpenDreamRuntime {
                 _appearanceSystem ??= _entitySystemManager.GetEntitySystem<ServerAppearanceSystem>();
                 idx = (int)_appearanceSystem.AddAppearance(appearance);
             } else if (value.TryGetValueAsDreamResource(out var refRsc)) {
-                // Bit of a hack. This should use a resource's ID once they are refactored to have them.
-                return $"{(int) RefType.DreamResource}{refRsc.ResourcePath}";
+                refType = RefType.DreamResource;
+                idx = refRsc.Id;
             } else {
                 throw new NotImplementedException($"Ref for {value} is unimplemented");
             }
@@ -240,37 +240,37 @@ namespace OpenDreamRuntime {
             var typeId = (RefType) int.Parse(refString.Substring(0, 1));
             var untypedRefString = refString.Substring(1); // The ref minus its ref type prefix
 
-            if (typeId == RefType.DreamResource) {
-                // DreamResource refs are a little special and use their path instead of an id
-                return new DreamValue(_dreamResourceManager.LoadResource(untypedRefString));
-            } else {
-                refId = int.Parse(untypedRefString);
+            refId = int.Parse(untypedRefString);
 
-                switch (typeId) {
-                    case RefType.Null:
-                        return DreamValue.Null;
-                    case RefType.DreamObject:
-                        foreach (KeyValuePair<DreamObject, int> referenceIdPair in ReferenceIDs) {
-                            if (referenceIdPair.Value == refId) return new DreamValue(referenceIdPair.Key);
-                        }
+            switch (typeId) {
+                case RefType.Null:
+                    return DreamValue.Null;
+                case RefType.DreamObject:
+                    foreach (KeyValuePair<DreamObject, int> referenceIdPair in ReferenceIDs) {
+                        if (referenceIdPair.Value == refId) return new DreamValue(referenceIdPair.Key);
+                    }
 
+                    return DreamValue.Null;
+                case RefType.String:
+                    return _objectTree.Strings.Count > refId
+                        ? new DreamValue(_objectTree.Strings[refId])
+                        : DreamValue.Null;
+                case RefType.DreamType:
+                    return _objectTree.Types.Length > refId
+                        ? new DreamValue(_objectTree.Types[refId])
+                        : DreamValue.Null;
+                case RefType.DreamResource:
+                    if (!_dreamResourceManager.TryGetResource(refId, out var resource))
                         return DreamValue.Null;
-                    case RefType.String:
-                        return _objectTree.Strings.Count > refId
-                            ? new DreamValue(_objectTree.Strings[refId])
-                            : DreamValue.Null;
-                    case RefType.DreamType:
-                        return _objectTree.Types.Length > refId
-                            ? new DreamValue(_objectTree.Types[refId])
-                            : DreamValue.Null;
-                    case RefType.DreamAppearance:
-                        _appearanceSystem ??= _entitySystemManager.GetEntitySystem<ServerAppearanceSystem>();
-                        return _appearanceSystem.TryGetAppearance((uint)refId, out IconAppearance? appearance)
-                            ? new DreamValue(appearance)
-                            : DreamValue.Null;
-                    default:
-                        throw new Exception($"Invalid reference type for ref {refString}");
-                }
+
+                    return new DreamValue(resource);
+                case RefType.DreamAppearance:
+                    _appearanceSystem ??= _entitySystemManager.GetEntitySystem<ServerAppearanceSystem>();
+                    return _appearanceSystem.TryGetAppearance((uint)refId, out IconAppearance? appearance)
+                        ? new DreamValue(appearance)
+                        : DreamValue.Null;
+                default:
+                    throw new Exception($"Invalid reference type for ref {refString}");
             }
         }
 

--- a/OpenDreamRuntime/Resources/DreamResourceManager.cs
+++ b/OpenDreamRuntime/Resources/DreamResourceManager.cs
@@ -80,10 +80,6 @@ namespace OpenDreamRuntime.Resources {
             return resource;
         }
 
-        public bool TryGetResource(int resourceId, [NotNullWhen(true)] out DreamResource? resource) {
-            return _resourceCache.TryGetValue(resourceId, out resource);
-        }
-
         public bool TryLoadResource(int resourceId, [NotNullWhen(true)] out DreamResource? resource) {
             if (resourceId >= 0 && resourceId < _resourceCache.Count) {
                 resource = _resourceCache[resourceId];

--- a/OpenDreamRuntime/Resources/DreamResourceManager.cs
+++ b/OpenDreamRuntime/Resources/DreamResourceManager.cs
@@ -5,6 +5,7 @@ using OpenDreamRuntime.Objects.MetaObjects;
 using OpenDreamShared.Network.Messages;
 using OpenDreamShared.Resources;
 using Robust.Shared.Network;
+using Robust.Shared.Utility;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -79,8 +80,8 @@ namespace OpenDreamRuntime.Resources {
             return resource;
         }
 
-        public DreamResource GetResource(int resourceId) {
-            return _resourceCache[resourceId];
+        public bool TryGetResource(int resourceId, [NotNullWhen(true)] out DreamResource? resource) {
+            return _resourceCache.TryGetValue(resourceId, out resource);
         }
 
         public bool TryLoadResource(int resourceId, [NotNullWhen(true)] out DreamResource? resource) {


### PR DESCRIPTION
Resources have IDs now so we can remove this hack.