### PR TITLE
One missed undocumented matrix() constructor

### DIFF
--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixUndocumented.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixUndocumented.dm
@@ -37,6 +37,18 @@
 	if(rotated ~! matrix(0,1,0,-1,0,0))
 		CRASH("MATRIX_ROTATE failure, expected \[0,1,0,-1,0,0\], got [json_encode(matrix(90, MATRIX_ROTATE))]")
 	
+	//MATRIX_ROTATE with matrix argument
+	var/matrix/before_rotate = matrix(1,2,3,4,5,6)
+	var/matrix/rotated2 = matrix(before_rotate, 90, MATRIX_ROTATE)
+	rotated2 = round_but_todo_please_fix_this_inaccuracy(rotated2)
+	if(rotated2 ~! matrix(4,5,6,-1,-2,-3))
+		CRASH("MATRIX_ROTATE failure, expected \[4,5,6,-1,-2,-3\], got [json_encode(matrix(matrix(1,2,3,4,5,6), 90, MATRIX_ROTATE))]")
+	if(before_rotate ~! matrix(1,2,3,4,5,6))
+		CRASH("MATRIX_ROTATE modified the matrix it was given, without being given a MATRIX_MODIFY flag.")
+	matrix(before_rotate, 90, MATRIX_ROTATE | MATRIX_MODIFY)
+	if(before_rotate ~! matrix(4,5,6,-1,-2,-3))
+		CRASH("MATRIX_ROTATE | MATRIX_MODIFY failed to leave a modified, rotated matrix. Matrix is instead [json_encode(before_rotate)].")
+
 	//MATRIX_INVERT
 	var/matrix/inv = matrix(doReMe,MATRIX_INVERT)
 	if(inv ~! matrix(-5/3,2/3,1,4/3,-1/3,-2))

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixUndocumented.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixUndocumented.dm
@@ -42,7 +42,7 @@
 	var/matrix/rotated2 = matrix(before_rotate, 90, MATRIX_ROTATE)
 	rotated2 = round_but_todo_please_fix_this_inaccuracy(rotated2)
 	if(rotated2 ~! matrix(4,5,6,-1,-2,-3))
-		CRASH("MATRIX_ROTATE failure, expected \[4,5,6,-1,-2,-3\], got [json_encode(matrix(matrix(1,2,3,4,5,6), 90, MATRIX_ROTATE))]")
+		CRASH("MATRIX_ROTATE failure, expected \[4,5,6,-1,-2,-3\], got [json_encode(rotated2)]")
 	if(before_rotate ~! matrix(1,2,3,4,5,6))
 		CRASH("MATRIX_ROTATE modified the matrix it was given, without being given a MATRIX_MODIFY flag.")
 	matrix(before_rotate, 90, MATRIX_ROTATE | MATRIX_MODIFY)

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1499,7 +1499,7 @@ namespace OpenDreamRuntime.Procs.Native {
                     return new DreamValue(invertableMatrix);
                 case MatrixOpcode.Rotate:
                     if (!firstArgument.TryGetValueAsFloat(out float rotationAngle))
-                        throw new ArgumentException($"/matrix() called with invalid rotation angle '{rotationAngle}'");
+                        throw new ArgumentException($"/matrix() called with invalid rotation angle '{firstArgument}'");
                     var (angleSin, angleCos) = ((float, float))Math.SinCos(Math.PI / 180.0 * rotationAngle); // NOTE: Not sure if BYOND uses double or float precision in this specific case.
                     if (float.IsSubnormal(angleSin)) // FIXME: Think of a better solution to bad results for some angles.
                         angleSin = 0;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1498,7 +1498,12 @@ namespace OpenDreamRuntime.Procs.Native {
                     }
                     return new DreamValue(invertableMatrix);
                 case MatrixOpcode.Rotate:
-                    if (!firstArgument.TryGetValueAsFloat(out float rotationAngle))
+                    var angleArgument = firstArgument;
+                    if (firstArgument.TryGetValueAsDreamObjectOfType(ObjectTree.Matrix, out DreamObject? matrixToRotate)) {
+                        //We have a matrix to rotate, and an angle to rotate it by.
+                        angleArgument = secondArgument;
+                    }
+                    if (!angleArgument.TryGetValueAsFloat(out float rotationAngle))
                         throw new ArgumentException($"/matrix() called with invalid rotation angle '{firstArgument}'");
                     var (angleSin, angleCos) = ((float, float))Math.SinCos(Math.PI / 180.0 * rotationAngle); // NOTE: Not sure if BYOND uses double or float precision in this specific case.
                     if (float.IsSubnormal(angleSin)) // FIXME: Think of a better solution to bad results for some angles.
@@ -1506,7 +1511,11 @@ namespace OpenDreamRuntime.Procs.Native {
                     if (float.IsSubnormal(angleCos))
                         angleCos = 0;
                     var rotationMatrix = DreamMetaObjectMatrix.MakeMatrix(ObjectTree, angleCos, angleSin, 0, -angleSin, angleCos, 0);
-                    return new DreamValue(rotationMatrix);
+                    if (matrixToRotate == null) return new DreamValue(rotationMatrix);
+                    if (!doModify)
+                        matrixToRotate = DreamMetaObjectMatrix.MatrixClone(ObjectTree, matrixToRotate);
+                    DreamMetaObjectMatrix.MultiplyMatrix(matrixToRotate, rotationMatrix);
+                    return new DreamValue(matrixToRotate);
                 case MatrixOpcode.Scale:
                     //Four possible signatures: two to create a scale-matrix, and one to scale an existing matrix
                     //matrix(scale, MATRIX_SCALE)

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1482,7 +1482,7 @@ namespace OpenDreamRuntime.Procs.Native {
                     return new DreamValue(invertableMatrix);
                 case MatrixOpcode.Rotate:
                     var angleArgument = firstArgument;
-                    if (firstArgument.TryGetValueAsDreamObjectOfType(ObjectTree.Matrix, out DreamObject? matrixToRotate)) {
+                    if (firstArgument.TryGetValueAsDreamObjectOfType(state.ObjectTree.Matrix, out DreamObject? matrixToRotate)) {
                         //We have a matrix to rotate, and an angle to rotate it by.
                         angleArgument = secondArgument;
                     }
@@ -1496,7 +1496,7 @@ namespace OpenDreamRuntime.Procs.Native {
                     var rotationMatrix = DreamMetaObjectMatrix.MakeMatrix(state.ObjectTree, angleCos, angleSin, 0, -angleSin, angleCos, 0);
                     if (matrixToRotate == null) return new DreamValue(rotationMatrix);
                     if (!doModify)
-                        matrixToRotate = DreamMetaObjectMatrix.MatrixClone(ObjectTree, matrixToRotate);
+                        matrixToRotate = DreamMetaObjectMatrix.MatrixClone(state.ObjectTree, matrixToRotate);
                     DreamMetaObjectMatrix.MultiplyMatrix(matrixToRotate, rotationMatrix);
                     return new DreamValue(matrixToRotate);
                 case MatrixOpcode.Scale:


### PR DESCRIPTION
`matrix(mat, angle, MATIRX_ROTATE)` specifically. With an unit test to make sure it works.

Also fixed an error message in the MATRIX_ROTATE part of the constructor code. Previously it always printed the uninitialized angle 0 instead of the actual argument it got.