### PR TITLE
Add drop_shadow filter

### DIFF
--- a/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
+++ b/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
@@ -138,6 +138,11 @@ namespace OpenDreamClient.Rendering {
                     case DreamFilterDisplace displace:
                         break;
                     case DreamFilterDropShadow dropShadow:
+                        instance.SetParameter("size", dropShadow.Size);
+                        instance.SetParameter("x", dropShadow.X);
+                        instance.SetParameter("y", dropShadow.Y);
+                        instance.SetParameter("shadow_color", dropShadow.Color);
+                        // TODO: offset
                         break;
                     case DreamFilterLayer layer:
                         break;

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -614,10 +614,10 @@ sealed class DreamViewOverlay : Overlay {
 
         } else { //Slower path for filtered icons
             //first we do ping pong rendering for the multiple filters
+            // TODO: This should determine the size from the filters and their settings, not just double the original
             IRenderTexture ping = RentRenderTarget(frame.Size * 2);
             IRenderTexture pong = RentRenderTarget(frame.Size * 2);
             IRenderTexture tmpHolder;
-
 
             handle.RenderInRenderTarget(pong,
                 () => {

--- a/Resources/Prototypes/Shaders/dreamshaders.yml
+++ b/Resources/Prototypes/Shaders/dreamshaders.yml
@@ -111,13 +111,13 @@
 - type: shader
   id: drop_shadow
   kind: source
-  path: "/Shaders/empty.swsl"
+  path: "/Shaders/drop_shadow.swsl"
   params:
-    x: 0
-    y: 0
-    size: 0 
+    x: 1
+    y: -1
+    size: 1
     offset: 0
-    color: 0
+    shadow_color: "#00000080"
 
 - type: shader
   id: layer

--- a/Resources/Shaders/drop_shadow.swsl
+++ b/Resources/Shaders/drop_shadow.swsl
@@ -1,7 +1,7 @@
 blend_mode none;
 light_mode unshaded;
 
-uniform highp float size;
+uniform highp float size; // TODO: Negative size creates an inset shadow
 uniform highp float offset;
 uniform highp float x;
 uniform highp float y;

--- a/Resources/Shaders/drop_shadow.swsl
+++ b/Resources/Shaders/drop_shadow.swsl
@@ -11,7 +11,7 @@ void fragment() {
     highp float shadow_blur_samples = pow(size * 2 + 1, 2);
     highp vec4 texture_color = zTexture(UV);
     highp vec2 ps = TEXTURE_PIXEL_SIZE;
-    highp vec2 shadow_uv = UV - (ps * vec2(x, y));
+    highp vec2 shadow_uv = UV - (ps * vec2(x, -y)); // Y is up
     
     highp float sampled_shadow_alpha = 0;
     for (highp float blur_x = -size; blur_x <= size; blur_x++) {

--- a/Resources/Shaders/drop_shadow.swsl
+++ b/Resources/Shaders/drop_shadow.swsl
@@ -1,0 +1,29 @@
+blend_mode none;
+light_mode unshaded;
+
+uniform highp float size;
+uniform highp float offset;
+uniform highp float x;
+uniform highp float y;
+uniform highp vec4 shadow_color;
+
+void fragment() {
+    highp float shadow_blur_samples = pow(size * 2 + 1, 2);
+    highp vec4 texture_color = zTexture(UV);
+    highp vec2 ps = TEXTURE_PIXEL_SIZE;
+    highp vec2 shadow_uv = UV - (ps * vec2(x, y));
+    
+    highp float sampled_shadow_alpha = 0;
+    for (highp float blur_x = -size; blur_x <= size; blur_x++) {
+        for (highp float blur_y = -size; blur_y <= size; blur_y++) {
+            vec2 blur_uv = shadow_uv + ps * vec2(blur_x, blur_y);
+            
+            sampled_shadow_alpha += zTexture(blur_uv).a / shadow_blur_samples;
+        }
+    }
+    
+    vec4 final_shadow_color = vec4(shadow_color.rgb, shadow_color.a * sampled_shadow_alpha);
+    
+    // Mix the shadow with the initial image based on the image's alpha
+    COLOR = final_shadow_color * (1 - texture_color.a) + texture_color * texture_color.a;
+}

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -113,7 +113,7 @@
 			src.filters = null
 			usr << "Filters cleared"
 		else
-			var/selected = input("Pick a filter", "Choose a filter to apply (with demo settings)", null) as null|anything in list("alpha", "alpha-swap", "alpha-inverse", "alpha-both", "color", "outline", "greyscale", "blur", "outline/grey", "grey/outline", "all")
+			var/selected = input("Pick a filter", "Choose a filter to apply (with demo settings)", null) as null|anything in list("alpha", "alpha-swap", "alpha-inverse", "alpha-both", "color", "outline", "greyscale", "blur", "outline/grey", "grey/outline", "drop_shadow")
 			if(isnull(selected))
 				src.filters = null
 				usr << "No filter selected, filters cleared"
@@ -121,11 +121,11 @@
 				if("alpha")
 					src.filters = filter(type="alpha", icon=icon('icons/objects.dmi',"checker"))
 				if("alpha-swap")
-					src.filters = filter(type="alpha", icon=icon('icons/objects.dmi',"checker"), flags=MASK_SWAP)					
+					src.filters = filter(type="alpha", icon=icon('icons/objects.dmi',"checker"), flags=MASK_SWAP)
 				if("alpha-inverse")
 					src.filters = filter(type="alpha", icon=icon('icons/objects.dmi',"checker"), flags=MASK_INVERSE)
 				if("alpha-both")
-					src.filters = filter(type="alpha", icon=icon('icons/objects.dmi',"checker"), flags=MASK_INVERSE|MASK_SWAP)					
+					src.filters = filter(type="alpha", icon=icon('icons/objects.dmi',"checker"), flags=MASK_INVERSE|MASK_SWAP)
 				if("outline")
 					src.filters = filter(type="outline", size=1, color=rgb(255,0,0))
 				if("greyscale")
@@ -138,12 +138,12 @@
 					src.filters = list(filter(type="greyscale"), filter(type="outline", size=1, color=rgb(255,0,0)))
 				if("color")
 					src.filters = filter(type="color", color=list("#de0000","#000000","#00ad00"))
-				if("all")
-					src.filters = list(filter(type="greyscale"), filter(type="outline", size=1, color=rgb(255,0,0)), filter(type="blur", size=2), filter(type="alpha", icon=icon('icons/objects.dmi',"checker")))
-			usr << "Applied [selected] filter"	
+				if("drop_shadow")
+                	src.filters = filter(type="drop_shadow", size=2)
+			usr << "Applied [selected] filter"
 
 	verb/toggle_see_invisibility()
-		if(src.see_invisible == 0)	
+		if(src.see_invisible == 0)
 			src.see_invisible = 101
 			usr << "now seeing invisible things"
 		else

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -139,7 +139,7 @@
 				if("color")
 					src.filters = filter(type="color", color=list("#de0000","#000000","#00ad00"))
 				if("drop_shadow")
-                	src.filters = filter(type="drop_shadow", size=2)
+					src.filters = filter(type="drop_shadow", size=2)
 			usr << "Applied [selected] filter"
 
 	verb/toggle_see_invisibility()


### PR DESCRIPTION
Implements the `drop_shadow` filter, necessary for the ambient occlusion effect used in SS13.

![screenshot](https://user-images.githubusercontent.com/30789242/233543401-df38c18e-f5d2-4a5b-b922-f6e865462f60.png)

Still want to finish the offset var and inset shadows.

Checks an item in #830