### PR TITLE
Fix `/client` stringification

### DIFF
--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -435,11 +435,9 @@ namespace OpenDreamRuntime {
 
                     return $"{owner.Path}{lastElement}";
                 case DreamValueType.DreamObject: {
-                    if (TryGetValueAsDreamObject(out var dreamObject) && dreamObject != null) {
-                        return dreamObject.GetDisplayName();
-                    }
+                    TryGetValueAsDreamObject(out var dreamObject);
 
-                    return String.Empty;
+                    return dreamObject?.GetDisplayName() ?? String.Empty;
                 }
                 case DreamValueType.Appearance:
                     return String.Empty;

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -196,16 +196,21 @@ namespace OpenDreamRuntime.Objects {
         /// Get the display name of this object, WITH ALL FORMATTING EVALUATED OR REMOVED!
         /// </summary>
         public string GetDisplayName(StringFormatEncoder.FormatSuffix? suffix = null) {
+            // /client is a little special and will return its key var
+            // TODO: Maybe MetaDreamObject should be handling GetDisplayName()?
+            if (IsSubtypeOf(ObjectDefinition.ObjectTree.Client) && TryGetVariable("key", out var keyVar) && keyVar.TryGetValueAsString(out var key))
+                return key;
+
             if (!TryGetVariable("name", out DreamValue nameVar) || !nameVar.TryGetValueAsString(out string? name))
                 return ObjectDefinition?.Type.ToString() ?? String.Empty;
+
             bool isProper = StringIsProper(name);
             name = StringFormatEncoder.RemoveFormatting(name); // TODO: Care about other formatting macros for obj names beyond \proper & \improper
-            if(!isProper)
-            {
+            if(!isProper) {
                 return name;
             }
-            switch(suffix)
-            {
+
+            switch(suffix) {
                 case StringFormatEncoder.FormatSuffix.UpperDefiniteArticle:
                     return isProper ? name : $"The {name}";
                 case StringFormatEncoder.FormatSuffix.LowerDefiniteArticle:
@@ -218,8 +223,7 @@ namespace OpenDreamRuntime.Objects {
         /// <summary>
         /// Similar to <see cref="GetDisplayName"/> except it just returns the name as plaintext, with formatting removed. No article or anything.
         /// </summary>
-        public string GetNameUnformatted()
-        {
+        public string GetNameUnformatted() {
             if (!TryGetVariable("name", out DreamValue nameVar) || !nameVar.TryGetValueAsString(out string? name))
                 return ObjectDefinition?.Type.ToString() ?? String.Empty;
             return StringFormatEncoder.RemoveFormatting(name);


### PR DESCRIPTION
Using a client in a string (such as `"[usr.client]"`) will now give you the client's key instead of its type (`"/client"`)

Fixes a bunch of places where "/client" would appear instead of player's usernames in Paradise.