### PR TITLE
Regex fixes and additions

### DIFF
--- a/Content.Tests/DMProject/Tests/Regex/regex_advance.dm
+++ b/Content.Tests/DMProject/Tests/Regex/regex_advance.dm
@@ -3,8 +3,21 @@
 	var/text = "foo foo foo foo"
 
 	ASSERT(R.Find(text) == 1)
+	ASSERT(R.next == 4)
 	ASSERT(R.Find(text) == 5)
+	ASSERT(R.next == 8)
 	ASSERT(R.Find(text) == 9)
+	ASSERT(R.next == 12)
 	ASSERT(R.Find(text) == 13)
+	ASSERT(R.next == 16)
 	ASSERT(R.Find(text) == 0)
+	ASSERT(isnull(R.next))
+	ASSERT(R.Find(text) == 1)
+	ASSERT(R.next == 4)
+
+	var/text2 = "foo foo"
+	ASSERT(R.Find(text2) == 1)
+	ASSERT(R.next == 4)
+	ASSERT(R.Find(text2) == 5)
+	ASSERT(R.next == 8)
 

--- a/Content.Tests/DMProject/Tests/Regex/regex_advance.dm
+++ b/Content.Tests/DMProject/Tests/Regex/regex_advance.dm
@@ -1,0 +1,10 @@
+/proc/RunTest()
+	var/regex/R = regex(@"foo", "g")
+	var/text = "foo foo foo foo"
+
+	ASSERT(R.Find(text) == 1)
+	ASSERT(R.Find(text) == 5)
+	ASSERT(R.Find(text) == 9)
+	ASSERT(R.Find(text) == 13)
+	ASSERT(R.Find(text) == 0)
+

--- a/Content.Tests/DMProject/Tests/Regex/regex_proc_replacement.dm
+++ b/Content.Tests/DMProject/Tests/Regex/regex_proc_replacement.dm
@@ -1,0 +1,19 @@
+var/i = 1
+
+/proc/counter(x)
+	. = "[i++]"
+
+/proc/bar()
+	. = "bar"
+
+/proc/RunTest()
+	var/regex/R = regex(@"foo", "g")
+	ASSERT(R.Replace("foo foo foo", /proc/bar) == "bar bar bar")
+	ASSERT(R.Replace("foo foo foo", /proc/counter) == "1 2 3")
+	ASSERT(R.Replace("foofoofoo", /proc/counter) == "456")
+
+	R = regex(@"ba", "g")
+	ASSERT(R.Replace("baa ba", "b") == "ba b")
+	
+	R = regex(@"foo") // not global
+	ASSERT(R.Replace("foo foo foo", /proc/bar) == "bar foo foo")

--- a/Content.Tests/DMProject/Tests/Regex/regex_start.dm
+++ b/Content.Tests/DMProject/Tests/Regex/regex_start.dm
@@ -1,0 +1,27 @@
+/proc/bar()
+	. = "bar"
+
+/proc/RunTest()
+	var/regex/R = regex(@"foo")
+	var/result = R.Replace("foo foo", "bar", start=1)
+	ASSERT(result == "bar foo")
+
+	var/result = R.Replace("foo foo", "bar", start=2)
+	ASSERT(result == "foo bar")
+
+	result = R.Replace("foo foo", /proc/bar, start=2)
+	ASSERT(result == "foo bar")
+
+	result = R.Replace("foo foo", "bar", start=5)
+	ASSERT(result == "foo bar")
+
+	result = R.Replace("foo foo", "bar", start=6)
+	ASSERT(result == "foo foo")
+
+	ASSERT(R.Find("foo foo", start=1) == 1)
+
+	ASSERT(R.Find("foo foo", start=2) == 5)
+
+	ASSERT(R.Find("foo foo", start=5) == 5)
+
+	ASSERT(R.Find("foo foo", start=6) == 0)

--- a/Content.Tests/DMProject/Tests/Regex/regex_start.dm
+++ b/Content.Tests/DMProject/Tests/Regex/regex_start.dm
@@ -9,6 +9,9 @@
 	result = R.Replace("foo foo", "bar", start=2)
 	ASSERT(result == "foo bar")
 
+	result = R.Replace("foo foo", "bar", 2)
+	ASSERT(result == "foo bar")
+
 	result = R.Replace("foo foo", /proc/bar, start=2)
 	ASSERT(result == "foo bar")
 
@@ -18,6 +21,9 @@
 	result = R.Replace("foo foo", "bar", start=6)
 	ASSERT(result == "foo foo")
 
+	result = R.Replace("foo foo", "bar", start=420)
+	ASSERT(result == "foo foo")
+
 	ASSERT(R.Find("foo foo", start=1) == 1)
 
 	ASSERT(R.Find("foo foo", start=2) == 5)
@@ -25,3 +31,5 @@
 	ASSERT(R.Find("foo foo", start=5) == 5)
 
 	ASSERT(R.Find("foo foo", start=6) == 0)
+
+	ASSERT(R.Find("foo foo", start=69) == 0)

--- a/Content.Tests/DMProject/Tests/Regex/regex_start.dm
+++ b/Content.Tests/DMProject/Tests/Regex/regex_start.dm
@@ -6,7 +6,7 @@
 	var/result = R.Replace("foo foo", "bar", start=1)
 	ASSERT(result == "bar foo")
 
-	var/result = R.Replace("foo foo", "bar", start=2)
+	result = R.Replace("foo foo", "bar", start=2)
 	ASSERT(result == "foo bar")
 
 	result = R.Replace("foo foo", /proc/bar, start=2)

--- a/DMCompiler/DMStandard/Types/Regex.dm
+++ b/DMCompiler/DMStandard/Types/Regex.dm
@@ -19,14 +19,14 @@
 			src.name = pattern
 			src.flags = flags
 
-	proc/Find(haystack, Start = 1, End = 0)
+	proc/Find(haystack, start = 1, end = 0)
 
-	proc/Find_char(haystack, Start = 1, End = 0)
+	proc/Find_char(haystack, start = 1, end = 0)
 		set opendream_unimplemented = TRUE
 
-	proc/Replace(haystack, replacement, Start = 1, End = 0)
+	proc/Replace(haystack, replacement, start = 1, end = 0)
 
-	proc/Replace_char(haystack, replacement, Start = 1, End = 0)
+	proc/Replace_char(haystack, replacement, start = 1, end = 0)
 		set opendream_unimplemented = TRUE
 		return haystack
 

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectRegex.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectRegex.cs
@@ -15,34 +15,13 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             IoCManager.InjectDependencies(this);
         }
 
-        private sealed class LastHaystack {
-            public string? Value;
-        }
-
         public struct DreamRegex {
             public readonly Regex Regex;
             public readonly bool IsGlobal;
             
-            private readonly LastHaystack? _lastHaystack;
-
-            /// <summary>
-            /// The last haystack this regex was used to search on. Only valid for global regexes.
-            /// </summary>
-            public string? LastHaystack {
-                get => _lastHaystack?.Value;
-                set {
-                    if (_lastHaystack == null) {
-                        throw new InvalidOperationException("Cannot set LastHaystack on non-global regex");
-                    }
-
-                    _lastHaystack.Value = value;
-                }
-            }
-            
             public DreamRegex(Regex regex, bool isGlobal) {
                 Regex = regex;
                 IsGlobal = isGlobal;
-                _lastHaystack = isGlobal ? new LastHaystack() : null;
             }
         }
 

--- a/OpenDreamRuntime/Procs/AsyncNativeProc.cs
+++ b/OpenDreamRuntime/Procs/AsyncNativeProc.cs
@@ -53,7 +53,7 @@ namespace OpenDreamRuntime.Procs {
             }
 
             public Task<DreamValue> Call(DreamProc proc, DreamObject src, DreamObject usr, DreamProcArguments arguments) {
-                _callTcs = new();
+                _callTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
                 _callProcNotify = proc.CreateState(Thread, src, usr, arguments);
 
                 // The field may be mutated by SafeResume, so cache the task
@@ -63,7 +63,7 @@ namespace OpenDreamRuntime.Procs {
             }
 
             public Task<DreamValue> CallNoWait(DreamProc proc, DreamObject src, DreamObject usr, DreamProcArguments arguments) {
-                _callTcs = new();
+                _callTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
                 _callProcNotify = proc.CreateState(Thread, src, usr, arguments);
                 _callProcNotify.WaitFor = false;
 
@@ -145,7 +145,7 @@ namespace OpenDreamRuntime.Procs {
                     var callResult = _callResult.Value;
                     _callTcs = null;
                     _callResult = null;
-
+                    
                     callTcs.SetResult(callResult);
                 }
 

--- a/OpenDreamRuntime/Procs/AsyncNativeProc.cs
+++ b/OpenDreamRuntime/Procs/AsyncNativeProc.cs
@@ -53,7 +53,7 @@ namespace OpenDreamRuntime.Procs {
             }
 
             public Task<DreamValue> Call(DreamProc proc, DreamObject src, DreamObject usr, DreamProcArguments arguments) {
-                _callTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                _callTcs = new();
                 _callProcNotify = proc.CreateState(Thread, src, usr, arguments);
 
                 // The field may be mutated by SafeResume, so cache the task

--- a/OpenDreamRuntime/Procs/AsyncNativeProc.cs
+++ b/OpenDreamRuntime/Procs/AsyncNativeProc.cs
@@ -145,7 +145,7 @@ namespace OpenDreamRuntime.Procs {
                     var callResult = _callResult.Value;
                     _callTcs = null;
                     _callResult = null;
-                    
+
                     callTcs.SetResult(callResult);
                 }
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
@@ -10,7 +10,7 @@ namespace OpenDreamRuntime.Procs.Native {
     static class DreamProcNativeRegex {
         [DreamProc("Find")]
         [DreamProcParameter("haystack", Type = DreamValue.DreamValueType.String)]
-        [DreamProcParameter("start", Type = DreamValue.DreamValueType.Float | DreamValue.DreamValueType.DreamObject)]
+        [DreamProcParameter("start", Type = DreamValue.DreamValueType.Float | DreamValue.DreamValueType.DreamObject)] // BYOND docs say these are uppercase, they're not
         [DreamProcParameter("end", DefaultValue = 0, Type = DreamValue.DreamValueType.Float)]
         public static DreamValue NativeProc_Find(NativeProc.State state) {
             DreamRegex dreamRegex = DreamMetaObjectRegex.ObjectToDreamRegex[state.Src];
@@ -130,12 +130,11 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProc("Replace")]
         [DreamProcParameter("haystack", Type = DreamValue.DreamValueType.String)]
         [DreamProcParameter("replacement", Type = DreamValue.DreamValueType.String | DreamValue.DreamValueType.DreamProc)]
-        [DreamProcParameter("start", DefaultValue = 1, Type = DreamValue.DreamValueType.Float)]
+        [DreamProcParameter("start", DefaultValue = 1, Type = DreamValue.DreamValueType.Float)] // BYOND docs say these are uppercase, they're not
         [DreamProcParameter("end", DefaultValue = 0, Type = DreamValue.DreamValueType.Float)]
         public static async Task<DreamValue> NativeProc_Replace(AsyncNativeProc.State state) {
             DreamValue haystack = state.GetArgument(0, "haystack");
             DreamValue replacement = state.GetArgument(1, "replacement");
-            // BYOND documentation mentions these two argument names as being capitalized but they actually aren't 🙃
             int start = state.GetArgument(2, "start").GetValueAsInteger();
             int end = state.GetArgument(3, "end").GetValueAsInteger();
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
@@ -83,7 +83,7 @@ namespace OpenDreamRuntime.Procs.Native {
                     throw new NotImplementedException("Proc global regex replacements are not implemented");
                 }
 
-                var match = regex.Regex.Match(haystackSubstring);
+                var match = regex.Regex.Match(haystackSubstring, Math.Clamp(start - 1, 0, haystackSubstring.Length));
                 var groups = match.Groups;
                 List<DreamValue> args = new List<DreamValue>(groups.Count);
                 foreach (Group group in groups) {
@@ -106,7 +106,7 @@ namespace OpenDreamRuntime.Procs.Native {
 
             DreamValue DoTextReplace(string replacement) {
                 string replaced = regex.Regex.Replace(haystackSubstring, replacement, regex.IsGlobal ? -1 : 1,
-                    start - 1);
+                    Math.Clamp(start - 1, 0, haystackSubstring.Length));
 
                 if (end != 0) replaced += haystackString.Substring(end - start + 1);
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
@@ -69,12 +69,7 @@ namespace OpenDreamRuntime.Procs.Native {
             DreamRegex regex = DreamMetaObjectRegex.ObjectToDreamRegex[regexInstance];
 
             if (!haystack.TryGetValueAsString(out var haystackString)) {
-                if (haystack == DreamValue.Null) {
-                    return DreamValue.Null;
-                }
-
-                //TODO Check what actually happens
-                throw new ArgumentException("Bad regex haystack");
+                return DreamValue.Null;
             }
 
             string haystackSubstring = haystackString;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
@@ -10,13 +10,13 @@ namespace OpenDreamRuntime.Procs.Native {
     static class DreamProcNativeRegex {
         [DreamProc("Find")]
         [DreamProcParameter("haystack", Type = DreamValue.DreamValueType.String)]
-        [DreamProcParameter("Start", Type = DreamValue.DreamValueType.Float | DreamValue.DreamValueType.DreamObject)]
-        [DreamProcParameter("End", DefaultValue = 0, Type = DreamValue.DreamValueType.Float)]
+        [DreamProcParameter("start", Type = DreamValue.DreamValueType.Float | DreamValue.DreamValueType.DreamObject)]
+        [DreamProcParameter("end", DefaultValue = 0, Type = DreamValue.DreamValueType.Float)]
         public static DreamValue NativeProc_Find(NativeProc.State state) {
             DreamRegex dreamRegex = DreamMetaObjectRegex.ObjectToDreamRegex[state.Src];
             DreamValue haystack = state.GetArgument(0, "haystack");
-            int next = GetNext(state.Src, state.GetArgument(1, "Start"), dreamRegex.IsGlobal);
-            int end = state.GetArgument(2, "End").GetValueAsInteger();
+            int next = GetNext(state.Src, state.GetArgument(1, "start"), dreamRegex.IsGlobal);
+            int end = state.GetArgument(2, "end").GetValueAsInteger();
 
             state.Src.SetVariable("text", haystack);
 
@@ -118,8 +118,8 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProc("Replace")]
         [DreamProcParameter("haystack", Type = DreamValue.DreamValueType.String)]
         [DreamProcParameter("replacement", Type = DreamValue.DreamValueType.String | DreamValue.DreamValueType.DreamProc)]
-        [DreamProcParameter("Start", DefaultValue = 1, Type = DreamValue.DreamValueType.Float)]
-        [DreamProcParameter("End", DefaultValue = 0, Type = DreamValue.DreamValueType.Float)]
+        [DreamProcParameter("start", DefaultValue = 1, Type = DreamValue.DreamValueType.Float)]
+        [DreamProcParameter("end", DefaultValue = 0, Type = DreamValue.DreamValueType.Float)]
         public static async Task<DreamValue> NativeProc_Replace(AsyncNativeProc.State state) {
             DreamValue haystack = state.GetArgument(0, "haystack");
             DreamValue replacement = state.GetArgument(1, "replacement");

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
@@ -28,7 +28,7 @@ namespace OpenDreamRuntime.Procs.Native {
             if (end == 0) end = haystackString.Length;
             if (haystackString.Length == next - 1) return new DreamValue(0);
 
-            Match match = dreamRegex.Regex.Match(haystackString, next - 1, end - next);
+            Match match = dreamRegex.Regex.Match(haystackString, Math.Clamp(next - 1, 0, haystackString.Length), end - next);
             if (match.Success) {
                 state.Src.SetVariable("index", new DreamValue(match.Index + 1));
                 state.Src.SetVariable("match", new DreamValue(match.Value));

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
@@ -28,7 +28,7 @@ namespace OpenDreamRuntime.Procs.Native {
             if (end == 0) end = haystackString.Length;
             if (haystackString.Length <= next - 1) return new DreamValue(0);
 
-            Match match = dreamRegex.Regex.Match(haystackString, Math.Clamp(next - 1, 0, haystackString.Length), end - next);
+            Match match = dreamRegex.Regex.Match(haystackString, Math.Clamp(next - 1, 0, haystackString.Length), end - next + 1);
             if (match.Success) {
                 state.Src.SetVariable("index", new DreamValue(match.Index + 1));
                 state.Src.SetVariable("match", new DreamValue(match.Value));

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
@@ -26,7 +26,7 @@ namespace OpenDreamRuntime.Procs.Native {
             }
 
             if (end == 0) end = haystackString.Length;
-            if (haystackString.Length == next - 1) return new DreamValue(0);
+            if (haystackString.Length <= next - 1) return new DreamValue(0);
 
             Match match = dreamRegex.Regex.Match(haystackString, Math.Clamp(next - 1, 0, haystackString.Length), end - next);
             if (match.Success) {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
@@ -123,8 +123,9 @@ namespace OpenDreamRuntime.Procs.Native {
         public static async Task<DreamValue> NativeProc_Replace(AsyncNativeProc.State state) {
             DreamValue haystack = state.GetArgument(0, "haystack");
             DreamValue replacement = state.GetArgument(1, "replacement");
-            int start = state.GetArgument(2, "Start").GetValueAsInteger();
-            int end = state.GetArgument(3, "End").GetValueAsInteger();
+            // BYOND documentation mentions these two argument names as being capitalized but they actually aren't 🙃
+            int start = state.GetArgument(2, "start").GetValueAsInteger();
+            int end = state.GetArgument(3, "end").GetValueAsInteger();
 
             return await RegexReplace(state, state.Src, haystack, replacement, start, end);
         }


### PR DESCRIPTION
- fix of keyword arguments for regex `Find` and `Replace` (docs say they are Start and End but they are actually start and end)
- fix of some cases where start greater than string length resulted in a runtime
- fix of regex.Find `next` advancement persisting between different haystack strings
- some off by one error that resulted in the last match not being found if it was at the end of the string I think?
- implemented proc replacement for global regexes
  - in order to do the previous `CallNoWait`'s task creation source now runs continuations asynchronously. Without this the continuations are run in `SetResult` which together with `_inResume` leads to the second proc invocation not running at all
 - unit tests for the above