### PR TITLE
Parsing of DMF attributes that are hidden verbs

### DIFF
--- a/OpenDreamClient/Interface/DMF/DMFParser.cs
+++ b/OpenDreamClient/Interface/DMF/DMFParser.cs
@@ -209,8 +209,7 @@ public sealed class DMFParser : Parser<char> {
                 valueText += attributeValue.Text;
                 if (!Check(TokenType.DMF_Value) && !Check(TokenType.DMF_Attribute))
                     Error($"Invalid attribute value ({valueText})");
-            }
-            else if (!Check(TokenType.DMF_Value))
+            } else if (!Check(TokenType.DMF_Value))
                 Error($"Invalid attribute value ({valueText})");
 
             Newline();

--- a/OpenDreamClient/Interface/DMF/DMFParser.cs
+++ b/OpenDreamClient/Interface/DMF/DMFParser.cs
@@ -203,12 +203,19 @@ public sealed class DMFParser : Parser<char> {
             }
 
             Token attributeValue = Current();
-            if (!Check(TokenType.DMF_Value))
-                Error($"Invalid attribute value ({attributeValue.Text})");
+            string valueText = attributeValue.Text;
+            if (Check(TokenType.DMF_Period)) { // hidden verbs start with a period
+                attributeValue = Current();
+                valueText += attributeValue.Text;
+                if (!Check(TokenType.DMF_Value) && !Check(TokenType.DMF_Attribute))
+                    Error($"Invalid attribute value ({valueText})");
+            }
+            else if (!Check(TokenType.DMF_Value))
+                Error($"Invalid attribute value ({valueText})");
 
             Newline();
             key = attributeToken.Text;
-            token = attributeValue.Text;
+            token = valueText;
             return true;
         }
 


### PR DESCRIPTION
For example `command=.observe_round` failed to parse. I'm unsure if this is the correct way to do this or if it should be more general / in other places too.