### PR TITLE
Support for subdirectory paths for browse_rsc

### DIFF
--- a/OpenDreamClient/Resources/DreamResourceManager.cs
+++ b/OpenDreamClient/Resources/DreamResourceManager.cs
@@ -56,7 +56,7 @@ namespace OpenDreamClient.Resources {
         }
 
         private void RxBrowseResource(MsgBrowseResource message) {
-            _resourceManager.UserData.WriteAllBytes(_cacheDirectory / message.Filename, message.Data);
+            CreateCacheFile(message.Filename, message.Data);
         }
 
         private void RxResource(MsgResource message) {
@@ -115,6 +115,7 @@ namespace OpenDreamClient.Resources {
         public ResourcePath CreateCacheFile(string filename, string data)
         {
             var path = _cacheDirectory / filename;
+            EnsureParentDirectoryExists(path);
             _resourceManager.UserData.WriteAllText(path, data);
             return new ResourcePath(filename);
         }
@@ -122,8 +123,18 @@ namespace OpenDreamClient.Resources {
         public ResourcePath CreateCacheFile(string filename, byte[] data)
         {
             var path = _cacheDirectory / filename;
+            EnsureParentDirectoryExists(path);
             _resourceManager.UserData.WriteAllBytes(path, data);
             return new ResourcePath(filename);
+        }
+
+        /// <summary>
+        /// Creates directory in which the file path is located if it doesn't exist.
+        /// </summary>
+        /// <param name="path"></param>
+        private void EnsureParentDirectoryExists(ResourcePath path) {
+            ResourcePath directoryPath = (path / "..").Clean();
+            _resourceManager.UserData.CreateDir(directoryPath);
         }
 
         private DreamResource GetCachedResource(int resourceId) {

--- a/OpenDreamClient/Resources/DreamResourceManager.cs
+++ b/OpenDreamClient/Resources/DreamResourceManager.cs
@@ -114,27 +114,16 @@ namespace OpenDreamClient.Resources {
 
         public ResourcePath CreateCacheFile(string filename, string data)
         {
-            var path = _cacheDirectory / filename;
-            EnsureParentDirectoryExists(path);
+            var path = _cacheDirectory / new ResourcePath(filename).Filename;
             _resourceManager.UserData.WriteAllText(path, data);
             return new ResourcePath(filename);
         }
 
         public ResourcePath CreateCacheFile(string filename, byte[] data)
         {
-            var path = _cacheDirectory / filename;
-            EnsureParentDirectoryExists(path);
+            var path = _cacheDirectory / new ResourcePath(filename).Filename;
             _resourceManager.UserData.WriteAllBytes(path, data);
             return new ResourcePath(filename);
-        }
-
-        /// <summary>
-        /// Creates directory in which the file path is located if it doesn't exist.
-        /// </summary>
-        /// <param name="path"></param>
-        private void EnsureParentDirectoryExists(ResourcePath path) {
-            ResourcePath directoryPath = (path / "..").Clean();
-            _resourceManager.UserData.CreateDir(directoryPath);
         }
 
         private DreamResource GetCachedResource(int resourceId) {

--- a/OpenDreamClient/Resources/DreamResourceManager.cs
+++ b/OpenDreamClient/Resources/DreamResourceManager.cs
@@ -114,6 +114,7 @@ namespace OpenDreamClient.Resources {
 
         public ResourcePath CreateCacheFile(string filename, string data)
         {
+            // in BYOND when filename is a path everything except the filename at the end gets ignored - meaning all resource files end up directly in the cache folder
             var path = _cacheDirectory / new ResourcePath(filename).Filename;
             _resourceManager.UserData.WriteAllText(path, data);
             return new ResourcePath(filename);
@@ -121,6 +122,7 @@ namespace OpenDreamClient.Resources {
 
         public ResourcePath CreateCacheFile(string filename, byte[] data)
         {
+            // in BYOND when filename is a path everything except the filename at the end gets ignored - meaning all resource files end up directly in the cache folder
             var path = _cacheDirectory / new ResourcePath(filename).Filename;
             _resourceManager.UserData.WriteAllBytes(path, data);
             return new ResourcePath(filename);


### PR DESCRIPTION
Trying to send a file to a path like `foo/bar/page.html` currently fails. ~~This PR makes it so the `foo` and `foo/bar` directories are created properly.~~ This PR strips `foo/bar/` from the path and creates `page.html` directly in the base cache directory, just like BYOND.