### PR TITLE
Implementation of text2path for proc paths and related fixes

### DIFF
--- a/Content.Tests/DMProject/Tests/Builtins/text2path.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/text2path.dm
@@ -1,0 +1,26 @@
+/proc/foobar()
+
+/verb/foobarverb()
+
+/datum/proc/foo()
+
+/datum/verb/fooverb()
+
+/datum/proc/bar()
+
+/datum/subtype/bar()
+
+/proc/RunTest()
+	ASSERT(text2path("/datum/proc/foo") == /datum/proc/foo)
+	ASSERT(text2path("/proc/foobar") == /proc/foobar)
+	ASSERT(text2path("/verb/foobar") == null)
+	ASSERT(text2path("/verb/foobarverb") == /verb/foobarverb)
+	ASSERT(text2path("/datum/subtype/proc/foo") == null)
+	ASSERT(text2path("/datum/subtype/bar") == null)
+	ASSERT(text2path("/datum/subtype/proc/bar") == null)
+	ASSERT(text2path("") == null)
+	ASSERT(text2path("/") == null)
+	ASSERT(text2path("/proc/invalid") == null)
+	ASSERT(text2path("/datum/proc/fooverb") == null)
+	ASSERT(text2path("/datum/verb/fooverb") == /datum/verb/fooverb)
+	ASSERT("[text2path("/datum/verb/fooverb")]" == "/datum/verb/fooverb")

--- a/Content.Tests/DMProject/Tests/Builtins/text2path.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/text2path.dm
@@ -19,6 +19,8 @@
 	ASSERT(text2path("/datum/subtype/bar") == null)
 	ASSERT(text2path("/datum/subtype/proc/bar") == null)
 	ASSERT(text2path("") == null)
+	ASSERT(text2path("    ") == null)
+	ASSERT(text2path("complete nonsense") == null)
 	ASSERT(text2path("/") == null)
 	ASSERT(text2path("/proc/invalid") == null)
 	ASSERT(text2path("/datum/proc/fooverb") == null)

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -48,6 +48,7 @@ namespace DMCompiler.DM {
         public List<DMValueType> ParameterTypes = new();
         public Location Location = Location.Unknown;
         public ProcAttributes Attributes;
+        public bool IsVerb = false;
         public string Name { get => _astDefinition?.Name ?? "<init>"; }
         public int Id;
         public Dictionary<string, int> GlobalVariables = new();
@@ -111,6 +112,7 @@ namespace DMCompiler.DM {
 
             procDefinition.OwningTypeId = _dmObject.Id;
             procDefinition.Name = Name;
+            procDefinition.IsVerb = IsVerb;
             procDefinition.Source = _astDefinition?.Location.SourceFile?.Replace("\\", "/");
             procDefinition.Line = _astDefinition?.Location.Line ?? 0;
 

--- a/DMCompiler/DM/Visitors/DMObjectBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMObjectBuilder.cs
@@ -255,6 +255,8 @@ namespace DMCompiler.DM.Visitors {
 
                 DMProc proc = DMObjectTree.CreateDMProc(dmObject, procDefinition);
 
+                proc.IsVerb = procDefinition.IsVerb;
+
                 if (procDefinition.ObjectPath == DreamPath.Root) {
                     if(procDefinition.IsOverride) {
                         DMCompiler.Emit(WarningCode.InvalidOverride, procDefinition.Location, $"Global procs cannot be overridden - '{procDefinition.Name}' override will be ignored");

--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -82,7 +82,6 @@ namespace OpenDreamRuntime {
 
         public override string ToString() {
             var procElement = (SuperProc == null) ? (IsVerb ? "verb/" : "proc/") : String.Empty; // Has "proc/" only if it's not an override
-            // TODO: "verb/" proc element
 
             return OwningType == DreamPath.Root ? $"/{procElement}{Name}" : $"{OwningType}/{procElement}{Name}";
         }

--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -18,6 +18,7 @@ namespace OpenDreamRuntime {
     public abstract class DreamProc {
         public DreamPath OwningType { get; }
         public string Name { get; }
+        public bool IsVerb { get; }
 
         // This is currently publicly settable because the loading code doesn't know what our super is until after we are instantiated
         public DreamProc? SuperProc { set; get; }
@@ -32,9 +33,10 @@ namespace OpenDreamRuntime {
         public string? VerbDesc { get; }
         public sbyte? Invisibility { get; }
 
-        protected DreamProc(DreamPath owningType, string name, DreamProc? superProc, ProcAttributes attributes, List<String>? argumentNames, List<DMValueType>? argumentTypes, string? verbName, string? verbCategory, string? verbDesc, sbyte? invisibility) {
+        protected DreamProc(DreamPath owningType, string name, DreamProc? superProc, ProcAttributes attributes, List<String>? argumentNames, List<DMValueType>? argumentTypes, string? verbName, string? verbCategory, string? verbDesc, sbyte? invisibility, bool isVerb = false) {
             OwningType = owningType;
             Name = name;
+            IsVerb = isVerb;
             SuperProc = superProc;
             Attributes = attributes;
             ArgumentNames = argumentNames;
@@ -79,7 +81,7 @@ namespace OpenDreamRuntime {
         }
 
         public override string ToString() {
-            var procElement = (SuperProc == null) ? "proc/" : String.Empty; // Has "proc/" only if it's not an override
+            var procElement = (SuperProc == null) ? (IsVerb ? "verb/" : "proc/") : String.Empty; // Has "proc/" only if it's not an override
             // TODO: "verb/" proc element
 
             return OwningType == DreamPath.Root ? $"/{procElement}{Name}" : $"{OwningType}/{procElement}{Name}";

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -473,7 +473,7 @@ namespace OpenDreamRuntime.Objects {
         public bool TryGetGlobalProc(string name, [NotNullWhen(true)] out DreamProc? globalProc);
         public TreeEntry GetTreeEntry(DreamPath path);
         public TreeEntry GetTreeEntry(int typeId);
-        public bool TryGetTreeEntry(DreamPath path, out TreeEntry? treeEntry);
+        public bool TryGetTreeEntry(DreamPath path, [NotNullWhen(true)] out TreeEntry? treeEntry);
         public DreamObjectDefinition GetObjectDefinition(int typeId);
         public IEnumerable<TreeEntry> GetAllDescendants(TreeEntry treeEntry);
         public DreamValue GetDreamValueFromJsonElement(object value);

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -27,7 +27,7 @@ namespace OpenDreamRuntime.Procs {
         private readonly int _maxStackSize;
 
         public DMProc(DreamPath owningType, ProcDefinitionJson json, string? name, IDreamManager dreamManager, IAtomManager atomManager, IDreamMapManager dreamMapManager, IDreamDebugManager dreamDebugManager, DreamResourceManager dreamResourceManager, IDreamObjectTree objectTree)
-            : base(owningType, name ?? json.Name, null, json.Attributes, GetArgumentNames(json), GetArgumentTypes(json), json.VerbName, json.VerbCategory, json.VerbDesc, json.Invisibility) {
+            : base(owningType, name ?? json.Name, null, json.Attributes, GetArgumentNames(json), GetArgumentTypes(json), json.VerbName, json.VerbCategory, json.VerbDesc, json.Invisibility, json.IsVerb) {
             Bytecode = json.Bytecode ?? Array.Empty<byte>();
             LocalNames = json.Locals;
             Source = json.Source;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2667,8 +2667,7 @@ namespace OpenDreamRuntime.Procs.Native {
 
             string? procName = null;
             if (isProcPath) {
-                // we strip the leading slash here
-                procName = path.FromElements(procElementIndex + 1).ToString()[1..];
+                procName = path.LastElement;
 
                 if (procElementIndex == 0) { // global procs
                     if (state.ObjectTree.TryGetGlobalProc(procName, out var globalProc) && globalProc.IsVerb == isVerb)

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2670,7 +2670,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 procName = path.LastElement;
 
                 if (procElementIndex == 0) { // global procs
-                    if (state.ObjectTree.TryGetGlobalProc(procName, out var globalProc) && globalProc.IsVerb == isVerb)
+                    if (procName != null && state.ObjectTree.TryGetGlobalProc(procName, out var globalProc) && globalProc.IsVerb == isVerb)
                         return new DreamValue(globalProc);
                     else
                         return DreamValue.Null;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2648,7 +2648,7 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProc("text2path")]
         [DreamProcParameter("T", Type = DreamValueType.String)]
         public static DreamValue NativeProc_text2path(NativeProc.State state) {
-            if (!state.GetArgument(0, "T").TryGetValueAsString(out var text) || text.Length == 0) {
+            if (!state.GetArgument(0, "T").TryGetValueAsString(out var text) || string.IsNullOrWhiteSpace(text)) {
                 return DreamValue.Null;
             }
 

--- a/OpenDreamShared/Json/DreamProcJson.cs
+++ b/OpenDreamShared/Json/DreamProcJson.cs
@@ -6,6 +6,7 @@ namespace OpenDreamShared.Json {
     public sealed class ProcDefinitionJson {
         public int OwningTypeId { get; set; }
         public string Name { get; set; }
+        public bool IsVerb { get; set; }
         public int MaxStackSize { get; set; }
         public List<ProcArgumentJson> Arguments { get; set; }
         public List<LocalVariableJson> Locals { get; set; }


### PR DESCRIPTION
Implements `text2path` for proc paths. In order to do this correctly we need to know whether a proc was declared as `proc/` or `verb/` so this information is now passed from the compiler and stored in proc classes. Proc path stringification now also correctly uses `"proc/"` and `"verb/"` based on this.

Also fixes incorrect values for `text2path("")` and `text2path("/")`