### PR TITLE
Support for ANY macro keybind

### DIFF
--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -30,6 +30,7 @@ namespace OpenDreamClient.Interface {
         [Dependency] private readonly ISerializationManager _serializationManager = default!;
         [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
         [Dependency] private readonly IInputManager _inputManager = default!;
+        [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
 
         public InterfaceDescriptor InterfaceDescriptor { get; private set; }
 
@@ -476,7 +477,7 @@ namespace OpenDreamClient.Interface {
         private void LoadDescriptor(ElementDescriptor descriptor) {
             switch (descriptor) {
                 case MacroSetDescriptor macroSetDescriptor:
-                    InterfaceMacroSet macroSet = new(macroSetDescriptor, _entitySystemManager, _inputManager);
+                    InterfaceMacroSet macroSet = new(macroSetDescriptor, _entitySystemManager, _inputManager, _uiManager);
 
                     MacroSets.Add(macroSet.Name, macroSet);
                     break;

--- a/OpenDreamClient/Interface/InterfaceMacro.cs
+++ b/OpenDreamClient/Interface/InterfaceMacro.cs
@@ -289,7 +289,7 @@ public sealed class InterfaceMacro : InterfaceElement {
                 return;
             string command = Command.Replace("[[*]]", keyName);
             commandSystem.RunCommand(command);
-            args.Handle();
+            // args.Handle() omitted on purpose, in BYOND both the "specific" keybind and the ANY keybind are triggered
         }
     }
 

--- a/OpenDreamClient/Interface/InterfaceMacro.cs
+++ b/OpenDreamClient/Interface/InterfaceMacro.cs
@@ -202,9 +202,6 @@ struct ParsedKeybind {
                     parsed.Alt = true;
                     break;
                 default:
-                    if (foundKey) {
-                        throw new Exception($"Duplicate key in keybind: {part}");
-                    }
                     if (part == "ANY") {
                         parsed.IsAny = true;
                     } else {
@@ -214,6 +211,9 @@ struct ParsedKeybind {
                         }
                     }
 
+                    if (foundKey) {
+                        throw new Exception($"Duplicate key in keybind: {part}");
+                    }
                     foundKey = true;
                     break;
             }

--- a/OpenDreamClient/Interface/InterfaceMacro.cs
+++ b/OpenDreamClient/Interface/InterfaceMacro.cs
@@ -146,7 +146,7 @@ struct ParsedKeybind {
         {"ADD", Keyboard.Key.NumpadAdd},
         {"SUBTRACT", Keyboard.Key.NumpadSubtract},
         {"DIVIDE", Keyboard.Key.NumpadDivide},
-        {";", Keyboard.Key.SemiColon},
+        {";", Keyboard.Key.SemiColon}, // undocumented but works in BYOND
         //TODO: Right shift/ctrl/alt
         {"SHIFT", Keyboard.Key.Shift},
         {"CTRL", Keyboard.Key.Control},

--- a/OpenDreamClient/Interface/InterfaceMacro.cs
+++ b/OpenDreamClient/Interface/InterfaceMacro.cs
@@ -5,6 +5,7 @@ using Robust.Client.Input;
 using Robust.Shared.Input;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Players;
+using Robust.Shared.Utility;
 using Key = Robust.Client.Input.Keyboard.Key;
 
 namespace OpenDreamClient.Interface;
@@ -47,6 +48,179 @@ public sealed class InterfaceMacroSet : InterfaceElement {
     }
 }
 
+struct ParsedKeybind {
+    public bool Up;
+    public bool Rep;
+    public bool Shift;
+    public bool Ctrl;
+    public bool Alt;
+    public bool IsAny;
+    public Key? Key;
+
+    private static Dictionary<string, Key> keyNameToKey = new Dictionary<string, Key>() {
+        {"A", Keyboard.Key.A},
+        {"B", Keyboard.Key.B},
+        {"C", Keyboard.Key.C},
+        {"D", Keyboard.Key.D},
+        {"E", Keyboard.Key.E},
+        {"F", Keyboard.Key.F},
+        {"G", Keyboard.Key.G},
+        {"H", Keyboard.Key.H},
+        {"I", Keyboard.Key.I},
+        {"J", Keyboard.Key.J},
+        {"K", Keyboard.Key.K},
+        {"L", Keyboard.Key.L},
+        {"M", Keyboard.Key.M},
+        {"N", Keyboard.Key.N},
+        {"O", Keyboard.Key.O},
+        {"P", Keyboard.Key.P},
+        {"Q", Keyboard.Key.Q},
+        {"R", Keyboard.Key.R},
+        {"S", Keyboard.Key.S},
+        {"T", Keyboard.Key.T},
+        {"U", Keyboard.Key.U},
+        {"V", Keyboard.Key.V},
+        {"W", Keyboard.Key.W},
+        {"X", Keyboard.Key.X},
+        {"Y", Keyboard.Key.Y},
+        {"Z", Keyboard.Key.Z},
+        {"0", Keyboard.Key.Num0},
+        {"1", Keyboard.Key.Num1},
+        {"2", Keyboard.Key.Num2},
+        {"3", Keyboard.Key.Num3},
+        {"4", Keyboard.Key.Num4},
+        {"5", Keyboard.Key.Num5},
+        {"6", Keyboard.Key.Num6},
+        {"7", Keyboard.Key.Num7},
+        {"8", Keyboard.Key.Num8},
+        {"9", Keyboard.Key.Num9},
+        {"F1", Keyboard.Key.F1},
+        {"F2", Keyboard.Key.F2},
+        {"F3", Keyboard.Key.F3},
+        {"F4", Keyboard.Key.F4},
+        {"F5", Keyboard.Key.F5},
+        {"F6", Keyboard.Key.F6},
+        {"F7", Keyboard.Key.F7},
+        {"F8", Keyboard.Key.F8},
+        {"F9", Keyboard.Key.F9},
+        {"F10", Keyboard.Key.F10},
+        {"F11", Keyboard.Key.F11},
+        {"F12", Keyboard.Key.F12},
+        {"F13", Keyboard.Key.F13},
+        {"F14", Keyboard.Key.F14},
+        {"F15", Keyboard.Key.F15},
+        {"NUMPAD0", Keyboard.Key.NumpadNum0},
+        {"NUMPAD1", Keyboard.Key.NumpadNum1},
+        {"NUMPAD2", Keyboard.Key.NumpadNum2},
+        {"NUMPAD3", Keyboard.Key.NumpadNum3},
+        {"NUMPAD4", Keyboard.Key.NumpadNum4},
+        {"NUMPAD5", Keyboard.Key.NumpadNum5},
+        {"NUMPAD6", Keyboard.Key.NumpadNum6},
+        {"NUMPAD7", Keyboard.Key.NumpadNum7},
+        {"NUMPAD8", Keyboard.Key.NumpadNum8},
+        {"NUMPAD9", Keyboard.Key.NumpadNum9},
+        {"NORTH", Keyboard.Key.Up},
+        {"SOUTH", Keyboard.Key.Down},
+        {"EAST", Keyboard.Key.Right},
+        {"WEST", Keyboard.Key.Left},
+        {"NORTHWEST", Keyboard.Key.Home},
+        {"SOUTHWEST", Keyboard.Key.End},
+        {"NORTHEAST", Keyboard.Key.PageUp},
+        {"SOUTHEAST", Keyboard.Key.PageDown},
+        //{"CENTER", Keyboard.Key.Clear},
+        {"RETURN", Keyboard.Key.Return},
+        {"ESCAPE", Keyboard.Key.Escape},
+        {"TAB", Keyboard.Key.Tab},
+        {"SPACE", Keyboard.Key.Space},
+        {"BACK", Keyboard.Key.BackSpace},
+        {"INSERT", Keyboard.Key.Insert},
+        {"DELETE", Keyboard.Key.Delete},
+        {"PAUSE", Keyboard.Key.Pause},
+        //{"SNAPSHOT", Keyboard.Key.PrintScreen},
+        {"LWIN", Keyboard.Key.LSystem},
+        {"RWIN", Keyboard.Key.RSystem},
+        //{"APPS", Keyboard.Key.Apps},
+        {"MULTIPLY", Keyboard.Key.NumpadMultiply},
+        {"ADD", Keyboard.Key.NumpadAdd},
+        {"SUBTRACT", Keyboard.Key.NumpadSubtract},
+        {"DIVIDE", Keyboard.Key.NumpadDivide},
+        {";", Keyboard.Key.SemiColon},
+        //TODO: Right shift/ctrl/alt
+        {"SHIFT", Keyboard.Key.Shift},
+        {"CTRL", Keyboard.Key.Control},
+        {"ALT", Keyboard.Key.Alt},
+    };
+
+    private static Dictionary<Key, String> keyToKeyName;
+
+    public static Key KeyNameToKey(string key) {
+        if (keyNameToKey.TryGetValue(key, out Key result)) {
+            return result;
+        } else {
+            return Keyboard.Key.Unknown;
+        }
+    }
+
+    [CanBeNull]
+    public static string KeyToKeyName(Key key) {
+        if (keyToKeyName == null) {
+            keyToKeyName = new Dictionary<Key, string>();
+            foreach (KeyValuePair<string, Key> entry in keyNameToKey) {
+                keyToKeyName[entry.Value] = entry.Key;
+            }
+        }
+
+        if (keyToKeyName.TryGetValue(key, out string result)) {
+            return result;
+        } else {
+            return null;
+        }
+    }
+
+    public static ParsedKeybind Parse(string keybind) {
+        ParsedKeybind parsed = new ParsedKeybind();
+
+        bool foundKey = false;
+        string[] parts = keybind.ToUpperInvariant().Split('+');
+        foreach (string part in parts) {
+            switch (part) {
+                case "UP":
+                    parsed.Up = true;
+                    break;
+                case "REP":
+                    parsed.Rep = true;
+                    break;
+                case "SHIFT":
+                    parsed.Shift = true;
+                    break;
+                case "CTRL":
+                    parsed.Ctrl = true;
+                    break;
+                case "ALT":
+                    parsed.Alt = true;
+                    break;
+                default:
+                    if (foundKey) {
+                        throw new Exception($"Duplicate key in keybind: {part}");
+                    }
+                    if (part == "ANY") {
+                        parsed.IsAny = true;
+                    } else {
+                        parsed.Key = KeyNameToKey(part);
+                        if (parsed.Key == Keyboard.Key.Unknown) {
+                            throw new Exception($"Invalid keybind part: {part}");
+                        }
+                    }
+
+                    foundKey = true;
+                    break;
+            }
+        }
+
+        return parsed;
+    }
+}
+
 public sealed class InterfaceMacro : InterfaceElement {
     public string Id => MacroDescriptor.Id;
     public string Command => MacroDescriptor.Id;
@@ -57,25 +231,62 @@ public sealed class InterfaceMacro : InterfaceElement {
 
     private readonly bool _isRepeating;
     private readonly bool _isRelease;
+    private readonly bool _isAny;
 
     public InterfaceMacro(string contextName, MacroDescriptor descriptor, IEntitySystemManager entitySystemManager, IInputManager inputManager, IInputCmdContext inputContext) : base(descriptor) {
         _entitySystemManager = entitySystemManager;
 
         BoundKeyFunction function = new BoundKeyFunction($"{contextName}_{Id}");
-        KeyBindingRegistration binding = CreateMacroBinding(function, Name.ToUpperInvariant());
-
-        if (binding == null)
+        ParsedKeybind parsedKeybind;
+        
+        try {
+            parsedKeybind = ParsedKeybind.Parse(Name);
+        } catch (Exception e) {
+            Logger.Warning($"Invalid keybind for macro {Id}: {e.Message}");
             return;
+        }
 
-        _isRepeating = Name.Contains("+REP");
-        _isRelease = Name.Contains("+UP");
+        _isRepeating = parsedKeybind.Rep;
+        _isRelease = parsedKeybind.Up;
+        _isAny = parsedKeybind.IsAny;
+
+        if (_isAny && (parsedKeybind.Shift || parsedKeybind.Ctrl || parsedKeybind.Alt || parsedKeybind.Rep))
+            throw new Exception("ANY can only be combined with the +UP modifier");
 
         if (_isRepeating && _isRelease)
             throw new Exception("A macro cannot be both +REP and +UP");
 
+        if (_isAny) {
+            inputManager.FirstChanceOnKeyEvent += FirstChanceKeyHandler;
+            return;
+        }
+
+        KeyBindingRegistration binding = CreateMacroBinding(function, parsedKeybind);
+
+        if (binding == null)
+            return;
+
         inputContext.AddFunction(function);
         inputManager.RegisterBinding(in binding);
         inputManager.SetInputCommand(function, InputCmdHandler.FromDelegate(OnMacroPress, OnMacroRelease, outsidePrediction: false));
+    }
+
+    private void FirstChanceKeyHandler(KeyEventArgs args, KeyEventType type) {
+        if (!_isAny)
+            return;
+        if ((type != KeyEventType.Up && _isRelease) || (type != KeyEventType.Down && !_isRelease))
+            return;
+        if (string.IsNullOrEmpty(Command))
+            return;
+        
+        if (_entitySystemManager.TryGetEntitySystem(out DreamCommandSystem commandSystem)) {
+            string? keyName = ParsedKeybind.KeyToKeyName(args.Key);
+            if (keyName == null)
+                return;
+            string command = Command.Replace("[[*]]", keyName);
+            commandSystem.RunCommand(command);
+            args.Handle();
+        }
     }
 
     private void OnMacroPress([CanBeNull] ICommonSession session) {
@@ -106,119 +317,19 @@ public sealed class InterfaceMacro : InterfaceElement {
         }
     }
 
-    private static KeyBindingRegistration CreateMacroBinding(BoundKeyFunction function, string macroName) {
-        macroName = macroName.Replace("+UP", String.Empty);
-        macroName = macroName.Replace("+REP", String.Empty);
-        macroName = macroName.Replace("SHIFT+", String.Empty);
-        macroName = macroName.Replace("CTRL+", String.Empty);
-        macroName = macroName.Replace("ALT+", String.Empty);
-
-        //TODO: modifiers
-        var key = KeyNameToKey(macroName);
-        if (key == Key.Unknown) {
-            Logger.Warning($"Unknown key: {macroName}");
+    private static KeyBindingRegistration CreateMacroBinding(BoundKeyFunction function, ParsedKeybind keybind) {
+        if (keybind.Key == null) {
+            Logger.Warning($"Invalid keybind: {keybind}");
             return null;
         }
 
         return new KeyBindingRegistration() {
-            BaseKey = key,
-            Function = function
+            BaseKey = keybind.Key.Value,
+            Function = function,
+            Mod1 = keybind.Shift ? Key.Shift : Key.Unknown,
+            Mod2 = keybind.Ctrl ? Key.Control : Key.Unknown,
+            Mod3 = keybind.Alt ? Key.Alt : Key.Unknown,
         };
     }
 
-    private static Key KeyNameToKey(string keyName) {
-        return keyName.ToUpper() switch {
-            "A" => Key.A,
-            "B" => Key.B,
-            "C" => Key.C,
-            "D" => Key.D,
-            "E" => Key.E,
-            "F" => Key.F,
-            "G" => Key.G,
-            "H" => Key.H,
-            "I" => Key.I,
-            "J" => Key.J,
-            "K" => Key.K,
-            "L" => Key.L,
-            "M" => Key.M,
-            "N" => Key.N,
-            "O" => Key.O,
-            "P" => Key.P,
-            "Q" => Key.Q,
-            "R" => Key.R,
-            "S" => Key.S,
-            "T" => Key.T,
-            "U" => Key.U,
-            "V" => Key.V,
-            "W" => Key.W,
-            "X" => Key.X,
-            "Y" => Key.Y,
-            "Z" => Key.Z,
-            "0" => Key.Num0,
-            "1" => Key.Num1,
-            "2" => Key.Num2,
-            "3" => Key.Num3,
-            "4" => Key.Num4,
-            "5" => Key.Num5,
-            "6" => Key.Num6,
-            "7" => Key.Num7,
-            "8" => Key.Num8,
-            "9" => Key.Num9,
-            "F1" => Key.F1,
-            "F2" => Key.F2,
-            "F3" => Key.F3,
-            "F4" => Key.F4,
-            "F5" => Key.F5,
-            "F6" => Key.F6,
-            "F7" => Key.F7,
-            "F8" => Key.F8,
-            "F9" => Key.F9,
-            "F10" => Key.F10,
-            "F11" => Key.F11,
-            "F12" => Key.F12,
-            "F13" => Key.F13,
-            "F14" => Key.F14,
-            "F15" => Key.F15,
-            "NUMPAD0" => Key.NumpadNum0,
-            "NUMPAD1" => Key.NumpadNum1,
-            "NUMPAD2" => Key.NumpadNum2,
-            "NUMPAD3" => Key.NumpadNum3,
-            "NUMPAD4" => Key.NumpadNum4,
-            "NUMPAD5" => Key.NumpadNum5,
-            "NUMPAD6" => Key.NumpadNum6,
-            "NUMPAD7" => Key.NumpadNum7,
-            "NUMPAD8" => Key.NumpadNum8,
-            "NUMPAD9" => Key.NumpadNum9,
-            "NORTH" => Key.Up,
-            "SOUTH" => Key.Down,
-            "EAST" => Key.Right,
-            "WEST" => Key.Left,
-            "NORTHWEST" => Key.Home,
-            "SOUTHWEST" => Key.End,
-            "NORTHEAST" => Key.PageUp,
-            "SOUTHEAST" => Key.PageDown,
-            //"CENTER" => Key.Clear,
-            "RETURN" => Key.Return,
-            "ESCAPE" => Key.Escape,
-            "TAB" => Key.Tab,
-            "SPACE" => Key.Space,
-            "BACK" => Key.BackSpace,
-            "INSERT" => Key.Insert,
-            "DELETE" => Key.Delete,
-            "PAUSE" => Key.Pause,
-            //"SNAPSHOT" => Key.PrintScreen,
-            "LWIN" => Key.LSystem,
-            "RWIN" => Key.RSystem,
-            //"APPS" => Key.Apps,
-            "MULTIPLY" => Key.NumpadMultiply,
-            "ADD" => Key.NumpadAdd,
-            "SUBTRACT" => Key.NumpadSubtract,
-            "DIVIDE" => Key.NumpadDivide,
-            //TODO: Right shift/ctrl/alt
-            "SHIFT" => Key.Shift,
-            "CTRL" => Key.Control,
-            "ALT" => Key.Alt,
-            _ => Key.Unknown
-        };
-    }
 }

--- a/OpenDreamClient/Interface/InterfaceMacro.cs
+++ b/OpenDreamClient/Interface/InterfaceMacro.cs
@@ -2,6 +2,7 @@
 using OpenDreamClient.Input;
 using OpenDreamClient.Interface.Descriptors;
 using Robust.Client.Input;
+using Robust.Client.UserInterface;
 using Robust.Shared.Input;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Players;
@@ -276,7 +277,7 @@ public sealed class InterfaceMacro : InterfaceElement {
     }
 
     private void FirstChanceKeyHandler(KeyEventArgs args, KeyEventType type) {
-        if (!_isAny)
+        if (!_isAny) // this is where we handle only the ANY macros
             return;
         if ((type != KeyEventType.Up && _isRelease) || (type != KeyEventType.Down && !_isRelease))
             return;

--- a/OpenDreamClient/Interface/InterfaceMacro.cs
+++ b/OpenDreamClient/Interface/InterfaceMacro.cs
@@ -282,6 +282,12 @@ public sealed class InterfaceMacro : InterfaceElement {
             return;
         if (string.IsNullOrEmpty(Command))
             return;
+        if (_uiManager.KeyboardFocused != null) {
+            // don't trigger  macros if we're typing somewhere
+            // Ideally this would be way more robust and would instead go through the RT keybind pipeline, most importantly passing through control.KeyBindDown.
+            // However, currently it all seems to be internal, protected or protected internal so no luck. 
+            return;
+        }
         
         if (_entitySystemManager.TryGetEntitySystem(out DreamCommandSystem commandSystem)) {
             string? keyName = ParsedKeybind.KeyToKeyName(args.Key);

--- a/OpenDreamClient/Interface/InterfaceMacro.cs
+++ b/OpenDreamClient/Interface/InterfaceMacro.cs
@@ -18,12 +18,14 @@ public sealed class InterfaceMacroSet : InterfaceElement {
     private readonly IInputManager _inputManager;
     private readonly IEntitySystemManager _entitySystemManager;
     private readonly IInputCmdContext _inputContext;
+    private readonly IUserInterfaceManager _uiManager;
 
     private readonly string _inputContextName;
 
-    public InterfaceMacroSet(MacroSetDescriptor descriptor, IEntitySystemManager entitySystemManager, IInputManager inputManager) : base(descriptor) {
+    public InterfaceMacroSet(MacroSetDescriptor descriptor, IEntitySystemManager entitySystemManager, IInputManager inputManager, IUserInterfaceManager uiManager) : base(descriptor) {
         _inputManager = inputManager;
         _entitySystemManager = entitySystemManager;
+        _uiManager = uiManager;
 
         _inputContextName = $"{InputContextPrefix}{Name}";
         if (inputManager.Contexts.Exists(_inputContextName)) {
@@ -40,7 +42,7 @@ public sealed class InterfaceMacroSet : InterfaceElement {
         if (descriptor is not MacroDescriptor macroDescriptor)
             throw new ArgumentException($"Attempted to add a {descriptor} to a macro set", nameof(descriptor));
 
-        Macros.Add(macroDescriptor.Name, new InterfaceMacro(_inputContextName, macroDescriptor, _entitySystemManager, _inputManager, _inputContext));
+        Macros.Add(macroDescriptor.Name, new InterfaceMacro(_inputContextName, macroDescriptor, _entitySystemManager, _inputManager, _inputContext, _uiManager));
     }
 
     public void SetActive() {
@@ -228,13 +230,15 @@ public sealed class InterfaceMacro : InterfaceElement {
     private MacroDescriptor MacroDescriptor => (ElementDescriptor as MacroDescriptor);
 
     private readonly IEntitySystemManager _entitySystemManager;
+    private readonly IUserInterfaceManager _uiManager;
 
     private readonly bool _isRepeating;
     private readonly bool _isRelease;
     private readonly bool _isAny;
 
-    public InterfaceMacro(string contextName, MacroDescriptor descriptor, IEntitySystemManager entitySystemManager, IInputManager inputManager, IInputCmdContext inputContext) : base(descriptor) {
+    public InterfaceMacro(string contextName, MacroDescriptor descriptor, IEntitySystemManager entitySystemManager, IInputManager inputManager, IInputCmdContext inputContext, IUserInterfaceManager uiManager) : base(descriptor) {
         _entitySystemManager = entitySystemManager;
+        _uiManager = uiManager;
 
         BoundKeyFunction function = new BoundKeyFunction($"{contextName}_{Id}");
         ParsedKeybind parsedKeybind;


### PR DESCRIPTION
PR adds support for the `ANY` keybind in BYOND.

Remaining issues:
 - Both here and in BYOND the ANY macro and the specific macro (if there are both) fire. However, in BYOND it seems that the order of them firing is determined by the position in the dmf macro definition while in this implementation the ANY macro always fires first. However, this is a fairly minor issue and I sure hope no one relies on it. (clueless)
 - The ANY keybind does only a rudimentary check for keyboard focus unlike regular keybinds which go through RT's whole pipeline. This might result in some differences in behaviour but I was not able to spot anything specific right now.

Misc changes:
 - keybind modifiers (ctrl, shift, alt) should now work as far as I can tell
 - the REP+UP check now correctly looks at the uppercased keybind
 - semicolon added to the possible keys, not documented in BYOND docs but works there. There are likely other such ommissions too, perhaps most ASCII characters?
 - keybind parsing slightly cleaned up