### PR TITLE
Optimize `DreamValue.Equals()`

### DIFF
--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -450,8 +450,7 @@ namespace OpenDreamRuntime {
 
         public bool Equals(DreamValue other) {
             if (Type != other.Type) return false;
-            switch (Type)
-            {
+            switch (Type) {
                 case DreamValueType.Float:
                     return _floatValue == other._floatValue;
                 // Ensure deleted DreamObjects are made null

--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -455,8 +455,7 @@ namespace OpenDreamRuntime {
                 case DreamValueType.Float:
                     return _floatValue == other._floatValue;
                 // Ensure deleted DreamObjects are made null
-                case DreamValueType.DreamObject:
-                {
+                case DreamValueType.DreamObject: {
                     if ((_refValue as DreamObject)?.Deleted == true)
                         _refValue = null;
                     if ((other._refValue as DreamObject)?.Deleted == true)

--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -449,14 +449,22 @@ namespace OpenDreamRuntime {
         public override bool Equals(object? obj) => obj is DreamValue other && Equals(other);
 
         public bool Equals(DreamValue other) {
-            // Ensure deleted DreamObjects are made null
-            if ((_refValue as DreamObject)?.Deleted == true)
-                _refValue = null;
-            if ((other._refValue as DreamObject)?.Deleted == true)
-                other._refValue = null;
-
             if (Type != other.Type) return false;
-            if (Type == DreamValueType.Float) return _floatValue == other._floatValue;
+            switch (Type)
+            {
+                case DreamValueType.Float:
+                    return _floatValue == other._floatValue;
+                // Ensure deleted DreamObjects are made null
+                case DreamValueType.DreamObject:
+                {
+                    if ((_refValue as DreamObject)?.Deleted == true)
+                        _refValue = null;
+                    if ((other._refValue as DreamObject)?.Deleted == true)
+                        other._refValue = null;
+                    break;
+                }
+            }
+
             if (_refValue == null) return other._refValue == null;
 
             return _refValue.Equals(other._refValue);


### PR DESCRIPTION
Shaves off 3.3 seconds in Paradise init profiling. Also see https://github.com/OpenDreamProject/OpenDream/issues/1204