### PR TITLE
Fix shift-clicking and the `.winset` command

### DIFF
--- a/OpenDreamClient/Input/DreamCommandSystem.cs
+++ b/OpenDreamClient/Input/DreamCommandSystem.cs
@@ -24,7 +24,8 @@ namespace OpenDreamClient.Input {
                     break;
 
                 case ".winset":
-                    string winsetParams = command.Substring(verb.Length + 1);
+                    // Everything after .winset, excluding the space and quotes
+                    string winsetParams = command.Substring(verb.Length + 2, command.Length - verb.Length - 3);
 
                     _interfaceManager.WinSet(null, winsetParams);
                     break;

--- a/OpenDreamClient/Interface/Controls/ControlMap.cs
+++ b/OpenDreamClient/Interface/Controls/ControlMap.cs
@@ -22,7 +22,7 @@ public sealed class ControlMap : InterfaceControl {
     }
 
     private void OnViewportKeyBindDown(GUIBoundKeyEventArgs e) {
-        if (e.Function == EngineKeyFunctions.Use || e.Function ==  EngineKeyFunctions.UIRightClick) {
+        if (e.Function == EngineKeyFunctions.Use || e.Function == EngineKeyFunctions.TextCursorSelect || e.Function ==  EngineKeyFunctions.UIRightClick) {
             IoCManager.Resolve<IEntitySystemManager>().Resolve(ref _mouseInput);
 
             if (_mouseInput.HandleViewportClick(Viewport, e)) {


### PR DESCRIPTION
You can shift-click atoms now, and `.winset` strips out the outer quotes which fixes hotkey mode on Paradise.