### PR TITLE
Get rid of DreamList event handlers

### DIFF
--- a/DMCompiler/DMStandard/Types/Client.dm
+++ b/DMCompiler/DMStandard/Types/Client.dm
@@ -1,6 +1,6 @@
 ﻿/client
 	var/list/verbs = null
-	var/list/screen = list()
+	var/list/screen = null
 	var/list/images = list() as opendream_unimplemented
 	var/list/vars
 

--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -16,10 +16,6 @@ namespace OpenDreamRuntime {
         public List<DreamObject> Mobs { get; } = new();
         public int AtomCount => Areas.Count + Turfs.Count + Movables.Count + Objects.Count + Mobs.Count;
 
-        //TODO: Maybe turn these into a special DreamList, similar to DreamListVars?
-        public Dictionary<DreamList, DreamObject> OverlaysListToAtom { get; } = new();
-        public Dictionary<DreamList, DreamObject> UnderlaysListToAtom { get; } = new();
-
         [Dependency] private readonly IEntityManager _entityManager = default!;
         [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
         [Dependency] private readonly IDreamObjectTree _objectTree = default!;
@@ -64,7 +60,7 @@ namespace OpenDreamRuntime {
             sprite.SetAppearance(CreateAppearanceFromDefinition(atom.ObjectDefinition));
 
             if (_entityManager.TryGetComponent(entity, out MetaDataComponent? metaData)) {
-                atom.GetVariable("desc").TryGetValueAsString(out string desc);
+                atom.GetVariable("desc").TryGetValueAsString(out var desc);
                 metaData.EntityName = atom.GetDisplayName();
                 metaData.EntityDescription = desc;
             }
@@ -434,9 +430,6 @@ namespace OpenDreamRuntime {
         public List<DreamObject> Objects { get; }
         public List<DreamObject> Mobs { get; }
         public int AtomCount { get; }
-
-        public Dictionary<DreamList, DreamObject> OverlaysListToAtom { get; }
-        public Dictionary<DreamList, DreamObject> UnderlaysListToAtom { get; }
 
         public DreamObject GetAtom(int index);
 

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -38,7 +38,6 @@ namespace OpenDreamRuntime {
         // Global state that may not really (really really) belong here
         public List<DreamValue> Globals { get; set; } = new();
         public IReadOnlyList<string> GlobalNames { get; private set; } = new List<string>();
-        public Dictionary<DreamObject, DreamList> AreaContents { get; set; } = new();
         public Dictionary<DreamObject, int> ReferenceIDs { get; set; } = new();
         public HashSet<DreamObject> Clients { get; set; } = new();
         public HashSet<DreamObject> Datums { get; set; } = new();

--- a/OpenDreamRuntime/IDreamManager.cs
+++ b/OpenDreamRuntime/IDreamManager.cs
@@ -17,7 +17,6 @@ namespace OpenDreamRuntime {
 
         public List<DreamValue> Globals { get; }
         public IReadOnlyList<string> GlobalNames { get; }
-        public Dictionary<DreamObject, DreamList> AreaContents { get; set; }
         public Dictionary<DreamObject, int> ReferenceIDs { get; set; }
         public HashSet<DreamObject> Clients { get; set; }
         public HashSet<DreamObject> Datums { get; set; }

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -1,18 +1,15 @@
 using System.Linq;
+using System.Runtime.CompilerServices;
 using OpenDreamRuntime.Objects.MetaObjects;
+using OpenDreamRuntime.Procs;
+using OpenDreamRuntime.Rendering;
 using OpenDreamShared.Dream;
 using Robust.Shared.Serialization.Manager;
 
 namespace OpenDreamRuntime.Objects {
-    delegate void DreamListValueAssignedEventHandler(DreamList list, DreamValue key, DreamValue value);
-    delegate void DreamListBeforeValueRemovedEventHandler(DreamList list, DreamValue key, DreamValue value);
-
     [Virtual]
     public class DreamList : DreamObject {
-        internal event DreamListValueAssignedEventHandler? ValueAssigned;
-        internal event DreamListBeforeValueRemovedEventHandler? BeforeValueRemoved;
-
-        private List<DreamValue> _values;
+        private readonly List<DreamValue> _values;
         private Dictionary<DreamValue, DreamValue>? _associativeValues;
 
         public virtual bool IsAssociative => (_associativeValues != null && _associativeValues.Count > 0);
@@ -69,8 +66,6 @@ namespace OpenDreamRuntime.Objects {
         }
 
         public virtual void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
-            ValueAssigned?.Invoke(this, key, value);
-
             if (key.TryGetValueAsInteger(out int keyInteger)) {
                 if (allowGrowth && keyInteger == _values.Count + 1) {
                     _values.Add(value);
@@ -85,12 +80,10 @@ namespace OpenDreamRuntime.Objects {
             }
         }
 
-        public void RemoveValue(DreamValue value) {
+        public virtual void RemoveValue(DreamValue value) {
             int valueIndex = _values.LastIndexOf(value);
 
             if (valueIndex != -1) {
-                BeforeValueRemoved?.Invoke(this, new DreamValue(valueIndex), _values[valueIndex]);
-
                 _associativeValues?.Remove(value);
                 _values.RemoveAt(valueIndex);
             }
@@ -98,8 +91,6 @@ namespace OpenDreamRuntime.Objects {
 
         public virtual void AddValue(DreamValue value) {
             _values.Add(value);
-
-            ValueAssigned?.Invoke(this, new DreamValue(_values.Count), value);
         }
 
         //Does not include associations
@@ -123,12 +114,6 @@ namespace OpenDreamRuntime.Objects {
 
         public virtual void Cut(int start = 1, int end = 0) {
             if (end == 0 || end > (_values.Count + 1)) end = _values.Count + 1;
-
-            if (BeforeValueRemoved != null) {
-                for (int i = end - 1; i >= start; i--) {
-                    BeforeValueRemoved.Invoke(this, new DreamValue(i), _values[i - 1]);
-                }
-            }
 
             _values.RemoveRange(start - 1, end - start);
         }
@@ -235,8 +220,8 @@ namespace OpenDreamRuntime.Objects {
 
     // global.vars list
     sealed class DreamGlobalVars : DreamList {
-        [Dependency] private readonly IDreamManager _dreamMan = default!;
-        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
+        [Robust.Shared.IoC.Dependency] private readonly IDreamManager _dreamMan = default!;
+        [Robust.Shared.IoC.Dependency] private readonly IDreamObjectTree _objectTree = default!;
 
         public override bool IsAssociative =>
             true; // We don't use the associative array but, yes, we behave like an associative list
@@ -352,12 +337,108 @@ namespace OpenDreamRuntime.Objects {
         }
     }
 
+    // atom.overlays or atom.underlays list
+    // Operates on an atom's appearance
+    public sealed class DreamOverlaysList : DreamList {
+        [Robust.Shared.IoC.Dependency] private readonly IAtomManager _atomManager = default!;
+        [Robust.Shared.IoC.Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
+        private readonly ServerAppearanceSystem _appearanceSystem;
+
+        private readonly DreamObject _atom;
+        private readonly bool _isUnderlays;
+
+        public DreamOverlaysList(DreamObjectDefinition listDef, DreamObject atom, bool isUnderlays) : base(listDef, 0) {
+            IoCManager.InjectDependencies(this);
+            _appearanceSystem = _entitySystemManager.GetEntitySystem<ServerAppearanceSystem>();
+
+            _atom = atom;
+            _isUnderlays = isUnderlays;
+        }
+
+        public override void Cut(int start = 1, int end = 0) {
+            _atomManager.UpdateAppearance(_atom, appearance => {
+                List<uint> overlaysList = GetOverlaysList(appearance);
+                int count = overlaysList.Count + 1;
+                if (end == 0 || end > count) end = count;
+
+                overlaysList.RemoveRange(start - 1, end - start);
+            });
+        }
+
+        public override DreamValue GetValue(DreamValue key) {
+            if (!key.TryGetValueAsInteger(out var overlayIndex) || overlayIndex < 1)
+                throw new Exception($"Invalid index into {(_isUnderlays ? "underlays" : "overlays")} list: {key}");
+
+            IconAppearance appearance = GetAppearance();
+            List<uint> overlaysList = GetOverlaysList(appearance);
+            if (overlayIndex > overlaysList.Count)
+                throw new Exception($"Atom only has {overlaysList.Count} {(_isUnderlays ? "underlay" : "overlay")}(s), cannot index {overlayIndex}");
+
+            uint overlayId = GetOverlaysList(appearance)[overlayIndex - 1];
+            IconAppearance overlayAppearance = _appearanceSystem.MustGetAppearance(overlayId);
+            return new DreamValue(overlayAppearance);
+        }
+
+        public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
+            throw new Exception($"Cannot write to an index of an {(_isUnderlays ? "underlays" : "overlays")} list");
+        }
+
+        public override void AddValue(DreamValue value) {
+            _atomManager.UpdateAppearance(_atom, appearance => {
+                IconAppearance overlayAppearance = CreateOverlayAppearance(value);
+
+                GetOverlaysList(appearance).Add(_appearanceSystem.AddAppearance(overlayAppearance));
+            });
+        }
+
+        public override void RemoveValue(DreamValue value) {
+            _atomManager.UpdateAppearance(_atom, appearance => {
+                IconAppearance overlayAppearance = CreateOverlayAppearance(value);
+
+                GetOverlaysList(appearance).Remove(_appearanceSystem.AddAppearance(overlayAppearance));
+            });
+        }
+
+        public override int GetLength() {
+            return GetOverlaysList(GetAppearance()).Count;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private List<uint> GetOverlaysList(IconAppearance appearance) =>
+            _isUnderlays ? appearance.Underlays : appearance.Overlays;
+
+        private IconAppearance GetAppearance() {
+            IconAppearance? appearance = _atomManager.MustGetAppearance(_atom);
+            if (appearance == null)
+                throw new Exception("Atom has no appearance");
+
+            return appearance;
+        }
+
+        private IconAppearance CreateOverlayAppearance(DreamValue value) {
+            IconAppearance overlay;
+
+            if (value.TryGetValueAsString(out var iconState)) {
+                overlay = new IconAppearance() {
+                    IconState = iconState
+                };
+            } else if (_atomManager.TryCreateAppearanceFrom(value, out var overlayAppearance)) {
+                overlay = overlayAppearance;
+            } else {
+                return new IconAppearance(); // Not a valid overlay, use a default appearance
+            }
+
+            overlay.Icon ??= GetAppearance().Icon;
+            return overlay;
+        }
+    }
+
     // atom.filters list
     // Operates on an atom's appearance
     public sealed class DreamFilterList : DreamList {
-        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
-        [Dependency] private readonly IAtomManager _atomManager = default!;
-        [Dependency] private readonly ISerializationManager _serializationManager = default!;
+        [Robust.Shared.IoC.Dependency] private readonly IDreamObjectTree _objectTree = default!;
+        [Robust.Shared.IoC.Dependency] private readonly IAtomManager _atomManager = default!;
+        [Robust.Shared.IoC.Dependency] private readonly ISerializationManager _serializationManager = default!;
 
         private readonly DreamObject _atom;
 
@@ -382,12 +463,10 @@ namespace OpenDreamRuntime.Objects {
         }
 
         public void SetFilter(int index, DreamFilter filter) {
-            IconAppearance appearance = GetAppearance();
-            if (index < 1 || index > appearance.Filters.Count)
-                throw new Exception($"Cannot index {index} on filter list");
-
-
             _atomManager.UpdateAppearance(_atom, appearance => {
+                if (index < 1 || index > appearance.Filters.Count)
+                    throw new Exception($"Cannot index {index} on filter list");
+
                 DreamFilter oldFilter = appearance.Filters[index - 1];
 
                 DreamMetaObjectFilter.FilterAttachedTo.Remove(oldFilter);
@@ -445,6 +524,66 @@ namespace OpenDreamRuntime.Objects {
                 throw new Exception("Atom has no appearance");
 
             return appearance;
+        }
+    }
+
+    // client.screen list
+    public sealed class ClientScreenList : DreamList {
+        private readonly IDreamObjectTree _objectTree;
+        private readonly ServerScreenOverlaySystem _screenOverlaySystem;
+
+        private readonly DreamConnection _connection;
+        private readonly List<DreamValue> _screenObjects = new();
+
+        public ClientScreenList(IDreamObjectTree objectTree, ServerScreenOverlaySystem screenOverlaySystem, DreamConnection connection) : base(objectTree.List.ObjectDefinition, 0) {
+            _objectTree = objectTree;
+            _screenOverlaySystem = screenOverlaySystem;
+
+            _connection = connection;
+        }
+
+        public override DreamValue GetValue(DreamValue key) {
+            if (!key.TryGetValueAsInteger(out var screenIndex) || screenIndex < 1 || screenIndex > _screenObjects.Count)
+                throw new Exception($"Invalid index into screen list: {key}");
+
+            return _screenObjects[screenIndex - 1];
+        }
+
+        public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
+            throw new Exception("Cannot write to an index of a screen list");
+        }
+
+        public override void AddValue(DreamValue value) {
+            if (!value.TryGetValueAsDreamObjectOfType(_objectTree.Movable, out var movable))
+                return;
+
+            _screenOverlaySystem.AddScreenObject(_connection, movable);
+            _screenObjects.Add(value);
+        }
+
+        public override void RemoveValue(DreamValue value) {
+            if (!value.TryGetValueAsDreamObjectOfType(_objectTree.Movable, out var movable))
+                return;
+
+            _screenOverlaySystem.RemoveScreenObject(_connection, movable);
+            _screenObjects.Remove(value);
+        }
+
+        public override void Cut(int start = 1, int end = 0) {
+            if (end == 0 || end > _screenObjects.Count + 1) end = _screenObjects.Count + 1;
+
+            for (int i = start - 1; i < end - 1; i++) {
+                if (!_screenObjects[i].TryGetValueAsDreamObjectOfType(_objectTree.Movable, out var movable))
+                    continue;
+
+                _screenOverlaySystem.RemoveScreenObject(_connection, movable);
+            }
+
+            _screenObjects.RemoveRange(start - 1, end - start);
+        }
+
+        public override int GetLength() {
+            return _screenObjects.Count;
         }
     }
 
@@ -539,6 +678,117 @@ namespace OpenDreamRuntime.Objects {
 
         public override int GetLength() {
             return _cell.Movables.Count;
+        }
+    }
+
+    // area.contents list
+    public sealed class AreaContentsList : DreamList {
+        private readonly IDreamObjectTree _objectTree;
+        private readonly IDreamMapManager _dreamMapManager;
+
+        private readonly DreamObject _area;
+        private readonly List<DreamValue> _turfs = new();
+
+        public AreaContentsList(IDreamObjectTree objectTree, IDreamMapManager dreamMapManager, DreamObject area) : base(
+            objectTree.List.ObjectDefinition, 0) {
+            _objectTree = objectTree;
+            _dreamMapManager = dreamMapManager;
+
+            _area = area;
+        }
+
+        public override DreamValue GetValue(DreamValue key) {
+            if (!key.TryGetValueAsInteger(out var index))
+                throw new Exception($"Invalid index into area contents list: {key}");
+            if (index < 1 || index > _turfs.Count)
+                throw new Exception($"Out of bounds index on turf contents list: {index}");
+
+            return _turfs[index - 1];
+        }
+
+        public override List<DreamValue> GetValues() {
+            return _turfs;
+        }
+
+        public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
+            throw new Exception("Cannot set an index of area contents list");
+        }
+
+        public override void AddValue(DreamValue value) {
+            if (!value.TryGetValueAsDreamObjectOfType(_objectTree.Turf, out var turf))
+                throw new Exception($"Cannot add {value} to area contents");
+
+            (Vector2i pos, IDreamMapManager.Level level) = _dreamMapManager.GetTurfPosition(turf);
+            level.SetArea(pos, _area);
+
+            // TODO: Actually keep track of every turf in an area, not just which ones have been added by DM through .contents
+            _turfs.Add(value);
+        }
+
+        public override void RemoveValue(DreamValue value) {
+            // TODO
+        }
+
+        public override void Cut(int start = 1, int end = 0) {
+            // TODO
+        }
+
+        public override int GetLength() {
+            return _turfs.Count;
+        }
+    }
+
+    // proc args list
+    sealed class ProcArgsList : DreamList {
+        private readonly DMProcState _state;
+
+        public ProcArgsList(DreamObjectDefinition listDef, DMProcState state) : base(listDef, 0) {
+            _state = state;
+        }
+
+        public override DreamValue GetValue(DreamValue key) {
+            if (!key.TryGetValueAsInteger(out var index))
+                throw new Exception($"Invalid index into args list: {key}");
+            if (index < 1 || index > _state.ArgumentCount)
+                throw new Exception($"Out of bounds index on args list: {index}");
+
+            return _state.GetArguments()[index - 1];
+        }
+
+        // TODO: This would preferably be an IEnumerable<> method. Probably as part of #985.
+        public override List<DreamValue> GetValues() {
+            List<DreamValue> values = new(_state.ArgumentCount);
+
+            foreach (DreamValue value in _state.GetArguments()) {
+                values.Add(value);
+            }
+
+            return values;
+        }
+
+        public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
+            if (!key.TryGetValueAsInteger(out var index))
+                throw new Exception($"Invalid index into args list: {key}");
+            if (index < 1 || index > _state.ArgumentCount)
+                throw new Exception($"Out of bounds index on args list: {index}");
+
+            _state.SetArgument(index - 1, value);
+        }
+
+        public override void AddValue(DreamValue value) {
+            throw new Exception("Cannot add new values to args list");
+        }
+
+        public override void RemoveValue(DreamValue value) {
+            throw new Exception("Cannot remove values to args list");
+        }
+
+        public override void Cut(int start = 1, int end = 0) {
+            throw new Exception("Cannot cut args list");
+        }
+
+        public override int GetLength() {
+            return _state.ArgumentCount;
         }
     }
 }

--- a/OpenDreamRuntime/Objects/DreamList.cs
+++ b/OpenDreamRuntime/Objects/DreamList.cs
@@ -5,6 +5,7 @@ using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Rendering;
 using OpenDreamShared.Dream;
 using Robust.Shared.Serialization.Manager;
+using Dependency = Robust.Shared.IoC.DependencyAttribute;
 
 namespace OpenDreamRuntime.Objects {
     [Virtual]
@@ -225,8 +226,8 @@ namespace OpenDreamRuntime.Objects {
 
     // global.vars list
     sealed class DreamGlobalVars : DreamList {
-        [Robust.Shared.IoC.Dependency] private readonly IDreamManager _dreamMan = default!;
-        [Robust.Shared.IoC.Dependency] private readonly IDreamObjectTree _objectTree = default!;
+        [Dependency] private readonly IDreamManager _dreamMan = default!;
+        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
 
         public override bool IsAssociative =>
             true; // We don't use the associative array but, yes, we behave like an associative list
@@ -345,8 +346,7 @@ namespace OpenDreamRuntime.Objects {
     // atom.overlays or atom.underlays list
     // Operates on an atom's appearance
     sealed class DreamOverlaysList : DreamList {
-        [Robust.Shared.IoC.Dependency] private readonly IAtomManager _atomManager = default!;
-        [Robust.Shared.IoC.Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
+        [Dependency] private readonly IAtomManager _atomManager = default!;
         private readonly ServerAppearanceSystem? _appearanceSystem;
 
         private readonly DreamObject _atom;
@@ -450,9 +450,9 @@ namespace OpenDreamRuntime.Objects {
     // atom.filters list
     // Operates on an atom's appearance
     public sealed class DreamFilterList : DreamList {
-        [Robust.Shared.IoC.Dependency] private readonly IDreamObjectTree _objectTree = default!;
-        [Robust.Shared.IoC.Dependency] private readonly IAtomManager _atomManager = default!;
-        [Robust.Shared.IoC.Dependency] private readonly ISerializationManager _serializationManager = default!;
+        [Dependency] private readonly IDreamObjectTree _objectTree = default!;
+        [Dependency] private readonly IAtomManager _atomManager = default!;
+        [Dependency] private readonly ISerializationManager _serializationManager = default!;
 
         private readonly DreamObject _atom;
 

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -11,12 +11,13 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public static readonly Dictionary<DreamObject, VerbsList> VerbLists = new();
 
         [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
-        [Dependency] private readonly IDreamMapManager _mapManager = default!;
         [Dependency] private readonly IDreamObjectTree _objectTree = default!;
         [Dependency] private readonly IAtomManager _atomManager = default!;
         private ServerAppearanceSystem? _appearanceSystem;
 
         private readonly Dictionary<DreamObject, DreamFilterList> _filterLists = new();
+        private readonly Dictionary<DreamObject, DreamOverlaysList> _overlayLists = new();
+        private readonly Dictionary<DreamObject, DreamOverlaysList> _underlayLists = new();
 
         public DreamMetaObjectAtom() {
             IoCManager.InjectDependencies(this);
@@ -25,10 +26,10 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
             VerbLists[dreamObject] = new VerbsList(_objectTree, dreamObject);
             _filterLists[dreamObject] = new DreamFilterList(_objectTree.List.ObjectDefinition, dreamObject);
+            _overlayLists[dreamObject] = new DreamOverlaysList(_objectTree.List.ObjectDefinition, dreamObject, false);
+            _underlayLists[dreamObject] = new DreamOverlaysList(_objectTree.List.ObjectDefinition, dreamObject, true);
 
             // TODO: These should use their own special list types
-            dreamObject.SetVariable("overlays", new(_objectTree.CreateList()));
-            dreamObject.SetVariable("underlays", new(_objectTree.CreateList()));
             dreamObject.SetVariableValue("vis_locs", new(_objectTree.CreateList()));
             dreamObject.SetVariableValue("vis_contents", new(_objectTree.CreateList()));
 
@@ -38,11 +39,11 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public void OnObjectDeleted(DreamObject dreamObject) {
             VerbLists.Remove(dreamObject);
             _filterLists.Remove(dreamObject);
+            _overlayLists.Remove(dreamObject);
+            _underlayLists.Remove(dreamObject);
 
             _atomManager.DeleteMovableEntity(dreamObject);
 
-            _atomManager.OverlaysListToAtom.Remove(dreamObject.GetVariable("overlays").GetValueAsDreamList());
-            _atomManager.UnderlaysListToAtom.Remove(dreamObject.GetVariable("underlays").GetValueAsDreamList());
             ParentType?.OnObjectDeleted(dreamObject);
         }
 
@@ -61,39 +62,35 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     break;
                 }
                 case "overlays": {
-                    if (oldValue.TryGetValueAsDreamList(out var oldList)) {
-                        oldList.Cut();
-                        oldList.ValueAssigned -= OverlayValueAssigned;
-                        oldList.BeforeValueRemoved -= OverlayBeforeValueRemoved;
-                        _atomManager.OverlaysListToAtom.Remove(oldList);
+                    DreamOverlaysList overlaysList = _overlayLists[dreamObject];
+
+                    overlaysList.Cut();
+
+                    if (value.TryGetValueAsDreamList(out var valueList)) {
+                        // TODO: This should postpone UpdateAppearance until after everything is added
+                        foreach (DreamValue overlayValue in valueList.GetValues()) {
+                            overlaysList.AddValue(overlayValue);
+                        }
+                    } else if (value != DreamValue.Null) {
+                        overlaysList.AddValue(value);
                     }
 
-                    if (!value.TryGetValueAsDreamList(out var overlayList)) {
-                        overlayList = _objectTree.CreateList();
-                    }
-
-                    overlayList.ValueAssigned += OverlayValueAssigned;
-                    overlayList.BeforeValueRemoved += OverlayBeforeValueRemoved;
-                    _atomManager.OverlaysListToAtom[overlayList] = dreamObject;
-                    dreamObject.SetVariableValue(varName, new DreamValue(overlayList));
                     break;
                 }
                 case "underlays": {
-                    if (oldValue.TryGetValueAsDreamList(out var oldList)) {
-                        oldList.Cut();
-                        oldList.ValueAssigned -= UnderlayValueAssigned;
-                        oldList.BeforeValueRemoved -= UnderlayBeforeValueRemoved;
-                        _atomManager.UnderlaysListToAtom.Remove(oldList);
+                    DreamOverlaysList underlaysList = _underlayLists[dreamObject];
+
+                    underlaysList.Cut();
+
+                    if (value.TryGetValueAsDreamList(out var valueList)) {
+                        // TODO: This should postpone UpdateAppearance until after everything is added
+                        foreach (DreamValue underlayValue in valueList.GetValues()) {
+                            underlaysList.AddValue(underlayValue);
+                        }
+                    } else if (value != DreamValue.Null) {
+                        underlaysList.AddValue(value);
                     }
 
-                    if (!value.TryGetValueAsDreamList(out var underlayList)) {
-                        underlayList = _objectTree.CreateList();
-                    }
-
-                    underlayList.ValueAssigned += UnderlayValueAssigned;
-                    underlayList.BeforeValueRemoved += UnderlayBeforeValueRemoved;
-                    _atomManager.UnderlaysListToAtom[underlayList] = dreamObject;
-                    dreamObject.SetVariableValue(varName, new DreamValue(underlayList));
                     break;
                 }
                 case "verbs": {
@@ -117,7 +114,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     filterList.Cut();
 
                     if (value.TryGetValueAsDreamList(out var valueList)) {
-                        // TODO: This should maybe postpone UpdateAppearance until after everything is added
+                        // TODO: This should postpone UpdateAppearance until after everything is added
                         foreach (DreamValue filterValue in valueList.GetValues()) {
                             filterList.AddValue(filterValue);
                         }
@@ -156,6 +153,10 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     return new DreamValue(matrix);
                 case "verbs":
                     return new DreamValue(VerbLists[dreamObject]);
+                case "overlays":
+                    return new DreamValue(_overlayLists[dreamObject]);
+                case "underlays":
+                    return new DreamValue(_underlayLists[dreamObject]);
                 case "filters":
                     return new DreamValue(_filterLists[dreamObject]);
                 default:
@@ -167,82 +168,6 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
                     return ParentType?.OnVariableGet(dreamObject, varName, value) ?? value;
             }
-        }
-
-        private IconAppearance CreateOverlayAppearance(DreamObject atom, DreamValue value) {
-            IconAppearance overlay;
-
-            if (value.TryGetValueAsString(out var iconState)) {
-                overlay = new IconAppearance() {
-                    IconState = iconState
-                };
-            } else if (_atomManager.TryCreateAppearanceFrom(value, out var overlayAppearance)) {
-                overlay = overlayAppearance;
-            } else {
-                return new IconAppearance(); // Not a valid overlay, use a default appearance
-            }
-
-            if (overlay.Icon == null) {
-                overlay.Icon = _atomManager.MustGetAppearance(atom)?.Icon;
-            }
-
-            return overlay;
-        }
-
-        private void OverlayValueAssigned(DreamList overlayList, DreamValue key, DreamValue value) {
-            if (value == DreamValue.Null) return;
-            if (_appearanceSystem == null && !_entitySystemManager.TryGetEntitySystem(out _appearanceSystem)) return;
-
-            DreamObject atom = _atomManager.OverlaysListToAtom[overlayList];
-
-            _atomManager.UpdateAppearance(atom, appearance => {
-                IconAppearance overlay = CreateOverlayAppearance(atom, value);
-                uint id = _appearanceSystem.AddAppearance(overlay);
-
-                appearance.Overlays.Add(id);
-            });
-        }
-
-        private void OverlayBeforeValueRemoved(DreamList overlayList, DreamValue key, DreamValue value) {
-            if (value == DreamValue.Null) return;
-            if (_appearanceSystem == null && !_entitySystemManager.TryGetEntitySystem(out _appearanceSystem)) return;
-
-            DreamObject atom = _atomManager.OverlaysListToAtom[overlayList];
-            IconAppearance overlayAppearance = CreateOverlayAppearance(atom, value);
-            uint? overlayAppearanceId = _appearanceSystem.GetAppearanceId(overlayAppearance);
-            if (overlayAppearanceId == null) return;
-
-            _atomManager.UpdateAppearance(atom, appearance => {
-                appearance.Overlays.Remove(overlayAppearanceId.Value);
-            });
-        }
-
-        private void UnderlayValueAssigned(DreamList underList, DreamValue key, DreamValue value) {
-            if (value == DreamValue.Null) return;
-            if (_appearanceSystem == null && !_entitySystemManager.TryGetEntitySystem(out _appearanceSystem)) return;
-
-            DreamObject atom = _atomManager.UnderlaysListToAtom[underList];
-
-            _atomManager.UpdateAppearance(atom, appearance => {
-                IconAppearance underlay = CreateOverlayAppearance(atom, value);
-                uint id = _appearanceSystem.AddAppearance(underlay);
-
-                appearance.Underlays.Add(id);
-            });
-        }
-
-        private void UnderlayBeforeValueRemoved(DreamList underlayList, DreamValue key, DreamValue value) {
-            if (value == DreamValue.Null) return;
-            if (_appearanceSystem == null && !_entitySystemManager.TryGetEntitySystem(out _appearanceSystem)) return;
-
-            DreamObject atom = _atomManager.UnderlaysListToAtom[underlayList];
-            IconAppearance underlayAppearance = CreateOverlayAppearance(atom, value);
-            uint? underlayAppearanceId = _appearanceSystem.GetAppearanceId(underlayAppearance);
-            if (underlayAppearanceId == null) return;
-
-            _atomManager.UpdateAppearance(atom, appearance => {
-                appearance.Underlays.Remove(underlayAppearanceId.Value);
-            });
         }
     }
 }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectAtom.cs
@@ -13,7 +13,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
         [Dependency] private readonly IDreamObjectTree _objectTree = default!;
         [Dependency] private readonly IAtomManager _atomManager = default!;
-        private ServerAppearanceSystem? _appearanceSystem;
+        private readonly ServerAppearanceSystem? _appearanceSystem;
 
         private readonly Dictionary<DreamObject, DreamFilterList> _filterLists = new();
         private readonly Dictionary<DreamObject, DreamOverlaysList> _overlayLists = new();
@@ -21,13 +21,15 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
         public DreamMetaObjectAtom() {
             IoCManager.InjectDependencies(this);
+
+            _entitySystemManager.TryGetEntitySystem(out _appearanceSystem);
         }
 
         public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
             VerbLists[dreamObject] = new VerbsList(_objectTree, dreamObject);
             _filterLists[dreamObject] = new DreamFilterList(_objectTree.List.ObjectDefinition, dreamObject);
-            _overlayLists[dreamObject] = new DreamOverlaysList(_objectTree.List.ObjectDefinition, dreamObject, false);
-            _underlayLists[dreamObject] = new DreamOverlaysList(_objectTree.List.ObjectDefinition, dreamObject, true);
+            _overlayLists[dreamObject] = new DreamOverlaysList(_objectTree.List.ObjectDefinition, dreamObject, _appearanceSystem, false);
+            _underlayLists[dreamObject] = new DreamOverlaysList(_objectTree.List.ObjectDefinition, dreamObject, _appearanceSystem, true);
 
             // TODO: These should use their own special list types
             dreamObject.SetVariableValue("vis_locs", new(_objectTree.CreateList()));

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
@@ -11,7 +11,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public static readonly Dictionary<DreamObject, ClientScreenList> ScreenLists = new();
         public static readonly Dictionary<DreamObject, VerbsList> VerbLists = new();
 
-        private readonly ServerScreenOverlaySystem _screenOverlaySystem;
+        private readonly ServerScreenOverlaySystem? _screenOverlaySystem;
 
         [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
         [Dependency] private readonly IDreamManager _dreamManager = default!;
@@ -20,7 +20,7 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public DreamMetaObjectClient() {
             IoCManager.InjectDependencies(this);
 
-            _screenOverlaySystem = _entitySystemManager.GetEntitySystem<ServerScreenOverlaySystem>();
+            _entitySystemManager.TryGetEntitySystem(out _screenOverlaySystem);
         }
 
         public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectClient.cs
@@ -8,10 +8,10 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public bool ShouldCallNew => true;
         public IDreamMetaObject? ParentType { get; set; }
 
+        public static readonly Dictionary<DreamObject, ClientScreenList> ScreenLists = new();
         public static readonly Dictionary<DreamObject, VerbsList> VerbLists = new();
 
-        private readonly ServerScreenOverlaySystem? _screenOverlaySystem;
-        private readonly Dictionary<DreamList, DreamObject> _screenListToClient = new();
+        private readonly ServerScreenOverlaySystem _screenOverlaySystem;
 
         [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
         [Dependency] private readonly IDreamManager _dreamManager = default!;
@@ -20,12 +20,14 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public DreamMetaObjectClient() {
             IoCManager.InjectDependencies(this);
 
-            _entitySystemManager.TryGetEntitySystem(out _screenOverlaySystem);
+            _screenOverlaySystem = _entitySystemManager.GetEntitySystem<ServerScreenOverlaySystem>();
         }
 
         public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
             ParentType?.OnObjectCreated(dreamObject, creationArguments);
 
+            var connection = _dreamManager.GetConnectionFromClient(dreamObject);
+            ScreenLists.Add(dreamObject, new ClientScreenList(_objectTree, _screenOverlaySystem, connection));
             VerbLists.Add(dreamObject, new VerbsList(_objectTree, dreamObject));
 
             _dreamManager.Clients.Add(dreamObject);
@@ -48,20 +50,18 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     break;
                 }
                 case "screen": {
-                    if (oldValue.TryGetValueAsDreamList(out var oldList)) {
-                        oldList.Cut();
-                        oldList.ValueAssigned -= ScreenValueAssigned;
-                        oldList.BeforeValueRemoved -= ScreenBeforeValueRemoved;
-                        _screenListToClient.Remove(oldList);
+                    ClientScreenList screenList = ScreenLists[dreamObject];
+
+                    screenList.Cut();
+
+                    if (value.TryGetValueAsDreamList(out var valueList)) {
+                        foreach (DreamValue screenValue in valueList.GetValues()) {
+                            screenList.AddValue(screenValue);
+                        }
+                    } else if (value != DreamValue.Null) {
+                        screenList.AddValue(value);
                     }
 
-                    if (!value.TryGetValueAsDreamList(out var screenList)) {
-                        screenList = _objectTree.CreateList();
-                    }
-
-                    screenList.ValueAssigned += ScreenValueAssigned;
-                    screenList.BeforeValueRemoved += ScreenBeforeValueRemoved;
-                    _screenListToClient[screenList] = dreamObject;
                     break;
                 }
                 case "images": {
@@ -118,6 +118,8 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                 }
                 case "connection":
                     return new DreamValue("seeker");
+                case "screen":
+                    return new DreamValue(ScreenLists[dreamObject]);
                 case "verbs":
                     return new DreamValue(VerbLists[dreamObject]);
                 case "vars": // /client has this too!
@@ -130,24 +132,6 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public void OperatorOutput(DreamObject client, DreamValue b) {
             DreamConnection connection = _dreamManager.GetConnectionFromClient(client);
             connection.OutputDreamValue(b);
-        }
-
-        private void ScreenValueAssigned(DreamList screenList, DreamValue screenKey, DreamValue screenValue) {
-            if (!screenValue.TryGetValueAsDreamObjectOfType(_objectTree.Movable, out var movable))
-                return;
-
-            var connection = _dreamManager.GetConnectionFromClient(_screenListToClient[screenList]);
-
-            _screenOverlaySystem?.AddScreenObject(connection, movable);
-        }
-
-        private void ScreenBeforeValueRemoved(DreamList screenList, DreamValue screenKey, DreamValue screenValue) {
-            if (!screenValue.TryGetValueAsDreamObjectOfType(_objectTree.Movable, out var movable))
-                return;
-
-            var connection = _dreamManager.GetConnectionFromClient(_screenListToClient[screenList]);
-
-            _screenOverlaySystem?.RemoveScreenObject(connection, movable);
         }
     }
 }

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -2062,9 +2062,16 @@ namespace OpenDreamRuntime.Procs {
                         default: return false;
                     }
                 }
+                case DreamValue.DreamValueType.Appearance: {
+                    if (!second.TryGetValueAsAppearance(out var secondValue))
+                        return false;
+
+                    IconAppearance firstValue = first.MustGetValueAsAppearance();
+                    return firstValue.Equals(secondValue);
+                }
             }
 
-            throw new NotImplementedException("Equal comparison for " + first + " and " + second + " is not implemented");
+            throw new NotImplementedException($"Equal comparison for {first} and {second} is not implemented");
         }
 
         private static bool IsEquivalent(DreamValue first, DreamValue second) {

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -409,6 +409,13 @@ namespace OpenDreamRuntime.Procs {
             return _localVariables.AsSpan(0, ArgumentCount);
         }
 
+        public void SetArgument(int id, DreamValue value) {
+            if (id < 0 || id >= ArgumentCount)
+                throw new IndexOutOfRangeException($"Given argument id ({id}) was out of range");
+
+            _localVariables[id] = value;
+        }
+
         #region Stack
         private DreamValue[] _stack;
         private int _stackIndex = 0;
@@ -537,7 +544,7 @@ namespace OpenDreamRuntime.Procs {
         public void AssignReference(DMReference reference, DreamValue value) {
             switch (reference.RefType) {
                 case DMReference.Type.Self: Result = value; break;
-                case DMReference.Type.Argument: _localVariables[reference.Index] = value; break;
+                case DMReference.Type.Argument: SetArgument(reference.Index, value); break;
                 case DMReference.Type.Local: _localVariables[ArgumentCount + reference.Index] = value; break;
                 case DMReference.Type.SrcField: Instance.SetVariable(reference.Name, value); break;
                 case DMReference.Type.Global: DreamManager.Globals[reference.Index] = value; break;
@@ -589,27 +596,7 @@ namespace OpenDreamRuntime.Procs {
                 case DMReference.Type.Global: return DreamManager.Globals[reference.Index];
                 case DMReference.Type.Argument: return _localVariables[reference.Index];
                 case DMReference.Type.Local: return _localVariables[ArgumentCount + reference.Index];
-                case DMReference.Type.Args: {
-                    DreamList argsList = Proc.ObjectTree.CreateList(ArgumentCount);
-
-                    for (int i = 0; i < ArgumentCount; i++) {
-                        argsList.AddValue(_localVariables[i]);
-                    }
-
-                    argsList.ValueAssigned += (DreamList argsList, DreamValue key, DreamValue value) => {
-                        if (!key.TryGetValueAsInteger(out int argIndex)) {
-                            throw new Exception($"Cannot index args with {key}");
-                        }
-
-                        if (argIndex > ArgumentCount) {
-                            throw new Exception($"Args index {argIndex} is too large");
-                        }
-
-                        _localVariables[argIndex - 1] = value;
-                    };
-
-                    return new(argsList);
-                }
+                case DMReference.Type.Args: return new(new ProcArgsList(Proc.ObjectTree.List.ObjectDefinition, this));
                 case DMReference.Type.Field: {
                     DreamValue owner = peek ? Peek() : Pop();
 
@@ -620,6 +607,11 @@ namespace OpenDreamRuntime.Procs {
                         return fieldValue;
                     } else if (owner.TryGetValueAsProc(out var ownerProc)) {
                         return ownerProc.GetField(reference.Name);
+                    } else if (owner.TryGetValueAsAppearance(out var appearance)) {
+                        if (!Proc.AtomManager.IsValidAppearanceVar(reference.Name))
+                            throw new Exception($"Invalid appearance var \"{reference.Name}\"");
+
+                        return Proc.AtomManager.GetAppearanceVar(appearance, reference.Name);
                     } else {
                         throw new Exception($"Cannot get field \"{reference.Name}\" from {owner}");
                     }

--- a/OpenDreamRuntime/Rendering/ServerScreenOverlaySystem.cs
+++ b/OpenDreamRuntime/Rendering/ServerScreenOverlaySystem.cs
@@ -4,10 +4,10 @@ using Robust.Server.GameStates;
 using Robust.Server.Player;
 
 namespace OpenDreamRuntime.Rendering {
-    sealed class ServerScreenOverlaySystem : SharedScreenOverlaySystem {
-        [Dependency] IAtomManager _atomManager = default!;
+    public sealed class ServerScreenOverlaySystem : SharedScreenOverlaySystem {
+        [Dependency] private readonly IAtomManager _atomManager = default!;
 
-        private Dictionary<IPlayerSession, HashSet<EntityUid>> _sessionToScreenObjects = new();
+        private readonly Dictionary<IPlayerSession, HashSet<EntityUid>> _sessionToScreenObjects = new();
 
         public override void Initialize() {
             SubscribeLocalEvent<ExpandPvsEvent>(HandleExpandPvsEvent);


### PR DESCRIPTION
This moves `/atom.overlays`, `/atom.underlays`, `/area.contents`, `/client.screen`, and `args` into their own special DreamList types. This allows them to handle more operations than just adding/removing, and allows for the removal of the events on DreamList.

Resolves #1210
Fixes #1089