### PR TITLE
Optimize `CreateAppearanceFromDefinition()`

### DIFF
--- a/OpenDreamRuntime/DreamMapManager.cs
+++ b/OpenDreamRuntime/DreamMapManager.cs
@@ -142,7 +142,7 @@ namespace OpenDreamRuntime {
                 DreamMetaObjectTurf.TurfContentsLists.Add(cell.Turf, new TurfContentsList(_objectTree.List.ObjectDefinition, _objectTree, cell));
             }
 
-            IconAppearance turfAppearance = _atomManager.CreateAppearanceFromDefinition(cell.Turf.ObjectDefinition);
+            IconAppearance turfAppearance = _atomManager.GetAppearanceFromDefinition(cell.Turf.ObjectDefinition);
             SetTurfAppearance(cell.Turf, turfAppearance);
 
             cell.Turf.InitSpawn(creationArguments);


### PR DESCRIPTION
Cache the results of `CreateAppearanceFromDefinition()` since these values never change.

Before:
![image](https://user-images.githubusercontent.com/30789242/236082612-f3990e74-f572-4387-b6ed-a1efdaf15206.png)
![image](https://user-images.githubusercontent.com/30789242/236082660-fff29d76-b91b-488f-8ba2-d1bf307e4d5a.png)

After:
![image](https://user-images.githubusercontent.com/30789242/236082343-cd81b3b4-a6f1-4dcc-89f9-b530b06d44c3.png)
![image](https://user-images.githubusercontent.com/30789242/236082412-df88e821-5365-464e-9aae-5b7c4a6a9c8e.png)