### PR TITLE
Don't flush savefile changes until shutdown

### DIFF
--- a/OpenDreamRuntime/EntryPoint.cs
+++ b/OpenDreamRuntime/EntryPoint.cs
@@ -1,4 +1,5 @@
 ﻿using OpenDreamRuntime.Input;
+using OpenDreamRuntime.Objects.MetaObjects;
 using OpenDreamRuntime.Procs.DebugAdapter;
 using OpenDreamShared;
 using Robust.Server.ServerStatus;
@@ -59,6 +60,11 @@ namespace OpenDreamRuntime {
         }
 
         protected override void Dispose(bool disposing) {
+            // Write every savefile to disk
+            foreach (var savefile in DreamMetaObjectSavefile.ObjectToSavefile.Values) {
+                savefile.Flush();
+            }
+
             _dreamManager.Shutdown();
             _debugManager.Shutdown();
         }

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectSavefile.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectSavefile.cs
@@ -121,7 +121,6 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
             if (!index.TryGetValueAsString(out string? entryName)) throw new Exception($"Invalid savefile index {index}");
 
             savefile.CurrentDir[entryName] = value;
-            savefile.Flush(); //TODO: Don't flush after every change
         }
     }
 }


### PR DESCRIPTION
Flushing every savefile change to disk is a fairly costly operation.