### PR TITLE
Optimize getting an atom's position and `IsObjectVisible()`

### DIFF
--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -432,14 +432,14 @@ namespace OpenDreamRuntime {
 
         public (int X, int Y, int Z) GetAtomPosition(DreamObject atom) {
             if (atom.IsSubtypeOf(_objectTree.Movable)) {
-                if (!_entitySystemManager.TryGetEntitySystem(out _transformSystem))
+                if (_transformSystem == null && !_entitySystemManager.TryGetEntitySystem(out _transformSystem))
                     return (0, 0, 0);
 
                 var entity = GetMovableEntity(atom);
-                if (!_transformSystem.TryGetMapOrGridCoordinates(entity, out var coordinates))
-                    return (0, 0, 0);
+                var transform = _entityManager.GetComponent<TransformComponent>(entity);
+                var worldPosition = _transformSystem.GetWorldPosition(transform);
 
-                return ((int)coordinates.Value.X, (int)coordinates.Value.Y, (int)coordinates.Value.GetMapId(_entityManager));
+                return ((int)worldPosition.X, (int)worldPosition.Y, (int)transform.MapID);
             } else if (atom.IsSubtypeOf(_objectTree.Turf)) {
                 var position = _dreamMapManager.GetTurfPosition(atom);
 

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMovable.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMovable.cs
@@ -61,9 +61,10 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
                     if (!_entityManager.TryGetComponent(entity, out TransformComponent? transform))
                         return;
 
-                    int x = (varName == "x") ? value.MustGetValueAsInteger() : (int)transform.WorldPosition.X;
-                    int y = (varName == "y") ? value.MustGetValueAsInteger() : (int)transform.WorldPosition.Y;
-                    int z = (varName == "z") ? value.MustGetValueAsInteger() : (int)transform.MapID;
+                    var position = _atomManager.GetAtomPosition(dreamObject);
+                    int x = (varName == "x") ? value.MustGetValueAsInteger() : position.X;
+                    int y = (varName == "y") ? value.MustGetValueAsInteger() : position.Y;
+                    int z = (varName == "z") ? value.MustGetValueAsInteger() : position.Z;
 
                     _dreamMapManager.TryGetTurfAt((x, y), z, out var newLoc);
                     dreamObject.SetVariable("loc", new DreamValue(newLoc));
@@ -124,20 +125,11 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
         public DreamValue OnVariableGet(DreamObject dreamObject, string varName, DreamValue value) {
             switch (varName) {
                 case "x":
+                    return new(_atomManager.GetAtomPosition(dreamObject).X);
                 case "y":
-                case "z": {
-                    EntityUid entity = _atomManager.GetMovableEntity(dreamObject);
-                    if (!_entityManager.TryGetComponent(entity, out TransformComponent? transform))
-                        return new(0);
-
-                    float coordinate = varName switch {
-                        "x" => transform.WorldPosition.X,
-                        "y" => transform.WorldPosition.Y,
-                        _ => (int)transform.MapID
-                    };
-
-                    return new(coordinate);
-                }
+                    return new(_atomManager.GetAtomPosition(dreamObject).Y);
+                case "z":
+                    return new(_atomManager.GetAtomPosition(dreamObject).Z);
                 case "contents": {
                     DreamList contents = _objectTree.CreateList();
                     EntityUid entity = _atomManager.GetMovableEntity(dreamObject);

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectTurf.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectTurf.cs
@@ -4,6 +4,7 @@
         public IDreamMetaObject? ParentType { get; set; }
 
         [Dependency] private readonly IDreamMapManager _dreamMapManager = default!;
+        [Dependency] private readonly IAtomManager _atomManager = default!;
 
         public static readonly Dictionary<DreamObject, TurfContentsList> TurfContentsLists = new();
 
@@ -34,15 +35,11 @@
         public DreamValue OnVariableGet(DreamObject dreamObject, string varName, DreamValue value) {
             switch (varName) {
                 case "x":
+                    return new(_atomManager.GetAtomPosition(dreamObject).X);
                 case "y":
-                case "z": {
-                    (Vector2i pos, IDreamMapManager.Level level) = _dreamMapManager.GetTurfPosition(dreamObject);
-
-                    int coord = varName == "x" ? pos.X :
-                                varName == "y" ? pos.Y :
-                                level.Z;
-                    return new(coord);
-                }
+                    return new(_atomManager.GetAtomPosition(dreamObject).Y);
+                case "z":
+                    return new(_atomManager.GetAtomPosition(dreamObject).Z);
                 case "loc":
                     return new(_dreamMapManager.GetAreaAt(dreamObject));
                 case "contents":

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
@@ -30,14 +30,9 @@ internal static class DreamProcNativeHelpers {
     /// <returns>Turfs, as <see cref="DreamObject"/>s, in the correct, parity order for the above procs.</returns>
     static public IEnumerable<DreamObject> MakeViewSpiral(DreamObject center, ViewRange distance) {
         var mapMgr = IoCManager.Resolve<IDreamMapManager>();
-        int centerX, centerY, centerZ;
-        try { // Me being visibly lazy here
-            centerX = center.GetVariable("x").MustGetValueAsInteger();
-            centerY = center.GetVariable("y").MustGetValueAsInteger();
-            centerZ = center.GetVariable("z").MustGetValueAsInteger();
-        } catch (InvalidCastException) {
-            yield break;
-        }
+        var atomMgr = IoCManager.Resolve<IAtomManager>();
+        var centerPos = atomMgr.GetAtomPosition(center);
+
         int WidthRange = (distance.Width - 1) >> 1; // TODO: Make rectangles work.
         int HeightRange = (distance.Height - 1) >> 1;
         int donutCount = Math.Max(WidthRange, HeightRange);
@@ -45,10 +40,10 @@ internal static class DreamProcNativeHelpers {
             int sideLength = d + d + 1;
             //The left column
             {
-                int leftColumnX = centerX - d;
-                int startingLeftColumnY = centerY - d;
+                int leftColumnX = centerPos.X - d;
+                int startingLeftColumnY = centerPos.Y - d;
                 for (int i = 0; i < sideLength; ++i) {
-                    if (mapMgr.TryGetTurfAt((leftColumnX, startingLeftColumnY + i), centerZ, out var turf)) {
+                    if (mapMgr.TryGetTurfAt((leftColumnX, startingLeftColumnY + i), centerPos.Z, out var turf)) {
                         yield return turf;
                     }
                 }
@@ -56,24 +51,24 @@ internal static class DreamProcNativeHelpers {
             //The criss-cross-apple-sauce
             {
                 int crissCrossLength = sideLength - 2;
-                int startingCrossX = centerX - d + 1;
+                int startingCrossX = centerPos.X - d + 1;
                 for(int i = 0; i < crissCrossLength; ++i) {
                     //the criss
-                    if (mapMgr.TryGetTurfAt((startingCrossX+i, centerY - d), centerZ, out var crissTurf)) {
+                    if (mapMgr.TryGetTurfAt((startingCrossX+i, centerPos.Y - d), centerPos.Z, out var crissTurf)) {
                         yield return crissTurf;
                     }
                     //the cross
-                    if (mapMgr.TryGetTurfAt((startingCrossX + i, centerY + d), centerZ, out var crossTurf)) {
+                    if (mapMgr.TryGetTurfAt((startingCrossX + i, centerPos.Y + d), centerPos.Z, out var crossTurf)) {
                         yield return crossTurf;
                     }
                 }
             }
             //The right column
             {
-                int rightColumnX = centerX + d;
-                int startingRightColumnY = centerY - d;
+                int rightColumnX = centerPos.X + d;
+                int startingRightColumnY = centerPos.Y - d;
                 for (int i = 0; i < sideLength; ++i) {
-                    if (mapMgr.TryGetTurfAt((rightColumnX, startingRightColumnY + i), centerZ, out var turf)) {
+                    if (mapMgr.TryGetTurfAt((rightColumnX, startingRightColumnY + i), centerPos.Z, out var turf)) {
                         yield return turf;
                     }
                 }
@@ -121,31 +116,27 @@ internal static class DreamProcNativeHelpers {
     /// <see langword="TODO:"/> This proc is DEFINITELY incomplete. <br/>
     /// </remarks>
     /// <returns>True if observer can see obj. False if not.</returns>
-    public static bool IsObjectVisible(IDreamObjectTree objectTree, DreamObject obj, DreamObject observer) {
+    public static bool IsObjectVisible(IAtomManager atomManager, IDreamObjectTree objectTree, DreamObject obj, DreamObject observer) {
         if(obj == observer) // Not proven to be true, but makes intuitive sense.
             return true;
-
-        if(!obj.IsSubtypeOf(objectTree.Atom)) {
+        if(!obj.IsSubtypeOf(objectTree.Atom))
             return false; // Can't see datums and nulls n stuff, I THINK???
-        }
+        if (!atomManager.TryGetAppearance(obj, out var appearance))
+            return false;
 
         // https://www.byond.com/docs/ref/#/atom/var/invisibility
-        if (obj.TryGetVariable("invisibility", out DreamValue invisibility)) {
-            if(invisibility.TryGetValueAsInteger(out int invisibilityValue)) {
-                // Ref says: "A value of 101 is absolutely invisible, no matter what"
-                if(invisibilityValue == 101) {
-                    return false;
-                }
-                // Ref:
-                // "This determines the object's level of invisibility."
-                // "The corresponding mob variable see_invisible controls the maximum level of invisibility that the mob may see."
-                if(observer.IsSubtypeOf(objectTree.Mob)) {
-                    if(observer.TryGetVariable("see_invisible",out var maxInvisibility)) {
-                        if(maxInvisibility.TryGetValueAsFloat(out float maxInvisibilityValue)) {
-                            if(maxInvisibilityValue < invisibilityValue) {
-                                return false;
-                            }
-                        }
+        // Ref says: "A value of 101 is absolutely invisible, no matter what"
+        if(appearance.Invisibility == 101)
+            return false;
+
+        // Ref:
+        // "This determines the object's level of invisibility."
+        // "The corresponding mob variable see_invisible controls the maximum level of invisibility that the mob may see."
+        if(observer.IsSubtypeOf(objectTree.Mob)) {
+            if(observer.TryGetVariable("see_invisible",out var maxInvisibility)) {
+                if(maxInvisibility.TryGetValueAsFloat(out float maxInvisibilityValue)) {
+                    if(maxInvisibilityValue < appearance.Invisibility) {
+                        return false;
                     }
                 }
             }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -738,29 +738,24 @@ namespace OpenDreamRuntime.Procs.Native {
             if (!state.GetArgument(1, "Loc2").TryGetValueAsDreamObjectOfType(state.ObjectTree.Atom, out var loc2))
                 return new DreamValue(0);
 
-            loc1.GetVariable("z").TryGetValueAsInteger(out var z1);
-            loc2.GetVariable("z").TryGetValueAsInteger(out var z2);
-            if (z1 != z2) // They must be on the same z-level
+            var loc1Pos = state.AtomManager.GetAtomPosition(loc1);
+            var loc2Pos = state.AtomManager.GetAtomPosition(loc2);
+
+            if (loc1Pos.Z != loc2Pos.Z) // They must be on the same z-level
                 return new DreamValue(0);
-
-            loc1.GetVariable("x").TryGetValueAsInteger(out var x1);
-            loc1.GetVariable("y").TryGetValueAsInteger(out var y1);
-
-            loc2.GetVariable("x").TryGetValueAsInteger(out var x2);
-            loc2.GetVariable("y").TryGetValueAsInteger(out var y2);
 
             int direction = 0;
 
             // East or West
-            if (x2 < x1)
+            if (loc2Pos.X < loc1Pos.X)
                 direction |= (int)AtomDirection.West;
-            else if (x2 > x1)
+            else if (loc2Pos.X > loc1Pos.X)
                 direction |= (int)AtomDirection.East;
 
             // North or South
-            if (y2 < y1)
+            if (loc2Pos.Y < loc1Pos.Y)
                 direction |= (int) AtomDirection.South;
-            else if (y2 > y1)
+            else if (loc2Pos.Y > loc1Pos.Y)
                 direction |= (int) AtomDirection.North;
 
             return new DreamValue(direction);
@@ -777,23 +772,21 @@ namespace OpenDreamRuntime.Procs.Native {
             if (dir >= 16) // Anything greater than (NORTH | SOUTH | EAST | WEST) is not valid. < 0 is fine though!
                 return DreamValue.Null;
 
-            loc.GetVariable("x").TryGetValueAsInteger(out var x);
-            loc.GetVariable("y").TryGetValueAsInteger(out var y);
-            loc.GetVariable("z").TryGetValueAsInteger(out var z);
+            var locPos = state.AtomManager.GetAtomPosition(loc);
 
             if (dir > 0) {
                 if ((dir & (int) AtomDirection.North) == (int) AtomDirection.North)
-                    y += 1;
+                    locPos.Y += 1;
                 if ((dir & (int) AtomDirection.South) == (int) AtomDirection.South) // A dir of NORTH | SOUTH will cancel out
-                    y -= 1;
+                    locPos.Y -= 1;
 
                 if ((dir & (int) AtomDirection.East) == (int) AtomDirection.East)
-                    x += 1;
+                    locPos.X += 1;
                 if ((dir & (int) AtomDirection.West) == (int) AtomDirection.West) // A dir of EAST | WEST will cancel out
-                    x -= 1;
+                    locPos.X -= 1;
             }
 
-            state.MapManager.TryGetTurfAt((x, y), z, out var turf);
+            state.MapManager.TryGetTurfAt((locPos.X, locPos.Y), locPos.Z, out var turf);
             return new DreamValue(turf);
         }
 
@@ -1622,14 +1615,14 @@ namespace OpenDreamRuntime.Procs.Native {
 
             DreamList view = state.ObjectTree.CreateList(range.Height * range.Width); // Should be a reasonable approximation for the list size.
             foreach (DreamObject turf in DreamProcNativeHelpers.MakeViewSpiral(center, range)) {
-                if(!DreamProcNativeHelpers.IsObjectVisible(state.ObjectTree, turf, center)) { //NOTE: I'm assuming here that a turf being invisible means its contents are, too
+                if(!DreamProcNativeHelpers.IsObjectVisible(state.AtomManager, state.ObjectTree, turf, center)) { //NOTE: I'm assuming here that a turf being invisible means its contents are, too
                     continue;
                 }
                 view.AddValue(new DreamValue(turf));
                 if(turf.GetVariable("contents").TryGetValueAsDreamList(out var contentsList)) {
                     foreach (DreamValue content in contentsList.GetValues()) {
-                        if (content.TryGetValueAsDreamObject(out DreamObject contentObject)) {
-                            if (!DreamProcNativeHelpers.IsObjectVisible(state.ObjectTree, contentObject, center)) {
+                        if (content.TryGetValueAsDreamObject(out var contentObject)) {
+                            if (!DreamProcNativeHelpers.IsObjectVisible(state.AtomManager, state.ObjectTree, contentObject, center)) {
                                 continue;
                             }
                         }
@@ -1668,16 +1661,14 @@ namespace OpenDreamRuntime.Procs.Native {
 
             DreamList view = state.ObjectTree.CreateList();
             int depth = (depthValue.Type == DreamValueType.Float) ? depthValue.GetValueAsInteger() : 5; //TODO: Default to world.view
-            int centerX = center.GetVariable("x").GetValueAsInteger();
-            int centerY = center.GetVariable("y").GetValueAsInteger();
+            var centerPos = state.AtomManager.GetAtomPosition(center);
 
             foreach (DreamObject mob in state.AtomManager.Mobs) {
-                int mobX = mob.GetVariable("x").GetValueAsInteger();
-                int mobY = mob.GetVariable("y").GetValueAsInteger();
+                var mobPos = state.AtomManager.GetAtomPosition(mob);
 
-                if (mobX == centerX && mobY == centerY) continue;
+                if (mobPos.X == centerPos.X && mobPos.Y == centerPos.Y) continue;
 
-                if (Math.Abs(centerX - mobX) <= depth && Math.Abs(centerY - mobY) <= depth) {
+                if (Math.Abs(centerPos.X - mobPos.X) <= depth && Math.Abs(centerPos.Y - mobPos.Y) <= depth) {
                     view.AddValue(new DreamValue(mob));
                 }
             }
@@ -2522,7 +2513,7 @@ namespace OpenDreamRuntime.Procs.Native {
             DreamPath path = new DreamPath(text);
 
             bool isVerb = false;
-            
+
             int procElementIndex = path.FindElement("proc");
             if (procElementIndex == -1) {
                 procElementIndex = path.FindElement("verb");
@@ -2805,12 +2796,12 @@ namespace OpenDreamRuntime.Procs.Native {
                 return DreamValue.Null; // NOTE: Not sure if parity
             DreamList view = state.ObjectTree.CreateList(range.Height * range.Width); // Should be a reasonable approximation for the list size.
             //Have to include centre
-            if(DreamProcNativeHelpers.IsObjectVisible(state.ObjectTree, center, center)) // NOTE: I think this is always true, but I'm not 100% sure.
+            if(DreamProcNativeHelpers.IsObjectVisible(state.AtomManager, state.ObjectTree, center, center)) // NOTE: I think this is always true, but I'm not 100% sure.
                 view.AddValue(new DreamValue(center));
             if (center.TryGetVariable("contents", out var centerContents) && centerContents.TryGetValueAsDreamList(out var centerContentsList)) {
                 foreach (DreamValue content in centerContentsList.GetValues()) {
-                    if (content.TryGetValueAsDreamObject(out DreamObject contentObject)) {
-                        if (!DreamProcNativeHelpers.IsObjectVisible(state.ObjectTree, contentObject, center)) {
+                    if (content.TryGetValueAsDreamObject(out var contentObject)) {
+                        if (!DreamProcNativeHelpers.IsObjectVisible(state.AtomManager, state.ObjectTree, contentObject, center)) {
                             continue;
                         }
                     }
@@ -2829,14 +2820,14 @@ namespace OpenDreamRuntime.Procs.Native {
             }
             //and then everything else
             foreach (DreamObject turf in DreamProcNativeHelpers.MakeViewSpiral(center, range)) {
-                if (!DreamProcNativeHelpers.IsObjectVisible(state.ObjectTree, turf, center)) { //NOTE: I'm assuming here that a turf being invisible means its contents are, too
+                if (!DreamProcNativeHelpers.IsObjectVisible(state.AtomManager, state.ObjectTree, turf, center)) { //NOTE: I'm assuming here that a turf being invisible means its contents are, too
                     continue;
                 }
                 view.AddValue(new DreamValue(turf));
                 if (turf.GetVariable("contents").TryGetValueAsDreamList(out var contentsList)) {
                     foreach (DreamValue content in contentsList.GetValues()) {
-                        if (content.TryGetValueAsDreamObject(out DreamObject contentObject)) {
-                            if (!DreamProcNativeHelpers.IsObjectVisible(state.ObjectTree, contentObject, center)) {
+                        if (content.TryGetValueAsDreamObject(out var contentObject)) {
+                            if (!DreamProcNativeHelpers.IsObjectVisible(state.AtomManager, state.ObjectTree, contentObject, center)) {
                                 continue;
                             }
                         }


### PR DESCRIPTION
Optimizes pieces of code that get an atom's position by getting their position directly instead of going through `GetVariable()`.

Similarly optimizes `IsObjectVisible()` too by getting an atom's invisibility through its appearance directly. This brings its total runtime during Paradise init from ~1000ms to ~250ms on my computer.