### PR TITLE
Fix `...` parsing

### DIFF
--- a/Content.Tests/DMProject/Tests/Expression/String/multi_arg.dm
+++ b/Content.Tests/DMProject/Tests/Expression/String/multi_arg.dm
@@ -13,7 +13,16 @@
 	ASSERT(b == 2)
 	ASSERT(args.len == 4)
 
+// For this one we just want to make sure the args can be parsed without erroring
+/proc/test(
+	datum/foo,
+	datum/bar,
+	...
+)
+	return
+
 /proc/RunTest()
 	A(b, 2, 3, 4)
 	fn1(1,2,3,4)
 	fn2(1,2,3,4)
+	test()


### PR DESCRIPTION
Fixes one of the two compilation errors in latest TG and adds it to the unit test.

I tried finagling the token checks in several different ways but this just ended up being the simplest that didn't break any tests.