### PR TITLE
Fix accessing `verb.desc` and mark it as implemented

### DIFF
--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -264,12 +264,12 @@ namespace DMCompiler.DM.Visitors {
 
                     break;
                 case "desc":
+                    // TODO: verb.desc is supposed to be printed when you type the verb name and press F1. Check the ref for details.
                     if (constant is not Expressions.String descStr) {
                         throw new CompileErrorException(statementSet.Location, "desc attribute must be a string");
                     }
 
                     _proc.VerbDesc = descStr.Value;
-                    DMCompiler.UnimplementedWarning(statementSet.Location, "set desc is not implemented");
                     break;
                 case "invisibility":
                     // The ref says 0-101 for atoms and 0-100 for verbs

--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -71,7 +71,7 @@ namespace OpenDreamRuntime {
                     return new DreamValue(VerbName);
                 case "category":
                     return new DreamValue(VerbCategory);
-                case "description":
+                case "desc":
                     return new DreamValue(VerbDesc);
                 case "invisibility":
                     return new DreamValue(Invisibility);


### PR DESCRIPTION
Woopsie.

I also marked it as implemented. There's additional behavior on both the compiler side and the runtime to support printing the description as help text and doing some funky arg parsing in the process, but I've literally never seen it before so I think we can safely downgrade the unimplemented warning to a TODO.

See https://www.byond.com/docs/ref/#/verb/set/desc for what I'm talking about.