### PR TITLE
Add a new `MissingInterpolatedExpression` pragma

### DIFF
--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -24,6 +24,7 @@
 #pragma InvalidSetStatement error
 #pragma InvalidOverride warning
 #pragma DanglingVarType warning
+#pragma MissingInterpolatedExpression warning
 
 //3000-3999
 #pragma EmptyBlock notice

--- a/OpenDreamShared/Compiler/CompilerError.cs
+++ b/OpenDreamShared/Compiler/CompilerError.cs
@@ -6,8 +6,7 @@ namespace OpenDreamShared.Compiler {
     /// <remarks>
     /// All values should be unique.
     /// </remarks>
-    public enum WarningCode
-    {
+    public enum WarningCode {
         // 0 - 999 are reserved for giving codes to fatal errors which cannot reasonably be demoted to a warning/notice/disable.
         Unknown = 0,
         BadToken = 1,
@@ -26,6 +25,7 @@ namespace OpenDreamShared.Compiler {
         HardConstContext = 500,
         WriteToConstant = 501,
         InvalidInclusion = 900,
+
         // 1000 - 1999 are reserved for preprocessor configuration.
         FileAlreadyIncluded = 1000,
         MissingIncludedFile = 1001,
@@ -49,6 +49,8 @@ namespace OpenDreamShared.Compiler {
         InvalidSetStatement = 2302,
         InvalidOverride = 2303,
         DanglingVarType = 2401, // For types inferred by a particular var definition and nowhere else, that ends up not existing (not forced-fatal because BYOND doesn't always error)
+        MissingInterpolatedExpression = 2500, // A text macro is missing a required interpolated expression
+
         // 3000 - 3999 are reserved for stylistic configuration.
         EmptyBlock = 3100,
 


### PR DESCRIPTION
Invalid text macros like `"\a vendomat"` now have the error code `OD2500` instead of `OD0000`

Also makes it a warning by default, since this passes without error in BYOND