### PR TITLE
Remove `new DreamValue(object)` constructor

### DIFF
--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -74,7 +74,7 @@ namespace OpenDreamRuntime {
                 case "description":
                     return new DreamValue(VerbDesc);
                 case "invisibility":
-                    return new DreamValue(Invisibility);
+                    return new DreamValue((int)Invisibility);
                 default:
                     throw new Exception($"Cannot get field \"{field}\" from {OwningType.ToString()}.{Name}()");
             }

--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -55,8 +55,6 @@ namespace OpenDreamRuntime {
 
         public DreamValue(int value) : this((float)value) { }
 
-        public DreamValue(UInt32 value) : this((float)value) { }
-
         public DreamValue(double value) : this((float)value) { }
 
         public DreamValue(DreamResource value) {
@@ -83,27 +81,6 @@ namespace OpenDreamRuntime {
         public DreamValue(IconAppearance appearance) {
             Type = DreamValueType.Appearance;
             _refValue = appearance;
-        }
-
-        public DreamValue(object value) {
-            if (value is int intValue) {
-                _floatValue = intValue;
-            } else if (value is float floatValue) {
-                _floatValue = floatValue;
-            } else {
-                _refValue = value;
-            }
-
-            Type = value switch {
-                string => DreamValueType.String,
-                int => DreamValueType.Float,
-                float => DreamValueType.Float,
-                DreamResource => DreamValueType.DreamResource,
-                DreamObject => DreamValueType.DreamObject,
-                IDreamObjectTree.TreeEntry => DreamValueType.DreamType,
-                DreamProc => DreamValueType.DreamProc,
-                _ => throw new ArgumentException($"Invalid DreamValue value ({value}, {value.GetType()})")
-            };
         }
 
         public static DreamValue CreateProcStub(IDreamObjectTree.TreeEntry type) {
@@ -427,8 +404,6 @@ namespace OpenDreamRuntime {
                     throw new NotImplementedException("Cannot stringify " + this);
             }
         }
-
-        public override bool Equals(object? obj) => obj is DreamValue other && Equals(other);
 
         public bool Equals(DreamValue other) {
             if (Type != other.Type) return false;

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectIcon.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectIcon.cs
@@ -75,8 +75,7 @@ sealed class DreamMetaObjectIcon : IDreamMetaObject {
         return icon;
     }
 
-    public static DreamIcon TurnIcon(DreamIcon icon, float angle) {
+    public static void TurnIcon(DreamIcon icon, float angle) {
         //TODO: actually rotate the icon clockwise x degrees
-        return icon;
     }
 }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeIcon.cs
@@ -104,14 +104,15 @@ namespace OpenDreamRuntime.Procs.Native {
                 return new DreamValue(state.Src); // Defaults to input on invalid angle
             }
 
-            return _NativeProc_TurnInternal(state.Src, state.Usr, angle);
+            _NativeProc_TurnInternal(state.Src, state.Usr, angle);
+            return DreamValue.Null;
         }
 
         /// <summary> Turns a given icon a given amount of degrees clockwise. </summary>
-        /// <returns> Returns a new icon which has been rotated </returns>
-        public static DreamValue _NativeProc_TurnInternal(DreamObject src, DreamObject usr, float angle) {
+        public static void _NativeProc_TurnInternal(DreamObject src, DreamObject usr, float angle) {
             DreamIcon dreamIconObject = DreamMetaObjectIcon.ObjectToDreamIcon[src];
-            return new DreamValue(DreamMetaObjectIcon.TurnIcon(dreamIconObject, angle));
+
+            DreamMetaObjectIcon.TurnIcon(dreamIconObject, angle);
         }
     }
 }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2522,7 +2522,7 @@ namespace OpenDreamRuntime.Procs.Native {
             DreamPath path = new DreamPath(text);
 
             bool isVerb = false;
-            
+
             int procElementIndex = path.FindElement("proc");
             if (procElementIndex == -1) {
                 procElementIndex = path.FindElement("verb");
@@ -2643,7 +2643,9 @@ namespace OpenDreamRuntime.Procs.Native {
             if (dirArg.TryGetValueAsDreamObjectOfType(state.ObjectTree.Icon, out var icon)) {
                 // Clone icon here since it's specified to return a new one
                 DreamObject clonedIcon = DreamMetaObjectIcon.CloneIcon(state.ObjectTree, icon);
-                return DreamProcNativeIcon._NativeProc_TurnInternal(clonedIcon, state.Usr, angle);
+
+                DreamProcNativeIcon._NativeProc_TurnInternal(clonedIcon, state.Usr, angle);
+                return new(clonedIcon);
             }
 
             // If Dir is actually a matrix, call /matrix.Turn

--- a/OpenDreamRuntime/Procs/NativeProc.cs
+++ b/OpenDreamRuntime/Procs/NativeProc.cs
@@ -23,9 +23,16 @@ namespace OpenDreamRuntime.Procs {
 
                 argumentNames.Add(parameterAttribute.Name);
                 if (parameterAttribute.DefaultValue != default) {
-                    if (defaultArgumentValues == null) defaultArgumentValues = new Dictionary<string, DreamValue>();
+                    defaultArgumentValues ??= new Dictionary<string, DreamValue>(1);
+                    DreamValue defaultValue = parameterAttribute.DefaultValue switch {
+                        // These are the only types you should be able to set in an attribute
+                        int intValue => new(intValue),
+                        float floatValue => new(floatValue),
+                        string stringValue => new(stringValue),
+                        _ => throw new Exception($"Invalid default value {parameterAttribute.DefaultValue}")
+                    };
 
-                    defaultArgumentValues.Add(parameterAttribute.Name, new DreamValue(parameterAttribute.DefaultValue));
+                    defaultArgumentValues.Add(parameterAttribute.Name, defaultValue);
                 }
             }
 


### PR DESCRIPTION
The existence of this constructor makes it too easy to provide the wrong value and create an invalid DreamValue.

`_NativeProc_TurnInternal()` and `DreamProc.GetField()` were both incorrectly using this constructor.