### PR TITLE
feat(DMCompiler, Constant): support relative resource paths

### DIFF
--- a/Content.Tests/DMProject/Tests/Expression/Constants/data/test.txt
+++ b/Content.Tests/DMProject/Tests/Expression/Constants/data/test.txt
@@ -1,0 +1,1 @@
+Test resource file's content

--- a/Content.Tests/DMProject/Tests/Expression/Constants/resource.dm
+++ b/Content.Tests/DMProject/Tests/Expression/Constants/resource.dm
@@ -1,0 +1,3 @@
+/proc/RunTest()
+	var/resource = 'data/test.txt'
+	ASSERT(file2text(resource) == "Test resource file's content")

--- a/Content.Tests/DMProject/Tests/Expression/Constants/resource_not_exists.dm
+++ b/Content.Tests/DMProject/Tests/Expression/Constants/resource_not_exists.dm
@@ -1,0 +1,4 @@
+// COMPILE ERROR
+
+/proc/RunTest()
+	var/resource = 'file_doesnt_exist.txt'


### PR DESCRIPTION
1. Support relative resource paths: resource paths can be set relatively to the .dm source file.
2. Emit compile error when resource file doesn't exist
3. Test loading of resource files

fix #1087