### PR TITLE
text2file: create parent directories for path arg

### DIFF
--- a/OpenDreamRuntime/Resources/DreamResourceManager.cs
+++ b/OpenDreamRuntime/Resources/DreamResourceManager.cs
@@ -176,7 +176,9 @@ namespace OpenDreamRuntime.Resources {
 
         public bool SaveTextToFile(string filePath, string text) {
             try {
-                File.WriteAllText(Path.Combine(RootPath, filePath), text);
+                string absoluteFilePath = Path.Combine(RootPath, filePath);
+                Directory.GetParent(absoluteFilePath)?.Create();
+                File.WriteAllText(absoluteFilePath, text);
             } catch (Exception) {
                 return false;
             }


### PR DESCRIPTION
dm ref for `text2file` says "If the file does not exist, one will be created."
previously it doesn't if there's an uncreated directory in the way.

- Expect: `root/folder_that_doesnt_exist_yet/thing.txt` to be created when I give it as a path
- What actually happens: `System.IO.DirectoryNotFoundException: Could not find a part of the path 'root/folder_that_doesnt_exist_yet/thing.txt'`

so, create it first. GetParent only returns `null` if the `absoluteFilePath` is the root of the entire filesystem. Reasonable to not create the directory if that is the case.