### PR TITLE
Wrap embedded winset parameters in quotes

### DIFF
--- a/OpenDreamClient/Interface/Controls/ControlBrowser.cs
+++ b/OpenDreamClient/Interface/Controls/ControlBrowser.cs
@@ -87,6 +87,15 @@ namespace OpenDreamClient.Interface.Controls
                     string? element = queryParams.Get("element");
                     queryParams.Remove("element");
 
+                    // Wrap each parameter in quotes so the entire value is used
+                    foreach (var paramKey in queryParams.AllKeys) {
+                        var paramValue = queryParams[paramKey];
+                        if (paramValue == null)
+                            continue;
+
+                        queryParams.Set(paramKey, $"\"{paramValue}\"");
+                    }
+
                     // Reassemble the query params without element then convert to winset syntax
                     var query = queryParams.ToString();
                     query = HttpUtility.UrlDecode(query);

--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -273,8 +273,8 @@ namespace OpenDreamRuntime {
         public void HandleCommand(string fullCommand) {
             // TODO: Arguments are a little more complicated than "split by spaces"
             // e.g. strings can be passed
-            string[] args = fullCommand.Split(' ');
-            string command = args[0].ToLowerInvariant().Replace(" ", "-"); // Case-insensitive, dashes instead of spaces
+            string[] args = fullCommand.Split(' ', StringSplitOptions.TrimEntries);
+            string command = args[0].ToLowerInvariant(); // Case-insensitive
 
             switch (command) {
                 //TODO: Maybe move these verbs to DM code?


### PR DESCRIPTION
Values with spaces were being cut off after the first space. This broke the close button in TGUI because it uses an embedded winset formatted as `byond://winset?command=uiclose 1234_1234`.