### PR TITLE
Fix runaway stack growth with background procs

### DIFF
--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -366,6 +366,7 @@ namespace DMCompiler.DM {
 
                 PushFloat(-1); // argument given to sleep()
                 Call(DMReference.CreateGlobalProc(sleepProc.Id), DMCallArgumentsType.FromStack, 1);
+                Pop(); // Pop the result of the sleep call
             }
         }
 


### PR DESCRIPTION
The return value of the implicit `sleep(-1)` call in procs with `set background = 1` wasn't being popped.