### PR TITLE
Use EAST/WEST dir when an icon state doesn't have diagonal dirs

### DIFF
--- a/OpenDreamClient/Resources/ResourceTypes/DMIResource.cs
+++ b/OpenDreamClient/Resources/ResourceTypes/DMIResource.cs
@@ -79,10 +79,20 @@ namespace OpenDreamClient.Resources.ResourceTypes {
             }
 
             public AtlasTexture[] GetFrames(AtomDirection direction) {
-                if (!Frames.TryGetValue(direction, out AtlasTexture[] frames))
-                    frames = Frames[AtomDirection.South];
+                // Find another direction to use if this one doesn't exist
+                if (!Frames.ContainsKey(direction)) {
+                    // The diagonal directions attempt to use east/west
+                    if (direction is AtomDirection.Northeast or AtomDirection.Southeast)
+                        direction = AtomDirection.East;
+                    else if (direction is AtomDirection.Northwest or AtomDirection.Southwest)
+                        direction = AtomDirection.West;
 
-                return frames;
+                    // Use the south direction if the above still isn't valid
+                    if (!Frames.ContainsKey(direction))
+                        direction = AtomDirection.South;
+                }
+
+                return Frames[direction];
             }
         }
 

--- a/OpenDreamShared/Resources/DMIParser.cs
+++ b/OpenDreamShared/Resources/DMIParser.cs
@@ -91,7 +91,18 @@ namespace OpenDreamShared.Resources {
             }
 
             public ParsedDMIFrame[] GetFrames(AtomDirection direction = AtomDirection.South) {
-                if (!Directions.ContainsKey(direction)) direction = Directions.Keys.First();
+                // Find another direction to use if this one doesn't exist
+                if (!Directions.ContainsKey(direction)) {
+                    // The diagonal directions attempt to use east/west
+                    if (direction is AtomDirection.Northeast or AtomDirection.Southeast)
+                        direction = AtomDirection.East;
+                    else if (direction is AtomDirection.Northwest or AtomDirection.Southwest)
+                        direction = AtomDirection.West;
+
+                    // Use the south direction if the above still isn't valid
+                    if (!Directions.ContainsKey(direction))
+                        direction = AtomDirection.South;
+                }
 
                 return Directions[direction];
             }


### PR DESCRIPTION
When an atom is facing a diagonal direction but the icon doesn't have diagonal directions, it should use the nearest `EAST` or `WEST` direction instead.

This bug is what was causing players to face south when moving diagonally.