### PR TITLE
Don't reuse DreamObject ref IDs

### DIFF
--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -17,7 +17,7 @@ using Robust.Shared.Configuration;
 using Robust.Shared.Timing;
 
 namespace OpenDreamRuntime {
-    partial class DreamManager : IDreamManager {
+    internal partial class DreamManager : IDreamManager {
         [Dependency] private readonly IConfigurationManager _configManager = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly IDreamMapManager _dreamMapManager = default!;
@@ -38,7 +38,8 @@ namespace OpenDreamRuntime {
         // Global state that may not really (really really) belong here
         public List<DreamValue> Globals { get; set; } = new();
         public IReadOnlyList<string> GlobalNames { get; private set; } = new List<string>();
-        public Dictionary<DreamObject, int> ReferenceIDs { get; set; } = new();
+        public Dictionary<DreamObject, int> ReferenceIDs { get; } = new();
+        public Dictionary<int, DreamObject> ReferenceIDsToDreamObject { get; } = new();
         public HashSet<DreamObject> Clients { get; set; } = new();
         public HashSet<DreamObject> Datums { get; set; } = new();
         public Random Random { get; set; } = new();
@@ -202,6 +203,7 @@ namespace OpenDreamRuntime {
                     if (!ReferenceIDs.TryGetValue(refObject, out idx)) {
                         idx = _dreamObjectRefIdCounter++;
                         ReferenceIDs.Add(refObject, idx);
+                        ReferenceIDsToDreamObject.Add(idx, refObject);
                     }
                 }
             } else if (value.TryGetValueAsString(out var refStr)) {
@@ -250,9 +252,8 @@ namespace OpenDreamRuntime {
                 case RefType.Null:
                     return DreamValue.Null;
                 case RefType.DreamObject:
-                    foreach (KeyValuePair<DreamObject, int> referenceIdPair in ReferenceIDs) {
-                        if (referenceIdPair.Value == refId) return new DreamValue(referenceIdPair.Key);
-                    }
+                    if (ReferenceIDsToDreamObject.TryGetValue(refId, out var dreamObject))
+                        return new(dreamObject);
 
                     return DreamValue.Null;
                 case RefType.String:

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -43,6 +43,7 @@ namespace OpenDreamRuntime {
         public HashSet<DreamObject> Datums { get; set; } = new();
         public Random Random { get; set; } = new();
         public Dictionary<string, List<DreamObject>> Tags { get; set; } = new();
+        private int _dreamObjectRefIdCounter;
 
         private DreamCompiledJson _compiledJson;
         public bool Initialized { get; private set; }
@@ -199,7 +200,7 @@ namespace OpenDreamRuntime {
 
                     refType = RefType.DreamObject;
                     if (!ReferenceIDs.TryGetValue(refObject, out idx)) {
-                        idx = ReferenceIDs.Count;
+                        idx = _dreamObjectRefIdCounter++;
                         ReferenceIDs.Add(refObject, idx);
                     }
                 }

--- a/OpenDreamRuntime/IDreamManager.cs
+++ b/OpenDreamRuntime/IDreamManager.cs
@@ -17,7 +17,8 @@ namespace OpenDreamRuntime {
 
         public List<DreamValue> Globals { get; }
         public IReadOnlyList<string> GlobalNames { get; }
-        public Dictionary<DreamObject, int> ReferenceIDs { get; set; }
+        public Dictionary<DreamObject, int> ReferenceIDs { get; }
+        public Dictionary<int, DreamObject> ReferenceIDsToDreamObject { get; }
         public HashSet<DreamObject> Clients { get; set; }
         public HashSet<DreamObject> Datums { get; set; }
         public Random Random { get; set; }

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -43,7 +43,8 @@ namespace OpenDreamRuntime.Objects {
             _variables = null;
             ObjectDefinition = null!;
 
-            manager.ReferenceIDs.Remove(this);
+            if (manager.ReferenceIDs.Remove(this, out var refId))
+                manager.ReferenceIDsToDreamObject.Remove(refId);
         }
 
         public void SetObjectDefinition(DreamObjectDefinition objectDefinition) {


### PR DESCRIPTION
`ref()` IDs for DreamObjects were using `ReferenceIDs.Count` which led to them being reused when a DreamObject is deleted.

I also optimized `locate()` for DreamObjects by creating a second ID->DreamObject dictionary.

Fixes #338