### PR TITLE
Rewrite `/list.Join()` in C#

### DIFF
--- a/Content.Tests/DMProject/Tests/List/ListJoin.dm
+++ b/Content.Tests/DMProject/Tests/List/ListJoin.dm
@@ -1,0 +1,18 @@
+﻿/proc/RunTest()
+	var/list/L = list(1, 2, 3, 4, 5)
+
+	ASSERT(L.Join(";") == "1;2;3;4;5")
+	ASSERT(L.Join("_") == "1_2_3_4_5")
+	ASSERT(L.Join(null) == "12345")
+	ASSERT(L.Join(1) == "12345")
+
+	ASSERT(L.Join(";", 2) == "2;3;4;5")
+	ASSERT(L.Join(";", 4) == "4;5")
+	ASSERT(L.Join(";", 0) == "")
+	ASSERT(L.Join(";", -3) == "3;4;5")
+	ASSERT(L.Join(";", new /datum()) == "1;2;3;4;5")
+
+	ASSERT(L.Join(";", 1, 0) == "1;2;3;4;5")
+	ASSERT(L.Join(";", -4, -2) == "2;3")
+
+

--- a/DMCompiler/DMStandard/Types/List.dm
+++ b/DMCompiler/DMStandard/Types/List.dm
@@ -9,17 +9,9 @@
 	proc/Cut(Start = 1, End = 0)
 	proc/Find(Elem, Start = 1, End = 0)
 	proc/Insert(Index, Item1)
+	proc/Join(Glue, Start = 1, End = 0)
 	proc/Remove(Item1)
 	proc/Swap(Index1, Index2)
 
 	proc/Splice(Start=1,End=0, ...)
 		set opendream_unimplemented = TRUE
-
-	proc/Join(Glue, Start = 1, End = 0)
-		if (End == 0) End = src.len
-
-		var/result = ""
-		for (var/i in Start to End)
-			result += "[src[i]][(i != End) ? Glue : null]"
-
-		return result

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -127,6 +127,7 @@ namespace OpenDreamRuntime.Procs.Native {
             objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Cut);
             objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Find);
             objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Insert);
+            objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Join);
             objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Remove);
             objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Swap);
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeList.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeList.cs
@@ -1,13 +1,13 @@
-﻿using System.Linq;
+﻿using System.Text;
 using OpenDreamRuntime.Objects;
 using DreamValueType = OpenDreamRuntime.DreamValue.DreamValueType;
 
 namespace OpenDreamRuntime.Procs.Native {
-    static class DreamProcNativeList {
+    internal static class DreamProcNativeList {
         [DreamProc("Add")]
         [DreamProcParameter("Item1")]
         public static DreamValue NativeProc_Add(NativeProc.State state) {
-            DreamList list = (DreamList)state.Src;
+            DreamList list = (DreamList)state.Src!;
 
             foreach (var argument in state.Arguments.Values) {
                 if (argument.TryGetValueAsDreamList(out var argumentList)) {
@@ -28,7 +28,7 @@ namespace OpenDreamRuntime.Procs.Native {
         public static DreamValue NativeProc_Copy(NativeProc.State state) {
             int start = state.GetArgument(0, "Start").GetValueAsInteger(); //1-indexed
             int end = state.GetArgument(1, "End").GetValueAsInteger(); //1-indexed
-            DreamList list = (DreamList)state.Src;
+            DreamList list = (DreamList)state.Src!;
             DreamList listCopy = list.CreateCopy(start, end);
 
             return new DreamValue(listCopy);
@@ -40,7 +40,7 @@ namespace OpenDreamRuntime.Procs.Native {
         public static DreamValue NativeProc_Cut(NativeProc.State state) {
             int start = state.GetArgument(0, "Start").GetValueAsInteger(); //1-indexed
             int end = state.GetArgument(1, "End").GetValueAsInteger(); //1-indexed
-            DreamList list = (DreamList)state.Src;
+            DreamList list = (DreamList)state.Src!;
 
             list.Cut(start, end);
             return DreamValue.Null;
@@ -54,7 +54,7 @@ namespace OpenDreamRuntime.Procs.Native {
             DreamValue element = state.GetArgument(0, "Elem");
             int start = state.GetArgument(1, "Start").GetValueAsInteger(); //1-indexed
             int end = state.GetArgument(2, "End").GetValueAsInteger(); //1-indexed
-            DreamList list = (DreamList)state.Src;
+            DreamList list = (DreamList)state.Src!;
 
             return new(list.FindValue(element, start, end));
         }
@@ -64,7 +64,7 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("Item1")]
         public static DreamValue NativeProc_Insert(NativeProc.State state) {
             int index = state.GetArgument(0, "Index").GetValueAsInteger(); //1-indexed
-            DreamList list = (DreamList)state.Src;
+            DreamList list = (DreamList)state.Src!;
 
             if (index <= 0) index = list.GetLength() + 1;
             if (state.Arguments.Count < 2) throw new Exception("No value given to insert");
@@ -84,10 +84,43 @@ namespace OpenDreamRuntime.Procs.Native {
             return new DreamValue(index);
         }
 
+        [DreamProc("Join")]
+        [DreamProcParameter("Glue", Type = DreamValueType.String)]
+        [DreamProcParameter("Start", Type = DreamValueType.Float, DefaultValue = 1)]
+        [DreamProcParameter("End", Type = DreamValueType.Float, DefaultValue = 0)]
+        public static DreamValue NativeProc_Join(NativeProc.State state) {
+            DreamList list = (DreamList)state.Src!;
+            List<DreamValue> values = list.GetValues();
+
+            state.GetArgument(0, "Glue").TryGetValueAsString(out var glue);
+            if (!state.GetArgument(1, "Start").TryGetValueAsInteger(out var start))
+                start = 1;
+            state.GetArgument(2, "End").TryGetValueAsInteger(out var end);
+
+            // Negative wrap-around
+            if (end <= 0)
+                end += values.Count + 1;
+            if (start < 0)
+                start += values.Count + 1;
+
+            if (start == 0 || start >= end)
+                return new(string.Empty);
+
+            StringBuilder result = new(end - start);
+            for (int i = start; i < end; i++) {
+                result.Append(values[i - 1].Stringify());
+
+                if (i != end - 1)
+                    result.Append(glue);
+            }
+
+            return new DreamValue(result.ToString());
+        }
+
         [DreamProc("Remove")]
         [DreamProcParameter("Item1")]
         public static DreamValue NativeProc_Remove(NativeProc.State state) {
-            DreamList list = (DreamList)state.Src;
+            DreamList list = (DreamList)state.Src!;
             bool itemRemoved = false;
 
             foreach (var argument in state.Arguments.Values) {
@@ -115,7 +148,7 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("Index1", Type = DreamValueType.Float)]
         [DreamProcParameter("Index2", Type = DreamValueType.Float)]
         public static DreamValue NativeProc_Swap(NativeProc.State state) {
-            DreamList list = (DreamList)state.Src;
+            DreamList list = (DreamList)state.Src!;
             int index1 = state.GetArgument(0, "Index1").GetValueAsInteger();
             int index2 = state.GetArgument(1, "Index2").GetValueAsInteger();
 


### PR DESCRIPTION
Massively improves its performance, especially on large lists.