### PR TITLE
Rewrites /matrix.New to be in C#

### DIFF
--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixNew.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixNew.dm
@@ -1,0 +1,7 @@
+﻿/proc/RunTest()
+	var/matrix/M = matrix(1,2,3,4,5,6)
+	var/matrix/N = matrix()
+	var/matrix/B = matrix(M)
+
+	if(B ~! M)
+		CRASH("Unexpected matrix/New/Copy result: [json_encode(M)] & [json_encode(B)]")

--- a/DMCompiler/DMStandard/Types/Matrix.dm
+++ b/DMCompiler/DMStandard/Types/Matrix.dm
@@ -11,22 +11,7 @@
 	proc/Interpolate(Matrix2, t)
 		set opendream_unimplemented = TRUE
 
-	New(var/a = 1, var/b = 0, var/c = 0, var/d = 0, var/e = 1, var/f = 0)
-		if (istype(a, /matrix))
-			var/matrix/mat = a
-			src.a = mat.a
-			src.b = mat.b
-			src.c = mat.c
-			src.d = mat.d
-			src.e = mat.e
-			src.f = mat.f
-		else
-			src.a = a
-			src.b = b
-			src.c = c
-			src.d = d
-			src.e = e
-			src.f = f
+	New(var/a, var/b, var/c, var/d, var/e, var/f)
 
 	proc/Add(matrix/Matrix2)
 		if(!istype(Matrix2))

--- a/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMatrix.cs
+++ b/OpenDreamRuntime/Objects/MetaObjects/DreamMetaObjectMatrix.cs
@@ -1,5 +1,6 @@
 ﻿using OpenDreamShared.Dream;
 using System.Collections.Immutable;
+using OpenDreamRuntime.Procs;
 
 namespace OpenDreamRuntime.Objects.MetaObjects {
     sealed class DreamMetaObjectMatrix : IDreamMetaObject {
@@ -13,6 +14,42 @@ namespace OpenDreamRuntime.Objects.MetaObjects {
 
         public DreamMetaObjectMatrix() {
             IoCManager.InjectDependencies(this);
+        }
+        public void OnObjectCreated(DreamObject dreamObject, DreamProcArguments creationArguments) {
+            if (creationArguments.Count > 0) {
+                DreamValue copyMatrixOrA = creationArguments.GetArgument(0);
+                if (copyMatrixOrA.TryGetValueAsDreamObjectOfType(_objectTree.Matrix, out var matrixToCopy)) {
+                    dreamObject.SetVariableValue("a", matrixToCopy.GetVariable("a"));
+                    dreamObject.SetVariableValue("b", matrixToCopy.GetVariable("b"));
+                    dreamObject.SetVariableValue("c", matrixToCopy.GetVariable("c"));
+                    dreamObject.SetVariableValue("d", matrixToCopy.GetVariable("d"));
+                    dreamObject.SetVariableValue("e", matrixToCopy.GetVariable("e"));
+                    dreamObject.SetVariableValue("f", matrixToCopy.GetVariable("f"));
+                } else {
+                    DreamValue b = creationArguments.GetArgument(1);
+                    DreamValue c = creationArguments.GetArgument(2);
+                    DreamValue d = creationArguments.GetArgument(3);
+                    DreamValue e = creationArguments.GetArgument(4);
+                    DreamValue f = creationArguments.GetArgument(5);
+                    try { // BYOND runtimes if args are of the wrong type
+                        copyMatrixOrA.MustGetValueAsFloat();
+                        b.MustGetValueAsFloat();
+                        c.MustGetValueAsFloat();
+                        d.MustGetValueAsFloat();
+                        e.MustGetValueAsFloat();
+                        f.MustGetValueAsFloat();
+                    } catch (InvalidCastException) {
+                        throw new ArgumentException($"Invalid arguments used to create matrix {dreamObject}");
+                    }
+                    dreamObject.SetVariableValue("a", copyMatrixOrA);
+                    dreamObject.SetVariableValue("b", b);
+                    dreamObject.SetVariableValue("c", c);
+                    dreamObject.SetVariableValue("d", d);
+                    dreamObject.SetVariableValue("e", e);
+                    dreamObject.SetVariableValue("f", f);
+                }
+            }
+            ParentType?.OnObjectCreated(dreamObject, creationArguments);
         }
 
         /// <summary> Used to create a float array understandable by <see cref="IconAppearance.Transform"/> to be a transform. </summary>


### PR DESCRIPTION
Rewrites /matrix.New to be in C#


## Reasoning

This is mainly done for performance as well as better failure modes/parity and general code safety.


Natural continuation of #1117 & #1236
Dev testing was fairly comprehensive and unit tests all pass.


## Performance comparisons (Release):

| Impl  | Operation (1,200,000 loops) | Time |
| ------------- | ------------- | ------------- |
| DM | Matrix.New | 84ds |
| C# | Matrix.New | 52ds |

**~38.1%** increase in perf 

<details>
<summary>Details</summary>
<pre>
/world/New()
	..()
	sleep(5)
	var/t = world.timeofday
	for (var/i in 1 to 1200000)
		one()
	world.log << "elapsed: [world.timeofday - t]ds"

var/global/Glob = null
/proc/one()
	var/matrix/M = matrix(1,2,3,4,5,6)
	var/matrix/N = matrix()
	var/matrix/B = matrix(M)
	Glob = B</pre>
</details>

