### PR TITLE
Put `AggressiveInlining` on operand reading methods

### DIFF
--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Objects.Types;
@@ -453,10 +454,12 @@ namespace OpenDreamRuntime.Procs {
         #endregion
 
         #region Operands
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int ReadByte() {
             return _proc.Bytecode[_pc++];
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int ReadInt() {
             int value = BitConverter.ToInt32(_proc.Bytecode, _pc);
             _pc += 4;
@@ -464,6 +467,7 @@ namespace OpenDreamRuntime.Procs {
             return value;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public float ReadFloat() {
             float value = BitConverter.ToSingle(_proc.Bytecode, _pc);
             _pc += 4;
@@ -471,12 +475,14 @@ namespace OpenDreamRuntime.Procs {
             return value;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ReadString() {
-            int stringID = ReadInt();
+            int stringId = ReadInt();
 
-            return Proc.ObjectTree.Strings[stringID];
+            return Proc.ObjectTree.Strings[stringId];
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public DMReference ReadReference() {
             DMReference.Type refType = (DMReference.Type)ReadByte();
 

--- a/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
+++ b/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace OpenDreamShared.Dream.Procs {
@@ -311,34 +312,41 @@ namespace OpenDreamShared.Dream.Procs {
         //Field, SrcField, Proc, SrcProc
         public string Name;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DMReference CreateArgument(int argId) {
             if (argId > 255) throw new Exception("Argument id is greater than the maximum of 255");
 
             return new DMReference() { RefType = Type.Argument, Index = (byte)argId };
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DMReference CreateLocal(int local) {
             if (local > 255) throw new Exception("Local variable id is greater than the maximum of 255");
 
             return new DMReference() { RefType = Type.Local, Index = (byte)local };
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DMReference CreateGlobal(int global) {
             return new DMReference() { RefType = Type.Global, Index = global };
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DMReference CreateField(string fieldName) {
             return new DMReference() { RefType = Type.Field, Name = fieldName };
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DMReference CreateSrcField(string fieldName) {
             return new DMReference() { RefType = Type.SrcField, Name = fieldName };
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DMReference CreateGlobalProc(int procId) {
             return new DMReference() { RefType = Type.GlobalProc, Index = procId };
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DMReference CreateSrcProc(string procName) {
             return new DMReference() { RefType = Type.SrcProc, Name = procName };
         }


### PR DESCRIPTION
Brought my Paradise init down to 41.9 seconds.