### PR TITLE
Ignore duplicate values being added to the `verbs` lists

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -523,6 +523,8 @@ namespace OpenDreamRuntime.Objects.Types {
         public override void AddValue(DreamValue value) {
             if (!value.TryGetValueAsProc(out var verb))
                 throw new Exception($"Cannot add {value} to verbs list");
+            if (_verbs.Contains(verb))
+                return; // Even += won't add the verb if it's already in this list
 
             _verbs.Add(verb);
         }


### PR DESCRIPTION
In this code snippet there won't be two `/proc/foo` values in the list despite `+=` being used instead of `|=`
```
mob.verbs += /proc/foo
mob.verbs += /proc/foo
```

Fixes #165