### PR TITLE
Remove unncessary single-statement labels

### DIFF
--- a/Content.Tests/DMProject/Tests/Statements/Control Flow/label_before_var.dm
+++ b/Content.Tests/DMProject/Tests/Statements/Control Flow/label_before_var.dm
@@ -1,8 +1,6 @@
 
 //# issue 1032
 
-#define ASSERT(x) x
-
 /proc/RunTest()
 	label:
 	var/b = 5

--- a/Content.Tests/DMProject/Tests/Statements/Control Flow/label_before_var.dm
+++ b/Content.Tests/DMProject/Tests/Statements/Control Flow/label_before_var.dm
@@ -1,0 +1,9 @@
+
+//# issue 1032
+
+#define ASSERT(x) x
+
+/proc/RunTest()
+	label:
+	var/b = 5
+	ASSERT(b == 5)

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -1447,12 +1447,6 @@ namespace DMCompiler.Compiler.DM {
             Newline();
 
             DMASTProcBlockInner? body = ProcBlock();
-            if (body == null) {
-                var loc = Current().Location;
-                DMASTProcStatement? statement = ProcStatement();
-
-                if (statement != null) body = new DMASTProcBlockInner(loc, statement);
-            }
 
             return new DMASTProcStatementLabel(expression.Location, expression.Identifier, body);
         }


### PR DESCRIPTION
- Fixes #1032 

So, turns out the code that I removed finds a statement if the label does not correspond to a properly scoped block (by indentation or bracing), it takes the next statement after the label and wraps it in its own scope. Which has the undesirable effect of moving local variables one wrong scope down and causing other issues related to the parser eating tokens when it should not. - The variable declaration in #1032 instead becomes an assignment expression.

While this would be true for named loops, it seems to be largely inconsequential and the best practice is to intent the loop body anyway. Plus the AST-nodes for the loops do not have any kind of polymorphism to distinguish them from other proc statement nodes. The solution to straight-up remove the feature had no regression on other tests or runtime, I am inclined to believe this is a good solution.