### PR TITLE
Fix adding two associative lists

### DIFF
--- a/Content.Tests/DMProject/Tests/List/AssocListAdd.dm
+++ b/Content.Tests/DMProject/Tests/List/AssocListAdd.dm
@@ -1,0 +1,8 @@
+﻿/proc/RunTest()
+	var/list/L1 = list("A" = 1)
+	var/list/L2 = list("B" = 2)
+
+	ASSERT( (L1 + L2)["B"] == 2 )
+
+	L1 += L2
+	ASSERT(L1["B"] == 2)

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -240,7 +240,11 @@ namespace OpenDreamRuntime.Objects.Types {
 
             if (b.TryGetValueAsDreamList(out var bList)) {
                 foreach (DreamValue value in bList.GetValues()) {
-                    listCopy.AddValue(value);
+                    if (bList._associativeValues?.TryGetValue(value, out var assocValue) is true) {
+                        listCopy.SetValue(value, assocValue);
+                    } else {
+                        listCopy.AddValue(value);
+                    }
                 }
             } else {
                 listCopy.AddValue(b);
@@ -279,7 +283,11 @@ namespace OpenDreamRuntime.Objects.Types {
         public override DreamValue OperatorAppend(DreamValue b) {
             if (b.TryGetValueAsDreamList(out var bList)) {
                 foreach (DreamValue value in bList.GetValues()) {
-                    AddValue(value);
+                    if (bList._associativeValues?.TryGetValue(value, out var assocValue) is true) {
+                        SetValue(value, assocValue);
+                    } else {
+                        AddValue(value);
+                    }
                 }
             } else {
                 AddValue(b);


### PR DESCRIPTION
Adding two associative lists with either `+` or `+=` wasn't keeping the associative values from the second list.