### PR TITLE
Show globals in alphabetical order in the debugger

### DIFF
--- a/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
@@ -666,7 +666,7 @@ internal sealed class DreamDebugManager : IDreamDebugManager {
     }
 
     private IEnumerable<Variable> ExpandGlobals(RequestVariables req) {
-        foreach (var (name, value) in _dreamManager.GlobalNames.Zip(_dreamManager.Globals)) {
+        foreach (var (name, value) in _dreamManager.GlobalNames.Order().Zip(_dreamManager.Globals)) {
             yield return DescribeValue(name, value);
         }
     }


### PR DESCRIPTION
This makes it easier to find a global from the huge list. In the future it may be better to only show globals used by the current proc.