### PR TITLE
Fix some uses of `params2list()`

### DIFF
--- a/Content.Tests/DMProject/Tests/Builtins/params2list.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/params2list.dm
@@ -1,0 +1,6 @@
+﻿/proc/RunTest()
+	ASSERT(params2list("a;b;c") ~= list(a="", b="", c=""))
+	ASSERT(params2list("a;a;a") ~= list(a=list("", "", ""))) // Crazy
+
+	ASSERT(params2list("a=1;b=2") ~= list(a="1", b="2"))
+	ASSERT(params2list("a=1;a=2") ~= list(a="2"))


### PR DESCRIPTION
Fixes some weird uses of `params2list()` and adds a test case for them.

Fixes the mining shuttle console on Paradise.