### PR TITLE
Remove `OutputReference` opcode's push

### DIFF
--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1677,13 +1677,11 @@ namespace OpenDreamRuntime.Procs {
                     // "savefile[A] << B" is the same as "savefile[A] = B"
 
                     state.AssignReference(leftRef, right);
-                    state.Push(DreamValue.Null);
                     return null;
                 }
             }
 
             PerformOutput(state.GetReferenceValue(leftRef), right);
-            state.Push(DreamValue.Null);
             return null;
         }
 


### PR DESCRIPTION
`OutputReference` was pushing null onto the stack, which is incorrect and led to stack errors.