### PR TITLE
Include frame delays in generated DMIs

### DIFF
--- a/OpenDream.sln.DotSettings
+++ b/OpenDream.sln.DotSettings
@@ -15,6 +15,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cmptext/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=copytext/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Debuggee/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=deciseconds/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fcopy/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=flist/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=isarea/@EntryIndexedValue">True</s:Boolean>

--- a/OpenDreamShared/Resources/DMIParser.cs
+++ b/OpenDreamShared/Resources/DMIParser.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Text;
 using OpenDreamShared.Dream;
 using System.Globalization;
-using JetBrains.Annotations;
 
 namespace OpenDreamShared.Resources {
     public static class DMIParser {
@@ -121,6 +120,19 @@ namespace OpenDreamShared.Resources {
                 text.Append("\tframes = ");
                 text.Append(FrameCount);
                 text.AppendLine();
+
+                if (Directions.Count > 0) {
+                    text.Append("\tdelay = ");
+                    var frames = Directions.Values.First(); // Delays should be the same in each direction
+                    for (int i = 0; i < frames.Length; i++) {
+                        var delay = frames[i].Delay / 100; // Convert back to deciseconds
+
+                        text.Append(delay.ToString(CultureInfo.InvariantCulture));
+                        if (i != frames.Length - 1)
+                            text.Append(',');
+                    }
+                    text.AppendLine();
+                }
 
                 if (!Loop) {
                     text.AppendLine("\tloop = 0");


### PR DESCRIPTION
DMIs created with `/icon` now have working animation frame delays.

The title screen on Paradise doesn't flash 5 times a second anymore.