### PR TITLE
Fixes "operator" not working as a valid type name

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -366,7 +366,18 @@ namespace DMCompiler.Compiler.DM {
                     if (pathElement != null) {
                         if(pathElement == "operator") {
                             Token operatorToken = Current();
-                            if(Check(OperatorOverloadTypes)) {
+                            if(Current().Type == TokenType.DM_Slash) {
+                                //Up to this point, it's ambiguous whether it's a slash to mean operator/(), like the division operator overload
+                                //or "operator" just being used as a normal type name, as in a/operator/b/c/d
+                                Token peekToken = Advance();
+                                if (peekToken.Type == TokenType.DM_LeftParenthesis) { // Disambiguated as an overload
+                                    operatorFlag = true;
+                                    pathElement += operatorToken.PrintableText;
+                                } else { //Otherwise it's just a normal path, resume
+                                    ReuseToken(operatorToken);
+                                    Warning("Using \"operator\" as a path element is ambiguous", Current()); // NOTE: Maybe should be SoftReservedKeyword? Unsure!
+                                }
+                            } else if(Check(OperatorOverloadTypes)) {
                                 operatorFlag = true;
                                 pathElement+=operatorToken.PrintableText;
                             }

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -375,7 +375,7 @@ namespace DMCompiler.Compiler.DM {
                                     pathElement += operatorToken.PrintableText;
                                 } else { //Otherwise it's just a normal path, resume
                                     ReuseToken(operatorToken);
-                                    Warning("Using \"operator\" as a path element is ambiguous", Current()); // NOTE: Maybe should be SoftReservedKeyword? Unsure!
+                                    Error(WarningCode.SoftReservedKeyword, "Using \"operator\" as a path element is ambiguous");
                                 }
                             } else if(Check(OperatorOverloadTypes)) {
                                 operatorFlag = true;


### PR DESCRIPTION
Previously, a phrase like "a/b/operator/c" would be interpreted by Path() as an imminent `a/b/operator/()` divison overload, to be followed by a `c` identifier token.

This was causing compile errors in Yogs, where NTSL makes use of a legit type called operator.

This allows Yogs to compile :^)
## Changelog
- Using `operator` as a type name is now allowed and behaves similarly to BYOND.