### PR TITLE
Perform a case-insensitive search for resource files

### DIFF
--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -41,8 +41,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
         private readonly Stack<bool?> _lastIfEvaluations = new(16);
         private Location _lastSeenIf = Location.Unknown; // used by the errors emitted for when the above var isn't empty at exit
 
-        private static readonly TokenType[] DirectiveTypes =
-        {
+        private static readonly TokenType[] DirectiveTypes = {
             TokenType.DM_Preproc_Include,
             TokenType.DM_Preproc_Define,
             TokenType.DM_Preproc_Undefine,
@@ -256,7 +255,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
             source = source.Replace("\r\n", "\n");
             source += '\n';
 
-            _lexerStack.Push(new DMPreprocessorLexer(includeDir, file, source));
+            _lexerStack.Push(new DMPreprocessorLexer(includeDir, file.Replace('\\', Path.DirectorySeparatorChar), source));
         }
 
         private bool VerifyDirectiveUsage(Token token) {

--- a/DMCompiler/DM/Expressions/Constant.cs
+++ b/DMCompiler/DM/Expressions/Constant.cs
@@ -370,25 +370,27 @@ namespace DMCompiler.DM.Expressions {
             if (directory != null) {
                 // Perform a case-insensitive search for the file
                 finalFilePath = FindFile(directory, fileName);
-                if (finalFilePath == null) { // Search relative to the source file if it wasn't in the project's directory
-                    var sourceDir = System.IO.Path.Combine(outputDir, System.IO.Path.GetDirectoryName(Location.SourceFile) ?? string.Empty);
-                    directory = FindDirectory(sourceDir, fileDir);
+            }
 
-                    if (directory != null)
-                        finalFilePath = FindFile(directory, fileName);
-                }
+            // Search relative to the source file if it wasn't in the project's directory
+            if (finalFilePath == null) {
+                var sourceDir = System.IO.Path.Combine(outputDir, System.IO.Path.GetDirectoryName(Location.SourceFile) ?? string.Empty);
+                directory = FindDirectory(sourceDir, fileDir);
+
+                if (directory != null)
+                    finalFilePath = FindFile(directory, fileName);
             }
 
             if (finalFilePath != null) {
-                _filePath = finalFilePath;
+                _filePath = System.IO.Path.GetRelativePath(outputDir, finalFilePath);
+
+                if (_isAmbiguous) {
+                    DMCompiler.Emit(WarningCode.AmbiguousResourcePath, Location,
+                        $"Resource {filePath} has multiple case-insensitive matches, using {_filePath}");
+                }
             } else {
                 DMCompiler.Emit(WarningCode.ItemDoesntExist, Location, $"Cannot find file '{filePath}'");
                 _filePath = filePath;
-            }
-
-            if (_isAmbiguous) {
-                DMCompiler.Emit(WarningCode.AmbiguousResourcePath, Location,
-                    $"Resource {filePath} has multiple case-insensitive matches, using {System.IO.Path.GetRelativePath(outputDir, _filePath)}");
             }
         }
 

--- a/DMCompiler/DM/Expressions/Constant.cs
+++ b/DMCompiler/DM/Expressions/Constant.cs
@@ -407,6 +407,13 @@ namespace DMCompiler.DM.Expressions {
             return true;
         }
 
+        /// <summary>
+        /// Performs a recursive case-insensitive for a directory.<br/>
+        /// Marks the resource as ambiguous if multiple are found.
+        /// </summary>
+        /// <param name="directory">Directory to search in (case-sensitive)</param>
+        /// <param name="searching">Directory to search for (case-insensitive)</param>
+        /// <returns>The found directory, null if none</returns>
         private string? FindDirectory(string directory, string searching) {
             var searchingDirectories = searching.Split('/', StringSplitOptions.RemoveEmptyEntries);
 
@@ -424,6 +431,13 @@ namespace DMCompiler.DM.Expressions {
             return directory;
         }
 
+        /// <summary>
+        /// Performs a case-insensitive search for a file inside a directory.<br/>
+        /// Marks the resource as ambiguous if multiple are found.
+        /// </summary>
+        /// <param name="directory">Directory to search in (case-sensitive)</param>
+        /// <param name="searching">File to search for (case-insensitive)</param>
+        /// <returns>The found file, null if none</returns>
         private string? FindFile(string directory, string searching) {
             var files = Directory.GetFiles(directory, searching, SearchOptions);
 

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -25,6 +25,7 @@
 #pragma InvalidOverride warning
 #pragma DanglingVarType warning
 #pragma MissingInterpolatedExpression warning
+#pragma AmbiguousResourcePath warning
 
 //3000-3999
 #pragma EmptyBlock notice

--- a/OpenDreamShared/Compiler/CompilerError.cs
+++ b/OpenDreamShared/Compiler/CompilerError.cs
@@ -50,6 +50,7 @@ namespace OpenDreamShared.Compiler {
         InvalidOverride = 2303,
         DanglingVarType = 2401, // For types inferred by a particular var definition and nowhere else, that ends up not existing (not forced-fatal because BYOND doesn't always error)
         MissingInterpolatedExpression = 2500, // A text macro is missing a required interpolated expression
+        AmbiguousResourcePath = 2600,
 
         // 3000 - 3999 are reserved for stylistic configuration.
         EmptyBlock = 3100,


### PR DESCRIPTION
The compiler now does a case-insensitive search for both the directory and file of a resource. I also added an `AmbiguousResourcePath` warning that tells you when there are multiple files that match a resource's path.

Fixes #591