### PR TITLE
Implement the view algorithm

### DIFF
--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -34,7 +34,7 @@
 	var/mouse_opacity = 1
 	var/infra_luminosity = 0 as opendream_unimplemented
 	var/luminosity = 0 as opendream_unimplemented
-	var/opacity = 0 as opendream_unimplemented
+	var/opacity = 0
 	var/matrix/transform
 	var/blend_mode = 0
 

--- a/OpenDreamClient/EntryPoint.cs
+++ b/OpenDreamClient/EntryPoint.cs
@@ -20,6 +20,7 @@ namespace OpenDreamClient {
         [Dependency] private readonly IDreamInterfaceManager _dreamInterface = default!;
         [Dependency] private readonly IDreamResourceManager _dreamResource = default!;
         [Dependency] private readonly IOverlayManager _overlayManager = default!;
+        [Dependency] private readonly ILightManager _lightManager = default!;
 
         private const string UserAgent =
             "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729)";
@@ -64,10 +65,7 @@ namespace OpenDreamClient {
         }
 
         public override void PostInit() {
-            ILightManager lightManager = IoCManager.Resolve<ILightManager>();
-            lightManager.Enabled = true;
-            lightManager.DrawLighting = false;
-            lightManager.DrawShadows = true;
+            _lightManager.Enabled = false;
 
             _overlayManager.AddOverlay(new DreamViewOverlay());
 

--- a/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
+++ b/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
@@ -1,6 +1,4 @@
 ﻿using OpenDreamShared.Dream;
-using Robust.Shared.Map;
-using Robust.Shared.Map.Components;
 using SharedAppearanceSystem = OpenDreamShared.Rendering.SharedAppearanceSystem;
 using Robust.Client.Graphics;
 using Robust.Shared.Prototypes;
@@ -8,26 +6,19 @@ using OpenDreamClient.Resources;
 using OpenDreamClient.Resources.ResourceTypes;
 
 namespace OpenDreamClient.Rendering {
-    sealed class ClientAppearanceSystem : SharedAppearanceSystem {
+    internal sealed class ClientAppearanceSystem : SharedAppearanceSystem {
         private Dictionary<uint, IconAppearance> _appearances = new();
         private readonly Dictionary<uint, List<Action<IconAppearance>>> _appearanceLoadCallbacks = new();
         private readonly Dictionary<uint, DreamIcon> _turfIcons = new();
         private readonly Dictionary<DreamFilter, ShaderInstance> _filterShaders = new();
 
-        /// <summary>
-        /// Holds the entities used by opaque turfs to block vision
-        /// </summary>
-        private readonly Dictionary<(MapGridComponent, Vector2i), EntityUid> _opaqueTurfEntities = new();
-
         [Dependency] private readonly IEntityManager _entityManager = default!;
-        [Dependency] private readonly OccluderSystem _occluderSystem = default!;
         [Dependency] private readonly IDreamResourceManager _dreamResourceManager = default!;
 
         public override void Initialize() {
             SubscribeNetworkEvent<AllAppearancesEvent>(OnAllAppearances);
             SubscribeNetworkEvent<NewAppearanceEvent>(OnNewAppearance);
             SubscribeNetworkEvent<AnimationEvent>(OnAnimation);
-            SubscribeLocalEvent<GridModifiedEvent>(OnGridModified);
         }
 
         public override void Shutdown() {
@@ -37,7 +28,7 @@ namespace OpenDreamClient.Rendering {
         }
 
         public void LoadAppearance(uint appearanceId, Action<IconAppearance> loadCallback) {
-            if (_appearances.TryGetValue(appearanceId, out IconAppearance appearance)) {
+            if (_appearances.TryGetValue(appearanceId, out var appearance)) {
                 loadCallback(appearance);
             }
 
@@ -182,34 +173,6 @@ namespace OpenDreamClient.Rendering {
             filter.Used = true;
             _filterShaders[filter] = instance;
             return instance;
-        }
-
-        private void OnGridModified(GridModifiedEvent e) {
-            foreach (var modified in e.Modified) {
-                UpdateTurfOpacity(e.Grid, modified.position, modified.tile);
-            }
-        }
-
-        private void UpdateTurfOpacity(MapGridComponent grid, Vector2i position, Tile newTile) {
-            LoadAppearance((uint)newTile.TypeId - 1, appearance => {
-                bool hasOpaqueEntity = _opaqueTurfEntities.TryGetValue((grid, position), out var opaqueEntity);
-
-                if (appearance.Opacity && !hasOpaqueEntity) {
-                    var entityPosition = grid.GridTileToWorld(position);
-
-                    // TODO: Maybe use a prototype?
-                    opaqueEntity = _entityManager.SpawnEntity(null, entityPosition);
-                    _entityManager.GetComponent<TransformComponent>(opaqueEntity).Anchored = true;
-                    var occluder = _entityManager.AddComponent<OccluderComponent>(opaqueEntity);
-                    _occluderSystem.SetBoundingBox(opaqueEntity, Box2.FromDimensions(-1.0f, -1.0f, 1.0f, 1.0f), occluder);
-                    _occluderSystem.SetEnabled(opaqueEntity, true, occluder);
-
-                    _opaqueTurfEntities.Add((grid, position), opaqueEntity);
-                } else if (hasOpaqueEntity) {
-                    _entityManager.DeleteEntity(opaqueEntity);
-                    _opaqueTurfEntities.Remove((grid, position));
-                }
-            });
         }
     }
 }

--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -351,6 +351,7 @@ namespace OpenDreamRuntime {
             def.TryGetVariable("alpha", out var alphaVar);
             def.TryGetVariable("dir", out var dirVar);
             def.TryGetVariable("invisibility", out var invisibilityVar);
+            def.TryGetVariable("opacity", out var opacityVar);
             def.TryGetVariable("mouse_opacity", out var mouseVar);
             def.TryGetVariable("pixel_x", out var xVar);
             def.TryGetVariable("pixel_y", out var yVar);
@@ -368,6 +369,7 @@ namespace OpenDreamRuntime {
             SetAppearanceVar(appearance, "alpha", alphaVar);
             SetAppearanceVar(appearance, "dir", dirVar);
             SetAppearanceVar(appearance, "invisibility", invisibilityVar);
+            SetAppearanceVar(appearance, "opacity", opacityVar);
             SetAppearanceVar(appearance, "mouse_opacity", mouseVar);
             SetAppearanceVar(appearance, "pixel_x", xVar);
             SetAppearanceVar(appearance, "pixel_y", yVar);

--- a/OpenDreamShared/Dream/ViewAlgorithm.cs
+++ b/OpenDreamShared/Dream/ViewAlgorithm.cs
@@ -1,0 +1,231 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace OpenDreamShared.Dream;
+
+public static class ViewAlgorithm {
+    [Flags]
+    public enum VisibilityFlags {
+        LineOfSight = 1,
+        Normal = 2,
+        Infrared = 4
+    }
+
+    public sealed class Tile {
+        public bool Opaque;
+        public int Luminosity;
+        public int InfraredLuminosity;
+
+        /// <summary>
+        /// The distance from the eye in tiles
+        /// </summary>
+        public int DeltaX, DeltaY;
+
+        private int AbsDeltaX => Math.Abs(DeltaX);
+        private int AbsDeltaY => Math.Abs(DeltaY);
+
+        public int MaxDelta => Math.Max(AbsDeltaX, AbsDeltaY);
+        public int SumDelta => AbsDeltaX + AbsDeltaY;
+
+        // Values used during calculation
+        public int Vis;
+        public int Vis2;
+
+        public VisibilityFlags Visibility;
+        public bool IsVisible => ((Visibility & VisibilityFlags.Normal) != 0);
+    }
+
+    private static readonly List<Tile> BoundaryTiles = new();
+
+    // As described by https://www.byond.com/forum/post/2130277#comment20659267
+    public static void CalculateVisibility(Tile?[,] tiles) {
+        var width = tiles.GetLength(0);
+        var height = tiles.GetLength(1);
+        Tile? eye = null;
+
+        // Step 2
+        var highestMaxDelta = 0;
+        var highestSumDelta = 0;
+        foreach (var tile in tiles) {
+            if (tile == null)
+                continue;
+
+            highestMaxDelta = Math.Max(highestMaxDelta, tile.MaxDelta);
+            highestSumDelta = Math.Max(highestSumDelta, tile.SumDelta);
+
+            tile.Vis = 0;
+            tile.Vis2 = 0;
+            tile.Visibility = 0;
+
+            if (tile.DeltaX == 0 && tile.DeltaY == 0)
+                eye = tile;
+        }
+
+        // TODO: Lummox mentions an optimization in step 3 and 4. Probably worthwhile.
+
+        // Step 3, Diagonal shadow loop
+        for (int d = 0; d < highestMaxDelta; d++) {
+            for (int x = 0; x < width; x++) {
+                for (int y = 0; y < height; y++) {
+                    var tile = tiles[x, y];
+                    if (tile == null)
+                        continue;
+
+                    if (tile.MaxDelta == d + 1 && CheckNeighborsVis(tiles, true, x, y, d)) {
+                        tile.Vis2 = (tile.Opaque) ? -1 : d + 1;
+                    }
+                }
+            }
+        }
+
+        // Step 4, Straight shadow loop
+        for (int d = 0; d < highestSumDelta; d++) {
+            for (int x = 0; x < width; x++) {
+                for (int y = 0; y < height; y++) {
+                    var tile = tiles[x, y];
+                    if (tile == null)
+                        continue;
+
+                    if (tile.SumDelta == d + 1 && CheckNeighborsVis(tiles, false, x, y, d)) {
+                        if (tile.Opaque) {
+                            tile.Vis = -1;
+                        } else if (tile.Vis2 != 0) {
+                            // Lummox says "set vis=d" but I think this is a typo?
+                            tile.Vis = d + 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Step 5
+        eye!.Vis = 1;
+
+        // TODO: Step 6, Light loop
+
+        // TODO: Step 7, Infrared sight
+
+        // Step 8
+        foreach (var tile in tiles) {
+            if (tile == null)
+                continue;
+
+            tile.Vis2 = tile.Vis;
+
+            // TODO: Luminosity & lit area check
+        }
+
+        // Step 9
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                var tile = tiles[x, y];
+                if (tile == null)
+                    continue;
+                if (!tile.Opaque || tile.Vis != 0)
+                    continue;
+
+                // Can't have both east and west visible if you're on the east or west border
+                if (x != 0 && x != width - 1) {
+                    var east = tiles[x - 1, y];
+                    var west = tiles[x + 1, y];
+
+                    if (east != null && west != null) {
+                        if (east.Vis != 0 && west.Vis != 0) {
+                            // Considered a "wall"
+                            BoundaryTiles.Add(tile);
+
+                            continue;
+                        }
+                    }
+                }
+
+                // Can't have both north and south visible if you're on the north or south border
+                if (y != 0 && y != height - 1) {
+                    var north = tiles[x, y - 1];
+                    var south = tiles[x, y + 1];
+
+                    if (north != null && south != null) {
+                        if (north.Vis != 0 && south.Vis != 0) {
+                            // Considered a "wall"
+                            BoundaryTiles.Add(tile);
+
+                            continue;
+                        }
+                    }
+                }
+
+                if (IsCorner(tiles, x, y, 1, 1) ||
+                    IsCorner(tiles, x, y, 1, -1) ||
+                    IsCorner(tiles, x, y, -1, -1) ||
+                    IsCorner(tiles, x, y, -1, 1)) {
+                    BoundaryTiles.Add(tile);
+                }
+            }
+        }
+
+        // Make all wall/corner tiles visible
+        foreach (var boundary in BoundaryTiles) {
+            boundary.Vis = -1;
+        }
+
+        BoundaryTiles.Clear();
+
+        // Step 10
+        foreach (var tile in tiles) {
+            if (tile == null)
+                continue;
+
+            if (tile.Vis != 0)
+                tile.Visibility |= VisibilityFlags.Normal;
+            if (tile.Vis2 != 0)
+                tile.Visibility |= VisibilityFlags.LineOfSight;
+            if (tile.InfraredLuminosity != 0)
+                tile.Visibility |= VisibilityFlags.Infrared;
+        }
+    }
+
+    /// <summary>
+    /// Checks if any of a tile's neighbors have Vis == d or Vis2 == d
+    /// </summary>
+    private static bool CheckNeighborsVis(Tile?[,] tiles, bool checkingVis2, int x, int y, int d) {
+        var width = tiles.GetLength(0);
+        var height = tiles.GetLength(1);
+
+        for (int neighborX = Math.Max(x - 1, 0); neighborX < Math.Min(x + 2, width); neighborX++) {
+            for (int neighborY = Math.Max(y - 1, 0); neighborY < Math.Min(y + 2, height); neighborY++) {
+                if (neighborX == x && neighborY == y) // Not a neighbor
+                    continue;
+
+                var tile = tiles[neighborX, neighborY];
+                if (tile == null)
+                    continue;
+
+                if (checkingVis2 && tile.Vis2 == d)
+                    return true;
+                if (!checkingVis2 && tile.Vis == d)
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Checks whether this tile fits the definition of a "corner"
+    /// </summary>
+    private static bool IsCorner(Tile?[,] tiles, int x, int y, int deltaX, int deltaY) {
+        int diagonalX = x + deltaX;
+        int diagonalY = y + deltaY;
+        if (diagonalX < 0 || diagonalY < 0 || diagonalX >= tiles.GetLength(0) || diagonalY >= tiles.GetLength(1))
+            return false; // Out of bounds
+
+        var diagonal = tiles[diagonalX, diagonalY];
+        var cardinal1 = tiles[x, diagonalY];
+        var cardinal2 = tiles[diagonalX, y];
+        if (diagonal == null)
+            return false;
+
+        return diagonal.Vis != 0 && cardinal1!.Vis != 0 && cardinal2!.Vis != 0 &&
+               cardinal1.Opaque && cardinal2.Opaque && !diagonal.Opaque;
+    }
+}


### PR DESCRIPTION
I implemented the view algorithm using Lummox's description of it in [this forum post](https://www.byond.com/forum/post/2130277#comment20659267).

I haven't hooked it up to the `view()` procs yet,  but I made the client use it to decide what turfs to render. Results appear to be equal to BYOND's.

The algorithm itself is agnostic to whether it's running on the client or server, so getting it to work on the server is just a matter of filling an array with information about a tile's opacity and luminosity.

![screenshot](https://github.com/OpenDreamProject/OpenDream/assets/30789242/b5258c56-4062-4235-8ee7-3d6a689e8672)
![screenshot2](https://github.com/OpenDreamProject/OpenDream/assets/30789242/4ffc725f-ae7c-4f03-9210-e78c31be8b8b)
