### PR TITLE
Implement `SEE_TURFS` and `SEE_OBJS`/`SEE_MOBS`

### DIFF
--- a/DMCompiler/DMStandard/Types/Atoms/Mob.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/Mob.dm
@@ -9,7 +9,7 @@
 
 	var/see_invisible = 0
 	var/see_infrared = 0 as opendream_unimplemented
-	var/sight = 0 as opendream_unimplemented
+	var/sight = 0
 	var/see_in_dark = 2 as opendream_unimplemented
 
 	layer = MOB_LAYER

--- a/OpenDreamRuntime/Objects/Types/DreamObjectMob.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectMob.cs
@@ -9,9 +9,17 @@ public sealed class DreamObjectMob : DreamObjectMovable {
 
     public int SeeInvisible {
         get => _sightComponent.SeeInvisibility;
-        set {
+        private set {
             _sightComponent.SeeInvisibility = (sbyte)value;
-            _sightComponent.Dirty();
+            EntityManager.Dirty(_sightComponent);
+        }
+    }
+
+    public SightFlags Sight {
+        get => _sightComponent.Sight;
+        private set {
+            _sightComponent.Sight = value;
+            EntityManager.Dirty(_sightComponent);
         }
     }
 
@@ -21,7 +29,10 @@ public sealed class DreamObjectMob : DreamObjectMovable {
         _sightComponent = EntityManager.AddComponent<DreamMobSightComponent>(Entity);
 
         objectDefinition.Variables["see_invisible"].TryGetValueAsInteger(out var seeVis);
+        objectDefinition.Variables["sight"].TryGetValueAsInteger(out var sight);
+
         SeeInvisible = seeVis;
+        Sight = (SightFlags)sight;
     }
 
     protected override bool TryGetVar(string varName, out DreamValue value) {
@@ -37,6 +48,9 @@ public sealed class DreamObjectMob : DreamObjectMovable {
                 return true;
             case "see_invisible":
                 value = new(SeeInvisible);
+                return true;
+            case "sight":
+                value = new((int)Sight);
                 return true;
             default:
                 return base.TryGetVar(varName, out value);
@@ -88,6 +102,11 @@ public sealed class DreamObjectMob : DreamObjectMovable {
                 value.TryGetValueAsInteger(out int seeVis);
 
                 SeeInvisible = seeVis;
+                break;
+            case "sight":
+                value.TryGetValueAsInteger(out int sight);
+
+                Sight = (SightFlags)sight;
                 break;
             default:
                 base.SetVar(varName, value);

--- a/OpenDreamShared/Rendering/DreamMobSightComponent.cs
+++ b/OpenDreamShared/Rendering/DreamMobSightComponent.cs
@@ -2,8 +2,6 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization;
 using System;
 using Robust.Shared.GameStates;
-using OpenDreamShared.Dream;
-using System.Collections.Generic;
 
 namespace OpenDreamShared.Rendering {
     [RegisterComponent]
@@ -12,32 +10,32 @@ namespace OpenDreamShared.Rendering {
         //this would be a good place for:
         //see_in_dark
         //see_infrared
-        //sight
 
         public sbyte SeeInvisibility;
-
-        public DreamMobSightComponent() {
-        }
+        public SightFlags Sight;
 
         public override ComponentState GetComponentState() {
-            return new DreamMobSightComponentState(SeeInvisibility);
+            return new DreamMobSightComponentState(SeeInvisibility, Sight);
         }
 
-        public override void HandleComponentState(ComponentState curState, ComponentState nextState) {
+        public override void HandleComponentState(ComponentState? curState, ComponentState? nextState) {
             if (curState == null)
                 return;
 
             DreamMobSightComponentState state = (DreamMobSightComponentState)curState;
 
-            this.SeeInvisibility = state.SeeInvisibility;
+            SeeInvisibility = state.SeeInvisibility;
+            Sight = state.Sight;
         }
 
         [Serializable, NetSerializable]
-        protected sealed class DreamMobSightComponentState : ComponentState {
+        private sealed class DreamMobSightComponentState : ComponentState {
             public readonly sbyte SeeInvisibility;
+            public readonly SightFlags Sight;
 
-            public DreamMobSightComponentState(sbyte SeeInvisibility) {
-                this.SeeInvisibility = SeeInvisibility;
+            public DreamMobSightComponentState(sbyte seeInvisibility, SightFlags sight) {
+                SeeInvisibility = seeInvisibility;
+                Sight = sight;
             }
         }
     }

--- a/OpenDreamShared/Rendering/SightFlags.cs
+++ b/OpenDreamShared/Rendering/SightFlags.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace OpenDreamShared.Rendering;
+
+// Same values as the SEE_* defines in DMStandard
+[Flags]
+public enum SightFlags {
+    SeeInfrared = (1<<6),
+    SeeSelf = (1<<5),
+    SeeMobs = (1<<2),
+    SeeObjs = (1<<3),
+    SeeTurfs = (1<<4),
+    SeePixels = (1<<8),
+    SeeThroughOpaque = (1<<9),
+    SeeBlackness = (1<<10),
+    Blind = (1<<0)
+}


### PR DESCRIPTION
Implement enough of `/mob.sight` to allow observers to see through walls. Having either `SEE_OBJS` and `SEE_MOBS` currently acts like both are enabled.

#72

![screenshot](https://github.com/OpenDreamProject/OpenDream/assets/30789242/884e352f-9321-47ba-9ab8-23b3e6189ba2)
