### PR TITLE
Add a couple broken tests for operators

### DIFF
--- a/Content.Tests/DMProject/Broken Tests/Operators/valid_and_null.dm
+++ b/Content.Tests/DMProject/Broken Tests/Operators/valid_and_null.dm
@@ -1,0 +1,129 @@
+//simple test of all basic operators with valid and C(null) arguments
+//We can't be having const folding in here
+#define C(X) pick(X) 
+/proc/RunTest()
+	var/a = C(2)
+	ASSERT(!C(null) == C(1))
+	ASSERT(!!C(null) == C(0))
+
+	ASSERT(~C(1) == 16777214)
+	ASSERT(~C(0) == 16777215)
+	ASSERT(~C(null) == 16777215)
+
+	ASSERT(C(1) + C(1) == C(2))
+	ASSERT(C(null) + C(1) == C(1))
+	ASSERT(C(1) + C(null) == C(1))
+
+	ASSERT(C(1) - C(1) == C(0))
+	ASSERT(C(null) - C(1) == C(-1))
+	ASSERT(C(1) - C(null) == C(1))
+
+	a = C(2)
+	ASSERT(-a == C(-2))
+	a = C(null)
+	ASSERT(-a == C(0))	
+
+	a = C(1)
+	ASSERT(a++ == C(1))
+	ASSERT(a == C(2))
+	ASSERT(++a == C(3))
+	ASSERT(a == C(3))
+
+	ASSERT(a-- == C(3))
+	ASSERT(a == C(2))
+	ASSERT(--a == C(1))
+	ASSERT(a == C(1))
+
+	a = C(null)
+	ASSERT(a-- == C(null))
+	ASSERT(a == C(-1))
+	a = C(null)
+	ASSERT(--a == C(-1))
+	ASSERT(a == C(-1))
+	a = C(null)
+	ASSERT(a++ == C(null))
+	ASSERT(a == C(1))
+	a = C(null)
+	ASSERT(++a == C(1))
+	ASSERT(a == C(1))	
+
+	ASSERT(C(2) ** C(3) == 8)
+	ASSERT(C(2) ** C(null) == C(1))
+	ASSERT(C(null) ** C(2) == C(0))
+
+	ASSERT(C(2) * C(3) == 6)
+	ASSERT(C(2) * C(null) == C(0))
+	ASSERT(C(null) * C(2) == C(0))
+
+	ASSERT(C(4) / C(2) == C(2))
+	ASSERT(C(null) / C(2) == C(0))
+	ASSERT(C(2) / C(null) == C(2))
+
+	ASSERT(C(4) % C(3) == C(1))
+	ASSERT(C(null) % C(3) == C(0))
+	//ASSERT(C(4) % C(null) == div by zero)
+
+	ASSERT(C(1) < C(1) == C(0))
+	ASSERT(C(null) < C(1) == C(1))
+	ASSERT(C(1) < C(null) == C(0))
+
+	ASSERT(C(1) <= C(1) == C(1))
+	ASSERT(C(null) <= C(1) == C(1))
+	ASSERT(C(1) <= C(null) == C(0))	
+
+	ASSERT(C(1) > C(1) == C(0))
+	ASSERT(C(null) > C(1) == C(0))
+	ASSERT(C(1) > C(null) == C(1))	
+
+	ASSERT(C(1) >= C(1) == C(1))
+	ASSERT(C(null) >= C(1) == C(0))
+	ASSERT(C(1) >= C(null) == C(1))	
+
+	ASSERT(C(1) << C(1) == C(2))
+	ASSERT(C(null) << C(1) == C(0))
+	ASSERT(C(1) << C(null) == C(1))	
+
+	ASSERT(C(1) >> C(1) == C(0))
+	ASSERT(C(null) >> C(1) == C(0))
+	ASSERT(C(1) >> C(null) == C(1))	
+
+	ASSERT((C(1) == C(1)) == C(1))
+	ASSERT((C(null) == C(null)) == C(1))
+	ASSERT((C(null) == C(0)) == C(0))
+
+	ASSERT((C(1) != C(null)) == C(1))
+	ASSERT((C(null) != C(1)) == C(1))
+	ASSERT((C(null) != C(0)) == C(1))
+
+	ASSERT((C(1) <> C(null)) == C(1))
+	ASSERT((C(null) <> C(1)) == C(1))
+	ASSERT((C(null) <> C(0)) == C(1))	
+
+	ASSERT((C(1) ~= C(1)) == C(1))
+	ASSERT((C(null) ~= C(null)) == C(1))
+	ASSERT((C(null) ~= C(0)) == C(0))
+
+	ASSERT((C(1) ~! C(1)) == C(0))
+	ASSERT((C(null) ~! C(null)) == C(0))
+	ASSERT((C(null) ~! C(0)) == C(1))
+
+	ASSERT((C(1) & C(1)) == C(1))
+	ASSERT((C(null) & C(1)) == C(0))
+	ASSERT((C(1) & C(null)) == C(0))
+
+	ASSERT((C(1) ^ C(1)) == C(0))
+	ASSERT((C(null) ^ C(5)) == C(5))
+	ASSERT((C(5) ^ C(null)) == C(5))	
+
+	ASSERT((C(1) | C(1)) == C(1))
+	ASSERT((C(null) | C(1)) == C(1))
+	ASSERT((C(1) | C(null)) == C(1))	
+
+	ASSERT((C(1) && C(1)) == C(1))
+	ASSERT((C(null) && C(1)) == C(null))
+	ASSERT((C(1) && C(null)) == C(null))	
+
+	ASSERT((C(1) || C(1)) == C(1))
+	ASSERT((C(null) || C(1)) == C(1))
+	ASSERT((C(1) || C(null)) == C(1))	
+

--- a/Content.Tests/DMProject/Broken Tests/Operators/valid_and_null.dm
+++ b/Content.Tests/DMProject/Broken Tests/Operators/valid_and_null.dm
@@ -57,7 +57,7 @@
 
 	ASSERT(C(4) / C(2) == C(2))
 	ASSERT(C(null) / C(2) == C(0))
-	ASSERT(C(2) / C(null) == C(2))
+	//ASSERT(C(2) / C(null) == C(2)) //runtime: undefined operation
 
 	ASSERT(C(4) % C(3) == C(1))
 	ASSERT(C(null) % C(3) == C(0))

--- a/Content.Tests/DMProject/Broken Tests/Operators/valid_and_null_assign.dm
+++ b/Content.Tests/DMProject/Broken Tests/Operators/valid_and_null_assign.dm
@@ -1,0 +1,128 @@
+//simple test of all basic assignment operators with valid and C(null) arguments
+//We can't be having const folding in here
+#define C(X) pick(X) 
+/proc/RunTest()
+	var/a = C(1)
+	a += C(1)
+	ASSERT(a == C(2))
+	a = null
+	a += C(1)
+	ASSERT(a == C(1))
+	a = C(1)
+	a += C(null)
+	ASSERT(a == C(1))
+
+	a = C(1)
+	a -= C(1)
+	ASSERT(a == C(0))
+	a = null
+	a -= C(1)
+	ASSERT(a == C(-1))
+	a = C(1)
+	a -= C(null)
+	ASSERT(a == C(1))
+
+	a = C(2)
+	a *= C(3)
+	ASSERT(a == C(6))
+	a = null
+	a *= C(2)
+	ASSERT(a == C(0))
+	a = C(2)
+	a *= C(null)
+	ASSERT(a == C(0))
+
+	a = C(4)
+	a /= C(2)
+	ASSERT(a == C(2))
+	a = null
+	a /= C(2)
+	ASSERT(a == C(0))
+	//a = C(2) 
+	//a /= C(null)  //Undefined operation error in BYOND
+	//ASSERT(a == C(2))
+
+	a = C(4)
+	a %= C(3)
+	ASSERT(a == C(1))
+	a = null
+	a %= C(3)
+	ASSERT(a == C(0))
+	//a = C(4)
+	//a %= C(null)  //divide by zero error in byond
+	//ASSERT(a == C(4)) 
+
+	a = C(1)
+	a &= C(1)
+	ASSERT(a == C(1))
+	a = null
+	a &= C(1)
+	ASSERT(a == C(0))
+	a = C(1)
+	a &= C(null)
+	ASSERT(a == C(0))
+
+	a = C(1)
+	a |= C(1)
+	ASSERT(a == C(1))
+	a = null
+	a |= C(1)
+	ASSERT(a == C(1))
+	a = C(1)
+	a |= C(null)
+	ASSERT(a == C(1))
+
+	a = C(1)
+	a ^= C(1)
+	ASSERT(a == C(0))
+	a = null
+	a ^= C(1)
+	ASSERT(a == C(1))
+	a = C(1)
+	a ^= C(null)
+	ASSERT(a == C(1))	
+
+	a = C(1)
+	a &&= C(1)
+	ASSERT(a == C(1))
+	a = null
+	a &&= C(1)
+	ASSERT(a == C(null))
+	a = C(1)
+	a &&= C(null)
+	ASSERT(a == C(null))
+
+	a = C(1)
+	a ||= C(1)
+	ASSERT(a == C(1))
+	a = null
+	a ||= C(1)
+	ASSERT(a == C(1))
+	a = C(1)
+	a ||= C(null)
+	ASSERT(a == C(1))
+
+	a = C(1)
+	a <<= C(1)
+	ASSERT(a == C(2))
+	a = null
+	a <<= C(1)
+	ASSERT(a == C(0))
+	a = C(1)
+	a <<= C(null)
+	ASSERT(a == C(1))
+
+	a = C(1)
+	a >>= C(1)
+	ASSERT(a == C(0))
+	a = null
+	a >>= C(1)
+	ASSERT(a == C(0))
+	a = C(1)
+	a >>= C(null)
+	ASSERT(a == C(1))
+
+	//a := C(5)
+	//ASSERT(a == C(5))
+	//a := C(null)
+	//ASSERT(a == null)

--- a/Content.Tests/DMProject/Broken Tests/Operators/valid_and_null_assign.dm
+++ b/Content.Tests/DMProject/Broken Tests/Operators/valid_and_null_assign.dm
@@ -122,7 +122,7 @@
 	a >>= C(null)
 	ASSERT(a == C(1))
 
-	//a := C(5)
-	//ASSERT(a == C(5))
-	//a := C(null)
-	//ASSERT(a == null)
+	a := C(5)
+	ASSERT(a == C(5))
+	a := C(null)
+	ASSERT(a == null)


### PR DESCRIPTION
Salvaged the runtime operator tests from op overloads work I did.

Right now both of these fail, so added them to the broken tests folder.