### PR TITLE
Implement `/client.eye`

### DIFF
--- a/DMCompiler/DMStandard/Types/Client.dm
+++ b/DMCompiler/DMStandard/Types/Client.dm
@@ -59,6 +59,7 @@
 		if (mob == null) // No existing mob, create a default one
 			mob = new world.mob(locate(1,1,1)) // TODO: Find nearest non-dense turf
 
+		eye = mob
 		return mob
 
 	proc/Del()

--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -36,6 +36,10 @@ namespace OpenDreamRuntime {
                         _mob.Connection = null;
                     }
 
+                    if (Eye != null && Eye == Mob) {
+                        Eye = value;
+                    }
+
                     if (value != null) {
                         // If the mob is already owned by another player, kick them out
                         if (value.Connection != null)
@@ -51,9 +55,17 @@ namespace OpenDreamRuntime {
 
                     UpdateAvailableVerbs();
                 }
+            }
+        }
 
-                if (_mob != null) {
-                    Session!.AttachToEntity(_mob.Entity);
+        [ViewVariables]
+        public DreamObjectMovable? Eye {
+            get => _eye;
+            set {
+                _eye = value;
+
+                if (_eye != null) {
+                    Session!.AttachToEntity(_eye.Entity);
                 } else {
                     Session!.DetachFromEntity();
                 }
@@ -66,6 +78,7 @@ namespace OpenDreamRuntime {
         [ViewVariables] private int _nextPromptEvent = 1;
 
         private DreamObjectMob? _mob;
+        private DreamObjectMovable? _eye;
 
         public string SelectedStatPanel {
             get => _selectedStatPanel;

--- a/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
@@ -37,6 +37,9 @@ public sealed class DreamObjectClient : DreamObject {
             case "mob":
                 value = new(Connection.Mob);
                 return true;
+            case "eye":
+                value = new(Connection.Eye);
+                return true;
             case "computer_id": // FIXME: This is not secure! Whenever RT implements a more robust (heh) method of uniquely identifying computers, replace this impl with that.
                 MD5 md5 = MD5.Create();
                 // Check on Robust.Shared.Network.NetUserData.HWId" if you want to seed from how RT does user identification.
@@ -82,6 +85,15 @@ public sealed class DreamObjectClient : DreamObject {
                 value.TryGetValueAsDreamObject<DreamObjectMob>(out var newMob);
 
                 Connection.Mob = newMob;
+                break;
+            }
+            case "eye": {
+                value.TryGetValueAsDreamObject<DreamObjectAtom>(out var newEye);
+                if (newEye is not (DreamObjectMovable or null)) {
+                    throw new Exception($"Cannot set eye to non-movable {value}"); // TODO: You can set it to a turf
+                }
+
+                Connection.Eye = newEye as DreamObjectMovable;
                 break;
             }
             case "screen": {


### PR DESCRIPTION
Allows you to set `/client.eye` to an /atom/movable object. BYOND also supports /turf here, but I left that unimplemented currently since turfs aren't an entity we can attach to.

Makes AI playable and the slime management console usable.

Fixes #1165