### PR TITLE
Fix null deref in client when appearance hasn't loaded

### DIFF
--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -175,6 +175,8 @@ sealed class DreamViewOverlay : Overlay {
                         continue;
                     if (!sprite.IsVisible(mapManager: _mapManager, seeInvis: seeVis))
                         continue;
+                    if(sprite.Icon.Appearance == null) //apearance hasn't loaded yet
+                        continue;
 
                     var worldPos = _transformSystem.GetWorldPosition(entity, xformQuery);
                     var tilePos = grid.WorldToTile(worldPos) - eyeTile.GridIndices + 8;


### PR DESCRIPTION
I don't know why this isn't caught by the try/catch, but it isn't and it causes a segfault for me when I'm not running in the debugger.