### PR TITLE
Make \ref[] format the same as byond

### DIFF
--- a/Content.Tests/DMProject/Tests/Text/ref.dm
+++ b/Content.Tests/DMProject/Tests/Text/ref.dm
@@ -2,6 +2,16 @@
 	var/obj/thing = new()
 	var/obj/thing2 = new()
 	var/obj/thing3 = new()
+	var/not_this_one = "\ref[thing]"
 	var/ref = "\ref[thing2]"
+	var/not_this_one_either = "\ref[thing]"
 	var/test_thing = locate(ref)
 	ASSERT(test_thing == thing2)
+
+	var/string = "farts"
+	var/string_ref = "\ref[string]"
+	ASSERT(locate(string_ref) == string)
+
+	var/proc_ref = "\ref[/proc/RunTest]"
+	ASSERT(length(proc_ref)==10)
+

--- a/Content.Tests/DMProject/Tests/Text/ref.dm
+++ b/Content.Tests/DMProject/Tests/Text/ref.dm
@@ -17,5 +17,5 @@
 	ASSERT(length(proc_ref)==12)
 
 	var/list/test = list(1,2,3)
-	ASSERT(lowertext(copytext("\ref[test]",4,5)) == "f")
+	ASSERT(copytext("\ref[test]",4,5) == "f")
 	ASSERT(locate("\ref[test]") == test)

--- a/Content.Tests/DMProject/Tests/Text/ref.dm
+++ b/Content.Tests/DMProject/Tests/Text/ref.dm
@@ -1,3 +1,4 @@
+#define ASSERT(expr) ((expr) ? null : CRASH("Assertion Failed: " + #expr))
 /proc/RunTest()
 	var/obj/thing = new()
 	var/obj/thing2 = new()
@@ -13,5 +14,8 @@
 	ASSERT(locate(string_ref) == string)
 
 	var/proc_ref = "\ref[/proc/RunTest]"
-	ASSERT(length(proc_ref)==10)
+	ASSERT(length(proc_ref)==12)
 
+	var/list/test = list(1,2,3)
+	ASSERT(lowertext(copytext("\ref[test]",4,5)) == "f")
+	ASSERT(locate("\ref[test]") == test)

--- a/Content.Tests/DMProject/Tests/Text/ref.dm
+++ b/Content.Tests/DMProject/Tests/Text/ref.dm
@@ -1,4 +1,3 @@
-#define ASSERT(expr) ((expr) ? null : CRASH("Assertion Failed: " + #expr))
 /proc/RunTest()
 	var/obj/thing = new()
 	var/obj/thing2 = new()

--- a/Content.Tests/DMProject/Tests/Text/ref.dm
+++ b/Content.Tests/DMProject/Tests/Text/ref.dm
@@ -1,0 +1,7 @@
+/proc/RunTest()
+	var/obj/thing = new()
+	var/obj/thing2 = new()
+	var/obj/thing3 = new()
+	var/ref = "\ref[thing2]"
+	var/test_thing = locate(ref)
+	ASSERT(test_thing == thing2)

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -205,11 +205,11 @@ namespace OpenDreamRuntime {
             }
 
             // The first digit is the type, i.e. 1 for objects and 2 for strings
-            return $"{(int) refType}{idx}";
+            return $"0x{(int) refType}{idx.ToString().PadLeft(6,'0')}";
         }
 
         public DreamValue LocateRef(string refString) {
-            if (!int.TryParse(refString, out var refId)) {
+            if (!int.TryParse(refString.Substring(2), out var refId)) { //strip "0x"
                 // If the ref is not an integer, it may be a tag
                 if (Tags.TryGetValue(refString, out var tagList)) {
                     return new DreamValue(tagList.First());
@@ -219,8 +219,8 @@ namespace OpenDreamRuntime {
             }
 
             // The first digit is the type
-            var typeId = (RefType) int.Parse(refString.Substring(0, 1));
-            var untypedRefString = refString.Substring(1); // The ref minus its ref type prefix
+            var typeId = (RefType) int.Parse(refString.Substring(2, 1));
+            var untypedRefString = refString.Substring(3); // The ref minus its ref type prefix
 
             refId = int.Parse(untypedRefString);
 

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -177,11 +177,12 @@ namespace OpenDreamRuntime {
                         case DreamObjectArea: refType = RefType.DreamObjectArea; break;
                         case DreamObjectClient: refType = RefType.DreamObjectArea; break;
                         case DreamObjectImage: refType = RefType.DreamObjectImage; break;
-                        case DreamList: refType = RefType.DreamObjectList; break;
                         default: {
                             refType = RefType.DreamObjectDatum;
                             if(refObject.IsSubtypeOf(_objectTree.Obj))
                                 refType = RefType.DreamObject;
+                            else if (refObject.GetType() == typeof(DreamList))
+                                refType = RefType.DreamObjectList;
                             break;
                         }
                     }
@@ -217,7 +218,7 @@ namespace OpenDreamRuntime {
             }
 
             // The first digit is the type
-            return $"[0x{((int) refType+idx):X}]";
+            return $"[0x{((int) refType+idx):x}]";
         }
 
         public DreamValue LocateRef(string refString) {

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -177,6 +177,7 @@ namespace OpenDreamRuntime {
                         case DreamObjectArea: refType = RefType.DreamObjectArea; break;
                         case DreamObjectClient: refType = RefType.DreamObjectArea; break;
                         case DreamObjectImage: refType = RefType.DreamObjectImage; break;
+                        case DreamList: refType = RefType.DreamObjectList; break;
                         default: {
                             refType = RefType.DreamObjectDatum;
                             if(refObject.IsSubtypeOf(_objectTree.Obj))
@@ -216,11 +217,11 @@ namespace OpenDreamRuntime {
             }
 
             // The first digit is the type
-            return $"0x{((int) refType+idx):X}";
+            return $"[0x{((int) refType+idx):X}]";
         }
 
         public DreamValue LocateRef(string refString) {
-            if (!int.TryParse(refString.Substring(2), System.Globalization.NumberStyles.HexNumber, null, out var refId)) { //strip "0x"
+            if (!int.TryParse(refString.Substring(3).TrimEnd(']'), System.Globalization.NumberStyles.HexNumber, null, out var refId)) { //strip "[0x" and "]"
                 // If the ref is not an integer, it may be a tag
                 if (Tags.TryGetValue(refString, out var tagList)) {
                     return new DreamValue(tagList.First());
@@ -236,6 +237,13 @@ namespace OpenDreamRuntime {
             switch (typeId) {
                 case RefType.Null:
                     return DreamValue.Null;
+                case RefType.DreamObjectArea:
+                case RefType.DreamObjectClient:
+                case RefType.DreamObjectDatum:
+                case RefType.DreamObjectImage:
+                case RefType.DreamObjectList:
+                case RefType.DreamObjectMob:
+                case RefType.DreamObjectTurf:
                 case RefType.DreamObject:
                     if (ReferenceIDsToDreamObject.TryGetValue(refId, out var dreamObject))
                         return new(dreamObject);

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -171,8 +171,19 @@ namespace OpenDreamRuntime {
                         // i dont believe this will **ever** be called, but just to be sure, funky errors /might/ appear in the future if someone does a fucky wucky and calls this on a deleted object.
                         throw new Exception("Cannot create reference ID for an object that is deleted");
                     }
-
-                    refType = RefType.DreamObject;
+                    switch(refObject){
+                        case DreamObjectTurf: refType = RefType.DreamObjectTurf; break;
+                        case DreamObjectMob: refType = RefType.DreamObjectMob; break;
+                        case DreamObjectArea: refType = RefType.DreamObjectArea; break;
+                        case DreamObjectClient: refType = RefType.DreamObjectArea; break;
+                        case DreamObjectImage: refType = RefType.DreamObjectImage; break;
+                        default: {
+                            refType = RefType.DreamObjectDatum;
+                            if(refObject.IsSubtypeOf(_objectTree.Obj))
+                                refType = RefType.DreamObject;
+                            break;
+                        }
+                    }
                     if (!ReferenceIDs.TryGetValue(refObject, out idx)) {
                         idx = _dreamObjectRefIdCounter++;
                         ReferenceIDs.Add(refObject, idx);
@@ -204,12 +215,12 @@ namespace OpenDreamRuntime {
                 throw new NotImplementedException($"Ref for {value} is unimplemented");
             }
 
-            // The first digit is the type, i.e. 1 for objects and 2 for strings
-            return $"0x{(int) refType}{idx.ToString().PadLeft(6,'0')}";
+            // The first digit is the type
+            return $"0x{((int) refType+idx):X}";
         }
 
         public DreamValue LocateRef(string refString) {
-            if (!int.TryParse(refString.Substring(2), out var refId)) { //strip "0x"
+            if (!int.TryParse(refString.Substring(2), System.Globalization.NumberStyles.HexNumber, null, out var refId)) { //strip "0x"
                 // If the ref is not an integer, it may be a tag
                 if (Tags.TryGetValue(refString, out var tagList)) {
                     return new DreamValue(tagList.First());
@@ -218,11 +229,9 @@ namespace OpenDreamRuntime {
                 return DreamValue.Null;
             }
 
-            // The first digit is the type
-            var typeId = (RefType) int.Parse(refString.Substring(2, 1));
-            var untypedRefString = refString.Substring(3); // The ref minus its ref type prefix
-
-            refId = int.Parse(untypedRefString);
+            // The first one/two digits give the type, the last 6 give the index
+            var typeId = (RefType) (refId & 0xFF000000);
+            refId = (refId & 0x00FFFFFF); // The ref minus its ref type prefix
 
             switch (typeId) {
                 case RefType.Null:

--- a/OpenDreamRuntime/IDreamManager.cs
+++ b/OpenDreamRuntime/IDreamManager.cs
@@ -54,7 +54,7 @@ namespace OpenDreamRuntime {
         DreamObjectDatum = 0x21000000,
         String = 0x6000000,
         DreamType = 0x9000000, //in byond type is from 0x8 to 0xb, but fuck that
-        DreamResource = 0xFF000000, //doesn't exist in byond
+        DreamResource = 0x27000000, //Equivalent to file
         DreamAppearance = 0x3A000000,
         Proc = 0x26000000
     }

--- a/OpenDreamRuntime/IDreamManager.cs
+++ b/OpenDreamRuntime/IDreamManager.cs
@@ -42,13 +42,19 @@ namespace OpenDreamRuntime {
     }
 
     // TODO: Could probably use DreamValueType instead
-    public enum RefType : int {
-        Null = 0,
-        DreamObject = 1,
-        String = 2,
-        DreamType = 3,
-        DreamResource = 4,
-        DreamAppearance = 5,
-        Proc = 6
+    public enum RefType : uint {
+        Null = 0x0,
+        DreamObjectTurf = 0x1000000,
+        DreamObject = 0x2000000,
+        DreamObjectMob = 0x3000000,
+        DreamObjectArea = 0x4000000,
+        DreamObjectClient = 0x5000000,
+        DreamObjectImage = 0xD000000,
+        DreamObjectDatum = 0x21000000,
+        String = 0x6000000,
+        DreamType = 0x9000000, //in byond type is from 0x8 to 0xb, but fuck that
+        DreamResource = 0xFF000000, //doesn't exist in byond
+        DreamAppearance = 0x3A000000,
+        Proc = 0x26000000
     }
 }

--- a/OpenDreamRuntime/IDreamManager.cs
+++ b/OpenDreamRuntime/IDreamManager.cs
@@ -50,6 +50,7 @@ namespace OpenDreamRuntime {
         DreamObjectArea = 0x4000000,
         DreamObjectClient = 0x5000000,
         DreamObjectImage = 0xD000000,
+        DreamObjectList = 0xF000000,
         DreamObjectDatum = 0x21000000,
         String = 0x6000000,
         DreamType = 0x9000000, //in byond type is from 0x8 to 0xb, but fuck that


### PR DESCRIPTION
type IDs are accurate for major types but does not fully adhere to [*the list*](https://gn32.uk/f/byond-typeids.txt) but otherwise make \ref return a string formatted like `[0x1000000]`