### PR TITLE
Dispose finished audio channels

### DIFF
--- a/OpenDreamClient/Audio/DreamSoundChannel.cs
+++ b/OpenDreamClient/Audio/DreamSoundChannel.cs
@@ -1,21 +1,20 @@
 using Robust.Client.Graphics;
 
-namespace OpenDreamClient.Audio
-{
-    public sealed class DreamSoundChannel : IDisposable {
-        public IClydeAudioSource Source { get; }
+namespace OpenDreamClient.Audio;
 
-        public DreamSoundChannel(IClydeAudioSource source) {
-            Source = source;
-        }
+public sealed class DreamSoundChannel : IDisposable {
+    public IClydeAudioSource Source { get; }
 
-        public void Stop() {
-            Source?.StopPlaying();
-        }
+    public DreamSoundChannel(IClydeAudioSource source) {
+        Source = source;
+    }
 
-        public void Dispose() {
-            Stop();
-            Source?.Dispose();
-        }
+    public void Stop() {
+        Source.StopPlaying();
+    }
+
+    public void Dispose() {
+        Stop();
+        Source.Dispose();
     }
 }

--- a/OpenDreamClient/Audio/DreamSoundEngine.cs
+++ b/OpenDreamClient/Audio/DreamSoundEngine.cs
@@ -10,46 +10,61 @@ namespace OpenDreamClient.Audio {
         private const int SoundChannelLimit = 1024;
 
         [Dependency] private readonly IDreamResourceManager _resourceManager = default!;
+        [Dependency] private readonly ILogManager _logManager = default!;
         [Dependency] private readonly INetManager _netManager = default!;
 
-        private readonly DreamSoundChannel[] _channels = new DreamSoundChannel[SoundChannelLimit];
+        private ISawmill _sawmill = default!;
+
+        private readonly DreamSoundChannel?[] _channels = new DreamSoundChannel[SoundChannelLimit];
 
         public void Initialize() {
+            _sawmill = _logManager.GetSawmill("opendream.audio");
+
             _netManager.RegisterNetMessage<MsgSound>(RxSound);
 
             _netManager.Disconnect += DisconnectedFromServer;
+        }
+
+        public void StopFinishedChannels() {
+            for (int i = 0; i < SoundChannelLimit; i++) {
+                if (_channels[i]?.Source.IsPlaying is false or null)
+                    StopChannel(i + 1);
+            }
         }
 
         public void PlaySound(int channel, MsgSound.FormatType format, ResourceSound sound, float volume) {
             if (channel == 0) {
                 //First available channel
                 for (int i = 0; i < _channels.Length; i++) {
-                    if (_channels[i] == null || !_channels[i].Source.IsPlaying) {
-                        _channels[i]?.Dispose();
+                    if (_channels[i] == null) {
                         channel = i + 1;
                         break;
                     }
                 }
 
-                if (channel == 0)
+                if (channel == 0) {
+                    _sawmill.Error("Failed to find a free audio channel to play a sound on");
                     return;
+                }
             }
 
             StopChannel(channel);
 
             // convert from DM volume (0-100) to OpenAL volume (db)
-            IClydeAudioSource source = sound.Play(format, AudioParams.Default.WithVolume(20 * MathF.Log10(volume)));
+            IClydeAudioSource? source = sound.Play(format, AudioParams.Default.WithVolume(20 * MathF.Log10(volume)));
+            if (source == null)
+                return;
+
             _channels[channel - 1] = new DreamSoundChannel(source);
         }
 
 
         public void StopChannel(int channel) {
-            if (_channels[channel - 1] != null) {
-                ref DreamSoundChannel ch = ref _channels[channel - 1];
-                ch.Dispose();
-                // This will null the corresponding index in the array.
-                ch = null;
-            }
+            ref DreamSoundChannel? ch = ref _channels[channel - 1];
+
+            ch?.Dispose();
+            // This will null the corresponding index in the array.
+            ch = null;
         }
 
         public void StopAllChannels() {

--- a/OpenDreamClient/Audio/IDreamSoundEngine.cs
+++ b/OpenDreamClient/Audio/IDreamSoundEngine.cs
@@ -5,6 +5,7 @@ namespace OpenDreamClient.Audio;
 
 public interface IDreamSoundEngine {
     void Initialize();
+    public void StopFinishedChannels();
     void PlaySound(int channel, MsgSound.FormatType format, ResourceSound sound, float volume);
     void StopChannel(int channel);
     void StopAllChannels();

--- a/OpenDreamClient/EntryPoint.cs
+++ b/OpenDreamClient/EntryPoint.cs
@@ -79,9 +79,13 @@ namespace OpenDreamClient {
         }
 
         public override void Update(ModUpdateLevel level, FrameEventArgs frameEventArgs) {
-            if (level == ModUpdateLevel.FramePostEngine) {
-                _soundEngine.StopFinishedChannels();
-                _dreamInterface.FrameUpdate(frameEventArgs);
+            switch (level) {
+                case ModUpdateLevel.FramePostEngine:
+                    _dreamInterface.FrameUpdate(frameEventArgs);
+                    break;
+                case ModUpdateLevel.PostEngine:
+                    _soundEngine.StopFinishedChannels();
+                    break;
             }
         }
 

--- a/OpenDreamClient/EntryPoint.cs
+++ b/OpenDreamClient/EntryPoint.cs
@@ -19,6 +19,7 @@ namespace OpenDreamClient {
     public sealed class EntryPoint : GameClient {
         [Dependency] private readonly IDreamInterfaceManager _dreamInterface = default!;
         [Dependency] private readonly IDreamResourceManager _dreamResource = default!;
+        [Dependency] private readonly IDreamSoundEngine _soundEngine = default!;
         [Dependency] private readonly IOverlayManager _overlayManager = default!;
         [Dependency] private readonly ILightManager _lightManager = default!;
 
@@ -79,6 +80,7 @@ namespace OpenDreamClient {
 
         public override void Update(ModUpdateLevel level, FrameEventArgs frameEventArgs) {
             if (level == ModUpdateLevel.FramePostEngine) {
+                _soundEngine.StopFinishedChannels();
                 _dreamInterface.FrameUpdate(frameEventArgs);
             }
         }

--- a/OpenDreamClient/Resources/ResourceTypes/ResourceSound.cs
+++ b/OpenDreamClient/Resources/ResourceTypes/ResourceSound.cs
@@ -1,28 +1,35 @@
 using System.IO;
+using JetBrains.Annotations;
 using OpenDreamShared.Network.Messages;
 using Robust.Client.Audio;
 using Robust.Client.Graphics;
 using Robust.Shared.Audio;
 
 namespace OpenDreamClient.Resources.ResourceTypes {
-    // ReSharper disable once ClassNeverInstantiated.Global
+    [UsedImplicitly]
     public sealed class ResourceSound : DreamResource {
-        private AudioStream _stream;
+        private AudioStream? _stream;
 
         public ResourceSound(int id, byte[] data) : base(id, data) { }
 
-        public IClydeAudioSource Play(MsgSound.FormatType format, AudioParams audioParams) {
+        public IClydeAudioSource? Play(MsgSound.FormatType format, AudioParams audioParams) {
             LoadStream(format);
+            if (_stream == null)
+                return null;
 
             // TODO: Positional audio.
             var source = IoCManager.Resolve<IClydeAudio>().CreateAudioSource(_stream);
-            source.SetGlobal();
-            source.SetPitch(audioParams.PitchScale);
-            source.SetVolume(audioParams.Volume);
-            source.SetPlaybackPosition(audioParams.PlayOffsetSeconds);
-            source.IsLooping = audioParams.Loop;
 
-            source.StartPlaying();
+            if (source != null) {
+                source.SetGlobal();
+                source.SetPitch(audioParams.PitchScale);
+                source.SetVolume(audioParams.Volume);
+                source.SetPlaybackPosition(audioParams.PlayOffsetSeconds);
+                source.IsLooping = audioParams.Loop;
+
+                source.StartPlaying();
+            }
+
             return source;
         }
 


### PR DESCRIPTION
At the end of every engine update, look for any audio channels that have finished and dispose of them. This seems to fix the AL memory errors that would start after a few minutes and prevent audio from playing.

Also fixed a few nullability warnings in the audio code.