### PR TITLE
Add NewPath and fix non-string `list()` keys for DMM parsing

### DIFF
--- a/DMCompiler/DM/DMExpression.cs
+++ b/DMCompiler/DM/DMExpression.cs
@@ -5,6 +5,7 @@ using DMCompiler.Compiler.DM;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Dream.Procs;
 using System.Diagnostics.CodeAnalysis;
+using System.Collections.Generic;
 
 namespace DMCompiler.DM {
     abstract class DMExpression {
@@ -174,6 +175,31 @@ namespace DMCompiler.DM {
             }
 
             return (_isKeyed ? DMCallArgumentsType.FromStackKeyed : DMCallArgumentsType.FromStack, stackCount);
+        }
+
+        public bool TryAsJsonRepresentation(out object? json) {
+            List<object?> list = new();
+            Dictionary<string, object?> associatedValues = new();
+
+            foreach (var value in Expressions) {
+                if (!value.Expr.TryAsJsonRepresentation(out var jsonValue)) {
+                    json = null;
+                    return false;
+                }
+
+                if (value.Name != null) {
+                    associatedValues.Add(value.Name, jsonValue);
+                } else {
+                    list.Add(jsonValue);
+                }
+            }
+
+            Dictionary<string, object> jsonRepresentation = new();
+            jsonRepresentation.Add("type", OpenDreamShared.Json.JsonVariableType.ArgList);
+            if (list.Count > 0) jsonRepresentation.Add("values", list);
+            if (associatedValues.Count > 0) jsonRepresentation.Add("associatedValues", associatedValues);
+            json = jsonRepresentation;
+            return true;
         }
     }
 }

--- a/DMCompiler/DM/Expressions/Builtins.cs
+++ b/DMCompiler/DM/Expressions/Builtins.cs
@@ -82,6 +82,7 @@ namespace DMCompiler.DM.Expressions {
                 json = null;
                 return false;
             }
+
             if(!_arguments.TryAsJsonRepresentation(out object? argsJson)){
                 json = null;
                 return false;

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -225,12 +225,11 @@ namespace OpenDreamRuntime.Objects {
                                 }
                             }
 
-                            if (jsonElement.TryGetProperty("associatedValues", out JsonElement associatedValues)) {
-                                foreach (JsonProperty associatedValue in associatedValues.EnumerateObject()) {
-                                    DreamValue key = new DreamValue(associatedValue.Name);
-
-                                    list.SetValue(key, GetDreamValueFromJsonElement(associatedValue.Value));
-                                }
+                            if (jsonElement.TryGetProperty("associatedValuesKeys", out JsonElement associatedValuesKeys) && jsonElement.TryGetProperty("associatedValuesValues", out JsonElement associatedValues)) {
+                                var valueEnumerator = associatedValues.EnumerateObject();
+                                var keyEnumerator = associatedValuesKeys.EnumerateObject();
+                                while(valueEnumerator.MoveNext() && keyEnumerator.MoveNext())
+                                    list.SetValue(GetDreamValueFromJsonElement(keyEnumerator.Current), GetDreamValueFromJsonElement(valueEnumerator.Current));
                             }
 
                             return new DreamValue(list);
@@ -238,6 +237,7 @@ namespace OpenDreamRuntime.Objects {
                             return new DreamValue(float.PositiveInfinity);
                         case JsonVariableType.NegativeInfinity:
                             return new DreamValue(float.NegativeInfinity);
+                        case JsonVariableType.NewPath:
                         default:
                             throw new Exception($"Invalid variable type ({variableType})");
                     }

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -242,9 +242,9 @@ namespace OpenDreamRuntime.Objects {
                             DreamValue typePath = GetDreamValueFromJsonElement(jsonElement.GetProperty("path"));
                             if(typePath.TryGetValueAsType(out TreeEntry? instanceType)) {
                                 returnObject = new(instanceType.ObjectDefinition);
+                                //TODO parse arguments and pass them to the constructor
                                 //DreamValue constructorArgs = GetDreamValueFromJsonElement(jsonElement.GetProperty("args"));
-                                //Help how do I do this part
-                                returnObject.Initialize(new DreamProcArguments());
+                                returnObject.InitSpawn(new DreamProcArguments());
                                 return new DreamValue(returnObject);
                             } else {
                                 throw new Exception($"Invalid path type ({typePath})");

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -226,8 +226,8 @@ namespace OpenDreamRuntime.Objects {
                             }
 
                             if (jsonElement.TryGetProperty("associatedValuesKeys", out JsonElement associatedValuesKeys) && jsonElement.TryGetProperty("associatedValuesValues", out JsonElement associatedValues)) {
-                                var valueEnumerator = associatedValues.EnumerateObject();
-                                var keyEnumerator = associatedValuesKeys.EnumerateObject();
+                                var valueEnumerator = associatedValues.EnumerateArray();
+                                var keyEnumerator = associatedValuesKeys.EnumerateArray();
                                 while(valueEnumerator.MoveNext() && keyEnumerator.MoveNext())
                                     list.SetValue(GetDreamValueFromJsonElement(keyEnumerator.Current), GetDreamValueFromJsonElement(valueEnumerator.Current));
                             }
@@ -238,6 +238,17 @@ namespace OpenDreamRuntime.Objects {
                         case JsonVariableType.NegativeInfinity:
                             return new DreamValue(float.NegativeInfinity);
                         case JsonVariableType.NewPath:
+                            DreamObject returnObject;
+                            DreamValue typePath = GetDreamValueFromJsonElement(jsonElement.GetProperty("path"));
+                            if(typePath.TryGetValueAsType(out TreeEntry? instanceType)) {
+                                returnObject = new(instanceType.ObjectDefinition);
+                                //DreamValue constructorArgs = GetDreamValueFromJsonElement(jsonElement.GetProperty("args"));
+                                //Help how do I do this part
+                                returnObject.Initialize(new DreamProcArguments());
+                                return new DreamValue(returnObject);
+                            } else {
+                                throw new Exception($"Invalid path type ({typePath})");
+                            }
                         default:
                             throw new Exception($"Invalid variable type ({variableType})");
                     }

--- a/OpenDreamShared/Json/DreamObjectJson.cs
+++ b/OpenDreamShared/Json/DreamObjectJson.cs
@@ -9,7 +9,9 @@ namespace OpenDreamShared.Json {
         ProcStub = 4,
         VerbStub = 5,
         PositiveInfinity = 6,
-        NegativeInfinity = 7
+        NegativeInfinity = 7,
+        NewPath = 8,
+        ArgList = 9,
     }
 
     public sealed class DreamTypeJson {


### PR DESCRIPTION
Goon needs it because 
```
Compiling goonstation.dme on 514.1584
Warning OD0000 at <internal>: Unimplemented proc & var warnings are currently suppressed
Error OD0000 at cogmap2.dmm:42594:12: Failed to serialize value to json (DMCompiler.DM.Expressions.NewPath)
Error OD0000 at z2.dmm:65063:17: Failed to serialize value to json (DMCompiler.DM.Expressions.List)
Error OD0000 at z2.dmm:66845:17: Failed to serialize value to json (DMCompiler.DM.Expressions.List)
Compilation failed with 3 errors and 1 warnings
Total time: 00:09
```

cogmap2.dmm:42594 
```
/obj/displaycase{
        displayed = new/obj/item/captaingun;
        pixel_y = 6
        },
```

z2.dmm:65063 (the other is a similar thing) 
```
/obj/item/storage/box/costume/clown{
        spawn_contents = list(/obj/item/clothing/mask/clown_hat,/obj/item/clothing/under/misc/clown,/obj/item/clothing/shoes/clown_shoes,/obj/item/storage/fanny/funny,/obj/item/card/id/clown)
        },
```