### PR TITLE
Split DMObjectBuilder into several steps

### DIFF
--- a/DMCompiler/DM/DMObject.cs
+++ b/DMCompiler/DM/DMObject.cs
@@ -1,13 +1,9 @@
-﻿using DMCompiler.DM.Visitors;
-using DMCompiler.Compiler.DM;
-using OpenDreamShared.Dream;
+﻿using OpenDreamShared.Dream;
 using OpenDreamShared.Json;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using OpenDreamShared.Compiler;
 using OpenDreamShared.Dream.Procs;
-using Robust.Shared.Utility;
 
 namespace DMCompiler.DM {
     /// <remarks>
@@ -15,7 +11,7 @@ namespace DMCompiler.DM {
     /// but rather stores the compile-time information necessary to describe a certain object definition, <br/>
     /// including its procs, vars, path, parent, etc.
     /// </remarks>
-    sealed class DMObject {
+    internal sealed class DMObject {
         public int Id;
         public DreamPath Path;
         public DMObject? Parent;
@@ -30,9 +26,6 @@ namespace DMCompiler.DM {
 
         public bool IsRoot => Path == DreamPath.Root;
 
-        // Statements waiting for LateVarDef event to happen
-        public Dictionary<string, List<DMASTStatement>> DanglingStatementsByUndefinedNames = new();
-        private bool _isSubscribedToVarDef = false;
         private List<DMProc>? _verbs;
 
         public DMObject(int id, DreamPath path, DMObject? parent) {
@@ -45,41 +38,6 @@ namespace DMCompiler.DM {
             if (!Procs.ContainsKey(name)) Procs.Add(name, new List<int>(1));
 
             Procs[name].Add(proc.Id);
-        }
-
-        private void HandleLateVarDef(object sender, DMVariable varDefined) {
-            DMObject? maybeAncestor = sender as DMObject;
-            if (maybeAncestor == null)
-                return;
-
-            if (DanglingStatementsByUndefinedNames.ContainsKey(varDefined.Name)) {
-                foreach (DMASTStatement statement in DanglingStatementsByUndefinedNames[varDefined.Name].ToList()) {
-                    if (statement is DMASTObjectVarOverride && !IsSubtypeOf(maybeAncestor.Path)) // Resolves the ambiguous var override
-                        continue;
-                    DMObjectBuilder.ProcessStatement(statement);
-                    DanglingStatementsByUndefinedNames[varDefined.Name].Remove(statement);
-                }
-                if (DanglingStatementsByUndefinedNames[varDefined.Name].Count == 0)
-                    DanglingStatementsByUndefinedNames.Remove(varDefined.Name);
-            }
-
-            if (DanglingStatementsByUndefinedNames.Count == 0) {
-                DMObjectBuilder.VarDefined -= this.HandleLateVarDef;
-                _isSubscribedToVarDef = false;
-            }
-        }
-
-        public void WaitForLateVarDefinition(string waitForName, DMASTStatement statement) {
-            if (DanglingStatementsByUndefinedNames.ContainsKey(waitForName)) {
-                DanglingStatementsByUndefinedNames[waitForName].Add(statement);
-            } else {
-                DanglingStatementsByUndefinedNames[waitForName] = new List<DMASTStatement> { statement };
-            }
-
-            if (_isSubscribedToVarDef == false) {
-                DMObjectBuilder.VarDefined += this.HandleLateVarDef;
-                _isSubscribedToVarDef = true;
-            }
         }
 
         ///<remarks>

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -196,31 +196,26 @@ namespace DMCompiler.DM {
         }
 
         public void WaitFor(bool waitFor) {
-            if (waitFor)
-            {
+            if (waitFor) {
                 // "waitfor" is true by default
                 Attributes &= ~ProcAttributes.DisableWaitfor;
-            }
-            else
-            {
+            } else {
                 Attributes |= ProcAttributes.DisableWaitfor;
             }
         }
 
-        public DMVariable CreateGlobalVariable(DreamPath? type, string name, bool isConst)
-        {
-            int id = DMObjectTree.CreateGlobal(out DMVariable global, type, name, isConst);
+        public DMVariable CreateGlobalVariable(DreamPath? type, string name, bool isConst, out int id) {
+            id = DMObjectTree.CreateGlobal(out DMVariable global, type, name, isConst);
 
             GlobalVariables[name] = id;
             return global;
         }
 
-        public int? GetGlobalVariableId(string name)
-        {
-            if (GlobalVariables.TryGetValue(name, out int id))
-            {
+        public int? GetGlobalVariableId(string name) {
+            if (GlobalVariables.TryGetValue(name, out int id)) {
                 return id;
             }
+
             return null;
         }
 

--- a/DMCompiler/DM/Visitors/DMObjectBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMObjectBuilder.cs
@@ -1,97 +1,134 @@
 using OpenDreamShared.Compiler;
 using DMCompiler.Compiler.DM;
 using OpenDreamShared.Dream;
-using System;
 using OpenDreamShared.Dream.Procs;
 using System.Collections.Generic;
-using Robust.Shared.Utility;
 
 namespace DMCompiler.DM.Visitors {
-    static class DMObjectBuilder {
-        /// <summary>
-        /// In DM, the definition of a base class may occur way after the definition of (perhaps numerous) derived classes. <br/>
-        /// At the time that we first evaluate the derived class, we do not know some important information, like the implicit type of certain things.<br/>
-        /// This event allows for delaying variable override evaluation until after we know what it is. </summary>
-        /// <remarks>
-        /// Further, it just so happens to also act as a container that can enumerate all objects which were expecting a definition but never got one.
-        /// </remarks>
-        public static event EventHandler<DMVariable>? VarDefined; // Fires if we define a new variable.
-
-        /// <summary>
-        /// A running collection of types that we need to find a definition for. <br/>
-        /// Comes up most especially when a var/some/type/x is defined before we know what /some/type even is. <br/>
-        /// The Location value can just be the first instance of this definition being promised, for errors' sake.
-        /// </summary>
-        public static Dictionary<DreamPath, Location> AwaitedObjectDefinitions = new();
-
-        /// <summary>
-        /// Similiar to <see cref="AwaitedObjectDefinitions"/> except for procs that are overridden before they are defined.
-        /// </summary>
-        public static Dictionary<string, DMObject> AwaitedProcDefinitions = new();
+    internal static class DMObjectBuilder {
+        private static readonly List<(DMObject, DMASTObjectVarDefinition)> VarDefinitions = new();
+        private static readonly List<(DMObject, DMASTObjectVarOverride)> VarOverrides = new();
+        private static readonly List<(DMObject?, DMASTProcDefinition)> ProcDefinitions = new();
+        private static readonly List<(DMObject DMObject, DMProc Proc, int Id, DMASTProcStatementVarDeclaration VarDecl)> StaticProcVars = new();
 
         public static void Reset() {
             DMObjectTree.Reset(); // Blank the object tree
-            VarDefined = null;
-            AwaitedObjectDefinitions.Clear(); // Need to do this since this static is re-used during unit testing :^)
-            AwaitedProcDefinitions.Clear();
+
+            VarDefinitions.Clear();
+            VarOverrides.Clear();
+            ProcDefinitions.Clear();
+            StaticProcVars.Clear();
         }
 
         public static void BuildObjectTree(DMASTFile astFile) {
             Reset();
-            ProcessFile(astFile); // generate it
 
-            if (VarDefined != null) { // This means some listeners are remaining, which means that variables were overridden but not defined! Bad!
-                foreach(var method in VarDefined.GetInvocationList()) { // For every object listening
-                    object? obj = method.Target;
-                    DMObject? realObj = (DMObject?)obj;
-                    if (realObj == null)
-                        continue;
+            // Step 1: Define every type in the code. Collect proc and var declarations for later.
+            ProcessFile(astFile);
 
-                    foreach (var (undefinedName, danglingStatements) in realObj.DanglingStatementsByUndefinedNames) {
-                        foreach (var danglingStatement in danglingStatements) {
-                            if (danglingStatement is DMASTObjectVarOverride)
-                                DMCompiler.Emit(WarningCode.DanglingOverride, danglingStatement.Location, $"Cannot override undefined var \"{undefinedName}\"");
-                            else
-                                DMCompiler.Emit(new CompilerEmission(ErrorLevel.Error, danglingStatement.Location, $"Unknown identifier \"{undefinedName}\""));
-                        }
-                    }
-                }
+            // Step 2: Define every proc and proc override (but do not compile!)
+            //          Collect static vars inside procs for later.
+            foreach (var procDef in ProcDefinitions) {
+                ProcessProcDefinition(procDef.Item2, procDef.Item1);
             }
 
-            //Lets check in on all the types we found promised before and see if we actually got them. :^)
-            //Note: Dynamically removing types as we find them would've made the compiler 4x slower, per some tests I did.
-            //      It's much more performant to do it this way.
-            foreach(var pair in AwaitedObjectDefinitions) {
-                if(!DMObjectTree.TryGetTypeId(pair.Key,out var _))
-                    DMCompiler.Emit(WarningCode.DanglingVarType, pair.Value, $"Definition for path {pair.Key} not found");
-            }
-
-            //And now all the proc definitions we were promised
-            foreach (var pair in AwaitedProcDefinitions) {
-                if (pair.Value.IsRoot) { // Have to do this since DMObjectTree is what holds global procs, not the root DMObject, interestingly enough
-                    if(!DMObjectTree.SeenGlobalProcDefinition.Contains(pair.Key)) { // If we didn't see a definition for it :(
-                        int ID = DMObjectTree.GlobalProcs[pair.Key];
-                        DMProc proc = DMObjectTree.AllProcs[ID];
-                        DMCompiler.Emit(WarningCode.DanglingOverride, proc.Location, $"Definition for global proc {pair.Key} not found");
-                    }
+            // Step 3: Create the static vars inside procs
+            List<(DMObject, DMProc, DMASTProcStatementVarDeclaration, int, UnknownIdentifierException e)> lateProcVarDefs = new();
+            foreach (var staticVar in StaticProcVars) {
+                if (staticVar.VarDecl.Value == null)
                     continue;
-                }
 
-                if (!pair.Value.HasProcDefined(pair.Key)) {
-                    DMProc proc = DMObjectTree.AllProcs[pair.Value.GetProcs(pair.Key)[0]];
-                    DMCompiler.Emit(WarningCode.DanglingOverride, proc.Location, $"Definition for proc {pair.Key} on type {pair.Value.Path} not found");
+                try {
+                    DMVisitorExpression._scopeMode = "static";
+                    DMExpression expression = DMExpression.Create(staticVar.DMObject, staticVar.Proc,
+                        staticVar.VarDecl.Value, staticVar.VarDecl.Type);
+
+                    DMObjectTree.AddGlobalInitAssign(staticVar.DMObject, staticVar.Id, expression);
+                } catch (UnknownIdentifierException e) {
+                    // For step 5
+                    lateProcVarDefs.Add((staticVar.DMObject, staticVar.Proc, staticVar.VarDecl, staticVar.Id, e));
+                } catch (CompileErrorException e) {
+                    DMCompiler.Emit(e.Error);
+                } finally {
+                    DMVisitorExpression._scopeMode = "normal";
                 }
             }
 
-            // TODO Nuke this pass
-            // (Note that VarDefined's lazy evaluation behaviour is dependent on happening BEFORE the the initialization proc statements are emitted)
+            // Step 4: Define vars. Collect static vars for later
+            List<(DMObject, DMASTObjectVarDefinition, UnknownIdentifierException e)> lateVarDefs = new();
+            foreach (var varDef in VarDefinitions) {
+                try {
+                    ProcessVarDefinition(varDef.Item1, varDef.Item2);
+                } catch (UnknownIdentifierException e) {
+                    lateVarDefs.Add((varDef.Item1, varDef.Item2, e)); // For step 5
+                }
+            }
+
+            // Step 5: Attempt to resolve all vars that referenced other not-yet-existing vars
+            int lastLateVarDefCount;
+            do {
+                lastLateVarDefCount = lateVarDefs.Count + lateProcVarDefs.Count;
+
+                // Static vars outside of procs
+                for (int i = 0; i < lateVarDefs.Count; i++) {
+                    var varDef = lateVarDefs[i];
+
+                    try {
+                        ProcessVarDefinition(varDef.Item1, varDef.Item2);
+
+                        // Success! Remove this one from the list
+                        lateVarDefs.RemoveAt(i--);
+                    } catch (UnknownIdentifierException) {
+                        // Keep it in the list, try again after the rest have been processed
+                    }
+                }
+
+                // Static vars inside procs
+                for (int i = 0; i < lateProcVarDefs.Count; i++) {
+                    var varDef = lateProcVarDefs[i];
+                    var varDecl = varDef.Item3;
+
+                    try {
+                        DMVisitorExpression._scopeMode = "static";
+                        DMExpression expression =
+                            DMExpression.Create(varDef.Item1, varDef.Item2, varDecl.Value!, varDecl.Type);
+
+                        DMObjectTree.AddGlobalInitAssign(varDef.Item1, varDef.Item4, expression);
+
+                        // Success! Remove this one from the list
+                        lateProcVarDefs.RemoveAt(i--);
+                    } catch (UnknownIdentifierException e) {
+                        // Keep it in the list, try again after the rest have been processed
+                    } finally {
+                        DMVisitorExpression._scopeMode = "normal";
+                    }
+                }
+            } while ((lateVarDefs.Count + lateProcVarDefs.Count) != lastLateVarDefCount); // As long as the lists are getting smaller, keep trying
+
+            // The vars these reference were never found, emit their errors
+            foreach (var lateVarDef in lateVarDefs) {
+                DMCompiler.Emit(lateVarDef.Item3.Error);
+            }
+
+            foreach (var lateVarDef in lateProcVarDefs) {
+                DMCompiler.Emit(lateVarDef.Item5.Error);
+            }
+
+            // Step 6: Apply var overrides
+            foreach (var varOverride in VarOverrides) {
+                ProcessVarOverride(varOverride.Item1, varOverride.Item2);
+            }
+
+            // Step 7: Create each types' initialization proc (initializes vars that aren't constants)
             foreach (DMObject dmObject in DMObjectTree.AllObjects) {
                 dmObject.CreateInitializationProc();
             }
 
+            // Step 8: Compile every proc
             foreach (DMProc proc in DMObjectTree.AllProcs)
                 proc.Compile();
 
+            // Step 9: Create & Compile the global init proc (initializes global vars)
             DMObjectTree.CreateGlobalInitProc();
         }
 
@@ -99,7 +136,7 @@ namespace DMCompiler.DM.Visitors {
             ProcessBlockInner(file.BlockInner, DMObjectTree.Root);
         }
 
-        private static void ProcessBlockInner(DMASTBlockInner blockInner, DMObject currentObject) {
+        private static void ProcessBlockInner(DMASTBlockInner blockInner, DMObject? currentObject) {
             foreach (DMASTStatement statement in blockInner.Statements) {
                 try {
                     ProcessStatement(statement, currentObject);
@@ -109,18 +146,24 @@ namespace DMCompiler.DM.Visitors {
             }
         }
 
-        public static void ProcessStatement(DMASTStatement statement, DMObject currentObject = null) {
+        public static void ProcessStatement(DMASTStatement statement, DMObject? currentObject = null) {
             switch (statement) {
-                case DMASTObjectDefinition objectDefinition: ProcessObjectDefinition(objectDefinition); break;
+                case DMASTObjectDefinition objectDefinition:
+                    ProcessObjectDefinition(objectDefinition);
+                    break;
 
-                //The above are the only cases where the currentObject could be set to a novel, new() value.
-                //The rest can just have it be passed as mutable ref like normal.
-                case DMASTObjectVarDefinition varDefinition: ProcessVarDefinition(varDefinition); break;
-                case DMASTObjectVarOverride varOverride: ProcessVarOverride(varOverride); break;
-                case DMASTProcDefinition procDefinition: ProcessProcDefinition(procDefinition, currentObject); break;
+                case DMASTObjectVarDefinition varDefinition:
+                    VarDefinitions.Add((DMObjectTree.GetDMObject(varDefinition.ObjectPath)!, varDefinition));
+                    break;
+                case DMASTObjectVarOverride varOverride:
+                    VarOverrides.Add((DMObjectTree.GetDMObject(varOverride.ObjectPath)!, varOverride));
+                    break;
+                case DMASTProcDefinition procDefinition:
+                    ProcDefinitions.Add((currentObject, procDefinition));
+                    break;
                 case DMASTMultipleObjectVarDefinitions multipleVarDefinitions: {
                     foreach (DMASTObjectVarDefinition varDefinition in multipleVarDefinitions.VarDefinitions) {
-                        ProcessVarDefinition(varDefinition);
+                        VarDefinitions.Add((DMObjectTree.GetDMObject(varDefinition.ObjectPath)!, varDefinition));
                     }
 
                     break;
@@ -130,15 +173,14 @@ namespace DMCompiler.DM.Visitors {
         }
 
         private static void ProcessObjectDefinition(DMASTObjectDefinition objectDefinition) {
-
             DMCompiler.VerbosePrint($"Generating {objectDefinition.Path}");
-            DMObject newCurrentObject = DMObjectTree.GetDMObject(objectDefinition.Path);
+
+            DMObject? newCurrentObject = DMObjectTree.GetDMObject(objectDefinition.Path);
             if (objectDefinition.InnerBlock != null) ProcessBlockInner(objectDefinition.InnerBlock, newCurrentObject);
         }
 
-        private static void ProcessVarDefinition(DMASTObjectVarDefinition varDefinition) {
+        private static void ProcessVarDefinition(DMObject? varObject, DMASTObjectVarDefinition? varDefinition) {
             DMVariable? variable = null;
-            DMObject varObject = DMObjectTree.GetDMObject(varDefinition.ObjectPath);
 
             //DMObjects store two bundles of variables; the statics in GlobalVariables and the non-statics in Variables.
             //Lets check if we're duplicating a definition, first.
@@ -158,10 +200,10 @@ namespace DMCompiler.DM.Visitors {
             DMExpression expression;
             try {
                 DMVisitorExpression._scopeMode = varDefinition.IsGlobal ? "static" : "normal";
-                expression = DMExpression.Create(varObject, varDefinition.IsGlobal ? DMObjectTree.GlobalInitProc : null, varDefinition.Value, varDefinition.Type);
-            } catch (UnknownIdentifierException e) {
-                varObject.WaitForLateVarDefinition(e.IdentifierName, varDefinition);
-                return;
+                expression = DMExpression.Create(varObject, varDefinition.IsGlobal ? DMObjectTree.GlobalInitProc : null,
+                    varDefinition.Value, varDefinition.Type);
+            } catch (UnknownIdentifierException) {
+                throw; // This should be handled by the calling code
             } catch (CompileErrorException e) {
                 DMCompiler.Emit(e.Error);
                 return;
@@ -178,22 +220,14 @@ namespace DMCompiler.DM.Visitors {
                 }
             }
 
-            //Check if this var definition implies a type we don't know about yet
-            if(variable.Type != null && !DMObjectTree.TryGetTypeId(variable.Type.Value,out var _)) {
-                AwaitedObjectDefinitions.TryAdd(variable.Type.Value, varDefinition.Location);
-            }
-
             try {
                 SetVariableValue(varObject, ref variable, varDefinition.Location, expression);
-                VarDefined?.Invoke(varObject, variable); // FIXME: God there HAS to be a better way of doing this
             } catch (CompileErrorException e) {
                 DMCompiler.Emit(e.Error);
             }
         }
 
-        private static void ProcessVarOverride(DMASTObjectVarOverride varOverride) {
-            DMObject varObject = DMObjectTree.GetDMObject(varOverride.ObjectPath);
-
+        private static void ProcessVarOverride(DMObject? varObject, DMASTObjectVarOverride? varOverride) {
             try {
                 switch (varOverride.VarName) { // Keep in mind that anything here, by default, affects all objects, even those who don't inherit from /datum
                     case "parent_type": {
@@ -218,28 +252,19 @@ namespace DMCompiler.DM.Visitors {
                 } else if (varObject.HasGlobalVariable(varOverride.VarName)) {
                     variable = varObject.GetGlobalVariable(varOverride.VarName);
                     DMCompiler.Emit(WarningCode.StaticOverride, varOverride.Location, $"var \"{varOverride.VarName}\" cannot be overridden - it is a global var");
-                } else { // So this is an awkward point where we have to be a little bit silly.
-                    //So, this override cannot be emitted until we know what the heck the DMVariable is supposed to be.
-                    //To do that, we are now going to cache this var override and wait for our parent class to be defined, so we can know wtf it is and resume!
-                    if(varObject.Path == DreamPath.Root) { // As per DM, we should just error out if a root global var is overwritten before it is defined.
-                        DMCompiler.Emit(WarningCode.ItemDoesntExist, varOverride.Location, $"var \"{varOverride.VarName}\" is not declared");
-                        return; // don't do the fancy event stuff if we're root
-                    }
-                    varObject.WaitForLateVarDefinition(varOverride.VarName, varOverride);
+                } else {
+                    DMCompiler.Emit(WarningCode.ItemDoesntExist, varOverride.Location, $"var \"{varOverride.VarName}\" is not declared");
                     return;
                 }
 
                 OverrideVariableValue(varObject, ref variable, varOverride.Value);
                 varObject.VariableOverrides[variable.Name] = variable;
-            } catch (UnknownIdentifierException e) {
-                varObject.WaitForLateVarDefinition(e.IdentifierName, varOverride);
-                return;
             } catch (CompileErrorException e) {
                 DMCompiler.Emit(e.Error);
             }
         }
 
-        private static void ProcessProcDefinition(DMASTProcDefinition procDefinition, DMObject currentObject) {
+        private static void ProcessProcDefinition(DMASTProcDefinition procDefinition, DMObject? currentObject) {
             string procName = procDefinition.Name;
             try {
                 DMObject dmObject = DMObjectTree.GetDMObject(currentObject.Path.Combine(procDefinition.ObjectPath));
@@ -252,19 +277,7 @@ namespace DMCompiler.DM.Visitors {
                     //Otherwise, it's ok
                 }
 
-                /*
-                    So the way that BYOND handles the distinction between definitions and overrides on the same type is kinda strange.
-                    There is NO visible dominance that one has over the other, except that the last one found is the first definition invoked when called.
-
-                    The only grammatical purpose the /proc/ phrase in one of the procs does,
-                    is to mark that this type should be the first one in its inheritence to have that proc defined.
-                    Nothing else.
-                */
-                if (procDefinition.IsOverride && !hasProc) // If an override for this proc was found before its definition
-                    AwaitedProcDefinitions.TryAdd(procName, dmObject); // Remember to check that we eventually found a definition, later :)
-
                 DMProc proc = DMObjectTree.CreateDMProc(dmObject, procDefinition);
-
                 proc.IsVerb = procDefinition.IsVerb;
 
                 if (procDefinition.ObjectPath == DreamPath.Root) {
@@ -287,15 +300,10 @@ namespace DMCompiler.DM.Visitors {
                     foreach (var stmt in GetStatements(procDefinition.Body)) {
                         // TODO multiple var definitions.
                         if (stmt is DMASTProcStatementVarDeclaration varDeclaration && varDeclaration.IsGlobal) {
-                            DMVariable variable = proc.CreateGlobalVariable(varDeclaration.Type, varDeclaration.Name, varDeclaration.IsConst);
+                            DMVariable variable = proc.CreateGlobalVariable(varDeclaration.Type, varDeclaration.Name, varDeclaration.IsConst, out var globalId);
                             variable.Value = new Expressions.Null(varDeclaration.Location);
 
-                            if (varDeclaration.Value != null) {
-                                DMVisitorExpression._scopeMode = "static";
-                                DMExpression expression = DMExpression.Create(dmObject, proc, varDeclaration.Value, varDeclaration.Type);
-                                DMVisitorExpression._scopeMode = "normal";
-                                DMObjectTree.AddGlobalInitAssign(dmObject, proc.GetGlobalVariableId(varDeclaration.Name).Value, expression);
-                            }
+                            StaticProcVars.Add((dmObject, proc, globalId, varDeclaration));
                         }
                     }
                 }

--- a/DMCompiler/DM/Visitors/DMObjectBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMObjectBuilder.cs
@@ -54,7 +54,7 @@ namespace DMCompiler.DM.Visitors {
                 }
             }
 
-            // Step 4: Define vars. Collect static vars for later
+            // Step 4: Define vars
             List<(DMObject, DMASTObjectVarDefinition, UnknownIdentifierException e)> lateVarDefs = new();
             foreach (var varDef in VarDefinitions) {
                 try {

--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -509,7 +509,7 @@ namespace DMCompiler.DM.Visitors {
 
                     var globalId = _dmObject.GetGlobalVariableId(firstOperation.Identifier.Identifier);
                     if (globalId == null) {
-                        throw new CompileErrorException(deref.Location, $"Invalid property global.{firstOperation.Identifier.Identifier}");
+                        throw new UnknownIdentifierException(deref.Location, $"global.{firstOperation.Identifier.Identifier}");
                     }
 
                     var property = DMObjectTree.Globals[globalId.Value];
@@ -583,7 +583,7 @@ namespace DMCompiler.DM.Visitors {
                             string field = astOperation.Identifier.Identifier;
 
                             if (prevPath == null) {
-                                throw new CompileErrorException(deref.Location, $"Invalid property \"{field}\"");
+                                throw new UnknownIdentifierException(deref.Location, field);
                             }
 
                             DMObject dmObject = DMObjectTree.GetDMObject(prevPath.Value, false);
@@ -616,7 +616,7 @@ namespace DMCompiler.DM.Visitors {
                             }
 
                             if (property == null) {
-                                throw new CompileErrorException(deref.Location, $"Invalid property \"{field}\" on type {prevPath}");
+                                throw new UnknownIdentifierException(deref.Location, field);
                             }
 
                             if ((property.ValType & DMValueType.Unimplemented) == DMValueType.Unimplemented) {
@@ -653,7 +653,7 @@ namespace DMCompiler.DM.Visitors {
                             ArgumentList argumentList = new(deref.Expression.Location, _dmObject, _proc, astOperation.Parameters, null);
 
                             if (prevPath == null) {
-                                throw new CompileErrorException(deref.Location, $"Invalid property \"{field}\"");
+                                throw new UnknownIdentifierException(deref.Location, field);
                             }
 
                             DMObject dmObject = DMObjectTree.GetDMObject(prevPath.Value, false);

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -1,5 +1,3 @@
-//The first global in the runtime is always `world`
-//So keep this at the top
 /var/world/world = null
 
 //These procs should be in alphabetical order, as in DreamProcNativeRoot.cs

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -37,7 +37,7 @@ namespace OpenDreamRuntime {
 
         // Global state that may not really (really really) belong here
         public List<DreamValue> Globals { get; set; } = new();
-        public IReadOnlyList<string> GlobalNames { get; private set; } = new List<string>();
+        public List<string> GlobalNames { get; private set; } = new List<string>();
         public Dictionary<DreamObject, int> ReferenceIDs { get; } = new();
         public Dictionary<int, DreamObject> ReferenceIDsToDreamObject { get; } = new();
         public HashSet<DreamObject> Clients { get; set; } = new();
@@ -135,8 +135,7 @@ namespace OpenDreamRuntime {
                 }
             }
 
-            // The first global is always `world`.
-            Globals[0] = new DreamValue(WorldInstance);
+            Globals[GlobalNames.IndexOf("world")] = new DreamValue(WorldInstance);
 
             // Load turfs and areas of compiled-in maps, recursively calling <init>, but suppressing all New
             _dreamMapManager.LoadAreasAndTurfs(_compiledJson.Maps[0]);

--- a/OpenDreamRuntime/IDreamManager.cs
+++ b/OpenDreamRuntime/IDreamManager.cs
@@ -16,7 +16,7 @@ namespace OpenDreamRuntime {
         public event EventHandler<Exception> OnException;
 
         public List<DreamValue> Globals { get; }
-        public IReadOnlyList<string> GlobalNames { get; }
+        public List<string> GlobalNames { get; }
         public Dictionary<DreamObject, int> ReferenceIDs { get; }
         public Dictionary<int, DreamObject> ReferenceIDsToDreamObject { get; }
         public HashSet<DreamObject> Clients { get; set; }


### PR DESCRIPTION
Aims to fix var/proc ordering issues by removing the late-var-def and late-object-def events in DMObjectBuilder and replacing them with these 9 steps in `BuildObjectTree()` (as copy-pasted from code comments):

1. Define every type in the code. Collect proc and var declarations for later.
2. Define every proc and proc override (but do not compile!). Collect static vars inside procs for later.
3. Create the static vars inside procs
4. Define vars
5. Attempt to resolve all vars that referenced other not-yet-existing vars
6. Apply var overrides
7. Create each types' initialization proc
8. Compile every proc
9. Create & Compile the global init proc

There is still only one pass over the entire AST, the relevant pieces are added to lists for processing later.

Passes all the existing unit tests, compiles ike's branch of Paradise, modern Paradise, and modern /tg/.

Fixes #901