### PR TITLE
Add support for a /list value in `stat()`

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
@@ -123,7 +123,10 @@ public sealed class DreamObjectClient : DreamObject {
                 break;
             }
             case "statpanel":
-                //connection.SelectedStatPanel = variableValue.GetValueAsString();
+                if (!value.TryGetValueAsString(out var statPanel))
+                    return;
+
+                Connection.SelectedStatPanel = statPanel;
                 break;
             default:
                 base.SetVar(varName, value);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2429,7 +2429,12 @@ namespace OpenDreamRuntime.Procs.Native {
             if (name != DreamValue.Null) {
                 connection.AddStatPanelLine(name.Stringify() + "\t" + value.Stringify());
             } else {
-                connection.AddStatPanelLine(value.Stringify());
+                if (value.TryGetValueAsDreamList(out var list)) {
+                    foreach (var item in list.GetValues())
+                        connection.AddStatPanelLine(item.Stringify());
+                } else {
+                    connection.AddStatPanelLine(value.Stringify());
+                }
             }
         }
 


### PR DESCRIPTION
According to the DM reference,
> If no name is specified and the value is a list, this is the same as calling stat on each item in the list.

I also fixed setting `/client.statpanel` since most of the logic was already there. The setter was just commented out.