### PR TITLE
Copy associated values when using `|=` with two lists

### DIFF
--- a/Content.Tests/DMProject/Tests/List/AssocListCombine.dm
+++ b/Content.Tests/DMProject/Tests/List/AssocListCombine.dm
@@ -1,0 +1,11 @@
+﻿/proc/RunTest()
+	var/list/L = list("A")
+	L |= list("B" = 1)
+	ASSERT(L ~= list("A", "B"))
+	ASSERT(L["A"] == null)
+	ASSERT(L["B"] == 1)
+
+	L = list("A")
+	L |= list("A" = 1)
+	ASSERT(L ~= list("A"))
+	ASSERT(L["A"] == null) // If the key already exists, it won't copy the associated value

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -313,9 +313,13 @@ namespace OpenDreamRuntime.Objects.Types {
         public override DreamValue OperatorCombine(DreamValue b) {
             if (b.TryGetValueAsDreamList(out var bList)) {
                 foreach (DreamValue value in bList.GetValues()) {
-                    if (!ContainsValue(value)) {
+                    if (ContainsValue(value))
+                        continue;
+
+                    if (bList._associativeValues?.TryGetValue(value, out var associatedValue) is true)
+                        SetValue(value, associatedValue);
+                    else
                         AddValue(value);
-                    }
                 }
             } else if (!ContainsValue(b)) {
                 AddValue(b);


### PR DESCRIPTION
Fixes PDAs on Paradise

![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/1a0be412-3429-48b1-ad1c-02e589118468)
