### PR TITLE
Fix wrapped output statements

### DIFF
--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -518,6 +518,14 @@ namespace DMCompiler.Compiler.DM {
         public virtual IEnumerable<DMASTExpression> Leaves() {
             yield break;
         }
+
+        /// <summary>
+        /// If this is a <see cref="DMASTExpressionWrapped"/>, returns the expression inside.
+        /// Returns this expression if not.
+        /// </summary>
+        public virtual DMASTExpression GetUnwrapped() {
+            return this;
+        }
     }
 
     public abstract class DMASTExpressionConstant : DMASTExpression {
@@ -2316,6 +2324,10 @@ namespace DMCompiler.Compiler.DM {
         }
     }
 
+    /// <summary>
+    /// An expression wrapped around parentheses
+    /// <code>(1 + 1)</code>
+    /// </summary>
     public sealed class DMASTExpressionWrapped : DMASTExpression {
         public DMASTExpression Expression;
 
@@ -2325,6 +2337,14 @@ namespace DMCompiler.Compiler.DM {
 
         public override void Visit(DMASTVisitor visitor) {
             Expression.Visit(visitor);
+        }
+
+        public override DMASTExpression GetUnwrapped() {
+            DMASTExpression expr = Expression;
+            while (expr is DMASTExpressionWrapped wrapped)
+                expr = wrapped.Expression;
+
+            return expr;
         }
     }
 

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -635,7 +635,7 @@ namespace DMCompiler.Compiler.DM {
                     case DMASTLeftShift leftShift: {
                         // A left shift on its own becomes a special "output" statement
                         // Or something else depending on what's on the right ( browse(), browse_rsc(), output(), etc )
-                        if (leftShift.B is DMASTProcCall {Callable: DMASTCallableProcIdentifier identifier} procCall) {
+                        if (leftShift.B.GetUnwrapped() is DMASTProcCall {Callable: DMASTCallableProcIdentifier identifier} procCall) {
                             switch (identifier.Identifier) {
                                 case "browse": {
                                     if (procCall.Parameters.Length != 1 && procCall.Parameters.Length != 2)


### PR DESCRIPTION
Fixes statements like `usr << (browse(...))`

Adds a new `GetUnwrapped()` method to `DMASTExpression` that returns the expression inside a `DMASTExpressionWrapped`

Fixes #1333