### PR TITLE
Implement `DreamOverlaysList.GetValues()`

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -570,6 +570,23 @@ namespace OpenDreamRuntime.Objects.Types {
             _isUnderlays = isUnderlays;
         }
 
+        public override List<DreamValue> GetValues() {
+            var appearance = _atomManager.MustGetAppearance(_atom);
+            if (appearance == null || _appearanceSystem == null)
+                return new List<DreamValue>();
+
+            var overlays = GetOverlaysList(appearance);
+            var values = new List<DreamValue>(overlays.Count);
+
+            foreach (var overlay in overlays) {
+                var overlayAppearance = _appearanceSystem.MustGetAppearance(overlay);
+
+                values.Add(new(overlayAppearance));
+            }
+
+            return values;
+        }
+
         public override void Cut(int start = 1, int end = 0) {
             _atomManager.UpdateAppearance(_atom, appearance => {
                 List<uint> overlaysList = GetOverlaysList(appearance);

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -623,7 +623,8 @@ namespace OpenDreamRuntime.Objects.Types {
                 return;
 
             _atomManager.UpdateAppearance(_atom, appearance => {
-                IconAppearance overlayAppearance = CreateOverlayAppearance(value);
+                IconAppearance? overlayAppearance = CreateOverlayAppearance(_atomManager, value, appearance.Icon);
+                overlayAppearance ??= new IconAppearance();
 
                 GetOverlaysList(appearance).Add(_appearanceSystem.AddAppearance(overlayAppearance));
             });
@@ -634,7 +635,8 @@ namespace OpenDreamRuntime.Objects.Types {
                 return;
 
             _atomManager.UpdateAppearance(_atom, appearance => {
-                IconAppearance overlayAppearance = CreateOverlayAppearance(value);
+                IconAppearance? overlayAppearance = CreateOverlayAppearance(_atomManager, value, appearance.Icon);
+                overlayAppearance ??= new IconAppearance();
 
                 GetOverlaysList(appearance).Remove(_appearanceSystem.AddAppearance(overlayAppearance));
             });
@@ -656,20 +658,20 @@ namespace OpenDreamRuntime.Objects.Types {
             return appearance;
         }
 
-        private IconAppearance CreateOverlayAppearance(DreamValue value) {
+        public static IconAppearance? CreateOverlayAppearance(IAtomManager atomManager, DreamValue value, int? defaultIcon) {
             IconAppearance overlay;
 
             if (value.TryGetValueAsString(out var iconState)) {
                 overlay = new IconAppearance() {
                     IconState = iconState
                 };
-            } else if (_atomManager.TryCreateAppearanceFrom(value, out var overlayAppearance)) {
+            } else if (atomManager.TryCreateAppearanceFrom(value, out var overlayAppearance)) {
                 overlay = overlayAppearance;
             } else {
-                return new IconAppearance(); // Not a valid overlay, use a default appearance
+                return null; // Not a valid overlay
             }
 
-            overlay.Icon ??= GetAppearance().Icon;
+            overlay.Icon ??= defaultIcon;
             return overlay;
         }
     }


### PR DESCRIPTION
Fixes `overlays.Copy()` which fixes `cut_overlays()` in SS13

Also made `/mutable_appearance.overlays`/`underlays` more accurate to BYOND behavior