### PR TITLE
Split ID and name attributes in skin controls

### DIFF
--- a/OpenDreamClient/Interface/BrowsePopup.cs
+++ b/OpenDreamClient/Interface/BrowsePopup.cs
@@ -3,54 +3,53 @@ using OpenDreamClient.Interface.Descriptors;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface.Controls;
 
-namespace OpenDreamClient.Interface
-{
-    sealed class BrowsePopup {
-        public event Action Closed;
+namespace OpenDreamClient.Interface;
 
-        public ControlBrowser Browser;
-        public ControlWindow WindowElement;
+internal sealed class BrowsePopup {
+    public event Action Closed;
 
-        private OSWindow _window;
+    public ControlBrowser Browser;
+    public ControlWindow WindowElement;
 
-        public BrowsePopup(
-            string name,
-            Vector2i size,
-            IClydeWindow ownerWindow) {
-            WindowDescriptor popupWindowDescriptor = new WindowDescriptor(name,
-                new() {
-                    new ControlDescriptorBrowser {
-                        Id = "browser",
-                        Size = size,
-                        Anchor1 = new Vector2i(0, 0),
-                        Anchor2 = new Vector2i(100, 100)
-                    }
-                }) {
-                    Size = size
-                };
+    private OSWindow _window;
 
-            WindowElement = new ControlWindow(popupWindowDescriptor);
-            WindowElement.CreateChildControls();
+    public BrowsePopup(
+        string name,
+        Vector2i size,
+        IClydeWindow ownerWindow) {
+        WindowDescriptor popupWindowDescriptor = new WindowDescriptor(name,
+            new() {
+                new ControlDescriptorBrowser {
+                    Id = "browser",
+                    Size = size,
+                    Anchor1 = new Vector2i(0, 0),
+                    Anchor2 = new Vector2i(100, 100)
+                }
+            }) {
+                Size = size
+            };
 
-            _window = WindowElement.CreateWindow();
-            _window.StartupLocation = WindowStartupLocation.CenterOwner;
-            _window.Owner = ownerWindow;
-            _window.Closed += OnWindowClosed;
+        WindowElement = new ControlWindow(popupWindowDescriptor);
+        WindowElement.CreateChildControls();
 
-            Browser = (ControlBrowser)WindowElement.ChildControls[0];
-        }
+        _window = WindowElement.CreateWindow();
+        _window.StartupLocation = WindowStartupLocation.CenterOwner;
+        _window.Owner = ownerWindow;
+        _window.Closed += OnWindowClosed;
 
-        public void Open() {
-            _window.Show();
-            // _window.Focus();
-        }
+        Browser = (ControlBrowser)WindowElement.ChildControls[0];
+    }
 
-        public void Close() {
-            _window.Close();
-        }
+    public void Open() {
+        _window.Show();
+        // _window.Focus();
+    }
 
-        private void OnWindowClosed() {
-            Closed?.Invoke();
-        }
+    public void Close() {
+        _window.Close();
+    }
+
+    private void OnWindowClosed() {
+        Closed?.Invoke();
     }
 }

--- a/OpenDreamClient/Interface/BrowsePopup.cs
+++ b/OpenDreamClient/Interface/BrowsePopup.cs
@@ -20,7 +20,7 @@ namespace OpenDreamClient.Interface
             WindowDescriptor popupWindowDescriptor = new WindowDescriptor(name,
                 new() {
                     new ControlDescriptorBrowser {
-                        Name = "browser",
+                        Id = "browser",
                         Size = size,
                         Anchor1 = new Vector2i(0, 0),
                         Anchor2 = new Vector2i(100, 100)

--- a/OpenDreamClient/Interface/Controls/ControlButton.cs
+++ b/OpenDreamClient/Interface/Controls/ControlButton.cs
@@ -3,40 +3,40 @@ using OpenDreamClient.Interface.Descriptors;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 
-namespace OpenDreamClient.Interface.Controls {
-    sealed class ControlButton : InterfaceControl {
-        public const string StyleClassDMFButton = "DMFbutton";
+namespace OpenDreamClient.Interface.Controls;
 
-        private Button _button;
+internal sealed class ControlButton : InterfaceControl {
+    public const string StyleClassDMFButton = "DMFbutton";
 
-        public ControlButton(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor, window) { }
+    private Button _button;
 
-        protected override Control CreateUIElement() {
-            _button = new Button() {
-                ClipText = true
-            };
+    public ControlButton(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor, window) { }
 
-            _button.OnPressed += OnButtonClick;
-            _button.Label.Margin = new Thickness(0, -3, 0, 0);
-            _button.Label.AddStyleClass(StyleClassDMFButton);
+    protected override Control CreateUIElement() {
+        _button = new Button() {
+            ClipText = true
+        };
 
-            return _button;
-        }
+        _button.OnPressed += OnButtonClick;
+        _button.Label.Margin = new Thickness(0, -3, 0, 0);
+        _button.Label.AddStyleClass(StyleClassDMFButton);
 
-        protected override void UpdateElementDescriptor() {
-            base.UpdateElementDescriptor();
+        return _button;
+    }
 
-            ControlDescriptorButton controlDescriptor = (ControlDescriptorButton)ElementDescriptor;
+    protected override void UpdateElementDescriptor() {
+        base.UpdateElementDescriptor();
 
-            _button.Text = controlDescriptor.Text;
-        }
+        ControlDescriptorButton controlDescriptor = (ControlDescriptorButton)ElementDescriptor;
 
-        private void OnButtonClick(BaseButton.ButtonEventArgs args) {
-            ControlDescriptorButton controlDescriptor = (ControlDescriptorButton)ElementDescriptor;
+        _button.Text = controlDescriptor.Text;
+    }
 
-            if (controlDescriptor.Command != null) {
-                EntitySystem.Get<DreamCommandSystem>().RunCommand(controlDescriptor.Command);
-            }
+    private void OnButtonClick(BaseButton.ButtonEventArgs args) {
+        ControlDescriptorButton controlDescriptor = (ControlDescriptorButton)ElementDescriptor;
+
+        if (controlDescriptor.Command != null) {
+            EntitySystem.Get<DreamCommandSystem>().RunCommand(controlDescriptor.Command);
         }
     }
 }

--- a/OpenDreamClient/Interface/Controls/ControlChild.cs
+++ b/OpenDreamClient/Interface/Controls/ControlChild.cs
@@ -2,63 +2,63 @@
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 
-namespace OpenDreamClient.Interface.Controls {
-    sealed class ControlChild : InterfaceControl {
-        // todo: robust needs GridSplitter.
-        // and a non-shit grid control.
+namespace OpenDreamClient.Interface.Controls;
 
-        [Dependency] private readonly IDreamInterfaceManager _dreamInterface = default!;
+internal sealed class ControlChild : InterfaceControl {
+    // todo: robust needs GridSplitter.
+    // and a non-shit grid control.
 
-        private SplitContainer _grid;
-        private ControlWindow? _leftElement, _rightElement;
+    [Dependency] private readonly IDreamInterfaceManager _dreamInterface = default!;
 
-        public ControlChild(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor, window) {
+    private SplitContainer _grid;
+    private ControlWindow? _leftElement, _rightElement;
+
+    public ControlChild(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor, window) {
+    }
+
+    protected override Control CreateUIElement() {
+        _grid = new SplitContainer();
+
+        return _grid;
+    }
+
+    protected override void UpdateElementDescriptor() {
+        base.UpdateElementDescriptor();
+
+        ControlDescriptorChild controlDescriptor = (ControlDescriptorChild)ElementDescriptor;
+
+        if (_leftElement != null) _grid.Children.Remove(_leftElement.UIElement);
+        if (_rightElement != null) _grid.Children.Remove(_rightElement.UIElement);
+
+        if (!string.IsNullOrEmpty(controlDescriptor.Left)) {
+            _leftElement = _dreamInterface.Windows[controlDescriptor.Left];
+            _leftElement.UIElement.HorizontalExpand = true;
+            _leftElement.UIElement.VerticalExpand = true;
+            _grid.Children.Add(_leftElement.UIElement);
+        } else {
+            _leftElement = null;
         }
 
-        protected override Control CreateUIElement() {
-            _grid = new SplitContainer();
-
-            return _grid;
+        if (!string.IsNullOrEmpty(controlDescriptor.Right)) {
+            _rightElement = _dreamInterface.Windows[controlDescriptor.Right];
+            _rightElement.UIElement.HorizontalExpand = true;
+            _rightElement.UIElement.VerticalExpand = true;
+            _grid.Children.Add(_rightElement.UIElement);
+        } else {
+            _rightElement = null;
         }
 
-        protected override void UpdateElementDescriptor() {
-            base.UpdateElementDescriptor();
+        UpdateGrid(controlDescriptor.IsVert);
+    }
 
-            ControlDescriptorChild controlDescriptor = (ControlDescriptorChild)ElementDescriptor;
+    public override void Shutdown() {
+        _leftElement?.Shutdown();
+        _rightElement?.Shutdown();
+    }
 
-            if (_leftElement != null) _grid.Children.Remove(_leftElement.UIElement);
-            if (_rightElement != null) _grid.Children.Remove(_rightElement.UIElement);
-
-            if (!String.IsNullOrEmpty(controlDescriptor.Left)) {
-                _leftElement = _dreamInterface.Windows[controlDescriptor.Left];
-                _leftElement.UIElement.HorizontalExpand = true;
-                _leftElement.UIElement.VerticalExpand = true;
-                _grid.Children.Add(_leftElement.UIElement);
-            } else {
-                _leftElement = null;
-            }
-
-            if (!String.IsNullOrEmpty(controlDescriptor.Right)) {
-                _rightElement = _dreamInterface.Windows[controlDescriptor.Right];
-                _rightElement.UIElement.HorizontalExpand = true;
-                _rightElement.UIElement.VerticalExpand = true;
-                _grid.Children.Add(_rightElement.UIElement);
-            } else {
-                _rightElement = null;
-            }
-
-            UpdateGrid(controlDescriptor.IsVert);
-        }
-
-        public override void Shutdown() {
-            _leftElement?.Shutdown();
-            _rightElement?.Shutdown();
-        }
-
-        private void UpdateGrid(bool isVert) {
-            _grid.Orientation = isVert
-                ? SplitContainer.SplitOrientation.Horizontal
-                : SplitContainer.SplitOrientation.Vertical;
-        }
+    private void UpdateGrid(bool isVert) {
+        _grid.Orientation = isVert
+            ? SplitContainer.SplitOrientation.Horizontal
+            : SplitContainer.SplitOrientation.Vertical;
     }
 }

--- a/OpenDreamClient/Interface/Controls/ControlGrid.cs
+++ b/OpenDreamClient/Interface/Controls/ControlGrid.cs
@@ -2,20 +2,20 @@ using OpenDreamClient.Interface.Descriptors;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 
-namespace OpenDreamClient.Interface.Controls {
-    sealed class ControlGrid : InterfaceControl {
-        private GridContainer _grid;
+namespace OpenDreamClient.Interface.Controls;
 
-        public ControlGrid(ControlDescriptor controlDescriptor, ControlWindow window) :
-            base(controlDescriptor, window) {
-        }
+internal sealed class ControlGrid : InterfaceControl {
+    private GridContainer _grid;
 
-        protected override Control CreateUIElement() {
-            _grid = new GridContainer() {
+    public ControlGrid(ControlDescriptor controlDescriptor, ControlWindow window) :
+        base(controlDescriptor, window) {
+    }
 
-            };
+    protected override Control CreateUIElement() {
+        _grid = new GridContainer() {
 
-            return _grid;
-        }
+        };
+
+        return _grid;
     }
 }

--- a/OpenDreamClient/Interface/Controls/ControlInfo.cs
+++ b/OpenDreamClient/Interface/Controls/ControlInfo.cs
@@ -8,272 +8,272 @@ using Robust.Shared.Input;
 using Robust.Shared.Network;
 using Robust.Shared.Utility;
 
-namespace OpenDreamClient.Interface.Controls {
-    [Virtual]
-    internal class InfoPanel : Control {
-        public string PanelName { get; }
+namespace OpenDreamClient.Interface.Controls;
 
-        protected InfoPanel(string name) {
-            PanelName = name;
-            TabContainer.SetTabTitle(this, name);
-        }
+[Virtual]
+internal class InfoPanel : Control {
+    public string PanelName { get; }
+
+    protected InfoPanel(string name) {
+        PanelName = name;
+        TabContainer.SetTabTitle(this, name);
     }
+}
 
-    internal sealed class StatPanel : InfoPanel {
-        private sealed class StatEntry {
-            public readonly RichTextLabel NameLabel = new();
-            public readonly RichTextLabel ValueLabel = new();
-
-            private readonly ControlInfo _owner;
-            private readonly IEntitySystemManager _entitySystemManager;
-            private readonly FormattedMessage _nameText = new();
-            private readonly FormattedMessage _valueText = new();
-            private string? _atomRef;
-
-            public StatEntry(ControlInfo owner, IEntitySystemManager entitySystemManager) {
-                _owner = owner;
-                _entitySystemManager = entitySystemManager;
-
-                // TODO: Change color when the mouse is hovering
-                //       I couldn't find a way to do this without recreating the FormattedMessage
-                ValueLabel.MouseFilter = MouseFilterMode.Stop;
-                ValueLabel.OnKeyBindDown += OnKeyBindDown;
-            }
-
-            public void Clear() {
-                _atomRef = null;
-                _nameText.Clear();
-                _valueText.Clear();
-
-                NameLabel.SetMessage(_nameText);
-                ValueLabel.SetMessage(_valueText);
-            }
-
-            public void UpdateLabels(string name, string value, string? atomRef) {
-                // TODO: Tabs should align with each other.
-                //       Probably should be done by RT, but it just ignores them currently.
-                name = name.Replace("\t", "    ");
-                value = value.Replace("\t", "    ");
-                _atomRef = atomRef;
-
-                _nameText.Clear();
-                _valueText.Clear();
-
-                // Use the default color and font
-                _nameText.PushColor(Color.Black);
-                _valueText.PushColor(Color.Black);
-                _nameText.PushTag(new MarkupNode("font", null, null));
-                _valueText.PushTag(new MarkupNode("font", null, null));
-
-                if (_owner.InfoDescriptor.AllowHtml) {
-                    // TODO: Look into using RobustToolbox's markup parser once it's customizable enough
-                    HtmlParser.Parse(name, _nameText);
-                    HtmlParser.Parse(value, _valueText);
-                } else {
-                    _nameText.AddText(name);
-                    _valueText.AddText(value);
-                }
-
-                NameLabel.SetMessage(_nameText);
-                ValueLabel.SetMessage(_valueText);
-            }
-
-            private void OnKeyBindDown(GUIBoundKeyEventArgs e) {
-                if (e.Function != EngineKeyFunctions.Use && e.Function != OpenDreamKeyFunctions.MouseMiddle &&
-                    e.Function != EngineKeyFunctions.TextCursorSelect)
-                    return;
-                if (_atomRef == null)
-                    return;
-                if (!_entitySystemManager.TryGetEntitySystem(out MouseInputSystem? mouseInputSystem))
-                    return;
-
-                e.Handle();
-                mouseInputSystem.HandleStatClick(_atomRef, e.Function == OpenDreamKeyFunctions.MouseMiddle);
-            }
-        }
+internal sealed class StatPanel : InfoPanel {
+    private sealed class StatEntry {
+        public readonly RichTextLabel NameLabel = new();
+        public readonly RichTextLabel ValueLabel = new();
 
         private readonly ControlInfo _owner;
         private readonly IEntitySystemManager _entitySystemManager;
-        private readonly GridContainer _grid;
-        private readonly List<StatEntry> _entries = new();
+        private readonly FormattedMessage _nameText = new();
+        private readonly FormattedMessage _valueText = new();
+        private string? _atomRef;
 
-        public StatPanel(ControlInfo owner, IEntitySystemManager entitySystemManager, string name) : base(name) {
+        public StatEntry(ControlInfo owner, IEntitySystemManager entitySystemManager) {
             _owner = owner;
             _entitySystemManager = entitySystemManager;
-            _grid = new() {
-                Columns = 2
-            };
 
-            var scrollViewer = new ScrollContainer() {
-                HScrollEnabled = false,
-                Children = { _grid }
-            };
-            AddChild(scrollViewer);
+            // TODO: Change color when the mouse is hovering
+            //       I couldn't find a way to do this without recreating the FormattedMessage
+            ValueLabel.MouseFilter = MouseFilterMode.Stop;
+            ValueLabel.OnKeyBindDown += OnKeyBindDown;
         }
 
-        public void UpdateLines(List<(string Name, string Value, string? AtomRef)> lines) {
-            for (int i = 0; i < Math.Max(_entries.Count, lines.Count); i++) {
-                var entry = GetEntry(i);
+        public void Clear() {
+            _atomRef = null;
+            _nameText.Clear();
+            _valueText.Clear();
 
-                if (i < lines.Count) {
-                    var line = lines[i];
-
-                    entry.UpdateLabels(line.Name, line.Value, line.AtomRef);
-                } else {
-                    entry.Clear();
-                }
-            }
+            NameLabel.SetMessage(_nameText);
+            ValueLabel.SetMessage(_valueText);
         }
 
-        private StatEntry GetEntry(int index) {
-            // Expand the entries if there aren't enough
-            if (_entries.Count <= index) {
-                for (int i = _entries.Count; i <= index; i++) {
-                    var entry = new StatEntry(_owner, _entitySystemManager);
+        public void UpdateLabels(string name, string value, string? atomRef) {
+            // TODO: Tabs should align with each other.
+            //       Probably should be done by RT, but it just ignores them currently.
+            name = name.Replace("\t", "    ");
+            value = value.Replace("\t", "    ");
+            _atomRef = atomRef;
 
-                    _grid.AddChild(entry.NameLabel);
-                    _grid.AddChild(entry.ValueLabel);
-                    _entries.Add(entry);
-                }
+            _nameText.Clear();
+            _valueText.Clear();
+
+            // Use the default color and font
+            _nameText.PushColor(Color.Black);
+            _valueText.PushColor(Color.Black);
+            _nameText.PushTag(new MarkupNode("font", null, null));
+            _valueText.PushTag(new MarkupNode("font", null, null));
+
+            if (_owner.InfoDescriptor.AllowHtml) {
+                // TODO: Look into using RobustToolbox's markup parser once it's customizable enough
+                HtmlParser.Parse(name, _nameText);
+                HtmlParser.Parse(value, _valueText);
+            } else {
+                _nameText.AddText(name);
+                _valueText.AddText(value);
             }
 
-            return _entries[index];
+            NameLabel.SetMessage(_nameText);
+            ValueLabel.SetMessage(_valueText);
+        }
+
+        private void OnKeyBindDown(GUIBoundKeyEventArgs e) {
+            if (e.Function != EngineKeyFunctions.Use && e.Function != OpenDreamKeyFunctions.MouseMiddle &&
+                e.Function != EngineKeyFunctions.TextCursorSelect)
+                return;
+            if (_atomRef == null)
+                return;
+            if (!_entitySystemManager.TryGetEntitySystem(out MouseInputSystem? mouseInputSystem))
+                return;
+
+            e.Handle();
+            mouseInputSystem.HandleStatClick(_atomRef, e.Function == OpenDreamKeyFunctions.MouseMiddle);
         }
     }
 
-    internal sealed class VerbPanel : InfoPanel {
-        [Dependency] private readonly IDreamInterfaceManager _dreamInterface = default!;
-        private readonly GridContainer _grid;
+    private readonly ControlInfo _owner;
+    private readonly IEntitySystemManager _entitySystemManager;
+    private readonly GridContainer _grid;
+    private readonly List<StatEntry> _entries = new();
 
-        public VerbPanel(string name) : base(name) {
-            _grid = new GridContainer { Columns = 4 };
-            IoCManager.InjectDependencies(this);
-            AddChild(_grid);
-        }
+    public StatPanel(ControlInfo owner, IEntitySystemManager entitySystemManager, string name) : base(name) {
+        _owner = owner;
+        _entitySystemManager = entitySystemManager;
+        _grid = new() {
+            Columns = 2
+        };
 
-        public void RefreshVerbs() {
-            _grid.Children.Clear();
+        var scrollViewer = new ScrollContainer() {
+            HScrollEnabled = false,
+            Children = { _grid }
+        };
+        AddChild(scrollViewer);
+    }
 
-            foreach ((string verbName, string verbId, string verbCategory) in _dreamInterface.AvailableVerbs) {
-                if (verbCategory != PanelName)
-                    continue;
+    public void UpdateLines(List<(string Name, string Value, string? AtomRef)> lines) {
+        for (int i = 0; i < Math.Max(_entries.Count, lines.Count); i++) {
+            var entry = GetEntry(i);
 
-                Button verbButton = new Button() {
-                    Margin = new Thickness(2),
-                    MinWidth = 100,
-                    Text = verbName
-                };
+            if (i < lines.Count) {
+                var line = lines[i];
 
-                verbButton.Label.Margin = new Thickness(6, 0, 6, 2);
-                verbButton.OnPressed += _ => {
-                    EntitySystem.Get<DreamCommandSystem>().RunCommand(verbId);
-                };
-
-                _grid.Children.Add(verbButton);
+                entry.UpdateLabels(line.Name, line.Value, line.AtomRef);
+            } else {
+                entry.Clear();
             }
         }
     }
 
-    public sealed class ControlInfo : InterfaceControl {
-        public ControlDescriptorInfo InfoDescriptor => (ControlDescriptorInfo)ControlDescriptor;
+    private StatEntry GetEntry(int index) {
+        // Expand the entries if there aren't enough
+        if (_entries.Count <= index) {
+            for (int i = _entries.Count; i <= index; i++) {
+                var entry = new StatEntry(_owner, _entitySystemManager);
 
-        [Dependency] private readonly IClientNetManager _netManager = default!;
-        [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
-
-        private TabContainer _tabControl;
-        private readonly Dictionary<string, StatPanel> _statPanels = new();
-        private readonly SortedDictionary<string, VerbPanel> _verbPanels = new();
-
-        private bool _defaultPanelSent = false;
-
-        public ControlInfo(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor, window) {
-            IoCManager.InjectDependencies(this);
-        }
-
-        protected override Control CreateUIElement() {
-            _tabControl = new TabContainer();
-            _tabControl.OnTabChanged += OnSelectionChanged;
-
-            RefreshVerbs();
-
-            return _tabControl;
-        }
-
-        public void RefreshVerbs() {
-            foreach (var panel in _verbPanels) {
-                _verbPanels[panel.Key].RefreshVerbs();
+                _grid.AddChild(entry.NameLabel);
+                _grid.AddChild(entry.ValueLabel);
+                _entries.Add(entry);
             }
         }
 
-        public void SelectStatPanel(string statPanelName) {
-            if (_statPanels.TryGetValue(statPanelName, out var panel))
-                _tabControl.CurrentTab = panel.GetPositionInParent();
+        return _entries[index];
+    }
+}
+
+internal sealed class VerbPanel : InfoPanel {
+    [Dependency] private readonly IDreamInterfaceManager _dreamInterface = default!;
+    private readonly GridContainer _grid;
+
+    public VerbPanel(string name) : base(name) {
+        _grid = new GridContainer { Columns = 4 };
+        IoCManager.InjectDependencies(this);
+        AddChild(_grid);
+    }
+
+    public void RefreshVerbs() {
+        _grid.Children.Clear();
+
+        foreach ((string verbName, string verbId, string verbCategory) in _dreamInterface.AvailableVerbs) {
+            if (verbCategory != PanelName)
+                continue;
+
+            Button verbButton = new Button() {
+                Margin = new Thickness(2),
+                MinWidth = 100,
+                Text = verbName
+            };
+
+            verbButton.Label.Margin = new Thickness(6, 0, 6, 2);
+            verbButton.OnPressed += _ => {
+                EntitySystem.Get<DreamCommandSystem>().RunCommand(verbId);
+            };
+
+            _grid.Children.Add(verbButton);
+        }
+    }
+}
+
+public sealed class ControlInfo : InterfaceControl {
+    public ControlDescriptorInfo InfoDescriptor => (ControlDescriptorInfo)ControlDescriptor;
+
+    [Dependency] private readonly IClientNetManager _netManager = default!;
+    [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
+
+    private TabContainer _tabControl;
+    private readonly Dictionary<string, StatPanel> _statPanels = new();
+    private readonly SortedDictionary<string, VerbPanel> _verbPanels = new();
+
+    private bool _defaultPanelSent = false;
+
+    public ControlInfo(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor, window) {
+        IoCManager.InjectDependencies(this);
+    }
+
+    protected override Control CreateUIElement() {
+        _tabControl = new TabContainer();
+        _tabControl.OnTabChanged += OnSelectionChanged;
+
+        RefreshVerbs();
+
+        return _tabControl;
+    }
+
+    public void RefreshVerbs() {
+        foreach (var panel in _verbPanels) {
+            _verbPanels[panel.Key].RefreshVerbs();
+        }
+    }
+
+    public void SelectStatPanel(string statPanelName) {
+        if (_statPanels.TryGetValue(statPanelName, out var panel))
+            _tabControl.CurrentTab = panel.GetPositionInParent();
+    }
+
+    public void UpdateStatPanels(MsgUpdateStatPanels pUpdateStatPanels) {
+        //Remove any panels the packet doesn't contain
+        foreach (KeyValuePair<string, StatPanel> existingPanel in _statPanels) {
+            if (!pUpdateStatPanels.StatPanels.ContainsKey(existingPanel.Key)) {
+                _tabControl.RemoveChild(existingPanel.Value);
+                _statPanels.Remove(existingPanel.Key);
+            }
         }
 
-        public void UpdateStatPanels(MsgUpdateStatPanels pUpdateStatPanels) {
-            //Remove any panels the packet doesn't contain
-            foreach (KeyValuePair<string, StatPanel> existingPanel in _statPanels) {
-                if (!pUpdateStatPanels.StatPanels.ContainsKey(existingPanel.Key)) {
-                    _tabControl.RemoveChild(existingPanel.Value);
-                    _statPanels.Remove(existingPanel.Key);
-                }
+        foreach (var updatingPanel in pUpdateStatPanels.StatPanels) {
+            if (!_statPanels.TryGetValue(updatingPanel.Key, out var panel)) {
+                panel = CreateStatPanel(updatingPanel.Key);
             }
 
-            foreach (var updatingPanel in pUpdateStatPanels.StatPanels) {
-                if (!_statPanels.TryGetValue(updatingPanel.Key, out var panel)) {
-                    panel = CreateStatPanel(updatingPanel.Key);
-                }
-
-                panel.UpdateLines(updatingPanel.Value);
-            }
-
-            // Tell the server we're ready to receive data
-            if (!_defaultPanelSent && _tabControl.ChildCount > 0) {
-                var msg = new MsgSelectStatPanel() {
-                    StatPanel = _tabControl.GetActualTabTitle(0)
-                };
-
-                _netManager.ClientSendMessage(msg);
-                _defaultPanelSent = true;
-            }
+            panel.UpdateLines(updatingPanel.Value);
         }
 
-        public bool HasVerbPanel(string name) {
-            return _verbPanels.ContainsKey(name);
-        }
-
-        public void CreateVerbPanel(string name) {
-            var panel = new VerbPanel(name);
-            _verbPanels.Add(name, panel);
-            SortPanels();
-        }
-
-        private StatPanel CreateStatPanel(string name) {
-            var panel = new StatPanel(this, _entitySystemManager, name);
-            panel.Margin = new Thickness(20, 2);
-            _statPanels.Add(name, panel);
-            SortPanels();
-            return panel;
-        }
-
-        private void SortPanels() {
-            _tabControl.Children.Clear();
-            foreach(var (_, statPanel) in _statPanels) {
-                _tabControl.AddChild(statPanel);
-            }
-
-            foreach(var (_, verbPanel) in _verbPanels) {
-                _tabControl.AddChild(verbPanel);
-            }
-        }
-
-        private void OnSelectionChanged(int tabIndex) {
-            InfoPanel panel = (InfoPanel)_tabControl.GetChild(tabIndex);
+        // Tell the server we're ready to receive data
+        if (!_defaultPanelSent && _tabControl.ChildCount > 0) {
             var msg = new MsgSelectStatPanel() {
-                StatPanel = panel.PanelName
+                StatPanel = _tabControl.GetActualTabTitle(0)
             };
 
             _netManager.ClientSendMessage(msg);
+            _defaultPanelSent = true;
         }
+    }
+
+    public bool HasVerbPanel(string name) {
+        return _verbPanels.ContainsKey(name);
+    }
+
+    public void CreateVerbPanel(string name) {
+        var panel = new VerbPanel(name);
+        _verbPanels.Add(name, panel);
+        SortPanels();
+    }
+
+    private StatPanel CreateStatPanel(string name) {
+        var panel = new StatPanel(this, _entitySystemManager, name);
+        panel.Margin = new Thickness(20, 2);
+        _statPanels.Add(name, panel);
+        SortPanels();
+        return panel;
+    }
+
+    private void SortPanels() {
+        _tabControl.Children.Clear();
+        foreach(var (_, statPanel) in _statPanels) {
+            _tabControl.AddChild(statPanel);
+        }
+
+        foreach(var (_, verbPanel) in _verbPanels) {
+            _tabControl.AddChild(verbPanel);
+        }
+    }
+
+    private void OnSelectionChanged(int tabIndex) {
+        InfoPanel panel = (InfoPanel)_tabControl.GetChild(tabIndex);
+        var msg = new MsgSelectStatPanel() {
+            StatPanel = panel.PanelName
+        };
+
+        _netManager.ClientSendMessage(msg);
     }
 }

--- a/OpenDreamClient/Interface/Controls/ControlInput.cs
+++ b/OpenDreamClient/Interface/Controls/ControlInput.cs
@@ -3,23 +3,22 @@ using OpenDreamClient.Interface.Descriptors;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 
-namespace OpenDreamClient.Interface.Controls {
-    sealed class ControlInput : InterfaceControl
-    {
-        private LineEdit _textBox;
+namespace OpenDreamClient.Interface.Controls;
 
-        public ControlInput(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor, window) { }
+internal sealed class ControlInput : InterfaceControl {
+    private LineEdit _textBox;
 
-        protected override Control CreateUIElement() {
-            _textBox = new LineEdit();
-            _textBox.OnTextEntered += TextBox_OnSubmit;
+    public ControlInput(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor, window) { }
 
-            return _textBox;
-        }
+    protected override Control CreateUIElement() {
+        _textBox = new LineEdit();
+        _textBox.OnTextEntered += TextBox_OnSubmit;
 
-        private void TextBox_OnSubmit(LineEdit.LineEditEventArgs lineEditEventArgs) {
-            EntitySystem.Get<DreamCommandSystem>().RunCommand(_textBox.Text);
-            _textBox.Clear();
-        }
+        return _textBox;
+    }
+
+    private void TextBox_OnSubmit(LineEdit.LineEditEventArgs lineEditEventArgs) {
+        EntitySystem.Get<DreamCommandSystem>().RunCommand(_textBox.Text);
+        _textBox.Clear();
     }
 }

--- a/OpenDreamClient/Interface/Controls/ControlLabel.cs
+++ b/OpenDreamClient/Interface/Controls/ControlLabel.cs
@@ -2,27 +2,26 @@ using OpenDreamClient.Interface.Descriptors;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 
-namespace OpenDreamClient.Interface.Controls
-{
-    sealed class ControlLabel : InterfaceControl {
-        private Label _label;
+namespace OpenDreamClient.Interface.Controls;
 
-        public ControlLabel(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor, window) { }
+internal sealed class ControlLabel : InterfaceControl {
+    private Label _label;
 
-        protected override Control CreateUIElement() {
-            _label = new Label() {
-                HorizontalAlignment = Control.HAlignment.Center,
-                VerticalAlignment = Control.VAlignment.Center,
-            };
+    public ControlLabel(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor, window) { }
 
-            return _label;
-        }
+    protected override Control CreateUIElement() {
+        _label = new Label() {
+            HorizontalAlignment = Control.HAlignment.Center,
+            VerticalAlignment = Control.VAlignment.Center,
+        };
 
-        protected override void UpdateElementDescriptor() {
-            base.UpdateElementDescriptor();
+        return _label;
+    }
 
-            ControlDescriptorLabel controlDescriptor = (ControlDescriptorLabel)ElementDescriptor;
-            _label.Text = controlDescriptor.Text;
-        }
+    protected override void UpdateElementDescriptor() {
+        base.UpdateElementDescriptor();
+
+        ControlDescriptorLabel controlDescriptor = (ControlDescriptorLabel)ElementDescriptor;
+        _label.Text = controlDescriptor.Text;
     }
 }

--- a/OpenDreamClient/Interface/Controls/ControlOutput.cs
+++ b/OpenDreamClient/Interface/Controls/ControlOutput.cs
@@ -4,38 +4,38 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Utility;
 
-namespace OpenDreamClient.Interface.Controls {
-    public sealed class ControlOutput : InterfaceControl {
-        private OutputPanel _textBox;
-        //private Border _border;
+namespace OpenDreamClient.Interface.Controls;
 
-        public ControlOutput(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor, window) { }
+public sealed class ControlOutput : InterfaceControl {
+    private OutputPanel _textBox;
+    //private Border _border;
 
-        protected override Control CreateUIElement() {
-            _textBox = new OutputPanel();
+    public ControlOutput(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor, window) { }
 
-            /*
-            _border = new Border() {
-                BorderBrush = Brushes.Black,
-                BorderThickness = new Thickness(1),
-                Child = _textBox
-            };
-            */
+    protected override Control CreateUIElement() {
+        _textBox = new OutputPanel();
 
-            return _textBox;
-        }
+        /*
+        _border = new Border() {
+            BorderBrush = Brushes.Black,
+            BorderThickness = new Thickness(1),
+            Child = _textBox
+        };
+        */
 
-        public override void Output(string value, string? data) {
-            var msg = new FormattedMessage(2);
+        return _textBox;
+    }
 
-            msg.PushColor(Color.Black);
-            msg.PushTag(new MarkupNode("font", null, null)); // Use the default font and font size
-            // TODO: Look into using RobustToolbox's markup parser once it's customizable enough
-            HtmlParser.Parse(value.Replace("\t", "    "), msg);
-            msg.Pop();
-            msg.Pop();
+    public override void Output(string value, string? data) {
+        var msg = new FormattedMessage(2);
 
-            _textBox.AddMessage(msg);
-        }
+        msg.PushColor(Color.Black);
+        msg.PushTag(new MarkupNode("font", null, null)); // Use the default font and font size
+        // TODO: Look into using RobustToolbox's markup parser once it's customizable enough
+        HtmlParser.Parse(value.Replace("\t", "    "), msg);
+        msg.Pop();
+        msg.Pop();
+
+        _textBox.AddMessage(msg);
     }
 }

--- a/OpenDreamClient/Interface/Controls/ControlTab.cs
+++ b/OpenDreamClient/Interface/Controls/ControlTab.cs
@@ -2,20 +2,20 @@ using OpenDreamClient.Interface.Descriptors;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 
-namespace OpenDreamClient.Interface.Controls {
-    sealed class ControlTab : InterfaceControl {
-        private TabContainer _tab;
+namespace OpenDreamClient.Interface.Controls;
 
-        public ControlTab(ControlDescriptor controlDescriptor, ControlWindow window) :
-            base(controlDescriptor, window) {
-        }
+internal sealed class ControlTab : InterfaceControl {
+    private TabContainer _tab;
 
-        protected override Control CreateUIElement() {
-            _tab = new TabContainer() {
+    public ControlTab(ControlDescriptor controlDescriptor, ControlWindow window) :
+        base(controlDescriptor, window) {
+    }
 
-            };
+    protected override Control CreateUIElement() {
+        _tab = new TabContainer() {
 
-            return _tab;
-        }
+        };
+
+        return _tab;
     }
 }

--- a/OpenDreamClient/Interface/Controls/ControlWindow.cs
+++ b/OpenDreamClient/Interface/Controls/ControlWindow.cs
@@ -4,243 +4,243 @@ using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 
-namespace OpenDreamClient.Interface.Controls {
-    public sealed class ControlWindow : InterfaceControl {
-        [Dependency] private readonly IUserInterfaceManager _uiMgr = default!;
-        [Dependency] private readonly IDreamInterfaceManager _dreamInterface = default!;
-        [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
+namespace OpenDreamClient.Interface.Controls;
 
-        private readonly ISawmill _sawmill = Logger.GetSawmill("opendream.window");
+public sealed class ControlWindow : InterfaceControl {
+    [Dependency] private readonly IUserInterfaceManager _uiMgr = default!;
+    [Dependency] private readonly IDreamInterfaceManager _dreamInterface = default!;
+    [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
 
-        // NOTE: a "window" in BYOND does not necessarily map 1:1 to OS windows.
-        // Just like in win32 (which is definitely what this is inspired by let's be real),
-        // windows can be embedded into other windows as a way to do nesting.
+    private readonly ISawmill _sawmill = Logger.GetSawmill("opendream.window");
 
-        public readonly List<InterfaceControl> ChildControls = new();
+    // NOTE: a "window" in BYOND does not necessarily map 1:1 to OS windows.
+    // Just like in win32 (which is definitely what this is inspired by let's be real),
+    // windows can be embedded into other windows as a way to do nesting.
 
-        public InterfaceMacroSet Macro => _dreamInterface.MacroSets[WindowDescriptor.Macro];
+    public readonly List<InterfaceControl> ChildControls = new();
 
-        private WindowDescriptor WindowDescriptor => (WindowDescriptor)ElementDescriptor;
+    public InterfaceMacroSet Macro => _dreamInterface.MacroSets[WindowDescriptor.Macro];
 
-        private Control _menuContainer = default!;
-        private LayoutContainer _canvas = default!;
-        private readonly List<(OSWindow? osWindow, IClydeWindow? clydeWindow)> _openWindows = new();
+    private WindowDescriptor WindowDescriptor => (WindowDescriptor)ElementDescriptor;
 
-        public ControlWindow(WindowDescriptor windowDescriptor) : base(windowDescriptor, null) {
-            IoCManager.InjectDependencies(this);
+    private Control _menuContainer = default!;
+    private LayoutContainer _canvas = default!;
+    private readonly List<(OSWindow? osWindow, IClydeWindow? clydeWindow)> _openWindows = new();
+
+    public ControlWindow(WindowDescriptor windowDescriptor) : base(windowDescriptor, null) {
+        IoCManager.InjectDependencies(this);
+    }
+
+    protected override void UpdateElementDescriptor() {
+        // Don't call base.UpdateElementDescriptor();
+
+        _menuContainer.RemoveAllChildren();
+        if (WindowDescriptor.Menu != null && _dreamInterface.Menus.TryGetValue(WindowDescriptor.Menu, out var menu)) {
+            _menuContainer.AddChild(menu.MenuBar);
+            _menuContainer.Visible = true;
+        } else {
+            _menuContainer.Visible = false;
         }
 
-        protected override void UpdateElementDescriptor() {
-            // Don't call base.UpdateElementDescriptor();
+        foreach (var window in _openWindows) {
+            UpdateWindowAttributes(window);
+        }
 
-            _menuContainer.RemoveAllChildren();
-            if (WindowDescriptor.Menu != null && _dreamInterface.Menus.TryGetValue(WindowDescriptor.Menu, out var menu)) {
-                _menuContainer.AddChild(menu.MenuBar);
-                _menuContainer.Visible = true;
-            } else {
-                _menuContainer.Visible = false;
+        if (WindowDescriptor.IsDefault) {
+            Macro.SetActive();
+        }
+    }
+
+    public OSWindow CreateWindow() {
+        OSWindow window = new();
+
+        window.Children.Add(UIElement);
+        window.SetWidth = ControlDescriptor.Size?.X ?? 640;
+        window.SetHeight = ControlDescriptor.Size?.Y ?? 440;
+        if (ControlDescriptor.Size?.X == 0)
+            window.SetWidth = window.MaxWidth;
+        if (ControlDescriptor.Size?.Y == 0)
+            window.SetHeight = window.MaxHeight;
+        window.Closing += _ => {
+            // A window can have a command set to be run when it's closed
+            if (WindowDescriptor.OnClose != null && _entitySystemManager.TryGetEntitySystem(out DreamCommandSystem? commandSystem)) {
+                commandSystem.RunCommand(WindowDescriptor.OnClose);
             }
 
-            foreach (var window in _openWindows) {
-                UpdateWindowAttributes(window);
-            }
+            _openWindows.Remove((window, null));
+        };
 
-            if (WindowDescriptor.IsDefault) {
-                Macro.SetActive();
-            }
-        }
+        _openWindows.Add((window, null));
+        UpdateWindowAttributes((window, null));
+        return window;
+    }
 
-        public OSWindow CreateWindow() {
-            OSWindow window = new();
+    public void RegisterOnClydeWindow(IClydeWindow window) {
+        // todo: listen for closed.
+        _openWindows.Add((null, window));
+        UpdateWindowAttributes((null, window));
+    }
 
-            window.Children.Add(UIElement);
-            window.SetWidth = ControlDescriptor.Size?.X ?? 640;
-            window.SetHeight = ControlDescriptor.Size?.Y ?? 440;
-            if (ControlDescriptor.Size?.X == 0)
-                window.SetWidth = window.MaxWidth;
-            if (ControlDescriptor.Size?.Y == 0)
-                window.SetHeight = window.MaxHeight;
-            window.Closing += _ => {
-                // A window can have a command set to be run when it's closed
-                if (WindowDescriptor.OnClose != null && _entitySystemManager.TryGetEntitySystem(out DreamCommandSystem? commandSystem)) {
-                    commandSystem.RunCommand(WindowDescriptor.OnClose);
-                }
+    public void UpdateAnchors() {
+        var windowSize = Size.GetValueOrDefault();
+        if (windowSize.X == 0)
+            windowSize.X = 640;
+        if (windowSize.Y == 0)
+            windowSize.Y = 440;
 
-                _openWindows.Remove((window, null));
-            };
+        for (int i = 0; i < ChildControls.Count; i++) {
+            InterfaceControl control = ChildControls[i];
+            var element = control.UIElement;
+            var elementPos = control.Pos.GetValueOrDefault();
+            var elementSize = control.Size.GetValueOrDefault();
 
-            _openWindows.Add((window, null));
-            UpdateWindowAttributes((window, null));
-            return window;
-        }
-
-        public void RegisterOnClydeWindow(IClydeWindow window) {
-            // todo: listen for closed.
-            _openWindows.Add((null, window));
-            UpdateWindowAttributes((null, window));
-        }
-
-        public void UpdateAnchors() {
-            var windowSize = Size.GetValueOrDefault();
-            if (windowSize.X == 0)
-                windowSize.X = 640;
-            if (windowSize.Y == 0)
-                windowSize.Y = 440;
-
-            for (int i = 0; i < ChildControls.Count; i++) {
-                InterfaceControl control = ChildControls[i];
-                var element = control.UIElement;
-                var elementPos = control.Pos.GetValueOrDefault();
-                var elementSize = control.Size.GetValueOrDefault();
-
-                if (control.Size?.Y == 0) {
-                    elementSize.Y = (windowSize.Y - elementPos.Y);
-                    if (ChildControls.Count - 1 > i) {
-                        if (ChildControls[i + 1].Pos != null) {
-                            var nextElementPos = ChildControls[i + 1].Pos.GetValueOrDefault();
-                            elementSize.Y = nextElementPos.Y - elementPos.Y;
-                        }
-                    }
-
-                    element.SetHeight = (elementSize.Y / windowSize.Y) * _canvas.Height;
-                }
-
-                if (control.Size?.X == 0) {
-                    elementSize.X = (windowSize.X - elementPos.X);
-                    if (ChildControls.Count - 1 > i) {
-                        if (ChildControls[i + 1].Pos != null) {
-                            var nextElementPos = ChildControls[i + 1].Pos.GetValueOrDefault();
-                            if (nextElementPos.X < (elementSize.X + elementPos.X) &&
-                                nextElementPos.Y < (elementSize.Y + elementPos.Y))
-                                elementSize.X = nextElementPos.X - elementPos.X;
-                        }
-                    }
-
-                    element.SetWidth = (elementSize.X / windowSize.X) * _canvas.Width;
-                }
-
-                if (control.Anchor1.HasValue) {
-                    var offset1X = elementPos.X - (windowSize.X * control.Anchor1.Value.X / 100f);
-                    var offset1Y = elementPos.Y - (windowSize.Y * control.Anchor1.Value.Y / 100f);
-                    var left = (_canvas.Width * control.Anchor1.Value.X / 100) + offset1X;
-                    var top = (_canvas.Height * control.Anchor1.Value.Y / 100) + offset1Y;
-                    LayoutContainer.SetMarginLeft(element, Math.Max(left, 0));
-                    LayoutContainer.SetMarginTop(element, Math.Max(top, 0));
-
-                    if (control.Anchor2.HasValue) {
-                        if (control.Anchor2.Value.X < control.Anchor1.Value.X ||
-                            control.Anchor2.Value.Y < control.Anchor1.Value.Y)
-                            _sawmill.Warning($"Invalid anchor2 value in DMF for element {control.Id}. Ignoring.");
-                        else {
-                            var offset2X = (elementPos.X + elementSize.X) -
-                                           (windowSize.X * control.Anchor2.Value.X / 100);
-                            var offset2Y = (elementPos.Y + elementSize.Y) -
-                                           (windowSize.Y * control.Anchor2.Value.Y / 100);
-                            var width = (_canvas.Width * control.Anchor2.Value.X / 100) + offset2X - left;
-                            var height = (_canvas.Height * control.Anchor2.Value.Y / 100) + offset2Y - top;
-                            element.SetWidth = Math.Max(width, 0);
-                            element.SetHeight = Math.Max(height, 0);
-                        }
-
+            if (control.Size?.Y == 0) {
+                elementSize.Y = (windowSize.Y - elementPos.Y);
+                if (ChildControls.Count - 1 > i) {
+                    if (ChildControls[i + 1].Pos != null) {
+                        var nextElementPos = ChildControls[i + 1].Pos.GetValueOrDefault();
+                        elementSize.Y = nextElementPos.Y - elementPos.Y;
                     }
                 }
+
+                element.SetHeight = (elementSize.Y / windowSize.Y) * _canvas.Height;
             }
-        }
 
-        private void UpdateWindowAttributes((OSWindow? osWindow, IClydeWindow? clydeWindow) windowRoot) {
-            // TODO: this would probably be cleaner if an OSWindow for MainWindow was available.
-            var (osWindow, clydeWindow) = windowRoot;
+            if (control.Size?.X == 0) {
+                elementSize.X = (windowSize.X - elementPos.X);
+                if (ChildControls.Count - 1 > i) {
+                    if (ChildControls[i + 1].Pos != null) {
+                        var nextElementPos = ChildControls[i + 1].Pos.GetValueOrDefault();
+                        if (nextElementPos.X < (elementSize.X + elementPos.X) &&
+                            nextElementPos.Y < (elementSize.Y + elementPos.Y))
+                            elementSize.X = nextElementPos.X - elementPos.X;
+                    }
+                }
 
-            var title = WindowDescriptor.Title ?? "OpenDream World";
-            if (osWindow != null) osWindow.Title = title;
-            else if (clydeWindow != null) clydeWindow.Title = title;
-
-            WindowRoot? root = null;
-            if (osWindow?.Window != null)
-                root = _uiMgr.GetWindowRoot(osWindow.Window);
-            else if (clydeWindow != null)
-                root = _uiMgr.GetWindowRoot(clydeWindow);
-
-            if (root != null) {
-                root.BackgroundColor = WindowDescriptor.BackgroundColor;
+                element.SetWidth = (elementSize.X / windowSize.X) * _canvas.Width;
             }
-        }
 
-        public void CreateChildControls() {
-            foreach (ControlDescriptor controlDescriptor in WindowDescriptor.ControlDescriptors) {
-                AddChild(controlDescriptor);
-            }
-        }
+            if (control.Anchor1.HasValue) {
+                var offset1X = elementPos.X - (windowSize.X * control.Anchor1.Value.X / 100f);
+                var offset1Y = elementPos.Y - (windowSize.Y * control.Anchor1.Value.Y / 100f);
+                var left = (_canvas.Width * control.Anchor1.Value.X / 100) + offset1X;
+                var top = (_canvas.Height * control.Anchor1.Value.Y / 100) + offset1Y;
+                LayoutContainer.SetMarginLeft(element, Math.Max(left, 0));
+                LayoutContainer.SetMarginTop(element, Math.Max(top, 0));
 
-        public override void AddChild(ElementDescriptor descriptor) {
-            if (descriptor is not ControlDescriptor controlDescriptor)
-                throw new Exception($"Attempted to add {descriptor} to a window, but it was not a control");
-            if (controlDescriptor is WindowDescriptor)
-                throw new Exception("Cannot add a window to a window");
-
-            InterfaceControl control = controlDescriptor switch {
-                ControlDescriptorChild => new ControlChild(controlDescriptor, this),
-                ControlDescriptorInput => new ControlInput(controlDescriptor, this),
-                ControlDescriptorButton => new ControlButton(controlDescriptor, this),
-                ControlDescriptorOutput => new ControlOutput(controlDescriptor, this),
-                ControlDescriptorInfo => new ControlInfo(controlDescriptor, this),
-                ControlDescriptorMap => new ControlMap(controlDescriptor, this),
-                ControlDescriptorBrowser => new ControlBrowser(controlDescriptor, this),
-                ControlDescriptorLabel => new ControlLabel(controlDescriptor, this),
-                ControlDescriptorGrid => new ControlGrid(controlDescriptor, this),
-                ControlDescriptorTab => new ControlTab(controlDescriptor, this),
-                _ => throw new Exception($"Invalid descriptor {controlDescriptor.GetType()}")
-            };
-
-            // Can't have out-of-order components, so make sure they're ordered properly
-            if (ChildControls.Count > 0) {
-                var prevPos = ChildControls[^1].Pos.GetValueOrDefault();
-                var curPos = control.Pos.GetValueOrDefault();
-                if (prevPos.X <= curPos.X && prevPos.Y <= curPos.Y)
-                    ChildControls.Add(control);
-                else {
-                    _sawmill.Warning(
-                        $"Out of order component {control.Id}. Elements should be defined in order of position. Attempting to fix automatically.");
-
-                    int i = 0;
-                    while (i < ChildControls.Count) {
-                        prevPos = ChildControls[i].Pos.GetValueOrDefault();
-                        if (prevPos.X <= curPos.X && prevPos.Y <= curPos.Y)
-                            i++;
-                        else
-                            break;
+                if (control.Anchor2.HasValue) {
+                    if (control.Anchor2.Value.X < control.Anchor1.Value.X ||
+                        control.Anchor2.Value.Y < control.Anchor1.Value.Y)
+                        _sawmill.Warning($"Invalid anchor2 value in DMF for element {control.Id}. Ignoring.");
+                    else {
+                        var offset2X = (elementPos.X + elementSize.X) -
+                                       (windowSize.X * control.Anchor2.Value.X / 100);
+                        var offset2Y = (elementPos.Y + elementSize.Y) -
+                                       (windowSize.Y * control.Anchor2.Value.Y / 100);
+                        var width = (_canvas.Width * control.Anchor2.Value.X / 100) + offset2X - left;
+                        var height = (_canvas.Height * control.Anchor2.Value.Y / 100) + offset2Y - top;
+                        element.SetWidth = Math.Max(width, 0);
+                        element.SetHeight = Math.Max(height, 0);
                     }
 
-                    ChildControls.Insert(i, control);
                 }
-            } else
+            }
+        }
+    }
+
+    private void UpdateWindowAttributes((OSWindow? osWindow, IClydeWindow? clydeWindow) windowRoot) {
+        // TODO: this would probably be cleaner if an OSWindow for MainWindow was available.
+        var (osWindow, clydeWindow) = windowRoot;
+
+        var title = WindowDescriptor.Title ?? "OpenDream World";
+        if (osWindow != null) osWindow.Title = title;
+        else if (clydeWindow != null) clydeWindow.Title = title;
+
+        WindowRoot? root = null;
+        if (osWindow?.Window != null)
+            root = _uiMgr.GetWindowRoot(osWindow.Window);
+        else if (clydeWindow != null)
+            root = _uiMgr.GetWindowRoot(clydeWindow);
+
+        if (root != null) {
+            root.BackgroundColor = WindowDescriptor.BackgroundColor;
+        }
+    }
+
+    public void CreateChildControls() {
+        foreach (ControlDescriptor controlDescriptor in WindowDescriptor.ControlDescriptors) {
+            AddChild(controlDescriptor);
+        }
+    }
+
+    public override void AddChild(ElementDescriptor descriptor) {
+        if (descriptor is not ControlDescriptor controlDescriptor)
+            throw new Exception($"Attempted to add {descriptor} to a window, but it was not a control");
+        if (controlDescriptor is WindowDescriptor)
+            throw new Exception("Cannot add a window to a window");
+
+        InterfaceControl control = controlDescriptor switch {
+            ControlDescriptorChild => new ControlChild(controlDescriptor, this),
+            ControlDescriptorInput => new ControlInput(controlDescriptor, this),
+            ControlDescriptorButton => new ControlButton(controlDescriptor, this),
+            ControlDescriptorOutput => new ControlOutput(controlDescriptor, this),
+            ControlDescriptorInfo => new ControlInfo(controlDescriptor, this),
+            ControlDescriptorMap => new ControlMap(controlDescriptor, this),
+            ControlDescriptorBrowser => new ControlBrowser(controlDescriptor, this),
+            ControlDescriptorLabel => new ControlLabel(controlDescriptor, this),
+            ControlDescriptorGrid => new ControlGrid(controlDescriptor, this),
+            ControlDescriptorTab => new ControlTab(controlDescriptor, this),
+            _ => throw new Exception($"Invalid descriptor {controlDescriptor.GetType()}")
+        };
+
+        // Can't have out-of-order components, so make sure they're ordered properly
+        if (ChildControls.Count > 0) {
+            var prevPos = ChildControls[^1].Pos.GetValueOrDefault();
+            var curPos = control.Pos.GetValueOrDefault();
+            if (prevPos.X <= curPos.X && prevPos.Y <= curPos.Y)
                 ChildControls.Add(control);
+            else {
+                _sawmill.Warning(
+                    $"Out of order component {control.Id}. Elements should be defined in order of position. Attempting to fix automatically.");
 
-            _canvas.Children.Add(control.UIElement);
-        }
-
-        // Because of how windows are not always real windows,
-        // UIControl contains the *contents* of the window, not the actual OS window itself.
-        protected override Control CreateUIElement() {
-            var container = new BoxContainer {
-                RectClipContent = true,
-                Orientation = BoxContainer.LayoutOrientation.Vertical,
-                Children = {
-                    (_menuContainer = new Control { Margin = new Thickness(4, 0)}),
-                    (_canvas = new LayoutContainer {
-                        InheritChildMeasure = false,
-                        VerticalExpand = true
-                    })
+                int i = 0;
+                while (i < ChildControls.Count) {
+                    prevPos = ChildControls[i].Pos.GetValueOrDefault();
+                    if (prevPos.X <= curPos.X && prevPos.Y <= curPos.Y)
+                        i++;
+                    else
+                        break;
                 }
-            };
 
-            _canvas.OnResized += CanvasOnResized;
+                ChildControls.Insert(i, control);
+            }
+        } else
+            ChildControls.Add(control);
 
-            return container;
-        }
+        _canvas.Children.Add(control.UIElement);
+    }
 
-        private void CanvasOnResized() {
-            UpdateAnchors();
-        }
+    // Because of how windows are not always real windows,
+    // UIControl contains the *contents* of the window, not the actual OS window itself.
+    protected override Control CreateUIElement() {
+        var container = new BoxContainer {
+            RectClipContent = true,
+            Orientation = BoxContainer.LayoutOrientation.Vertical,
+            Children = {
+                (_menuContainer = new Control { Margin = new Thickness(4, 0)}),
+                (_canvas = new LayoutContainer {
+                    InheritChildMeasure = false,
+                    VerticalExpand = true
+                })
+            }
+        };
+
+        _canvas.OnResized += CanvasOnResized;
+
+        return container;
+    }
+
+    private void CanvasOnResized() {
+        UpdateAnchors();
     }
 }

--- a/OpenDreamClient/Interface/Controls/ControlWindow.cs
+++ b/OpenDreamClient/Interface/Controls/ControlWindow.cs
@@ -130,7 +130,7 @@ namespace OpenDreamClient.Interface.Controls {
                     if (control.Anchor2.HasValue) {
                         if (control.Anchor2.Value.X < control.Anchor1.Value.X ||
                             control.Anchor2.Value.Y < control.Anchor1.Value.Y)
-                            _sawmill.Warning($"Invalid anchor2 value in DMF for element {control.Name}. Ignoring.");
+                            _sawmill.Warning($"Invalid anchor2 value in DMF for element {control.Id}. Ignoring.");
                         else {
                             var offset2X = (elementPos.X + elementSize.X) -
                                            (windowSize.X * control.Anchor2.Value.X / 100);
@@ -200,7 +200,7 @@ namespace OpenDreamClient.Interface.Controls {
                     ChildControls.Add(control);
                 else {
                     _sawmill.Warning(
-                        $"Out of order component {control.Name}. Elements should be defined in order of position. Attempting to fix automatically.");
+                        $"Out of order component {control.Id}. Elements should be defined in order of position. Attempting to fix automatically.");
 
                     int i = 0;
                     while (i < ChildControls.Count) {

--- a/OpenDreamClient/Interface/Controls/InterfaceControl.cs
+++ b/OpenDreamClient/Interface/Controls/InterfaceControl.cs
@@ -4,63 +4,63 @@ using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 
-namespace OpenDreamClient.Interface.Controls {
-    public abstract class InterfaceControl : InterfaceElement {
-        public readonly Control UIElement;
-        public bool IsDefault => ControlDescriptor.IsDefault;
-        public Vector2i? Size => ControlDescriptor.Size;
-        public Vector2i? Pos => ControlDescriptor.Pos;
-        public Vector2i? Anchor1 => ControlDescriptor.Anchor1;
-        public Vector2i? Anchor2 => ControlDescriptor.Anchor2;
+namespace OpenDreamClient.Interface.Controls;
 
-        protected ControlDescriptor ControlDescriptor => (ControlDescriptor) ElementDescriptor;
+public abstract class InterfaceControl : InterfaceElement {
+    public readonly Control UIElement;
+    public bool IsDefault => ControlDescriptor.IsDefault;
+    public Vector2i? Size => ControlDescriptor.Size;
+    public Vector2i? Pos => ControlDescriptor.Pos;
+    public Vector2i? Anchor1 => ControlDescriptor.Anchor1;
+    public Vector2i? Anchor2 => ControlDescriptor.Anchor2;
 
-        private readonly ControlWindow _window;
+    protected ControlDescriptor ControlDescriptor => (ControlDescriptor) ElementDescriptor;
 
-        [SuppressMessage("ReSharper", "VirtualMemberCallInConstructor")]
-        protected InterfaceControl(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor) {
-            IoCManager.InjectDependencies(this);
+    private readonly ControlWindow _window;
 
-            _window = window;
-            UIElement = CreateUIElement();
+    [SuppressMessage("ReSharper", "VirtualMemberCallInConstructor")]
+    protected InterfaceControl(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor) {
+        IoCManager.InjectDependencies(this);
 
-            UpdateElementDescriptor();
-        }
+        _window = window;
+        UIElement = CreateUIElement();
 
-        protected abstract Control CreateUIElement();
+        UpdateElementDescriptor();
+    }
 
-        protected override void UpdateElementDescriptor() {
-            UIElement.Name = ControlDescriptor.Name;
+    protected abstract Control CreateUIElement();
 
-            var pos = ControlDescriptor.Pos.GetValueOrDefault();
-            LayoutContainer.SetMarginLeft(UIElement, pos.X);
-            LayoutContainer.SetMarginTop(UIElement, pos.Y);
+    protected override void UpdateElementDescriptor() {
+        UIElement.Name = ControlDescriptor.Name;
 
-            if (ControlDescriptor.Size is { } size)
-                UIElement.SetSize = size;
+        var pos = ControlDescriptor.Pos.GetValueOrDefault();
+        LayoutContainer.SetMarginLeft(UIElement, pos.X);
+        LayoutContainer.SetMarginTop(UIElement, pos.Y);
 
-            _window?.UpdateAnchors();
+        if (ControlDescriptor.Size is { } size)
+            UIElement.SetSize = size;
 
-            if (ControlDescriptor.BackgroundColor is { } bgColor) {
-                var styleBox = new StyleBoxFlat {BackgroundColor = bgColor};
+        _window?.UpdateAnchors();
 
-                switch (UIElement) {
-                    case PanelContainer panel:
-                        panel.PanelOverride = styleBox;
-                        break;
-                    case LineEdit lineEdit:
-                        lineEdit.StyleBoxOverride = styleBox;
-                        break;
-                }
+        if (ControlDescriptor.BackgroundColor is { } bgColor) {
+            var styleBox = new StyleBoxFlat {BackgroundColor = bgColor};
+
+            switch (UIElement) {
+                case PanelContainer panel:
+                    panel.PanelOverride = styleBox;
+                    break;
+                case LineEdit lineEdit:
+                    lineEdit.StyleBoxOverride = styleBox;
+                    break;
             }
-
-            UIElement.Visible = ControlDescriptor.IsVisible;
-            // TODO: enablement
-            //UIControl.IsEnabled = !_controlDescriptor.IsDisabled;
         }
 
-        public virtual void Output(string value, string? data) {
+        UIElement.Visible = ControlDescriptor.IsVisible;
+        // TODO: enablement
+        //UIControl.IsEnabled = !_controlDescriptor.IsDisabled;
+    }
 
-        }
+    public virtual void Output(string value, string? data) {
+
     }
 }

--- a/OpenDreamClient/Interface/Controls/ScalingViewport.cs
+++ b/OpenDreamClient/Interface/Controls/ScalingViewport.cs
@@ -3,351 +3,312 @@ using Robust.Client.Input;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.Map;
-using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using SixLabors.ImageSharp.PixelFormats;
 
 #nullable enable
 
-namespace OpenDreamClient.Interface.Controls
-{
+namespace OpenDreamClient.Interface.Controls;
+
+/// <summary>
+///     Viewport control that has a fixed viewport size and scales it appropriately.
+/// </summary>
+public sealed class ScalingViewport : Control, IViewportControl {
+    [Dependency] private readonly IClyde _clyde = default!;
+    [Dependency] private readonly IInputManager _inputManager = default!;
+
+    // Internal viewport creation is deferred.
+    private IClydeViewport? _viewport;
+    private IEye? _eye;
+    private Vector2i _viewportSize;
+    private int _curRenderScale;
+    private ScalingViewportStretchMode _stretchMode = ScalingViewportStretchMode.Bilinear;
+    private ScalingViewportRenderScaleMode _renderScaleMode = ScalingViewportRenderScaleMode.CeilInt;
+    private int _fixedRenderScale = 1;
+
+    private readonly List<CopyPixelsDelegate<Rgba32>> _queuedScreenshots = new();
+
+    public int CurrentRenderScale => _curRenderScale;
+
     /// <summary>
-    ///     Viewport control that has a fixed viewport size and scales it appropriately.
+    ///     The eye to render.
     /// </summary>
-    public sealed class ScalingViewport : Control, IViewportControl
-    {
-        [Dependency] private readonly IClyde _clyde = default!;
-        [Dependency] private readonly IInputManager _inputManager = default!;
+    public IEye? Eye {
+        get => _eye;
+        set {
+            _eye = value;
 
-        // Internal viewport creation is deferred.
-        private IClydeViewport? _viewport;
-        private IEye? _eye;
-        private Vector2i _viewportSize;
-        private int _curRenderScale;
-        private ScalingViewportStretchMode _stretchMode = ScalingViewportStretchMode.Bilinear;
-        private ScalingViewportRenderScaleMode _renderScaleMode = ScalingViewportRenderScaleMode.CeilInt;
-        private int _fixedRenderScale = 1;
-
-        private readonly List<CopyPixelsDelegate<Rgba32>> _queuedScreenshots = new();
-
-        public int CurrentRenderScale => _curRenderScale;
-
-        /// <summary>
-        ///     The eye to render.
-        /// </summary>
-        public IEye? Eye
-        {
-            get => _eye;
-            set
-            {
-                _eye = value;
-
-                if (_viewport != null)
-                    _viewport.Eye = value;
-            }
+            if (_viewport != null)
+                _viewport.Eye = value;
         }
+    }
 
-        /// <summary>
-        ///     The size, in unscaled pixels, of the internal viewport.
-        /// </summary>
-        /// <remarks>
-        ///     The actual viewport may have render scaling applied based on parameters.
-        /// </remarks>
-        public Vector2i ViewportSize
-        {
-            get => _viewportSize;
-            set
-            {
-                _viewportSize = value;
-                InvalidateViewport();
-            }
-        }
-
-        // Do not need to InvalidateViewport() since it doesn't affect viewport creation.
-
-        [ViewVariables(VVAccess.ReadWrite)] public Vector2i? FixedStretchSize { get; set; }
-
-        [ViewVariables(VVAccess.ReadWrite)]
-        public ScalingViewportStretchMode StretchMode
-        {
-            get => _stretchMode;
-            set
-            {
-                _stretchMode = value;
-                InvalidateViewport();
-            }
-        }
-
-        [ViewVariables(VVAccess.ReadWrite)]
-        public ScalingViewportRenderScaleMode RenderScaleMode
-        {
-            get => _renderScaleMode;
-            set
-            {
-                _renderScaleMode = value;
-                InvalidateViewport();
-            }
-        }
-
-        [ViewVariables(VVAccess.ReadWrite)]
-        public int FixedRenderScale
-        {
-            get => _fixedRenderScale;
-            set
-            {
-                _fixedRenderScale = value;
-                InvalidateViewport();
-            }
-        }
-
-        public ScalingViewport()
-        {
-            IoCManager.InjectDependencies(this);
-            RectClipContent = true;
-        }
-
-        protected override void KeyBindDown(GUIBoundKeyEventArgs args)
-        {
-            base.KeyBindDown(args);
-
-            if (args.Handled)
-                return;
-
-            _inputManager.ViewportKeyEvent(this, args);
-        }
-
-        protected override void KeyBindUp(GUIBoundKeyEventArgs args)
-        {
-            base.KeyBindUp(args);
-
-            if (args.Handled)
-                return;
-
-            _inputManager.ViewportKeyEvent(this, args);
-        }
-
-        protected override void Draw(DrawingHandleScreen handle)
-        {
-            EnsureViewportCreated();
-
-            DebugTools.AssertNotNull(_viewport);
-
-            _viewport!.Render();
-
-            if (_queuedScreenshots.Count != 0)
-            {
-                var callbacks = _queuedScreenshots.ToArray();
-
-                _viewport.RenderTarget.CopyPixelsToMemory<Rgba32>(image =>
-                {
-                    foreach (var callback in callbacks)
-                    {
-                        callback(image);
-                    }
-                });
-
-                _queuedScreenshots.Clear();
-            }
-
-            var drawBox = GetDrawBox();
-            var drawBoxGlobal = drawBox.Translated(GlobalPixelPosition);
-            _viewport.RenderScreenOverlaysBelow(handle, this, drawBoxGlobal);
-            handle.DrawTextureRect(_viewport.RenderTarget.Texture, drawBox);
-            _viewport.RenderScreenOverlaysAbove(handle, this, drawBoxGlobal);
-        }
-
-        public void Screenshot(CopyPixelsDelegate<Rgba32> callback)
-        {
-            _queuedScreenshots.Add(callback);
-        }
-
-        // Draw box in pixel coords to draw the viewport at.
-        public UIBox2i GetDrawBox()
-        {
-            DebugTools.AssertNotNull(_viewport);
-
-            var vpSize = _viewport!.Size;
-            var ourSize = (Vector2) PixelSize;
-
-            if (FixedStretchSize == null)
-            {
-                var (ratioX, ratioY) = ourSize / vpSize;
-                var ratio = Math.Min(ratioX, ratioY);
-
-                var size = vpSize * ratio;
-                // Size
-                var pos = (ourSize - size) / 2;
-
-                return (UIBox2i) UIBox2.FromDimensions(pos, size);
-            }
-            else
-            {
-                // Center only, no scaling.
-                var pos = (ourSize - FixedStretchSize.Value) / 2;
-                return (UIBox2i) UIBox2.FromDimensions(pos, FixedStretchSize.Value);
-            }
-        }
-
-        private void RegenerateViewport()
-        {
-            DebugTools.AssertNull(_viewport);
-
-            var vpSizeBase = ViewportSize;
-            var ourSize = PixelSize;
-            var (ratioX, ratioY) = ourSize / (Vector2) vpSizeBase;
-            var ratio = Math.Min(ratioX, ratioY);
-            var renderScale = 1;
-            switch (_renderScaleMode)
-            {
-                case ScalingViewportRenderScaleMode.CeilInt:
-                    renderScale = (int) Math.Ceiling(ratio);
-                    break;
-                case ScalingViewportRenderScaleMode.FloorInt:
-                    renderScale = (int) Math.Floor(ratio);
-                    break;
-                case ScalingViewportRenderScaleMode.Fixed:
-                    renderScale = _fixedRenderScale;
-                    break;
-            }
-
-            // Always has to be at least one to avoid passing 0,0 to the viewport constructor
-            renderScale = Math.Max(1, renderScale);
-
-            _curRenderScale = renderScale;
-
-            _viewport = _clyde.CreateViewport(
-                ViewportSize * renderScale,
-                new TextureSampleParameters
-                {
-                    Filter = StretchMode == ScalingViewportStretchMode.Bilinear,
-                });
-
-            _viewport.RenderScale = (renderScale, renderScale);
-
-            _viewport.Eye = _eye;
-        }
-
-        protected override void Resized()
-        {
-            base.Resized();
-
+    /// <summary>
+    ///     The size, in unscaled pixels, of the internal viewport.
+    /// </summary>
+    /// <remarks>
+    ///     The actual viewport may have render scaling applied based on parameters.
+    /// </remarks>
+    public Vector2i ViewportSize {
+        get => _viewportSize;
+        set {
+            _viewportSize = value;
             InvalidateViewport();
         }
+    }
 
-        private void InvalidateViewport()
-        {
-            _viewport?.Dispose();
-            _viewport = null;
-        }
+    // Do not need to InvalidateViewport() since it doesn't affect viewport creation.
 
-        public MapCoordinates ScreenToMap(Vector2 coords)
-        {
-            if (_eye == null)
-                return default;
+    [ViewVariables(VVAccess.ReadWrite)] public Vector2i? FixedStretchSize { get; set; }
 
-            EnsureViewportCreated();
-
-            var matrix = Matrix3.Invert(LocalToScreenMatrix());
-
-            return _viewport!.LocalToWorld(matrix.Transform(coords));
-        }
-
-        public Vector2 WorldToScreen(Vector2 map)
-        {
-            if (_eye == null)
-                return default;
-
-            EnsureViewportCreated();
-
-            var vpLocal = _viewport!.WorldToLocal(map);
-
-            var matrix = LocalToScreenMatrix();
-
-            return matrix.Transform(vpLocal);
-        }
-
-        private Matrix3 LocalToScreenMatrix()
-        {
-            DebugTools.AssertNotNull(_viewport);
-
-            var drawBox = GetDrawBox();
-            var scaleFactor = drawBox.Size / (Vector2) _viewport!.Size;
-
-            if (scaleFactor == (0, 0))
-                // Basically a nonsense scenario, at least make sure to return something that can be inverted.
-                return Matrix3.Identity;
-
-            var scale = Matrix3.CreateScale(scaleFactor);
-            var translate = Matrix3.CreateTranslation(GlobalPixelPosition + drawBox.TopLeft);
-
-            return scale * translate;
-        }
-
-        private void EnsureViewportCreated()
-        {
-            if (_viewport == null)
-            {
-                RegenerateViewport();
-            }
-
-            DebugTools.AssertNotNull(_viewport);
-        }
-
-        public Matrix3 GetWorldToScreenMatrix()
-        {
-            EnsureViewportCreated();
-            return _viewport!.GetWorldToLocalMatrix() * GetLocalToScreenMatrix();
-        }
-
-        public Matrix3 GetLocalToScreenMatrix()
-        {
-            EnsureViewportCreated();
-
-            var drawBox = GetDrawBox();
-            var scaleFactor = drawBox.Size / (Vector2) _viewport!.Size;
-
-            if (scaleFactor.X == 0 || scaleFactor.Y == 0)
-                // Basically a nonsense scenario, at least make sure to return something that can be inverted.
-                return Matrix3.Identity;
-
-            return Matrix3.CreateTransform(GlobalPixelPosition + drawBox.TopLeft, 0, scaleFactor);
+    [ViewVariables(VVAccess.ReadWrite)]
+    public ScalingViewportStretchMode StretchMode {
+        get => _stretchMode;
+        set {
+            _stretchMode = value;
+            InvalidateViewport();
         }
     }
+
+    [ViewVariables(VVAccess.ReadWrite)]
+    public ScalingViewportRenderScaleMode RenderScaleMode {
+        get => _renderScaleMode;
+        set {
+            _renderScaleMode = value;
+            InvalidateViewport();
+        }
+    }
+
+    [ViewVariables(VVAccess.ReadWrite)]
+    public int FixedRenderScale {
+        get => _fixedRenderScale;
+        set {
+            _fixedRenderScale = value;
+            InvalidateViewport();
+        }
+    }
+
+    public ScalingViewport() {
+        IoCManager.InjectDependencies(this);
+        RectClipContent = true;
+    }
+
+    protected override void KeyBindDown(GUIBoundKeyEventArgs args) {
+        base.KeyBindDown(args);
+
+        if (args.Handled)
+            return;
+
+        _inputManager.ViewportKeyEvent(this, args);
+    }
+
+    protected override void KeyBindUp(GUIBoundKeyEventArgs args) {
+        base.KeyBindUp(args);
+
+        if (args.Handled)
+            return;
+
+        _inputManager.ViewportKeyEvent(this, args);
+    }
+
+    protected override void Draw(DrawingHandleScreen handle) {
+        EnsureViewportCreated();
+
+        DebugTools.AssertNotNull(_viewport);
+
+        _viewport!.Render();
+
+        if (_queuedScreenshots.Count != 0) {
+            var callbacks = _queuedScreenshots.ToArray();
+
+            _viewport.RenderTarget.CopyPixelsToMemory<Rgba32>(image => {
+                foreach (var callback in callbacks) {
+                    callback(image);
+                }
+            });
+
+            _queuedScreenshots.Clear();
+        }
+
+        var drawBox = GetDrawBox();
+        var drawBoxGlobal = drawBox.Translated(GlobalPixelPosition);
+        _viewport.RenderScreenOverlaysBelow(handle, this, drawBoxGlobal);
+        handle.DrawTextureRect(_viewport.RenderTarget.Texture, drawBox);
+        _viewport.RenderScreenOverlaysAbove(handle, this, drawBoxGlobal);
+    }
+
+    public void Screenshot(CopyPixelsDelegate<Rgba32> callback) {
+        _queuedScreenshots.Add(callback);
+    }
+
+    // Draw box in pixel coords to draw the viewport at.
+    public UIBox2i GetDrawBox() {
+        DebugTools.AssertNotNull(_viewport);
+
+        var vpSize = _viewport!.Size;
+        var ourSize = (Vector2)PixelSize;
+
+        if (FixedStretchSize == null) {
+            var (ratioX, ratioY) = ourSize / vpSize;
+            var ratio = Math.Min(ratioX, ratioY);
+
+            var size = vpSize * ratio;
+            // Size
+            var pos = (ourSize - size) / 2;
+
+            return (UIBox2i)UIBox2.FromDimensions(pos, size);
+        } else {
+            // Center only, no scaling.
+            var pos = (ourSize - FixedStretchSize.Value) / 2;
+            return (UIBox2i)UIBox2.FromDimensions(pos, FixedStretchSize.Value);
+        }
+    }
+
+    private void RegenerateViewport() {
+        DebugTools.AssertNull(_viewport);
+
+        var vpSizeBase = ViewportSize;
+        var ourSize = PixelSize;
+        var (ratioX, ratioY) = ourSize / (Vector2) vpSizeBase;
+        var ratio = Math.Min(ratioX, ratioY);
+        var renderScale = 1;
+        switch (_renderScaleMode) {
+            case ScalingViewportRenderScaleMode.CeilInt:
+                renderScale = (int) Math.Ceiling(ratio);
+                break;
+            case ScalingViewportRenderScaleMode.FloorInt:
+                renderScale = (int) Math.Floor(ratio);
+                break;
+            case ScalingViewportRenderScaleMode.Fixed:
+                renderScale = _fixedRenderScale;
+                break;
+        }
+
+        // Always has to be at least one to avoid passing 0,0 to the viewport constructor
+        renderScale = Math.Max(1, renderScale);
+
+        _curRenderScale = renderScale;
+
+        _viewport = _clyde.CreateViewport(
+            ViewportSize * renderScale,
+            new TextureSampleParameters {
+                Filter = StretchMode == ScalingViewportStretchMode.Bilinear,
+            });
+
+        _viewport.RenderScale = (renderScale, renderScale);
+
+        _viewport.Eye = _eye;
+    }
+
+    protected override void Resized() {
+        base.Resized();
+
+        InvalidateViewport();
+    }
+
+    private void InvalidateViewport() {
+        _viewport?.Dispose();
+        _viewport = null;
+    }
+
+    public MapCoordinates ScreenToMap(Vector2 coords) {
+        if (_eye == null)
+            return default;
+
+        EnsureViewportCreated();
+
+        var matrix = Matrix3.Invert(LocalToScreenMatrix());
+
+        return _viewport!.LocalToWorld(matrix.Transform(coords));
+    }
+
+    public Vector2 WorldToScreen(Vector2 map) {
+        if (_eye == null)
+            return default;
+
+        EnsureViewportCreated();
+
+        var vpLocal = _viewport!.WorldToLocal(map);
+
+        var matrix = LocalToScreenMatrix();
+
+        return matrix.Transform(vpLocal);
+    }
+
+    private Matrix3 LocalToScreenMatrix() {
+        DebugTools.AssertNotNull(_viewport);
+
+        var drawBox = GetDrawBox();
+        var scaleFactor = drawBox.Size / (Vector2)_viewport!.Size;
+
+        if (scaleFactor == (0, 0))
+            // Basically a nonsense scenario, at least make sure to return something that can be inverted.
+            return Matrix3.Identity;
+
+        var scale = Matrix3.CreateScale(scaleFactor);
+        var translate = Matrix3.CreateTranslation(GlobalPixelPosition + drawBox.TopLeft);
+
+        return scale * translate;
+    }
+
+    private void EnsureViewportCreated() {
+        if (_viewport == null) {
+            RegenerateViewport();
+        }
+
+        DebugTools.AssertNotNull(_viewport);
+    }
+
+    public Matrix3 GetWorldToScreenMatrix() {
+        EnsureViewportCreated();
+        return _viewport!.GetWorldToLocalMatrix() * GetLocalToScreenMatrix();
+    }
+
+    public Matrix3 GetLocalToScreenMatrix() {
+        EnsureViewportCreated();
+
+        var drawBox = GetDrawBox();
+        var scaleFactor = drawBox.Size / (Vector2)_viewport!.Size;
+
+        if (scaleFactor.X == 0 || scaleFactor.Y == 0)
+            // Basically a nonsense scenario, at least make sure to return something that can be inverted.
+            return Matrix3.Identity;
+
+        return Matrix3.CreateTransform(GlobalPixelPosition + drawBox.TopLeft, 0, scaleFactor);
+    }
+}
+
+/// <summary>
+///     Defines how the viewport is stretched if it does not match the size of the control perfectly.
+/// </summary>
+public enum ScalingViewportStretchMode {
+    /// <summary>
+    ///     Bilinear sampling is used.
+    /// </summary>
+    Bilinear = 0,
 
     /// <summary>
-    ///     Defines how the viewport is stretched if it does not match the size of the control perfectly.
+    ///     Nearest neighbor sampling is used.
     /// </summary>
-    public enum ScalingViewportStretchMode
-    {
-        /// <summary>
-        ///     Bilinear sampling is used.
-        /// </summary>
-        Bilinear = 0,
+    Nearest
+}
 
-        /// <summary>
-        ///     Nearest neighbor sampling is used.
-        /// </summary>
-        Nearest
-    }
+/// <summary>
+///     Defines how the base render scale of the viewport is selected.
+/// </summary>
+public enum ScalingViewportRenderScaleMode {
+    /// <summary>
+    ///     <see cref="ScalingViewport.FixedRenderScale"/> is used.
+    /// </summary>
+    Fixed = 0,
 
     /// <summary>
-    ///     Defines how the base render scale of the viewport is selected.
+    ///     Floor to the closest integer scale possible.
     /// </summary>
-    public enum ScalingViewportRenderScaleMode
-    {
-        /// <summary>
-        ///     <see cref="ScalingViewport.FixedRenderScale"/> is used.
-        /// </summary>
-        Fixed = 0,
+    FloorInt,
 
-        /// <summary>
-        ///     Floor to the closest integer scale possible.
-        /// </summary>
-        FloorInt,
-
-        /// <summary>
-        ///     Ceiling to the closest integer scale possible.
-        /// </summary>
-        CeilInt
-    }
+    /// <summary>
+    ///     Ceiling to the closest integer scale possible.
+    /// </summary>
+    CeilInt
 }

--- a/OpenDreamClient/Interface/Descriptors/ControlDescriptors.cs
+++ b/OpenDreamClient/Interface/Descriptors/ControlDescriptors.cs
@@ -41,9 +41,9 @@ public sealed class WindowDescriptor : ControlDescriptor {
 
     public readonly List<ControlDescriptor> ControlDescriptors;
 
-    public WindowDescriptor(string name, List<ControlDescriptor>? controlDescriptors = null) {
+    public WindowDescriptor(string id, List<ControlDescriptor>? controlDescriptors = null) {
         ControlDescriptors = controlDescriptors ?? new();
-        Name = name;
+        Id = id;
     }
 
     [UsedImplicitly]
@@ -90,10 +90,10 @@ public sealed class WindowDescriptor : ControlDescriptor {
         return child;
     }
 
-    public override ElementDescriptor CreateCopy(ISerializationManager serializationManager, string name) {
+    public override ElementDescriptor CreateCopy(ISerializationManager serializationManager, string id) {
         var copy = serializationManager.CreateCopy(this, notNullableOverride: true);
 
-        copy._name = name;
+        copy._id = id;
         return copy;
     }
 

--- a/OpenDreamClient/Interface/Descriptors/InterfaceDescriptor.cs
+++ b/OpenDreamClient/Interface/Descriptors/InterfaceDescriptor.cs
@@ -26,13 +26,18 @@ public class ElementDescriptor {
     [DataField("type")]
     public string _type;
 
-    [DataField("name")]
-    protected string _name;
+    [DataField("id")]
+    protected string _id;
 
-    public string Name {
-        get => _name;
-        init => _name = value;
+    [DataField("name")]
+    protected string? _name;
+
+    public string Id {
+        get => _id;
+        init => _id = value;
     }
+
+    public string Name => _name ?? Id;
 
     public string Type {
         get => _type;
@@ -43,7 +48,7 @@ public class ElementDescriptor {
         throw new InvalidOperationException($"{this} cannot create a child descriptor");
     }
 
-    public virtual ElementDescriptor CreateCopy(ISerializationManager serializationManager, string name) {
+    public virtual ElementDescriptor CreateCopy(ISerializationManager serializationManager, string id) {
         throw new InvalidOperationException($"{this} cannot create a copy of itself");
     }
 

--- a/OpenDreamClient/Interface/Descriptors/MacroDescriptors.cs
+++ b/OpenDreamClient/Interface/Descriptors/MacroDescriptors.cs
@@ -8,9 +8,9 @@ public sealed class MacroSetDescriptor : ElementDescriptor {
     private readonly List<MacroDescriptor> _macros = new();
     public IReadOnlyList<MacroDescriptor> Macros => _macros;
 
-    public MacroSetDescriptor(string name) {
+    public MacroSetDescriptor(string id) {
         Type = "MACRO_SET";
-        Name = name;
+        Id = id;
     }
 
     [UsedImplicitly]
@@ -25,24 +25,16 @@ public sealed class MacroSetDescriptor : ElementDescriptor {
         return macro;
     }
 
-    public override ElementDescriptor CreateCopy(ISerializationManager serializationManager, string name) {
+    public override ElementDescriptor CreateCopy(ISerializationManager serializationManager, string id) {
         var copy = serializationManager.CreateCopy(this, notNullableOverride: true);
 
-        copy._name = name;
+        copy._id = id;
         return copy;
     }
 }
 
 [UsedImplicitly]
 public sealed class MacroDescriptor : ElementDescriptor {
-    public string Id {
-        get => _id ?? Command;
-        init => _id = value;
-    }
-
-    [DataField("id")]
-    private readonly string _id;
-
     [DataField("command")]
     public string Command  { get; init; }
 }

--- a/OpenDreamClient/Interface/Descriptors/MenuDescriptors.cs
+++ b/OpenDreamClient/Interface/Descriptors/MenuDescriptors.cs
@@ -8,9 +8,9 @@ public sealed class MenuDescriptor : ElementDescriptor {
     private readonly List<MenuElementDescriptor> _elements = new();
     public IReadOnlyList<MenuElementDescriptor> Elements => _elements;
 
-    public MenuDescriptor(string name) {
+    public MenuDescriptor(string id) {
         Type = "MENU";
-        Name = name;
+        Id = id;
     }
 
     [UsedImplicitly]
@@ -25,22 +25,22 @@ public sealed class MenuDescriptor : ElementDescriptor {
         return menuElement;
     }
 
-    public override ElementDescriptor CreateCopy(ISerializationManager serializationManager, string name) {
+    public override ElementDescriptor CreateCopy(ISerializationManager serializationManager, string id) {
         var copy = serializationManager.CreateCopy(this, notNullableOverride: true);
 
-        copy._name = name;
+        copy._id = id;
         return copy;
     }
 }
 
 public sealed class MenuElementDescriptor : ElementDescriptor {
-    private string _category;
+    private string? _category;
 
     [DataField("command")]
     public string Command { get; init; }
 
     [DataField("category")]
-    public string Category {
+    public string? Category {
         get => _category;
         init => _category = value;
     }

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -23,574 +23,574 @@ using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using SixLabors.ImageSharp;
 
-namespace OpenDreamClient.Interface {
-    internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
-        private static readonly ResPath DefaultInterfaceFile = new("/OpenDream/DefaultInterface.dmf");
+namespace OpenDreamClient.Interface;
 
-        [Dependency] private readonly IClyde _clyde = default!;
-        [Dependency] private readonly IBaseClient _client = default!;
-        [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;
-        [Dependency] private readonly IEyeManager _eyeManager = default!;
-        [Dependency] private readonly IClientNetManager _netManager = default!;
-        [Dependency] private readonly IDreamResourceManager _dreamResource = default!;
-        [Dependency] private readonly IResourceManager _resourceManager = default!;
-        [Dependency] private readonly IFileDialogManager _fileDialogManager = default!;
-        [Dependency] private readonly ISerializationManager _serializationManager = default!;
-        [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
-        [Dependency] private readonly IInputManager _inputManager = default!;
-        [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
+internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
+    private static readonly ResPath DefaultInterfaceFile = new("/OpenDream/DefaultInterface.dmf");
 
-        private readonly ISawmill _sawmill = Logger.GetSawmill("opendream.interface");
+    [Dependency] private readonly IClyde _clyde = default!;
+    [Dependency] private readonly IBaseClient _client = default!;
+    [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;
+    [Dependency] private readonly IEyeManager _eyeManager = default!;
+    [Dependency] private readonly IClientNetManager _netManager = default!;
+    [Dependency] private readonly IDreamResourceManager _dreamResource = default!;
+    [Dependency] private readonly IResourceManager _resourceManager = default!;
+    [Dependency] private readonly IFileDialogManager _fileDialogManager = default!;
+    [Dependency] private readonly ISerializationManager _serializationManager = default!;
+    [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
+    [Dependency] private readonly IInputManager _inputManager = default!;
+    [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
 
-        public InterfaceDescriptor InterfaceDescriptor { get; private set; }
+    private readonly ISawmill _sawmill = Logger.GetSawmill("opendream.interface");
 
-        public ControlWindow? DefaultWindow { get; private set; }
-        public ControlOutput? DefaultOutput { get; private set; }
-        public ControlInfo? DefaultInfo { get; private set; }
-        public ControlMap? DefaultMap { get; private set; }
+    public InterfaceDescriptor InterfaceDescriptor { get; private set; }
 
-        public (string, string, string)[] AvailableVerbs { get; private set; } = Array.Empty<(string, string, string)>();
+    public ControlWindow? DefaultWindow { get; private set; }
+    public ControlOutput? DefaultOutput { get; private set; }
+    public ControlInfo? DefaultInfo { get; private set; }
+    public ControlMap? DefaultMap { get; private set; }
 
-        public Dictionary<string, ControlWindow> Windows { get; } = new();
-        public Dictionary<string, InterfaceMenu> Menus { get; } = new();
-        public Dictionary<string, InterfaceMacroSet> MacroSets { get; } = new();
+    public (string, string, string)[] AvailableVerbs { get; private set; } = Array.Empty<(string, string, string)>();
 
-        private readonly Dictionary<string, BrowsePopup> _popupWindows = new();
+    public Dictionary<string, ControlWindow> Windows { get; } = new();
+    public Dictionary<string, InterfaceMenu> Menus { get; } = new();
+    public Dictionary<string, InterfaceMacroSet> MacroSets { get; } = new();
 
-        public void LoadInterfaceFromSource(string source) {
-            DMFLexer dmfLexer = new DMFLexer("interface.dmf", source);
-            DMFParser dmfParser = new DMFParser(dmfLexer, _serializationManager);
+    private readonly Dictionary<string, BrowsePopup> _popupWindows = new();
 
-            InterfaceDescriptor? interfaceDescriptor = null;
-            try {
-                interfaceDescriptor = dmfParser.Interface();
-            } catch (CompileErrorException) { }
+    public void LoadInterfaceFromSource(string source) {
+        DMFLexer dmfLexer = new DMFLexer("interface.dmf", source);
+        DMFParser dmfParser = new DMFParser(dmfLexer, _serializationManager);
 
-            int errorCount = 0;
-            foreach (CompilerEmission warning in dmfParser.Emissions) {
-                if (warning.Level == ErrorLevel.Error) {
-                    _sawmill.Error(warning.ToString());
-                    errorCount++;
-                } else {
-                    _sawmill.Warning(warning.ToString());
+        InterfaceDescriptor? interfaceDescriptor = null;
+        try {
+            interfaceDescriptor = dmfParser.Interface();
+        } catch (CompileErrorException) { }
+
+        int errorCount = 0;
+        foreach (CompilerEmission warning in dmfParser.Emissions) {
+            if (warning.Level == ErrorLevel.Error) {
+                _sawmill.Error(warning.ToString());
+                errorCount++;
+            } else {
+                _sawmill.Warning(warning.ToString());
+            }
+        }
+
+        if (interfaceDescriptor == null || errorCount > 0) {
+            // Open an error message that disconnects from the server once closed
+            OpenAlert(
+                "Error",
+                "Encountered error(s) while parsing interface source.\nCheck the console for details.",
+                "Ok", null, null,
+                (_, _) => _client.DisconnectFromServer("Errors while parsing interface"));
+
+            return;
+        }
+
+        LoadInterface(interfaceDescriptor);
+    }
+
+    public void Initialize() {
+        _userInterfaceManager.MainViewport.Visible = false;
+
+        AvailableVerbs = Array.Empty<(string, string, string)>();
+        Windows.Clear();
+        Menus.Clear();
+        MacroSets.Clear();
+        _popupWindows.Clear();
+
+        // Set up the middle-mouse button keybind
+        _inputManager.Contexts.GetContext("common").AddFunction(OpenDreamKeyFunctions.MouseMiddle);
+        _inputManager.RegisterBinding(new KeyBindingRegistration() {
+            Function = OpenDreamKeyFunctions.MouseMiddle,
+            BaseKey = Keyboard.Key.MouseMiddle
+        });
+
+        _netManager.RegisterNetMessage<MsgUpdateStatPanels>(RxUpdateStatPanels);
+        _netManager.RegisterNetMessage<MsgSelectStatPanel>(RxSelectStatPanel);
+        _netManager.RegisterNetMessage<MsgUpdateAvailableVerbs>(RxUpdateAvailableVerbs);
+        _netManager.RegisterNetMessage<MsgOutput>(RxOutput);
+        _netManager.RegisterNetMessage<MsgAlert>(RxAlert);
+        _netManager.RegisterNetMessage<MsgPrompt>(RxPrompt);
+        _netManager.RegisterNetMessage<MsgPromptList>(RxPromptList);
+        _netManager.RegisterNetMessage<MsgPromptResponse>();
+        _netManager.RegisterNetMessage<MsgBrowse>(RxBrowse);
+        _netManager.RegisterNetMessage<MsgTopic>();
+        _netManager.RegisterNetMessage<MsgWinSet>(RxWinSet);
+        _netManager.RegisterNetMessage<MsgWinClone>(RxWinClone);
+        _netManager.RegisterNetMessage<MsgWinExists>(RxWinExists);
+        _netManager.RegisterNetMessage<MsgFtp>(RxFtp);
+        _netManager.RegisterNetMessage<MsgLoadInterface>(RxLoadInterface);
+        _netManager.RegisterNetMessage<MsgAckLoadInterface>();
+    }
+
+    private void RxUpdateStatPanels(MsgUpdateStatPanels message) {
+        DefaultInfo?.UpdateStatPanels(message);
+    }
+
+    private void RxSelectStatPanel(MsgSelectStatPanel message) {
+        DefaultInfo?.SelectStatPanel(message.StatPanel);
+    }
+
+    private void RxUpdateAvailableVerbs(MsgUpdateAvailableVerbs message) {
+        AvailableVerbs = message.AvailableVerbs;
+
+        // Verbs are displayed alphabetically with uppercase coming first
+        Array.Sort(AvailableVerbs, (a, b) => string.CompareOrdinal(a.Item1, b.Item1));
+
+        if (DefaultInfo == null)
+            return; // No verb panel to show these on
+
+        foreach (var verb in AvailableVerbs) {
+            // Verb category
+            if (verb.Item3 != string.Empty && !DefaultInfo.HasVerbPanel(verb.Item3)) {
+                DefaultInfo.CreateVerbPanel(verb.Item3);
+            }
+        }
+
+        DefaultInfo.RefreshVerbs();
+    }
+
+    private void RxOutput(MsgOutput pOutput) {
+        InterfaceControl? interfaceElement;
+        string? data = null;
+
+        if (pOutput.Control != null) {
+            string[] split = pOutput.Control.Split(":");
+
+            interfaceElement = (InterfaceControl?)FindElementWithId(split[0]);
+            if (split.Length > 1) data = split[1];
+        } else {
+            interfaceElement = DefaultOutput;
+        }
+
+        interfaceElement?.Output(pOutput.Value, data);
+    }
+
+    private void RxAlert(MsgAlert message) {
+        OpenAlert(
+            message.Title,
+            message.Message,
+            message.Button1, message.Button2, message.Button3,
+            (responseType, response) => OnPromptFinished(message.PromptId, responseType, response));
+    }
+
+    public void OpenAlert(string title, string message, string button1, string? button2, string? button3, Action<DMValueType, object?>? onClose) {
+        var alert = new AlertWindow(
+            title,
+            message,
+            button1, button2, button3,
+            onClose);
+
+        alert.Owner = _clyde.MainWindow;
+        alert.Show();
+    }
+
+    private void RxPrompt(MsgPrompt pPrompt) {
+        PromptWindow? prompt = null;
+        bool canCancel = (pPrompt.Types & DMValueType.Null) == DMValueType.Null;
+
+        void OnPromptClose(DMValueType responseType, object? response) {
+            OnPromptFinished(pPrompt.PromptId, responseType, response);
+        }
+
+        if ((pPrompt.Types & DMValueType.Text) == DMValueType.Text) {
+            prompt = new TextPrompt(pPrompt.Title, pPrompt.Message, pPrompt.DefaultValue, canCancel, OnPromptClose);
+        } else if ((pPrompt.Types & DMValueType.Num) == DMValueType.Num) {
+            prompt = new NumberPrompt(pPrompt.Title, pPrompt.Message, pPrompt.DefaultValue, canCancel, OnPromptClose);
+        } else if ((pPrompt.Types & DMValueType.Message) == DMValueType.Message) {
+            prompt = new MessagePrompt(pPrompt.Title, pPrompt.Message, pPrompt.DefaultValue, canCancel, OnPromptClose);
+        }
+
+        if (prompt != null) {
+            ShowPrompt(prompt);
+        }
+    }
+
+    private void RxPromptList(MsgPromptList pPromptList) {
+        var prompt = new ListPrompt(
+            pPromptList.Title,
+            pPromptList.Message,
+            pPromptList.DefaultValue,
+            pPromptList.CanCancel,
+            pPromptList.Values,
+            (responseType, response) => OnPromptFinished(pPromptList.PromptId, responseType, response)
+        );
+
+        ShowPrompt(prompt);
+    }
+
+    private void RxBrowse(MsgBrowse pBrowse) {
+        if (pBrowse.HtmlSource == null && pBrowse.Window != null) {
+            //Closing a popup
+            if (_popupWindows.TryGetValue(pBrowse.Window, out var popup)) {
+                popup.Close();
+            }
+        } else if (pBrowse.HtmlSource != null) {
+            //Outputting to a browser
+            string htmlFileName;
+            ControlBrowser? outputBrowser;
+            BrowsePopup? popup = null;
+
+            if (pBrowse.Window != null) {
+                htmlFileName = pBrowse.Window;
+                outputBrowser = FindElementWithId(pBrowse.Window) as ControlBrowser;
+
+                if (outputBrowser == null) {
+                    if (!_popupWindows.TryGetValue(pBrowse.Window, out popup)) {
+                        // Creating a new popup
+                        popup = new BrowsePopup(pBrowse.Window, pBrowse.Size, _clyde.MainWindow);
+                        popup.Closed += () => { _popupWindows.Remove(pBrowse.Window); };
+
+                        _popupWindows.Add(pBrowse.Window, popup);
+                    }
+
+                    outputBrowser = popup.Browser;
                 }
+            } else {
+                //TODO: Find embedded browser panel
+                return;
             }
 
-            if (interfaceDescriptor == null || errorCount > 0) {
+            var cacheFile = _dreamResource.CreateCacheFile(htmlFileName + ".html", pBrowse.HtmlSource);
+            outputBrowser.SetFileSource(cacheFile, true);
+
+            popup?.Open();
+        }
+    }
+
+    private void RxWinSet(MsgWinSet message) {
+        WinSet(message.ControlId, message.Params);
+    }
+
+    private void RxWinClone(MsgWinClone message) {
+        WinClone(message.ControlId, message.CloneId);
+    }
+
+    private void RxWinExists(MsgWinExists message) {
+        InterfaceElement? element = FindElementWithId(message.ControlId);
+        MsgPromptResponse response = new() {
+            PromptId = message.PromptId,
+            Type = DMValueType.Text,
+            Value = element?.Type ?? string.Empty
+        };
+
+        _netManager.ClientSendMessage(response);
+    }
+
+    private void RxFtp(MsgFtp message) {
+        _dreamResource.LoadResourceAsync<DreamResource>(message.ResourceId, async resource => {
+            // TODO: Default the filename to message.SuggestedName
+            // RT doesn't seem to support this currently
+            var tuple = await _fileDialogManager.SaveFile();
+            if (tuple == null) // User cancelled
+                return;
+
+            await using var file = tuple.Value.fileStream;
+            resource.WriteTo(file);
+        });
+    }
+
+    private void RxLoadInterface(MsgLoadInterface message) {
+        string? interfaceText = message.InterfaceText;
+        if (interfaceText == null) {
+            if (!_resourceManager.TryContentFileRead(DefaultInterfaceFile.CanonPath, out var defaultInterface)) {
                 // Open an error message that disconnects from the server once closed
                 OpenAlert(
                     "Error",
-                    "Encountered error(s) while parsing interface source.\nCheck the console for details.",
+                    "The server did not provide an interface and there is no default interface in the resources folder.",
                     "Ok", null, null,
-                    (_, _) => _client.DisconnectFromServer("Errors while parsing interface"));
+                    (_, _) => _client.DisconnectFromServer("No interface to use"));
 
                 return;
             }
 
-            LoadInterface(interfaceDescriptor);
+            using var defaultInterfaceReader = new StreamReader(defaultInterface);
+            interfaceText = defaultInterfaceReader.ReadToEnd();
         }
 
-        public void Initialize() {
-            _userInterfaceManager.MainViewport.Visible = false;
+        LoadInterfaceFromSource(interfaceText);
+        _netManager.ClientSendMessage(new MsgAckLoadInterface());
+    }
 
-            AvailableVerbs = Array.Empty<(string, string, string)>();
-            Windows.Clear();
-            Menus.Clear();
-            MacroSets.Clear();
-            _popupWindows.Clear();
+    private void ShowPrompt(PromptWindow prompt) {
+        prompt.Owner = _clyde.MainWindow;
+        prompt.Show();
+    }
 
-            // Set up the middle-mouse button keybind
-            _inputManager.Contexts.GetContext("common").AddFunction(OpenDreamKeyFunctions.MouseMiddle);
-            _inputManager.RegisterBinding(new KeyBindingRegistration() {
-                Function = OpenDreamKeyFunctions.MouseMiddle,
-                BaseKey = Keyboard.Key.MouseMiddle
-            });
+    public void FrameUpdate(FrameEventArgs frameEventArgs) {
+        if (DefaultMap != null)
+            DefaultMap.Viewport.Eye = _eyeManager.CurrentEye;
+    }
 
-            _netManager.RegisterNetMessage<MsgUpdateStatPanels>(RxUpdateStatPanels);
-            _netManager.RegisterNetMessage<MsgSelectStatPanel>(RxSelectStatPanel);
-            _netManager.RegisterNetMessage<MsgUpdateAvailableVerbs>(RxUpdateAvailableVerbs);
-            _netManager.RegisterNetMessage<MsgOutput>(RxOutput);
-            _netManager.RegisterNetMessage<MsgAlert>(RxAlert);
-            _netManager.RegisterNetMessage<MsgPrompt>(RxPrompt);
-            _netManager.RegisterNetMessage<MsgPromptList>(RxPromptList);
-            _netManager.RegisterNetMessage<MsgPromptResponse>();
-            _netManager.RegisterNetMessage<MsgBrowse>(RxBrowse);
-            _netManager.RegisterNetMessage<MsgTopic>();
-            _netManager.RegisterNetMessage<MsgWinSet>(RxWinSet);
-            _netManager.RegisterNetMessage<MsgWinClone>(RxWinClone);
-            _netManager.RegisterNetMessage<MsgWinExists>(RxWinExists);
-            _netManager.RegisterNetMessage<MsgFtp>(RxFtp);
-            _netManager.RegisterNetMessage<MsgLoadInterface>(RxLoadInterface);
-            _netManager.RegisterNetMessage<MsgAckLoadInterface>();
-        }
+    public InterfaceElement? FindElementWithId(string id) {
+        string[] split = id.Split(".");
 
-        private void RxUpdateStatPanels(MsgUpdateStatPanels message) {
-            DefaultInfo?.UpdateStatPanels(message);
-        }
+        if (split.Length == 2) {
+            string windowId = split[0];
+            string elementId = split[1];
+            ControlWindow? window = null;
 
-        private void RxSelectStatPanel(MsgSelectStatPanel message) {
-            DefaultInfo?.SelectStatPanel(message.StatPanel);
-        }
+            if (Windows.ContainsKey(windowId)) {
+                window = Windows[windowId];
+            } else if (_popupWindows.TryGetValue(windowId, out var popup)) {
+                window = popup.WindowElement;
+            }
 
-        private void RxUpdateAvailableVerbs(MsgUpdateAvailableVerbs message) {
-            AvailableVerbs = message.AvailableVerbs;
-
-            // Verbs are displayed alphabetically with uppercase coming first
-            Array.Sort(AvailableVerbs, (a, b) => string.CompareOrdinal(a.Item1, b.Item1));
-
-            if (DefaultInfo == null)
-                return; // No verb panel to show these on
-
-            foreach (var verb in AvailableVerbs) {
-                // Verb category
-                if (verb.Item3 != string.Empty && !DefaultInfo.HasVerbPanel(verb.Item3)) {
-                    DefaultInfo.CreateVerbPanel(verb.Item3);
+            if (window != null) {
+                foreach (InterfaceControl element in window.ChildControls) {
+                    if (element.Id == elementId) return element;
                 }
             }
-
-            DefaultInfo.RefreshVerbs();
-        }
-
-        private void RxOutput(MsgOutput pOutput) {
-            InterfaceControl? interfaceElement;
-            string? data = null;
-
-            if (pOutput.Control != null) {
-                string[] split = pOutput.Control.Split(":");
-
-                interfaceElement = (InterfaceControl?)FindElementWithId(split[0]);
-                if (split.Length > 1) data = split[1];
-            } else {
-                interfaceElement = DefaultOutput;
-            }
-
-            interfaceElement?.Output(pOutput.Value, data);
-        }
-
-        private void RxAlert(MsgAlert message) {
-            OpenAlert(
-                message.Title,
-                message.Message,
-                message.Button1, message.Button2, message.Button3,
-                (responseType, response) => OnPromptFinished(message.PromptId, responseType, response));
-        }
-
-        public void OpenAlert(string title, string message, string button1, string? button2, string? button3, Action<DMValueType, object?>? onClose) {
-            var alert = new AlertWindow(
-                title,
-                message,
-                button1, button2, button3,
-                onClose);
-
-            alert.Owner = _clyde.MainWindow;
-            alert.Show();
-        }
-
-        private void RxPrompt(MsgPrompt pPrompt) {
-            PromptWindow? prompt = null;
-            bool canCancel = (pPrompt.Types & DMValueType.Null) == DMValueType.Null;
-
-            void OnPromptClose(DMValueType responseType, object? response) {
-                OnPromptFinished(pPrompt.PromptId, responseType, response);
-            }
-
-            if ((pPrompt.Types & DMValueType.Text) == DMValueType.Text) {
-                prompt = new TextPrompt(pPrompt.Title, pPrompt.Message, pPrompt.DefaultValue, canCancel, OnPromptClose);
-            } else if ((pPrompt.Types & DMValueType.Num) == DMValueType.Num) {
-                prompt = new NumberPrompt(pPrompt.Title, pPrompt.Message, pPrompt.DefaultValue, canCancel, OnPromptClose);
-            } else if ((pPrompt.Types & DMValueType.Message) == DMValueType.Message) {
-                prompt = new MessagePrompt(pPrompt.Title, pPrompt.Message, pPrompt.DefaultValue, canCancel, OnPromptClose);
-            }
-
-            if (prompt != null) {
-                ShowPrompt(prompt);
-            }
-        }
-
-        private void RxPromptList(MsgPromptList pPromptList) {
-            var prompt = new ListPrompt(
-                pPromptList.Title,
-                pPromptList.Message,
-                pPromptList.DefaultValue,
-                pPromptList.CanCancel,
-                pPromptList.Values,
-                (responseType, response) => OnPromptFinished(pPromptList.PromptId, responseType, response)
-            );
-
-            ShowPrompt(prompt);
-        }
-
-        private void RxBrowse(MsgBrowse pBrowse) {
-            if (pBrowse.HtmlSource == null && pBrowse.Window != null) {
-                //Closing a popup
-                if (_popupWindows.TryGetValue(pBrowse.Window, out var popup)) {
-                    popup.Close();
-                }
-            } else if (pBrowse.HtmlSource != null) {
-                //Outputting to a browser
-                string htmlFileName;
-                ControlBrowser? outputBrowser;
-                BrowsePopup? popup = null;
-
-                if (pBrowse.Window != null) {
-                    htmlFileName = pBrowse.Window;
-                    outputBrowser = FindElementWithId(pBrowse.Window) as ControlBrowser;
-
-                    if (outputBrowser == null) {
-                        if (!_popupWindows.TryGetValue(pBrowse.Window, out popup)) {
-                            // Creating a new popup
-                            popup = new BrowsePopup(pBrowse.Window, pBrowse.Size, _clyde.MainWindow);
-                            popup.Closed += () => { _popupWindows.Remove(pBrowse.Window); };
-
-                            _popupWindows.Add(pBrowse.Window, popup);
-                        }
-
-                        outputBrowser = popup.Browser;
-                    }
-                } else {
-                    //TODO: Find embedded browser panel
-                    return;
-                }
-
-                var cacheFile = _dreamResource.CreateCacheFile(htmlFileName + ".html", pBrowse.HtmlSource);
-                outputBrowser.SetFileSource(cacheFile, true);
-
-                popup?.Open();
-            }
-        }
-
-        private void RxWinSet(MsgWinSet message) {
-            WinSet(message.ControlId, message.Params);
-        }
-
-        private void RxWinClone(MsgWinClone message) {
-            WinClone(message.ControlId, message.CloneId);
-        }
-
-        private void RxWinExists(MsgWinExists message) {
-            InterfaceElement? element = FindElementWithId(message.ControlId);
-            MsgPromptResponse response = new() {
-                PromptId = message.PromptId,
-                Type = DMValueType.Text,
-                Value = element?.Type ?? string.Empty
-            };
-
-            _netManager.ClientSendMessage(response);
-        }
-
-        private void RxFtp(MsgFtp message) {
-            _dreamResource.LoadResourceAsync<DreamResource>(message.ResourceId, async resource => {
-                // TODO: Default the filename to message.SuggestedName
-                // RT doesn't seem to support this currently
-                var tuple = await _fileDialogManager.SaveFile();
-                if (tuple == null) // User cancelled
-                    return;
-
-                await using var file = tuple.Value.fileStream;
-                resource.WriteTo(file);
-            });
-        }
-
-        private void RxLoadInterface(MsgLoadInterface message) {
-            string? interfaceText = message.InterfaceText;
-            if (interfaceText == null) {
-                if (!_resourceManager.TryContentFileRead(DefaultInterfaceFile.CanonPath, out var defaultInterface)) {
-                    // Open an error message that disconnects from the server once closed
-                    OpenAlert(
-                        "Error",
-                        "The server did not provide an interface and there is no default interface in the resources folder.",
-                        "Ok", null, null,
-                        (_, _) => _client.DisconnectFromServer("No interface to use"));
-
-                    return;
-                }
-
-                using var defaultInterfaceReader = new StreamReader(defaultInterface);
-                interfaceText = defaultInterfaceReader.ReadToEnd();
-            }
-
-            LoadInterfaceFromSource(interfaceText);
-            _netManager.ClientSendMessage(new MsgAckLoadInterface());
-        }
-
-        private void ShowPrompt(PromptWindow prompt) {
-            prompt.Owner = _clyde.MainWindow;
-            prompt.Show();
-        }
-
-        public void FrameUpdate(FrameEventArgs frameEventArgs) {
-            if (DefaultMap != null)
-                DefaultMap.Viewport.Eye = _eyeManager.CurrentEye;
-        }
-
-        public InterfaceElement? FindElementWithId(string id) {
-            string[] split = id.Split(".");
-
-            if (split.Length == 2) {
-                string windowId = split[0];
-                string elementId = split[1];
-                ControlWindow? window = null;
-
-                if (Windows.ContainsKey(windowId)) {
-                    window = Windows[windowId];
-                } else if (_popupWindows.TryGetValue(windowId, out var popup)) {
-                    window = popup.WindowElement;
-                }
-
-                if (window != null) {
-                    foreach (InterfaceControl element in window.ChildControls) {
-                        if (element.Id == elementId) return element;
-                    }
-                }
-            } else {
-                string elementId = split[0];
-
-                foreach (ControlWindow window in Windows.Values) {
-                    if (window.Id == elementId)
-                        return window;
-
-                    foreach (InterfaceControl element in window.ChildControls) {
-                        if (element.Id == elementId) return element;
-                    }
-                }
-
-                foreach (InterfaceMenu menu in Menus.Values) {
-                    if (menu.Id == elementId)
-                        return menu;
-
-                    if (menu.MenuElements.TryGetValue(elementId, out var menuElement))
-                        return menuElement;
-                }
-
-                foreach (var macroSet in MacroSets.Values) {
-                    if (macroSet.Id == elementId)
-                        return macroSet;
-
-                    if (macroSet.Macros.TryGetValue(elementId, out var macroElement))
-                        return macroElement;
-                }
-
-                if (_popupWindows.TryGetValue(elementId, out var popup))
-                    return popup.WindowElement;
-            }
-
-            return null;
-        }
-
-        public void SaveScreenshot(bool openDialog) {
-            // ReSharper disable once AsyncVoidLambda
-            DefaultMap?.Viewport.Screenshot(async img => {
-                //TODO: Support automatically choosing a location if openDialog == false
-                var filters = new FileDialogFilters(new FileDialogFilters.Group("png"));
-                var tuple = await _fileDialogManager.SaveFile(filters);
-                if (tuple == null)
-                    return;
-
-                await using var file = tuple.Value.fileStream;
-                await img.SaveAsPngAsync(file);
-            });
-        }
-
-        public void WinSet(string? controlId, string winsetParams) {
-            DMFLexer lexer = new DMFLexer($"winset({controlId}, \"{winsetParams}\")", winsetParams);
-            DMFParser parser = new DMFParser(lexer, _serializationManager);
-
-            bool CheckParserErrors() {
-                if (parser.Emissions.Count > 0) {
-                    bool hadError = false;
-                    foreach (CompilerEmission emission in parser.Emissions) {
-                        if (emission.Level == ErrorLevel.Error) {
-                            _sawmill.Error(emission.ToString());
-                            hadError = true;
-                        } else {
-                            _sawmill.Warning(emission.ToString());
-                        }
-                    }
-
-                    return hadError;
-                }
-
-                return false;
-            }
-
-            if (string.IsNullOrEmpty(controlId)) {
-                List<DMFWinSet> winSets = parser.GlobalWinSet();
-
-                if (CheckParserErrors())
-                    return;
-
-                foreach (DMFWinSet winSet in winSets) {
-                    if (winSet.Element == null) {
-                        if (winSet.Attribute == "command") {
-                            DreamCommandSystem commandSystem = _entitySystemManager.GetEntitySystem<DreamCommandSystem>();
-
-                            commandSystem.RunCommand(winSet.Value);
-                        } else {
-                            _sawmill.Error($"Invalid global winset \"{winsetParams}\"");
-                        }
-                    } else {
-                        InterfaceElement? element = FindElementWithId(winSet.Element);
-                        MappingDataNode node = new() {
-                            {winSet.Attribute, winSet.Value}
-                        };
-
-                        if (element != null) {
-                            element.PopulateElementDescriptor(node, _serializationManager);
-                        } else {
-                            _sawmill.Error($"Invalid element \"{controlId}\"");
-                        }
-                    }
-                }
-            } else {
-                InterfaceElement? element = FindElementWithId(controlId);
-                MappingDataNode node = parser.Attributes();
-
-                if (CheckParserErrors())
-                    return;
-
-                if (element == null && node.TryGet("parent", out ValueDataNode? parentNode)) {
-                    var parent = FindElementWithId(parentNode.Value);
-                    if (parent == null) {
-                        _sawmill.Error($"Attempted to create an element with nonexistent parent \"{parentNode.Value}\" ({winsetParams})");
-                        return;
-                    }
-
-                    node.Add("id", controlId);
-                    var childDescriptor = parent.ElementDescriptor.CreateChildDescriptor(_serializationManager, node);
-                    if (childDescriptor == null)
-                        return;
-
-                    parent.AddChild(childDescriptor);
-                } else if (element != null) {
-                    element.PopulateElementDescriptor(node, _serializationManager);
-                } else {
-                    _sawmill.Error($"Invalid element \"{controlId}\"");
-                }
-            }
-        }
-
-        public void WinClone(string controlId, string cloneId) {
-            ElementDescriptor? elementDescriptor = InterfaceDescriptor.GetElementDescriptor(controlId);
-
-            elementDescriptor = elementDescriptor?.CreateCopy(_serializationManager, cloneId);
-
-            // If window_name is "window", "pane", "menu", or "macro", and the skin file does not have a control of
-            // that name already, we will create a new control of that type from scratch.
-            if (elementDescriptor == null) {
-                switch (controlId) {
-                    case "window" :
-                        elementDescriptor = new WindowDescriptor(cloneId);
-                        break;
-                    case "menu":
-                        elementDescriptor = new MenuDescriptor(cloneId);
-                        break;
-                    case "macro":
-                        elementDescriptor = new MacroSetDescriptor(cloneId);
-                        break;
-                    default:
-                        _sawmill.Error($"Invalid element to winclone \"{controlId}\"");
-                        return;
-                }
-            }
-
-            if (elementDescriptor is WindowDescriptor windowDescriptor) {
-                // Cloned windows start off non-visible
-                elementDescriptor = windowDescriptor.WithVisible(_serializationManager, false);
-            }
-
-            LoadDescriptor(elementDescriptor);
-        }
-
-        private void LoadInterface(InterfaceDescriptor descriptor) {
-            InterfaceDescriptor = descriptor;
-
-            foreach (MacroSetDescriptor macroSet in descriptor.MacroSetDescriptors) {
-                LoadDescriptor(macroSet);
-            }
-
-            foreach (MenuDescriptor menuDescriptor in InterfaceDescriptor.MenuDescriptors) {
-                LoadDescriptor(menuDescriptor);
-            }
-
-            foreach (WindowDescriptor windowDescriptor in InterfaceDescriptor.WindowDescriptors) {
-                LoadDescriptor(windowDescriptor);
-            }
+        } else {
+            string elementId = split[0];
 
             foreach (ControlWindow window in Windows.Values) {
-                window.CreateChildControls();
+                if (window.Id == elementId)
+                    return window;
 
-                foreach (InterfaceControl control in window.ChildControls) {
-                    if (control.IsDefault) {
-                        switch (control) {
-                            case ControlOutput controlOutput: DefaultOutput = controlOutput; break;
-                            case ControlInfo controlInfo: DefaultInfo = controlInfo; break;
-                            case ControlMap controlMap: DefaultMap = controlMap; break;
-                        }
-                    }
+                foreach (InterfaceControl element in window.ChildControls) {
+                    if (element.Id == elementId) return element;
                 }
             }
 
-            if (DefaultWindow == null)
-                throw new Exception("Given DMF did not have a default window");
+            foreach (InterfaceMenu menu in Menus.Values) {
+                if (menu.Id == elementId)
+                    return menu;
 
-            DefaultWindow.RegisterOnClydeWindow(_clyde.MainWindow);
-            DefaultWindow.UIElement.Name = "MainWindow";
+                if (menu.MenuElements.TryGetValue(elementId, out var menuElement))
+                    return menuElement;
+            }
 
-            LayoutContainer.SetAnchorRight(DefaultWindow.UIElement, 1);
-            LayoutContainer.SetAnchorBottom(DefaultWindow.UIElement, 1);
+            foreach (var macroSet in MacroSets.Values) {
+                if (macroSet.Id == elementId)
+                    return macroSet;
 
-            _userInterfaceManager.StateRoot.AddChild(DefaultWindow.UIElement);
+                if (macroSet.Macros.TryGetValue(elementId, out var macroElement))
+                    return macroElement;
+            }
+
+            if (_popupWindows.TryGetValue(elementId, out var popup))
+                return popup.WindowElement;
         }
 
-        private void LoadDescriptor(ElementDescriptor descriptor) {
-            switch (descriptor) {
-                case MacroSetDescriptor macroSetDescriptor:
-                    InterfaceMacroSet macroSet = new(macroSetDescriptor, _entitySystemManager, _inputManager, _uiManager);
+        return null;
+    }
 
-                    MacroSets[macroSet.Id] = macroSet;
-                    break;
-                case MenuDescriptor menuDescriptor:
-                    InterfaceMenu menu = new(menuDescriptor);
+    public void SaveScreenshot(bool openDialog) {
+        // ReSharper disable once AsyncVoidLambda
+        DefaultMap?.Viewport.Screenshot(async img => {
+            //TODO: Support automatically choosing a location if openDialog == false
+            var filters = new FileDialogFilters(new FileDialogFilters.Group("png"));
+            var tuple = await _fileDialogManager.SaveFile(filters);
+            if (tuple == null)
+                return;
 
-                    Menus.Add(menu.Id, menu);
-                    break;
-                case WindowDescriptor windowDescriptor:
-                    ControlWindow window = new ControlWindow(windowDescriptor);
+            await using var file = tuple.Value.fileStream;
+            await img.SaveAsPngAsync(file);
+        });
+    }
 
-                    Windows.Add(windowDescriptor.Name, window);
-                    if (window.IsDefault) {
-                        DefaultWindow = window;
+    public void WinSet(string? controlId, string winsetParams) {
+        DMFLexer lexer = new DMFLexer($"winset({controlId}, \"{winsetParams}\")", winsetParams);
+        DMFParser parser = new DMFParser(lexer, _serializationManager);
+
+        bool CheckParserErrors() {
+            if (parser.Emissions.Count > 0) {
+                bool hadError = false;
+                foreach (CompilerEmission emission in parser.Emissions) {
+                    if (emission.Level == ErrorLevel.Error) {
+                        _sawmill.Error(emission.ToString());
+                        hadError = true;
+                    } else {
+                        _sawmill.Warning(emission.ToString());
                     }
+                }
+
+                return hadError;
+            }
+
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(controlId)) {
+            List<DMFWinSet> winSets = parser.GlobalWinSet();
+
+            if (CheckParserErrors())
+                return;
+
+            foreach (DMFWinSet winSet in winSets) {
+                if (winSet.Element == null) {
+                    if (winSet.Attribute == "command") {
+                        DreamCommandSystem commandSystem = _entitySystemManager.GetEntitySystem<DreamCommandSystem>();
+
+                        commandSystem.RunCommand(winSet.Value);
+                    } else {
+                        _sawmill.Error($"Invalid global winset \"{winsetParams}\"");
+                    }
+                } else {
+                    InterfaceElement? element = FindElementWithId(winSet.Element);
+                    MappingDataNode node = new() {
+                        {winSet.Attribute, winSet.Value}
+                    };
+
+                    if (element != null) {
+                        element.PopulateElementDescriptor(node, _serializationManager);
+                    } else {
+                        _sawmill.Error($"Invalid element \"{controlId}\"");
+                    }
+                }
+            }
+        } else {
+            InterfaceElement? element = FindElementWithId(controlId);
+            MappingDataNode node = parser.Attributes();
+
+            if (CheckParserErrors())
+                return;
+
+            if (element == null && node.TryGet("parent", out ValueDataNode? parentNode)) {
+                var parent = FindElementWithId(parentNode.Value);
+                if (parent == null) {
+                    _sawmill.Error($"Attempted to create an element with nonexistent parent \"{parentNode.Value}\" ({winsetParams})");
+                    return;
+                }
+
+                node.Add("id", controlId);
+                var childDescriptor = parent.ElementDescriptor.CreateChildDescriptor(_serializationManager, node);
+                if (childDescriptor == null)
+                    return;
+
+                parent.AddChild(childDescriptor);
+            } else if (element != null) {
+                element.PopulateElementDescriptor(node, _serializationManager);
+            } else {
+                _sawmill.Error($"Invalid element \"{controlId}\"");
+            }
+        }
+    }
+
+    public void WinClone(string controlId, string cloneId) {
+        ElementDescriptor? elementDescriptor = InterfaceDescriptor.GetElementDescriptor(controlId);
+
+        elementDescriptor = elementDescriptor?.CreateCopy(_serializationManager, cloneId);
+
+        // If window_name is "window", "pane", "menu", or "macro", and the skin file does not have a control of
+        // that name already, we will create a new control of that type from scratch.
+        if (elementDescriptor == null) {
+            switch (controlId) {
+                case "window" :
+                    elementDescriptor = new WindowDescriptor(cloneId);
                     break;
+                case "menu":
+                    elementDescriptor = new MenuDescriptor(cloneId);
+                    break;
+                case "macro":
+                    elementDescriptor = new MacroSetDescriptor(cloneId);
+                    break;
+                default:
+                    _sawmill.Error($"Invalid element to winclone \"{controlId}\"");
+                    return;
             }
         }
 
-        private void OnPromptFinished(int promptId, DMValueType responseType, object? response) {
-            var msg = new MsgPromptResponse() {
-                PromptId = promptId,
-                Type = responseType,
-                Value = response
-            };
+        if (elementDescriptor is WindowDescriptor windowDescriptor) {
+            // Cloned windows start off non-visible
+            elementDescriptor = windowDescriptor.WithVisible(_serializationManager, false);
+        }
 
-            _netManager.ClientSendMessage(msg);
+        LoadDescriptor(elementDescriptor);
+    }
+
+    private void LoadInterface(InterfaceDescriptor descriptor) {
+        InterfaceDescriptor = descriptor;
+
+        foreach (MacroSetDescriptor macroSet in descriptor.MacroSetDescriptors) {
+            LoadDescriptor(macroSet);
+        }
+
+        foreach (MenuDescriptor menuDescriptor in InterfaceDescriptor.MenuDescriptors) {
+            LoadDescriptor(menuDescriptor);
+        }
+
+        foreach (WindowDescriptor windowDescriptor in InterfaceDescriptor.WindowDescriptors) {
+            LoadDescriptor(windowDescriptor);
+        }
+
+        foreach (ControlWindow window in Windows.Values) {
+            window.CreateChildControls();
+
+            foreach (InterfaceControl control in window.ChildControls) {
+                if (control.IsDefault) {
+                    switch (control) {
+                        case ControlOutput controlOutput: DefaultOutput = controlOutput; break;
+                        case ControlInfo controlInfo: DefaultInfo = controlInfo; break;
+                        case ControlMap controlMap: DefaultMap = controlMap; break;
+                    }
+                }
+            }
+        }
+
+        if (DefaultWindow == null)
+            throw new Exception("Given DMF did not have a default window");
+
+        DefaultWindow.RegisterOnClydeWindow(_clyde.MainWindow);
+        DefaultWindow.UIElement.Name = "MainWindow";
+
+        LayoutContainer.SetAnchorRight(DefaultWindow.UIElement, 1);
+        LayoutContainer.SetAnchorBottom(DefaultWindow.UIElement, 1);
+
+        _userInterfaceManager.StateRoot.AddChild(DefaultWindow.UIElement);
+    }
+
+    private void LoadDescriptor(ElementDescriptor descriptor) {
+        switch (descriptor) {
+            case MacroSetDescriptor macroSetDescriptor:
+                InterfaceMacroSet macroSet = new(macroSetDescriptor, _entitySystemManager, _inputManager, _uiManager);
+
+                MacroSets[macroSet.Id] = macroSet;
+                break;
+            case MenuDescriptor menuDescriptor:
+                InterfaceMenu menu = new(menuDescriptor);
+
+                Menus.Add(menu.Id, menu);
+                break;
+            case WindowDescriptor windowDescriptor:
+                ControlWindow window = new ControlWindow(windowDescriptor);
+
+                Windows.Add(windowDescriptor.Name, window);
+                if (window.IsDefault) {
+                    DefaultWindow = window;
+                }
+                break;
         }
     }
 
-    public interface IDreamInterfaceManager {
-        (string, string, string)[] AvailableVerbs { get; }
-        Dictionary<string, ControlWindow> Windows { get; }
-        Dictionary<string, InterfaceMenu> Menus { get; }
-        Dictionary<string, InterfaceMacroSet> MacroSets { get; }
-        public ControlWindow? DefaultWindow { get; }
-        public ControlOutput? DefaultOutput { get; }
-        public ControlInfo? DefaultInfo { get; }
-        public ControlMap? DefaultMap { get; }
+    private void OnPromptFinished(int promptId, DMValueType responseType, object? response) {
+        var msg = new MsgPromptResponse() {
+            PromptId = promptId,
+            Type = responseType,
+            Value = response
+        };
 
-        void Initialize();
-        void FrameUpdate(FrameEventArgs frameEventArgs);
-        InterfaceElement? FindElementWithId(string id);
-        void SaveScreenshot(bool openDialog);
-        void LoadInterfaceFromSource(string source);
-        void WinSet(string? controlId, string winsetParams);
+        _netManager.ClientSendMessage(msg);
     }
+}
+
+public interface IDreamInterfaceManager {
+    (string, string, string)[] AvailableVerbs { get; }
+    Dictionary<string, ControlWindow> Windows { get; }
+    Dictionary<string, InterfaceMenu> Menus { get; }
+    Dictionary<string, InterfaceMacroSet> MacroSets { get; }
+    public ControlWindow? DefaultWindow { get; }
+    public ControlOutput? DefaultOutput { get; }
+    public ControlInfo? DefaultInfo { get; }
+    public ControlMap? DefaultMap { get; }
+
+    void Initialize();
+    void FrameUpdate(FrameEventArgs frameEventArgs);
+    InterfaceElement? FindElementWithId(string id);
+    void SaveScreenshot(bool openDialog);
+    void LoadInterfaceFromSource(string source);
+    void WinSet(string? controlId, string winsetParams);
 }

--- a/OpenDreamClient/Interface/DreamStylesheet.cs
+++ b/OpenDreamClient/Interface/DreamStylesheet.cs
@@ -6,171 +6,171 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
 using static Robust.Client.UserInterface.StylesheetHelpers;
 
-namespace OpenDreamClient.Interface {
-    public static class DreamStylesheet {
-        public static Stylesheet Make() {
-            var res = IoCManager.Resolve<IResourceCache>();
-            var textureCloseButton = res.GetResource<TextureResource>("/cross.svg.png").Texture;
-            var notoSansFont = res.GetResource<FontResource>("/Fonts/NotoSans-Regular.ttf");
-            var notoSansBoldFont = res.GetResource<FontResource>("/Fonts/NotoSans-Bold.ttf");
-            var notoSansFont10 = new VectorFont(notoSansFont, 10);
-            var notoSansFont12 = new VectorFont(notoSansFont, 12);
-            var notoSansBoldFont14 = new VectorFont(notoSansBoldFont, 14);
+namespace OpenDreamClient.Interface;
 
-            var scrollBarNormal = new StyleBoxFlat {
-                BackgroundColor = Color.Gray.WithAlpha(0.35f), ContentMarginLeftOverride = 10,
-                ContentMarginTopOverride = 10
-            };
+public static class DreamStylesheet {
+    public static Stylesheet Make() {
+        var res = IoCManager.Resolve<IResourceCache>();
+        var textureCloseButton = res.GetResource<TextureResource>("/cross.svg.png").Texture;
+        var notoSansFont = res.GetResource<FontResource>("/Fonts/NotoSans-Regular.ttf");
+        var notoSansBoldFont = res.GetResource<FontResource>("/Fonts/NotoSans-Bold.ttf");
+        var notoSansFont10 = new VectorFont(notoSansFont, 10);
+        var notoSansFont12 = new VectorFont(notoSansFont, 12);
+        var notoSansBoldFont14 = new VectorFont(notoSansBoldFont, 14);
 
-            var scrollBarHovered = new StyleBoxFlat {
-                BackgroundColor = new Color(140, 140, 140).WithAlpha(0.35f), ContentMarginLeftOverride = 10,
-                ContentMarginTopOverride = 10
-            };
+        var scrollBarNormal = new StyleBoxFlat {
+            BackgroundColor = Color.Gray.WithAlpha(0.35f), ContentMarginLeftOverride = 10,
+            ContentMarginTopOverride = 10
+        };
 
-            var scrollBarGrabbed = new StyleBoxFlat {
-                BackgroundColor = new Color(160, 160, 160).WithAlpha(0.35f), ContentMarginLeftOverride = 10,
-                ContentMarginTopOverride = 10
-            };
+        var scrollBarHovered = new StyleBoxFlat {
+            BackgroundColor = new Color(140, 140, 140).WithAlpha(0.35f), ContentMarginLeftOverride = 10,
+            ContentMarginTopOverride = 10
+        };
 
-            return new Stylesheet(new StyleRule[] {
-                Element<WindowRoot>()
-                    .Prop("background", Color.White),
+        var scrollBarGrabbed = new StyleBoxFlat {
+            BackgroundColor = new Color(160, 160, 160).WithAlpha(0.35f), ContentMarginLeftOverride = 10,
+            ContentMarginTopOverride = 10
+        };
 
-                Element<PanelContainer>().Class("MapBackground")
-                    .Prop("panel", new StyleBoxFlat { BackgroundColor = Color. Black}),
+        return new Stylesheet(new StyleRule[] {
+            Element<WindowRoot>()
+                .Prop("background", Color.White),
 
-                Element<PanelContainer>().Class("ContextMenuBackground")
-                    .Prop("panel", new StyleBoxFlat() {
-                        BackgroundColor = Color.White,
-                        BorderColor = Color.DarkGray,
-                        BorderThickness = new Thickness(1)
-                    }),
+            Element<PanelContainer>().Class("MapBackground")
+                .Prop("panel", new StyleBoxFlat { BackgroundColor = Color. Black}),
 
-                // Default font.
-                Element()
-                    .Prop("font", notoSansFont12)
-                    .Prop("font-color", Color.Black),
+            Element<PanelContainer>().Class("ContextMenuBackground")
+                .Prop("panel", new StyleBoxFlat() {
+                    BackgroundColor = Color.White,
+                    BorderColor = Color.DarkGray,
+                    BorderThickness = new Thickness(1)
+                }),
 
-                // VScrollBar grabber normal
-                Element<VScrollBar>()
-                    .Prop(ScrollBar.StylePropertyGrabber, scrollBarNormal),
+            // Default font.
+            Element()
+                .Prop("font", notoSansFont12)
+                .Prop("font-color", Color.Black),
 
-                // VScrollBar grabber hovered
-                Element<VScrollBar>().Pseudo(ScrollBar.StylePseudoClassHover)
-                    .Prop(ScrollBar.StylePropertyGrabber, scrollBarHovered),
+            // VScrollBar grabber normal
+            Element<VScrollBar>()
+                .Prop(ScrollBar.StylePropertyGrabber, scrollBarNormal),
 
-                // VScrollBar grabber grabbed
-                Element<VScrollBar>().Pseudo(ScrollBar.StylePseudoClassGrabbed)
-                    .Prop(ScrollBar.StylePropertyGrabber, scrollBarGrabbed),
+            // VScrollBar grabber hovered
+            Element<VScrollBar>().Pseudo(ScrollBar.StylePseudoClassHover)
+                .Prop(ScrollBar.StylePropertyGrabber, scrollBarHovered),
 
-                // HScrollBar grabber normal
-                Element<HScrollBar>()
-                    .Prop(ScrollBar.StylePropertyGrabber, scrollBarNormal),
+            // VScrollBar grabber grabbed
+            Element<VScrollBar>().Pseudo(ScrollBar.StylePseudoClassGrabbed)
+                .Prop(ScrollBar.StylePropertyGrabber, scrollBarGrabbed),
 
-                // HScrollBar grabber hovered
-                Element<HScrollBar>().Pseudo(ScrollBar.StylePseudoClassHover)
-                    .Prop(ScrollBar.StylePropertyGrabber, scrollBarHovered),
+            // HScrollBar grabber normal
+            Element<HScrollBar>()
+                .Prop(ScrollBar.StylePropertyGrabber, scrollBarNormal),
 
-                // HScrollBar grabber grabbed
-                Element<HScrollBar>().Pseudo(ScrollBar.StylePseudoClassGrabbed)
-                    .Prop(ScrollBar.StylePropertyGrabber, scrollBarGrabbed),
+            // HScrollBar grabber hovered
+            Element<HScrollBar>().Pseudo(ScrollBar.StylePseudoClassHover)
+                .Prop(ScrollBar.StylePropertyGrabber, scrollBarHovered),
 
-                // Window background default color.
-                Element().Class(DefaultWindow.StyleClassWindowPanel)
-                    .Prop("panel", new StyleBoxFlat { BackgroundColor = Color.FromHex("#4A4A4A") }),
+            // HScrollBar grabber grabbed
+            Element<HScrollBar>().Pseudo(ScrollBar.StylePseudoClassGrabbed)
+                .Prop(ScrollBar.StylePropertyGrabber, scrollBarGrabbed),
 
-                // Window title properties
-                Element().Class(DefaultWindow.StyleClassWindowTitle)
-                    // Color
-                    .Prop(Label.StylePropertyFontColor, Color.FromHex("#000000"))
-                    // Font
-                    .Prop(Label.StylePropertyFont, notoSansBoldFont14),
+            // Window background default color.
+            Element().Class(DefaultWindow.StyleClassWindowPanel)
+                .Prop("panel", new StyleBoxFlat { BackgroundColor = Color.FromHex("#4A4A4A") }),
 
-                // Window header color.
-                Element().Class(DefaultWindow.StyleClassWindowHeader)
-                    .Prop(PanelContainer.StylePropertyPanel, new StyleBoxFlat {
-                        BackgroundColor = Color.FromHex("#636396"), Padding = new Thickness(1, 1)
-                    }),
+            // Window title properties
+            Element().Class(DefaultWindow.StyleClassWindowTitle)
+                // Color
+                .Prop(Label.StylePropertyFontColor, Color.FromHex("#000000"))
+                // Font
+                .Prop(Label.StylePropertyFont, notoSansBoldFont14),
 
-                // Window close button
-                Element().Class(DefaultWindow.StyleClassWindowCloseButton)
-                    // Button texture
-                    .Prop(TextureButton.StylePropertyTexture, textureCloseButton)
-                    // Normal button color
-                    .Prop(Control.StylePropertyModulateSelf, Color.FromHex("#000000")),
+            // Window header color.
+            Element().Class(DefaultWindow.StyleClassWindowHeader)
+                .Prop(PanelContainer.StylePropertyPanel, new StyleBoxFlat {
+                    BackgroundColor = Color.FromHex("#636396"), Padding = new Thickness(1, 1)
+                }),
 
-                // Window close button hover color
-                Element().Class(DefaultWindow.StyleClassWindowCloseButton).Pseudo(TextureButton.StylePseudoClassHover)
-                    .Prop(Control.StylePropertyModulateSelf, Color.FromHex("#505050")),
+            // Window close button
+            Element().Class(DefaultWindow.StyleClassWindowCloseButton)
+                // Button texture
+                .Prop(TextureButton.StylePropertyTexture, textureCloseButton)
+                // Normal button color
+                .Prop(Control.StylePropertyModulateSelf, Color.FromHex("#000000")),
 
-                // Window close button pressed color
-                Element().Class(DefaultWindow.StyleClassWindowCloseButton).Pseudo(TextureButton.StylePseudoClassPressed)
-                    .Prop(Control.StylePropertyModulateSelf, Color.FromHex("#808080")),
+            // Window close button hover color
+            Element().Class(DefaultWindow.StyleClassWindowCloseButton).Pseudo(TextureButton.StylePseudoClassHover)
+                .Prop(Control.StylePropertyModulateSelf, Color.FromHex("#505050")),
 
-                // Button style normal
-                Element<ContainerButton>().Class(ContainerButton.StyleClassButton).Pseudo(ContainerButton.StylePseudoClassNormal)
-                    .Prop(ContainerButton.StylePropertyStyleBox, new StyleBoxFlat { BackgroundColor = Color.FromHex("#C0C0C0"), BorderThickness = new Thickness(1), BorderColor = Color.FromHex("#707070")}),
+            // Window close button pressed color
+            Element().Class(DefaultWindow.StyleClassWindowCloseButton).Pseudo(TextureButton.StylePseudoClassPressed)
+                .Prop(Control.StylePropertyModulateSelf, Color.FromHex("#808080")),
 
-                // Button style hovered
-                Element<ContainerButton>().Class(ContainerButton.StyleClassButton).Pseudo(ContainerButton.StylePseudoClassHover)
-                    .Prop(ContainerButton.StylePropertyStyleBox, new StyleBoxFlat { BackgroundColor = Color.FromHex("#D0D0D0"), BorderThickness = new Thickness(1), BorderColor = Color.FromHex("#707070")}),
+            // Button style normal
+            Element<ContainerButton>().Class(ContainerButton.StyleClassButton).Pseudo(ContainerButton.StylePseudoClassNormal)
+                .Prop(ContainerButton.StylePropertyStyleBox, new StyleBoxFlat { BackgroundColor = Color.FromHex("#C0C0C0"), BorderThickness = new Thickness(1), BorderColor = Color.FromHex("#707070")}),
 
-                // Button style pressed
-                Element<ContainerButton>().Class(ContainerButton.StyleClassButton).Pseudo(ContainerButton.StylePseudoClassPressed)
-                    .Prop(ContainerButton.StylePropertyStyleBox, new StyleBoxFlat { BackgroundColor = Color.FromHex("#E0E0E0"), BorderThickness = new Thickness(1), BorderColor = Color.FromHex("#707070") }),
+            // Button style hovered
+            Element<ContainerButton>().Class(ContainerButton.StyleClassButton).Pseudo(ContainerButton.StylePseudoClassHover)
+                .Prop(ContainerButton.StylePropertyStyleBox, new StyleBoxFlat { BackgroundColor = Color.FromHex("#D0D0D0"), BorderThickness = new Thickness(1), BorderColor = Color.FromHex("#707070")}),
 
-                // Button style disabled
-                Element<ContainerButton>().Class(ContainerButton.StyleClassButton).Pseudo(ContainerButton.StylePseudoClassDisabled)
-                    .Prop(ContainerButton.StylePropertyStyleBox, new StyleBoxFlat { BackgroundColor = Color.FromHex("#FAFAFA"), BorderThickness = new Thickness(1), BorderColor = Color.FromHex("#707070")}),
+            // Button style pressed
+            Element<ContainerButton>().Class(ContainerButton.StyleClassButton).Pseudo(ContainerButton.StylePseudoClassPressed)
+                .Prop(ContainerButton.StylePropertyStyleBox, new StyleBoxFlat { BackgroundColor = Color.FromHex("#E0E0E0"), BorderThickness = new Thickness(1), BorderColor = Color.FromHex("#707070") }),
 
-                // DMF ControlButton
-                Element<Label>().Class(ControlButton.StyleClassDMFButton)
-                    .Prop(Label.StylePropertyAlignMode, Label.AlignMode.Center)
-                    .Prop(Label.StylePropertyFont, notoSansFont10),
+            // Button style disabled
+            Element<ContainerButton>().Class(ContainerButton.StyleClassButton).Pseudo(ContainerButton.StylePseudoClassDisabled)
+                .Prop(ContainerButton.StylePropertyStyleBox, new StyleBoxFlat { BackgroundColor = Color.FromHex("#FAFAFA"), BorderThickness = new Thickness(1), BorderColor = Color.FromHex("#707070")}),
 
-                // CheckBox unchecked
-                Element<TextureRect>().Class(CheckBox.StyleClassCheckBox)
-                    .Prop(TextureRect.StylePropertyTexture, Texture.Black), // TODO: Add actual texture instead of this.
+            // DMF ControlButton
+            Element<Label>().Class(ControlButton.StyleClassDMFButton)
+                .Prop(Label.StylePropertyAlignMode, Label.AlignMode.Center)
+                .Prop(Label.StylePropertyFont, notoSansFont10),
 
-                // CheckBox unchecked
-                Element<TextureRect>().Class(CheckBox.StyleClassCheckBox, CheckBox.StyleClassCheckBoxChecked)
-                    .Prop(TextureRect.StylePropertyTexture, Texture.White), // TODO: Add actual texture instead of this.
+            // CheckBox unchecked
+            Element<TextureRect>().Class(CheckBox.StyleClassCheckBox)
+                .Prop(TextureRect.StylePropertyTexture, Texture.Black), // TODO: Add actual texture instead of this.
 
-                // LineEdit
-                Element<LineEdit>()
-                    // background color
-                    .Prop(LineEdit.StylePropertyStyleBox, new StyleBoxFlat{ BackgroundColor = Color.FromHex("#D3B5B5"), BorderThickness = new Thickness(1), BorderColor = Color.FromHex("#abadb3")})
-                    // default font color
-                    .Prop("font-color", Color.Black)
-                    .Prop("cursor-color", Color.Black),
+            // CheckBox unchecked
+            Element<TextureRect>().Class(CheckBox.StyleClassCheckBox, CheckBox.StyleClassCheckBoxChecked)
+                .Prop(TextureRect.StylePropertyTexture, Texture.White), // TODO: Add actual texture instead of this.
 
-                // LineEdit non-editable text color
-                Element<LineEdit>().Class(LineEdit.StyleClassLineEditNotEditable)
-                    .Prop("font-color", Color.FromHex("#363636")),
+            // LineEdit
+            Element<LineEdit>()
+                // background color
+                .Prop(LineEdit.StylePropertyStyleBox, new StyleBoxFlat{ BackgroundColor = Color.FromHex("#D3B5B5"), BorderThickness = new Thickness(1), BorderColor = Color.FromHex("#abadb3")})
+                // default font color
+                .Prop("font-color", Color.Black)
+                .Prop("cursor-color", Color.Black),
 
-                // LineEdit placeholder text color
-                Element<LineEdit>().Pseudo(LineEdit.StylePseudoClassPlaceholder)
-                    .Prop("font-color", Color.FromHex("#7d7d7d")),
+            // LineEdit non-editable text color
+            Element<LineEdit>().Class(LineEdit.StyleClassLineEditNotEditable)
+                .Prop("font-color", Color.FromHex("#363636")),
 
-                // ItemList selected item
-                Element<ItemList>()
-                    .Prop(ItemList.StylePropertySelectedItemBackground, new StyleBoxFlat { BackgroundColor = Color.Blue }),
+            // LineEdit placeholder text color
+            Element<LineEdit>().Pseudo(LineEdit.StylePseudoClassPlaceholder)
+                .Prop("font-color", Color.FromHex("#7d7d7d")),
 
-                // TabContainer
-                Element<TabContainer>()
-                    // Panel style
-                    .Prop(TabContainer.StylePropertyPanelStyleBox, new StyleBoxFlat { BackgroundColor = Color.White, BorderThickness = new Thickness(1), BorderColor = Color.Black})
-                    // Active tab style
-                    .Prop(TabContainer.StylePropertyTabStyleBox, new StyleBoxFlat {
-                        BackgroundColor = Color.FromHex("#707070"), PaddingLeft = 1, PaddingRight = 1, ContentMarginLeftOverride = 5, ContentMarginRightOverride = 5
-                    })
-                    // Inactive tab style
-                    .Prop(TabContainer.StylePropertyTabStyleBoxInactive, new StyleBoxFlat {
-                        BackgroundColor = Color.FromHex("#D0D0D0"), PaddingLeft = 1, PaddingRight = 1, ContentMarginLeftOverride = 5, ContentMarginRightOverride = 5
-                    })
-                    .Prop("font", notoSansFont10),
+            // ItemList selected item
+            Element<ItemList>()
+                .Prop(ItemList.StylePropertySelectedItemBackground, new StyleBoxFlat { BackgroundColor = Color.Blue }),
 
-            });
-        }
+            // TabContainer
+            Element<TabContainer>()
+                // Panel style
+                .Prop(TabContainer.StylePropertyPanelStyleBox, new StyleBoxFlat { BackgroundColor = Color.White, BorderThickness = new Thickness(1), BorderColor = Color.Black})
+                // Active tab style
+                .Prop(TabContainer.StylePropertyTabStyleBox, new StyleBoxFlat {
+                    BackgroundColor = Color.FromHex("#707070"), PaddingLeft = 1, PaddingRight = 1, ContentMarginLeftOverride = 5, ContentMarginRightOverride = 5
+                })
+                // Inactive tab style
+                .Prop(TabContainer.StylePropertyTabStyleBoxInactive, new StyleBoxFlat {
+                    BackgroundColor = Color.FromHex("#D0D0D0"), PaddingLeft = 1, PaddingRight = 1, ContentMarginLeftOverride = 5, ContentMarginRightOverride = 5
+                })
+                .Prop("font", notoSansFont10),
+
+        });
     }
 }

--- a/OpenDreamClient/Interface/DummyDreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DummyDreamInterfaceManager.cs
@@ -2,43 +2,43 @@ using OpenDreamClient.Interface.Controls;
 using OpenDreamClient.Interface.Descriptors;
 using Robust.Shared.Timing;
 
-namespace OpenDreamClient.Interface {
-    /// <summary>
-    /// Used in unit testing to run a headless client.
-    /// </summary>
-    public sealed class DummyDreamInterfaceManager : IDreamInterfaceManager {
-        public (string, string, string)[] AvailableVerbs => Array.Empty<(string, string, string)>();
-        public Dictionary<string, ControlWindow> Windows { get; } = new();
-        public Dictionary<string, InterfaceMenu> Menus { get; } = new();
-        public Dictionary<string, InterfaceMacroSet> MacroSets { get; } = new();
-        public ControlWindow? DefaultWindow => null;
-        public ControlOutput? DefaultOutput => null;
-        public ControlInfo? DefaultInfo => null;
-        public ControlMap? DefaultMap => null;
-        public InterfaceDescriptor InterfaceDescriptor { get; }
+namespace OpenDreamClient.Interface;
 
-        public void Initialize() {
+/// <summary>
+/// Used in unit testing to run a headless client.
+/// </summary>
+public sealed class DummyDreamInterfaceManager : IDreamInterfaceManager {
+    public (string, string, string)[] AvailableVerbs => Array.Empty<(string, string, string)>();
+    public Dictionary<string, ControlWindow> Windows { get; } = new();
+    public Dictionary<string, InterfaceMenu> Menus { get; } = new();
+    public Dictionary<string, InterfaceMacroSet> MacroSets { get; } = new();
+    public ControlWindow? DefaultWindow => null;
+    public ControlOutput? DefaultOutput => null;
+    public ControlInfo? DefaultInfo => null;
+    public ControlMap? DefaultMap => null;
+    public InterfaceDescriptor InterfaceDescriptor { get; }
 
-        }
+    public void Initialize() {
 
-        public void FrameUpdate(FrameEventArgs frameEventArgs) {
+    }
 
-        }
+    public void FrameUpdate(FrameEventArgs frameEventArgs) {
 
-        public InterfaceElement? FindElementWithId(string id) {
-            return null;
-        }
+    }
 
-        public void SaveScreenshot(bool openDialog) {
+    public InterfaceElement? FindElementWithId(string id) {
+        return null;
+    }
 
-        }
+    public void SaveScreenshot(bool openDialog) {
 
-        public void LoadInterfaceFromSource(string source) {
+    }
 
-        }
+    public void LoadInterfaceFromSource(string source) {
 
-        public void WinSet(string? controlId, string winsetParams) {
+    }
 
-        }
+    public void WinSet(string? controlId, string winsetParams) {
+
     }
 }

--- a/OpenDreamClient/Interface/DummyDreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DummyDreamInterfaceManager.cs
@@ -25,7 +25,7 @@ namespace OpenDreamClient.Interface {
 
         }
 
-        public InterfaceElement? FindElementWithName(string name) {
+        public InterfaceElement? FindElementWithId(string id) {
             return null;
         }
 

--- a/OpenDreamClient/Interface/InterfaceElement.cs
+++ b/OpenDreamClient/Interface/InterfaceElement.cs
@@ -6,7 +6,7 @@ namespace OpenDreamClient.Interface {
     [Virtual]
     public class InterfaceElement {
         public string Type => ElementDescriptor.Type;
-        public string Name => ElementDescriptor.Name;
+        public string Id => ElementDescriptor.Id;
 
         public ElementDescriptor ElementDescriptor;
 

--- a/OpenDreamClient/Interface/InterfaceElement.cs
+++ b/OpenDreamClient/Interface/InterfaceElement.cs
@@ -2,39 +2,39 @@
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Markdown.Mapping;
 
-namespace OpenDreamClient.Interface {
-    [Virtual]
-    public class InterfaceElement {
-        public string Type => ElementDescriptor.Type;
-        public string Id => ElementDescriptor.Id;
+namespace OpenDreamClient.Interface;
 
-        public ElementDescriptor ElementDescriptor;
+[Virtual]
+public class InterfaceElement {
+    public string Type => ElementDescriptor.Type;
+    public string Id => ElementDescriptor.Id;
 
-        protected InterfaceElement(ElementDescriptor elementDescriptor) {
-            ElementDescriptor = elementDescriptor;
+    public ElementDescriptor ElementDescriptor;
+
+    protected InterfaceElement(ElementDescriptor elementDescriptor) {
+        ElementDescriptor = elementDescriptor;
+    }
+
+    public void PopulateElementDescriptor(MappingDataNode node, ISerializationManager serializationManager) {
+        MappingDataNode original = (MappingDataNode)serializationManager.WriteValue(ElementDescriptor.GetType(), ElementDescriptor);
+        foreach (var key in node.Keys) {
+            original.Remove(key);
         }
 
-        public void PopulateElementDescriptor(MappingDataNode node, ISerializationManager serializationManager) {
-            MappingDataNode original = (MappingDataNode)serializationManager.WriteValue(ElementDescriptor.GetType(), ElementDescriptor);
-            foreach (var key in node.Keys) {
-                original.Remove(key);
-            }
+        MappingDataNode newNode = original.Merge(node);
+        ElementDescriptor = (ElementDescriptor)serializationManager.Read(ElementDescriptor.GetType(), newNode);
+        UpdateElementDescriptor();
+    }
 
-            MappingDataNode newNode = original.Merge(node);
-            ElementDescriptor = (ElementDescriptor)serializationManager.Read(ElementDescriptor.GetType(), newNode);
-            UpdateElementDescriptor();
-        }
+    protected virtual void UpdateElementDescriptor() {
 
-        protected virtual void UpdateElementDescriptor() {
+    }
 
-        }
+    public virtual void AddChild(ElementDescriptor descriptor) {
+        throw new InvalidOperationException($"{this} cannot add a child");
+    }
 
-        public virtual void AddChild(ElementDescriptor descriptor) {
-            throw new InvalidOperationException($"{this} cannot add a child");
-        }
+    public virtual void Shutdown() {
 
-        public virtual void Shutdown() {
-
-        }
     }
 }

--- a/OpenDreamClient/Interface/InterfaceMenu.cs
+++ b/OpenDreamClient/Interface/InterfaceMenu.cs
@@ -34,11 +34,11 @@ public sealed class InterfaceMenu : InterfaceElement {
             if (!MenuElements.TryGetValue(elementDescriptor.Category, out var parentMenu)) {
                 //if category is set but the parent element doesn't exist, create it
                 var parentMenuDescriptor = new MenuElementDescriptor() {
-                    Name = elementDescriptor.Category
+                    Id = elementDescriptor.Category
                 };
 
                 parentMenu = new(parentMenuDescriptor, this);
-                MenuElements.Add(parentMenu.Name, parentMenu);
+                MenuElements.Add(parentMenu.Id, parentMenu);
             }
 
             //now add this as a child
@@ -46,7 +46,7 @@ public sealed class InterfaceMenu : InterfaceElement {
             parentMenu.Children.Add(element);
         }
 
-        MenuElements.Add(element.Name, element);
+        MenuElements.Add(element.Id, element);
         CreateMenu(); // Update the menu to include the new child
     }
 
@@ -61,7 +61,7 @@ public sealed class InterfaceMenu : InterfaceElement {
                 continue;
 
             MenuBar.Menu menu = new() {
-                Title = menuElement.Name
+                Title = menuElement.ElementDescriptor.Name
             };
 
             if (menu.Title?.StartsWith("&") ?? false)
@@ -78,7 +78,7 @@ public sealed class InterfaceMenu : InterfaceElement {
         public readonly List<MenuElement> Children = new();
 
         private MenuElementDescriptor MenuElementDescriptor => (MenuElementDescriptor) ElementDescriptor;
-        public string Category => MenuElementDescriptor.Category;
+        public string? Category => MenuElementDescriptor.Category;
         public string Command => MenuElementDescriptor.Command;
 
         private readonly InterfaceMenu _menu;
@@ -88,7 +88,7 @@ public sealed class InterfaceMenu : InterfaceElement {
         }
 
         public MenuBar.MenuEntry CreateMenuEntry() {
-            string text = Name;
+            string text = ElementDescriptor.Name;
             if (text.StartsWith("&"))
                 text = text[1..]; //TODO: First character in name becomes a selection shortcut
 

--- a/OpenDreamClient/Interface/Prompts/AlertWindow.cs
+++ b/OpenDreamClient/Interface/Prompts/AlertWindow.cs
@@ -2,31 +2,31 @@
 using JetBrains.Annotations;
 using Robust.Shared.Console;
 
-namespace OpenDreamClient.Interface.Prompts {
-    internal sealed class AlertWindow : PromptWindow {
-        public AlertWindow(string title, string message, string button1, string? button2, string? button3, Action<DMValueType, object?>? onClose) :
-            base(title, message, onClose) {
-            CreateButton(button1, true);
-            if (!string.IsNullOrEmpty(button2)) CreateButton(button2, false);
-            if (!string.IsNullOrEmpty(button3)) CreateButton(button3, false);
-        }
+namespace OpenDreamClient.Interface.Prompts;
 
-        protected override void ButtonClicked(string button) {
-            FinishPrompt(DMValueType.Text, button);
-
-            base.ButtonClicked(button);
-        }
+internal sealed class AlertWindow : PromptWindow {
+    public AlertWindow(string title, string message, string button1, string? button2, string? button3, Action<DMValueType, object?>? onClose) :
+        base(title, message, onClose) {
+        CreateButton(button1, true);
+        if (!string.IsNullOrEmpty(button2)) CreateButton(button2, false);
+        if (!string.IsNullOrEmpty(button3)) CreateButton(button3, false);
     }
 
-    [UsedImplicitly]
-    public sealed class AlertCommand : IConsoleCommand {
-        public string Command => "alert";
-        public string Description => "Opens a test alert";
-        public string Help => "alert";
+    protected override void ButtonClicked(string button) {
+        FinishPrompt(DMValueType.Text, button);
 
-        public void Execute(IConsoleShell shell, string argStr, string[] args) {
-            var mgr = (DreamInterfaceManager)IoCManager.Resolve<IDreamInterfaceManager>();
-            mgr.OpenAlert("A", "B", "C", null, null, null);
-        }
+        base.ButtonClicked(button);
+    }
+}
+
+[UsedImplicitly]
+public sealed class AlertCommand : IConsoleCommand {
+    public string Command => "alert";
+    public string Description => "Opens a test alert";
+    public string Help => "alert";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args) {
+        var mgr = (DreamInterfaceManager)IoCManager.Resolve<IDreamInterfaceManager>();
+        mgr.OpenAlert("A", "B", "C", null, null, null);
     }
 }

--- a/OpenDreamClient/Interface/Prompts/InputWindow.cs
+++ b/OpenDreamClient/Interface/Prompts/InputWindow.cs
@@ -1,30 +1,30 @@
 ﻿using OpenDreamShared.Dream.Procs;
 using Robust.Client.UserInterface;
 
-namespace OpenDreamClient.Interface.Prompts {
-    [Virtual]
-    internal class InputWindow : PromptWindow {
-        protected InputWindow(string title, string message, bool canCancel,
-            Action<DMValueType, object?>? onClose) : base(title, message, onClose) {
-            CreateButton("Ok", true);
-            if (canCancel) CreateButton("Cancel", false);
-        }
+namespace OpenDreamClient.Interface.Prompts;
 
-        protected void SetPromptControl(Control promptControl, bool grabKeyboard = true) {
-            InputControl.RemoveAllChildren();
-            InputControl.AddChild(promptControl);
-            if (grabKeyboard) promptControl.GrabKeyboardFocus();
-        }
+[Virtual]
+internal class InputWindow : PromptWindow {
+    protected InputWindow(string title, string message, bool canCancel,
+        Action<DMValueType, object?>? onClose) : base(title, message, onClose) {
+        CreateButton("Ok", true);
+        if (canCancel) CreateButton("Cancel", false);
+    }
 
-        protected override void ButtonClicked(string button) {
-            if (button == "Ok") OkButtonClicked();
-            else FinishPrompt(DMValueType.Null, null);
+    protected void SetPromptControl(Control promptControl, bool grabKeyboard = true) {
+        InputControl.RemoveAllChildren();
+        InputControl.AddChild(promptControl);
+        if (grabKeyboard) promptControl.GrabKeyboardFocus();
+    }
 
-            base.ButtonClicked(button);
-        }
+    protected override void ButtonClicked(string button) {
+        if (button == "Ok") OkButtonClicked();
+        else FinishPrompt(DMValueType.Null, null);
 
-        protected virtual void OkButtonClicked() {
-            throw new NotImplementedException();
-        }
+        base.ButtonClicked(button);
+    }
+
+    protected virtual void OkButtonClicked() {
+        throw new NotImplementedException();
     }
 }

--- a/OpenDreamClient/Interface/Prompts/MessagePrompt.cs
+++ b/OpenDreamClient/Interface/Prompts/MessagePrompt.cs
@@ -2,25 +2,25 @@
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Utility;
 
-namespace OpenDreamClient.Interface.Prompts {
-    internal sealed class MessagePrompt : InputWindow {
-        private readonly TextEdit _textEdit;
+namespace OpenDreamClient.Interface.Prompts;
 
-        public MessagePrompt(string title, string message, string defaultValue, bool canCancel,
-            Action<DMValueType, object?>? onClose) : base(title, message, canCancel, onClose) {
-            _textEdit = new TextEdit {
-                TextRope = new Rope.Leaf(defaultValue),
+internal sealed class MessagePrompt : InputWindow {
+    private readonly TextEdit _textEdit;
 
-                // Select all the text by default
-                CursorPosition = new TextEdit.CursorPos(defaultValue.Length, TextEdit.LineBreakBias.Bottom),
-                SelectionStart = new TextEdit.CursorPos(0, TextEdit.LineBreakBias.Bottom)
-            };
+    public MessagePrompt(string title, string message, string defaultValue, bool canCancel,
+        Action<DMValueType, object?>? onClose) : base(title, message, canCancel, onClose) {
+        _textEdit = new TextEdit {
+            TextRope = new Rope.Leaf(defaultValue),
 
-            SetPromptControl(_textEdit);
-        }
+            // Select all the text by default
+            CursorPosition = new TextEdit.CursorPos(defaultValue.Length, TextEdit.LineBreakBias.Bottom),
+            SelectionStart = new TextEdit.CursorPos(0, TextEdit.LineBreakBias.Bottom)
+        };
 
-        protected override void OkButtonClicked() {
-            FinishPrompt(DMValueType.Message, Rope.Collapse(_textEdit.TextRope));
-        }
+        SetPromptControl(_textEdit);
+    }
+
+    protected override void OkButtonClicked() {
+        FinishPrompt(DMValueType.Message, Rope.Collapse(_textEdit.TextRope));
     }
 }

--- a/OpenDreamClient/Interface/Prompts/NumberPrompt.cs
+++ b/OpenDreamClient/Interface/Prompts/NumberPrompt.cs
@@ -1,32 +1,32 @@
 ﻿using OpenDreamShared.Dream.Procs;
 using Robust.Client.UserInterface.Controls;
 
-namespace OpenDreamClient.Interface.Prompts {
-    internal sealed class NumberPrompt : InputWindow {
-        private readonly LineEdit _numberInput;
+namespace OpenDreamClient.Interface.Prompts;
 
-        public NumberPrompt(string title, string message, string defaultValue, bool canCancel,
-            Action<DMValueType, object?>? onClose) : base(title, message, canCancel, onClose) {
-            _numberInput = new() {
-                Text = defaultValue,
-                VerticalAlignment = VAlignment.Top,
-                IsValid = static str => float.TryParse(str, out float _),
-            };
+internal sealed class NumberPrompt : InputWindow {
+    private readonly LineEdit _numberInput;
 
-            _numberInput.OnTextEntered += NumberInput_TextEntered;
-            SetPromptControl(_numberInput);
+    public NumberPrompt(string title, string message, string defaultValue, bool canCancel,
+        Action<DMValueType, object?>? onClose) : base(title, message, canCancel, onClose) {
+        _numberInput = new() {
+            Text = defaultValue,
+            VerticalAlignment = VAlignment.Top,
+            IsValid = static str => float.TryParse(str, out float _),
+        };
+
+        _numberInput.OnTextEntered += NumberInput_TextEntered;
+        SetPromptControl(_numberInput);
+    }
+
+    protected override void OkButtonClicked() {
+        if (!float.TryParse(_numberInput.Text, out float num)) {
+            Logger.GetSawmill("opendream.prompt").Error($"Error while trying to convert {_numberInput.Text} to a number.");
         }
 
-        protected override void OkButtonClicked() {
-            if (!float.TryParse(_numberInput.Text, out float num)) {
-                Logger.GetSawmill("opendream.prompt").Error($"Error while trying to convert {_numberInput.Text} to a number.");
-            }
+        FinishPrompt(DMValueType.Num, num);
+    }
 
-            FinishPrompt(DMValueType.Num, num);
-        }
-
-        private void NumberInput_TextEntered(LineEdit.LineEditEventArgs obj) {
-            ButtonClicked(DefaultButton);
-        }
+    private void NumberInput_TextEntered(LineEdit.LineEditEventArgs obj) {
+        ButtonClicked(DefaultButton);
     }
 }

--- a/OpenDreamClient/Interface/Prompts/PromptWindow.cs
+++ b/OpenDreamClient/Interface/Prompts/PromptWindow.cs
@@ -4,83 +4,83 @@ using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 
-namespace OpenDreamClient.Interface.Prompts {
-    public abstract class PromptWindow : OSWindow {
-        protected readonly Control InputControl;
-        protected string DefaultButton;
+namespace OpenDreamClient.Interface.Prompts;
 
-        private readonly BoxContainer _buttonPanel;
-        private bool _promptFinished;
+public abstract class PromptWindow : OSWindow {
+    protected readonly Control InputControl;
+    protected string DefaultButton;
 
-        private readonly Action<DMValueType, object?>? _closeAction;
+    private readonly BoxContainer _buttonPanel;
+    private bool _promptFinished;
 
-        protected PromptWindow(string? title, string? message, Action<DMValueType, object?>? onClose) {
-            _closeAction = onClose;
+    private readonly Action<DMValueType, object?>? _closeAction;
 
-            Title = !string.IsNullOrEmpty(title) ? title : "OpenDream";
+    protected PromptWindow(string? title, string? message, Action<DMValueType, object?>? onClose) {
+        _closeAction = onClose;
 
-            Label messageLabel = new Label();
-            messageLabel.Margin = new Thickness(5);
-            messageLabel.Text = message;
+        Title = !string.IsNullOrEmpty(title) ? title : "OpenDream";
 
-            _buttonPanel = new BoxContainer();
-            _buttonPanel.Margin = new Thickness(5);
-            _buttonPanel.Orientation = BoxContainer.LayoutOrientation.Horizontal;
-            _buttonPanel.HorizontalAlignment = HAlignment.Right;
-            _buttonPanel.VerticalAlignment = VAlignment.Bottom;
+        Label messageLabel = new Label();
+        messageLabel.Margin = new Thickness(5);
+        messageLabel.Text = message;
 
-            InputControl = new Control {
-                VerticalExpand = true
-            };
+        _buttonPanel = new BoxContainer();
+        _buttonPanel.Margin = new Thickness(5);
+        _buttonPanel.Orientation = BoxContainer.LayoutOrientation.Horizontal;
+        _buttonPanel.HorizontalAlignment = HAlignment.Right;
+        _buttonPanel.VerticalAlignment = VAlignment.Bottom;
 
-            var dockPanel = new BoxContainer();
-            dockPanel.Orientation = BoxContainer.LayoutOrientation.Vertical;
-            dockPanel.Margin = new Thickness(5);
-            dockPanel.Children.Add(messageLabel);
-            dockPanel.Children.Add(InputControl);
-            dockPanel.Children.Add(_buttonPanel);
+        InputControl = new Control {
+            VerticalExpand = true
+        };
 
-            SizeToContent = WindowSizeToContent.WidthAndHeight;
-            MinWidth = 300;
-            MinHeight = 150;
-            StartupLocation = WindowStartupLocation.CenterOwner;
-            Closing += PromptWindow_Closing;
-            WindowStyles = OSWindowStyles.NoTitleOptions;
+        var dockPanel = new BoxContainer();
+        dockPanel.Orientation = BoxContainer.LayoutOrientation.Vertical;
+        dockPanel.Margin = new Thickness(5);
+        dockPanel.Children.Add(messageLabel);
+        dockPanel.Children.Add(InputControl);
+        dockPanel.Children.Add(_buttonPanel);
 
-            AddChild(dockPanel);
-        }
+        SizeToContent = WindowSizeToContent.WidthAndHeight;
+        MinWidth = 300;
+        MinHeight = 150;
+        StartupLocation = WindowStartupLocation.CenterOwner;
+        Closing += PromptWindow_Closing;
+        WindowStyles = OSWindowStyles.NoTitleOptions;
 
-        protected void CreateButton(string text, bool isDefault) {
-            Button button = new Button() {
-                Margin = new Thickness(15, 0, 0, 0),
-                Children = { new Label { Text = text, Margin = new Thickness(5, 2, 5, 2) } }
-            };
+        AddChild(dockPanel);
+    }
 
-            if (isDefault)
-                DefaultButton = text;
+    protected void CreateButton(string text, bool isDefault) {
+        Button button = new Button() {
+            Margin = new Thickness(15, 0, 0, 0),
+            Children = { new Label { Text = text, Margin = new Thickness(5, 2, 5, 2) } }
+        };
 
-            button.OnPressed += _ => ButtonClicked(text);
-            _buttonPanel.Children.Add(button);
-        }
+        if (isDefault)
+            DefaultButton = text;
 
-        protected virtual void ButtonClicked(string button) {
-            Close();
-        }
+        button.OnPressed += _ => ButtonClicked(text);
+        _buttonPanel.Children.Add(button);
+    }
 
-        protected void FinishPrompt(DMValueType responseType, object? value) {
-            if (_promptFinished) return;
-            _promptFinished = true;
+    protected virtual void ButtonClicked(string button) {
+        Close();
+    }
 
-            _closeAction?.Invoke(responseType, value);
-        }
+    protected void FinishPrompt(DMValueType responseType, object? value) {
+        if (_promptFinished) return;
+        _promptFinished = true;
 
-        private void PromptWindow_Closing(CancelEventArgs e) {
-            //Don't allow closing if there hasn't been a response to the prompt
-            if (!_promptFinished) {
-                e.Cancel = true;
-            } else {
-                Owner = null;
-            }
+        _closeAction?.Invoke(responseType, value);
+    }
+
+    private void PromptWindow_Closing(CancelEventArgs e) {
+        //Don't allow closing if there hasn't been a response to the prompt
+        if (!_promptFinished) {
+            e.Cancel = true;
+        } else {
+            Owner = null;
         }
     }
 }


### PR DESCRIPTION
We've been treating ID and name as the same thing which isn't correct. These are now separate and uses of `Name` have been switched to `Id` where I think is appropriate.

This fixes attempts to reparent existing macros with names different from their id. That and a change to wincloning macro sets fixes non-hotkey mode in modern Paradise.

I also made every file in the `Interface/` folder use file-scoped namespaces.