### PR TITLE
Fix default `/client.statobj` assignment

### DIFF
--- a/DMCompiler/DMStandard/Types/Atoms/Mob.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/Mob.dm
@@ -15,6 +15,5 @@
 	layer = MOB_LAYER
 
 	proc/Login()
-		client.statobj = src
 
 	proc/Logout()

--- a/DMCompiler/DMStandard/Types/Client.dm
+++ b/DMCompiler/DMStandard/Types/Client.dm
@@ -60,6 +60,7 @@
 			mob = new world.mob(locate(1,1,1)) // TODO: Find nearest non-dense turf
 
 		eye = mob
+		statobj = mob
 		return mob
 
 	proc/Del()

--- a/DMCompiler/DMStandard/Types/Client.dm
+++ b/DMCompiler/DMStandard/Types/Client.dm
@@ -71,7 +71,8 @@
 			hsrc.Topic(href, href_list)
 
 	proc/Stat()
-		if (statobj != null) statobj.Stat()
+		if (istype(statobj, /atom))
+			statobj.Stat()
 
 	proc/Command(command as command_text)
 		set opendream_unimplemented = TRUE

--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -37,6 +37,7 @@ namespace OpenDreamRuntime {
                         _mob.Connection = null;
                     }
 
+                    StatObj = new(value);
                     if (Eye != null && Eye == Mob) {
                         Eye = value;
                     }
@@ -72,6 +73,9 @@ namespace OpenDreamRuntime {
                 }
             }
         }
+
+        [ViewVariables]
+        public DreamValue StatObj { get; set; } // This can be just any DreamValue. Only atoms will function though.
 
         [ViewVariables] private string? _outputStatPanel;
         [ViewVariables] private string _selectedStatPanel;

--- a/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
@@ -37,6 +37,9 @@ public sealed class DreamObjectClient : DreamObject {
             case "mob":
                 value = new(Connection.Mob);
                 return true;
+            case "statobj":
+                value = Connection.StatObj;
+                return true;
             case "eye":
                 value = new(Connection.Eye);
                 return true;
@@ -87,6 +90,9 @@ public sealed class DreamObjectClient : DreamObject {
                 Connection.Mob = newMob;
                 break;
             }
+            case "statobj":
+                Connection.StatObj = value;
+                break;
             case "eye": {
                 value.TryGetValueAsDreamObject<DreamObjectAtom>(out var newEye);
                 if (newEye is not (DreamObjectMovable or null)) {


### PR DESCRIPTION
The DM reference lies here. It says `/mob/Login()` sets `/client.statobj` but it's actually `/client/New()` that does this. Not calling `..()` in mob's Login will still result in `statobj` being set. This is not the case in client's New.

Fixes stat panels in modern Paradise.