### PR TITLE
Remove associative values in `/list.Cut()`

### DIFF
--- a/Content.Tests/DMProject/Tests/List/ListCut.dm
+++ b/Content.Tests/DMProject/Tests/List/ListCut.dm
@@ -3,3 +3,9 @@
 	ASSERT(A.len == 3)
 	A.Cut()
 	ASSERT(A.len == 0)
+
+	A = list(a = 10, b = 20)
+	A.Cut(1, 2)
+	ASSERT(A ~= list("b"))
+	ASSERT(A["a"] == null)
+	ASSERT(A["b"] == 20)

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -161,6 +161,11 @@ namespace OpenDreamRuntime.Objects.Types {
         public virtual void Cut(int start = 1, int end = 0) {
             if (end == 0 || end > (_values.Count + 1)) end = _values.Count + 1;
 
+            if (_associativeValues != null) {
+                for (int i = start; i < end; i++)
+                    _associativeValues.Remove(_values[i - 1]);
+            }
+
             _values.RemoveRange(start - 1, end - start);
         }
 


### PR DESCRIPTION
`/list.Cut()` was not removing the values associated with what was being removed.