### PR TITLE
Use random filenames for `browse()`

### DIFF
--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -16,6 +16,7 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.ContentPack;
 using Robust.Shared.Network;
+using Robust.Shared.Random;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.Markdown.Value;
@@ -39,6 +40,7 @@ namespace OpenDreamClient.Interface {
         [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
         [Dependency] private readonly IInputManager _inputManager = default!;
         [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
+        [Dependency] private readonly IRobustRandom _random = default!;
 
         private readonly ISawmill _sawmill = Logger.GetSawmill("opendream.interface");
 
@@ -233,7 +235,7 @@ namespace OpenDreamClient.Interface {
                 BrowsePopup? popup = null;
 
                 if (pBrowse.Window != null) {
-                    htmlFileName = pBrowse.Window;
+                    htmlFileName = $"browse{_random.Next()}"; // TODO: Possible collisions and explicit file names
                     outputBrowser = FindElementWithName(pBrowse.Window) as ControlBrowser;
 
                     if (outputBrowser == null) {


### PR DESCRIPTION
Using the window name can be problematic since that can contain slashes. The DM reference says it generates a unique name anyways.