### PR TITLE
Make `/world.Reboot()` shutdown the server

### DIFF
--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -506,6 +506,7 @@ namespace OpenDreamRuntime.Objects {
         public void LoadJson(DreamCompiledJson json);
         public void SetGlobalNativeProc(NativeProc.HandlerFn func);
         public void SetGlobalNativeProc(Func<AsyncNativeProc.State, Task<DreamValue>> func);
+        public NativeProc CreateNativeProc(DreamPath owningType, NativeProc.HandlerFn func);
         public void SetNativeProc(TreeEntry type, NativeProc.HandlerFn func);
         public void SetNativeProc(TreeEntry type, Func<AsyncNativeProc.State, Task<DreamValue>> func);
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectWorld.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectWorld.cs
@@ -2,6 +2,7 @@
 using System.Net.Sockets;
 using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
+using Robust.Server;
 using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.Network;
@@ -12,6 +13,7 @@ namespace OpenDreamRuntime.Objects.Types;
 public sealed class DreamObjectWorld : DreamObject {
     public override bool ShouldCallNew => false; // Gets called manually later
 
+    [Dependency] private readonly IBaseServer _server = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly INetManager _netManager = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
@@ -72,6 +74,12 @@ public sealed class DreamObjectWorld : DreamObject {
 
             _viewRange = new ViewRange(viewInt);
         }
+    }
+
+    protected override void HandleDeletion() {
+        base.HandleDeletion();
+
+        _server.Shutdown("world was deleted");
     }
 
     protected override bool TryGetVar(string varName, out DreamValue value) {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using OpenDreamRuntime.Objects.Types;
+using Robust.Server;
 
 namespace OpenDreamRuntime.Procs.Native {
     internal static class DreamProcNativeWorld {
@@ -109,6 +110,15 @@ namespace OpenDreamRuntime.Procs.Native {
 
                 return new(dataList);
             }
+        }
+
+        [DreamProc("Reboot")]
+        [DreamProcParameter("reason", Type = DreamValue.DreamValueType.Float)]
+        public static DreamValue NativeProc_Reboot(NativeProc.State state) {
+            var server = IoCManager.Resolve<IBaseServer>();
+
+            server.Shutdown("/world.Reboot() was called but restarting is very broken");
+            return DreamValue.Null;
         }
 
         [DreamProc("SetConfig")]


### PR DESCRIPTION
I tried making this use RT's `IBaseServer.Restart()` method but that led to a lot of exceptions and a broken server. I checked the implementation and was met by this:
```cs
// FIXME: This explodes very violently.
Cleanup();
Start(Options, _logHandlerFactory);
```

So I'm just gonna have this shutdown for now.