### PR TITLE
Define two missing `world` vars

### DIFF
--- a/DMCompiler/DMStandard/Types/World.dm
+++ b/DMCompiler/DMStandard/Types/World.dm
@@ -10,6 +10,7 @@
 
 	var/name = "OpenDream World"
 	var/time
+	var/timezone = 0 as opendream_unimplemented
 	var/timeofday
 	var/realtime
 	var/tick_lag = 1
@@ -54,6 +55,7 @@
 	var/host as opendream_unimplemented
 	var/map_format = TOPDOWN_MAP as opendream_unimplemented
 	var/cache_lifespan = 30 as opendream_unimplemented
+	var/executor as opendream_unimplemented
 
 	proc/Profile(command, type, format)
 		set opendream_unimplemented = TRUE


### PR DESCRIPTION
- defines `timezone`, see #1301 
- defines `executor`, see #1353 

It will not fix or close those issues, but it should not block any code using those from compiling