### PR TITLE
Make `(L[1]).property` dereferences fuzzy

### DIFF
--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -471,6 +471,7 @@ namespace DMCompiler.DM.Visitors {
 
             static bool IsFuzzy(DMExpression expr) {
                 switch (expr) {
+                    case Dereference when expr.Path == null:
                     case ProcCall when expr.Path == null:
                     case New when expr.Path == null:
                     case List:


### PR DESCRIPTION
The expression `(injures[injure]).len` is now treated as `(injures[injure]):len`