### PR TITLE
Fix upward path searches for types

### DIFF
--- a/Content.Tests/DMProject/Tests/Tree/upward_search_path2.dm
+++ b/Content.Tests/DMProject/Tests/Tree/upward_search_path2.dm
@@ -1,0 +1,7 @@
+/datum/a/b/c
+
+/datum/d
+
+/proc/RunTest()
+	ASSERT(/datum/a/b/c.d == /datum/d)
+	ASSERT(/datum.d == /datum/d)

--- a/DMCompiler/DM/DMObjectTree.cs
+++ b/DMCompiler/DM/DMObjectTree.cs
@@ -9,7 +9,7 @@ using OpenDreamShared.Dream.Procs;
 using Robust.Shared.Utility;
 
 namespace DMCompiler.DM {
-    static class DMObjectTree {
+    internal static class DMObjectTree {
         public static List<DMObject> AllObjects = new();
         public static List<DMProc> AllProcs = new();
 
@@ -145,7 +145,7 @@ namespace DMCompiler.DM {
                         return new DreamPath("/proc/" + searchingProcName);
                     }
                 } else if (foundType) { // We're searching for a type
-                    break;
+                    return currentPath.Combine(search);
                 }
 
                 if (currentPath == DreamPath.Root) {


### PR DESCRIPTION
`DMObjectTree.UpwardSearch()` was not returning the correct value if you were searching for a type instead of a proc.