### PR TITLE
Fix potential infinite recursion in `/Logout()`

### DIFF
--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -31,28 +31,28 @@ namespace OpenDreamRuntime {
             get => _mob;
             set {
                 if (_mob != value) {
-                    if (_mob != null) {
-                        _mob.Key = null;
-                        _mob.SpawnProc("Logout");
-                        _mob.Connection = null;
+                    var oldMob = _mob;
+                    _mob = value;
+
+                    if (oldMob != null) {
+                        oldMob.Key = null;
+                        oldMob.SpawnProc("Logout");
+                        oldMob.Connection = null;
                     }
 
                     StatObj = new(value);
-                    if (Eye != null && Eye == Mob) {
+                    if (Eye != null && Eye == oldMob) {
                         Eye = value;
                     }
 
-                    if (value != null) {
+                    if (_mob != null) {
                         // If the mob is already owned by another player, kick them out
-                        if (value.Connection != null)
-                            value.Connection.Mob = null;
+                        if (_mob.Connection != null)
+                            _mob.Connection.Mob = null;
 
-                        _mob = value;
                         _mob.Connection = this;
                         _mob.Key = Session!.Name;
                         _mob.SpawnProc("Login", usr: _mob);
-                    } else {
-                        _mob = null;
                     }
 
                     UpdateAvailableVerbs();
@@ -120,8 +120,11 @@ namespace OpenDreamRuntime {
             if (_mob != null) {
                 // Don't null out the ckey here
                 _mob.SpawnProc("Logout");
-                _mob.Connection = null;
-                _mob = null;
+
+                if (_mob != null) { // Logout() may have removed our mob
+                    _mob.Connection = null;
+                    _mob = null;
+                }
             }
 
             Client.Delete();


### PR DESCRIPTION
Setting the mob or key in `/mob/Logout()` would lead to calling `/mob/Logout()` again.