### PR TITLE
Improve verb panel layout

### DIFF
--- a/OpenDreamClient/Interface/Controls/ControlInfo.cs
+++ b/OpenDreamClient/Interface/Controls/ControlInfo.cs
@@ -144,12 +144,21 @@ internal sealed class StatPanel : InfoPanel {
 
 internal sealed class VerbPanel : InfoPanel {
     [Dependency] private readonly IDreamInterfaceManager _dreamInterface = default!;
-    private readonly GridContainer _grid;
+    private readonly VerbPanelGrid _grid;
 
     public VerbPanel(string name) : base(name) {
-        _grid = new GridContainer { Columns = 4 };
         IoCManager.InjectDependencies(this);
-        AddChild(_grid);
+
+        var scrollContainer = new ScrollContainer {
+            HScrollEnabled = false
+        };
+
+        _grid = new VerbPanelGrid {
+            VerticalAlignment = VAlignment.Top
+        };
+
+        scrollContainer.AddChild(_grid);
+        AddChild(scrollContainer);
     }
 
     public void RefreshVerbs() {
@@ -161,8 +170,8 @@ internal sealed class VerbPanel : InfoPanel {
 
             Button verbButton = new Button() {
                 Margin = new Thickness(2),
-                MinWidth = 100,
-                Text = verbName
+                Text = verbName,
+                TextAlign = Label.AlignMode.Center
             };
 
             verbButton.Label.Margin = new Thickness(6, 0, 6, 2);

--- a/OpenDreamClient/Interface/Controls/VerbPanelGrid.cs
+++ b/OpenDreamClient/Interface/Controls/VerbPanelGrid.cs
@@ -1,0 +1,72 @@
+using Robust.Client.UserInterface;
+
+namespace OpenDreamClient.Interface.Controls;
+
+/// <summary>
+/// The control responsible for sizing & layout of verb panels in INFO controls
+/// Necessary because RT's grid control can't dynamically adjust the amount of columns
+/// </summary>
+public sealed class VerbPanelGrid : Control {
+    private int _columns;
+    private Vector2 _cellSize;
+
+    protected override Vector2 MeasureOverride(Vector2 availableSize) {
+        var largest = Vector2.Zero;
+        int childCount = 0;
+
+        // Measure every child to find the largest one
+        foreach (var child in Children) {
+            child.Measure(availableSize);
+            largest = Vector2.Max(largest, child.DesiredSize);
+
+            childCount++;
+        }
+
+        if (childCount == 0)
+            return Vector2.Zero;
+
+        // Find the maximum amount of columns we can fit in the available space
+        if (float.IsPositiveInfinity(availableSize.X)) {
+            // Just go with 3 if we have infinite horizontal space
+            _columns = 3;
+        } else {
+            _columns = Math.Min(
+                (int)(availableSize.X / largest.X),
+                childCount
+            );
+        }
+
+        // The size of each cell with the given columns
+        _cellSize = largest with {
+            X = availableSize.X / _columns
+        };
+
+        // Amount of rows is the number of children divided by the columns, rounded up
+        int rows = (int)Math.Ceiling((double)childCount / _columns);
+
+        return new Vector2(_cellSize.X * _columns, _cellSize.Y * rows);
+    }
+
+    protected override Vector2 ArrangeOverride(Vector2 finalSize) {
+        Vector2 cellPosition = Vector2.Zero;
+        int currentColumn = 0;
+        int currentRow = 1;
+
+        foreach (var child in Children) {
+            child.Arrange(UIBox2.FromDimensions(cellPosition, _cellSize));
+
+            currentColumn++;
+            if (currentColumn == _columns) {
+                currentColumn = 0;
+                currentRow++;
+
+                cellPosition.X = 0;
+                cellPosition.Y += _cellSize.Y;
+            } else {
+                cellPosition.X += _cellSize.X;
+            }
+        }
+
+        return new Vector2(_cellSize.X * _columns, _cellSize.Y * currentRow);
+    }
+}

--- a/OpenDreamClient/Interface/Controls/VerbPanelGrid.cs
+++ b/OpenDreamClient/Interface/Controls/VerbPanelGrid.cs
@@ -1,4 +1,4 @@
-using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
 
 namespace OpenDreamClient.Interface.Controls;
 
@@ -6,7 +6,7 @@ namespace OpenDreamClient.Interface.Controls;
 /// The control responsible for sizing & layout of verb panels in INFO controls
 /// Necessary because RT's grid control can't dynamically adjust the amount of columns
 /// </summary>
-public sealed class VerbPanelGrid : Control {
+public sealed class VerbPanelGrid : Container {
     private int _columns;
     private Vector2 _cellSize;
 


### PR DESCRIPTION
Verb panels now dynamically adjust the amount of columns depending on the available size. The size of the buttons will stretch horizontally, and they can now be scrolled.

(every proc turned into a verb for demonstration)
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/d5f52bd6-b617-4c18-8410-6231815acbdd)
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/da3f9d03-9926-4e58-8e82-8f3b6a80fea2)

![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/6be459db-f3d4-4cfb-8f06-cdb3f342bca6)
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/2210d558-df64-4910-93a4-8df588042896)
