### PR TITLE
Combine identifiers/numbers during macro expansion

### DIFF
--- a/Content.Tests/DMProject/Tests/Preprocessor/nested_macro_numeric_end.dm
+++ b/Content.Tests/DMProject/Tests/Preprocessor/nested_macro_numeric_end.dm
@@ -1,0 +1,18 @@
+#define APPLY_PREFIX(prefix, ARGS...) _APPLY_PREFIX(prefix, ##ARGS, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+#define _APPLY_PREFIX(prefix, a, b, c, d, e, f, g, h, i, j, ...) _APPLY_PREFIX_##j(prefix, a, b, c, d, e, f, g, h, i, j)
+#define _APPLY_PREFIX_0(prefix, a, b, c, d, e, f, g, h, i, j, ...)
+#define _APPLY_PREFIX_1(prefix, a, b, c, d, e, f, g, h, i, j, ...) prefix##a
+#define _APPLY_PREFIX_2(prefix, a, b, c, d, e, f, g, h, i, j, ...) prefix##a, _APPLY_PREFIX_1(prefix, b, c, d, e, f, g, h, i, j, -1)
+#define TEST_CASE(TYPE, PROCNAME...) var/testlist = list(APPLY_PREFIX(TYPE/, PROCNAME))
+
+TEST_CASE(/obj/critter/domestic_bee, proc/dance, proc/puke_honey)
+
+/obj/critter/domestic_bee
+	proc/dance()
+		return "DANCE"
+
+	proc/puke_honey()
+		return "HONEY"
+
+proc/RunTest()
+	return 0

--- a/DMCompiler/Compiler/DM/DMLexer.cs
+++ b/DMCompiler/Compiler/DM/DMLexer.cs
@@ -284,8 +284,8 @@ namespace DMCompiler.Compiler.DM {
                         case TokenType.DM_Preproc_Identifier: {
                             StringBuilder identifierTextBuilder = new StringBuilder();
 
-                            //An identifier can end up making being made out of multiple tokens
-                            //This is caused by preprocessor macros and escaped identifiers
+                            //An identifier can end up being made out of multiple tokens
+                            //This is caused by escaped identifiers
                             do {
                                 identifierTextBuilder.Append(GetCurrent().Text);
                             } while (ValidIdentifierComponents.Contains(Advance().Type) && !AtEndOfSource);

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -4,13 +4,11 @@ using System.Text;
 using OpenDreamShared.Compiler;
 
 namespace DMCompiler.Compiler.DMPreprocessor {
-
-
     /// <summary>
     /// This class acts as the first layer of digestion for the compiler, <br/>
     /// taking in raw text and outputting vague tokens descriptive enough for the preprocessor to run on them.
     /// </summary>
-    sealed class DMPreprocessorLexer : TextLexer {
+    internal sealed class DMPreprocessorLexer : TextLexer {
         public string IncludeDirectory;
 
         public DMPreprocessorLexer(string includeDirectory, string sourceName, string source) : base(sourceName, source) {


### PR DESCRIPTION
An alternative solution to #1316

Identifier/number tokens are combined during macro expansion instead of doing a search on every identifier token during preprocessing.