### PR TITLE
Blending parity - brings OD's normal alpha blending a lot closer to Byond's

### DIFF
--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -368,6 +368,7 @@ internal sealed class DreamViewOverlay : Overlay {
         blendAndColor = blendAndColor.Duplicate();
         blendAndColor.SetParameter("colorMatrix", colorMatrix.GetMatrix4());
         blendAndColor.SetParameter("offsetVector", colorMatrix.GetOffsetVector());
+        blendAndColor.SetParameter("isPlaneMaster", iconMetaData.IsPlaneMaster);
         return blendAndColor;
     }
 
@@ -502,6 +503,7 @@ internal sealed class DreamViewOverlay : Overlay {
                 ShaderInstance colorShader = _colorInstance.Duplicate();
                 colorShader.SetParameter("colorMatrix", colorMatrix.GetMatrix4());
                 colorShader.SetParameter("offsetVector", colorMatrix.GetOffsetVector());
+                colorShader.SetParameter("isPlaneMaster",iconMetaData.IsPlaneMaster);
                 handle.UseShader(colorShader);
 
                 handle.DrawTextureRect(frame,

--- a/Resources/Shaders/blendoverlay.swsl
+++ b/Resources/Shaders/blendoverlay.swsl
@@ -1,8 +1,8 @@
 light_mode unshaded;
-blend_mode normal;
 
 uniform lowp mat4 colorMatrix;
 uniform lowp vec4 offsetVector; // The final row of the 4x5 matrix it kinda is
+uniform bool isPlaneMaster;
 
 void fragment() {
     highp vec4 oldColor = zToSrgb(zTexture(UV)); // TODO: It'd be easier and more precise if we avoided this color-space conversion.
@@ -26,6 +26,5 @@ void fragment() {
                 oldColor[2] * colorMatrix[3][2] + 
                 oldColor[3] * colorMatrix[3][3];
     COLOR = zFromSrgb(COLOR + offsetVector);
+    COLOR.rgb *= isPlaneMaster ? 1 : COLOR.a;
 }
-
-    

--- a/Resources/Shaders/drop_shadow.swsl
+++ b/Resources/Shaders/drop_shadow.swsl
@@ -25,7 +25,7 @@ void fragment() {
     vec4 final_shadow_color = vec4(shadow_color.rgb, shadow_color.a * sampled_shadow_alpha);
     
     // Mix the shadow with the initial image based on the image's alpha
-    COLOR.rgb = final_shadow_color.rgb * (1 - texture_color.a) + (texture_color.rgb / texture_color.a); //texture color need to be divided by alpha to account for alpha premultiplication in the overlay shader
+    COLOR.rgb = final_shadow_color.rgb * (1 - texture_color.a) + (texture_color.rgb / texture_color.a); //texture color needs to be divided by alpha to account for alpha premultiplication in the overlay shader
     COLOR.a = clamp(sampled_shadow_alpha * final_shadow_color.a + texture_color.a, 0, 1);
     COLOR.rgb *= COLOR.a;
 }

--- a/Resources/Shaders/drop_shadow.swsl
+++ b/Resources/Shaders/drop_shadow.swsl
@@ -25,5 +25,7 @@ void fragment() {
     vec4 final_shadow_color = vec4(shadow_color.rgb, shadow_color.a * sampled_shadow_alpha);
     
     // Mix the shadow with the initial image based on the image's alpha
-    COLOR = final_shadow_color * (1 - texture_color.a) + texture_color * texture_color.a;
+    COLOR.rgb = final_shadow_color.rgb * (1 - texture_color.a) + (texture_color.rgb / texture_color.a); //texture color need to be divided by alpha to account for alpha premultiplication in the overlay shader
+    COLOR.a = clamp(sampled_shadow_alpha * final_shadow_color.a + texture_color.a, 0, 1);
+    COLOR.rgb *= COLOR.a;
 }

--- a/Resources/Shaders/drop_shadow.swsl
+++ b/Resources/Shaders/drop_shadow.swsl
@@ -26,6 +26,6 @@ void fragment() {
     
     // Mix the shadow with the initial image based on the image's alpha
     COLOR.rgb = final_shadow_color.rgb * (1 - texture_color.a) + (texture_color.rgb / texture_color.a); //texture color needs to be divided by alpha to account for alpha premultiplication in the overlay shader
-    COLOR.a = clamp(sampled_shadow_alpha * final_shadow_color.a + texture_color.a, 0, 1);
+    COLOR.a = clamp(final_shadow_color.a + texture_color.a, 0, 1);
     COLOR.rgb *= COLOR.a;
 }


### PR DESCRIPTION
Title! Working on this PR was one hell of a rabbit hole, starting off as a simple investigation of the blending function used in `blendoverlay.swsl`, and eventually escalating towards viciously tearing apart both OD and Byond in Renderdoc to figure out what's going on, and to figure out how to get a bit closer to parity with our relatively limited knowledge of OpenGL (And we've gotta say: DX9 *really* spoiled us). We're genuinely surprised this ultimately ended up being a small PR!

The bulk of this PR's work is making the `blendoverlay.swsl` simply use the default blend mode, as the `normal` blend mode causes particularly funky behavior with alpha blending, most notable being that the transparency of an object ends up bleeding through to whatever it's layered over.

However, that on it's own isn't enough, as simply axing `blend_mode normal;` causes transparency to end up way too bright! So this PR adds an rgb premultiplication pass, which, on it's own, brings alpha blending to a state that's *almost* at perfect parity with Byond. (Additionally, this premultiplication pass is simply not applied to planemasters, as doing so just deepfries the sprites being alpha-blended)

![image](https://github.com/OpenDreamProject/OpenDream/assets/6356337/7376efd2-0d36-45aa-9f7c-d959f736ff04)
(Pictured: the golfing involved in approaching the ballpark of Byond's alpha blending)

Additionally, this PR has to make some changes to the dropshadow shader, as the color blending did some pretty funky stuff to the alpha and color itself!

<details>
<summary>Here's before all of the shader changes</summary>

![image](https://github.com/OpenDreamProject/OpenDream/assets/6356337/98ca2b5b-602d-4564-9559-b73b451b40c8)

</details>

<details>
<summary>And the after. The ultimate result of what this PR looks like in Para.</summary>

![image](https://github.com/OpenDreamProject/OpenDream/assets/6356337/5d5137db-71ad-4ce1-aa6a-37ea7113fe12)

</details>



<details>
<summary>(For the sake of completeness, here's a screenshot of Byond in roughly the same location.)</summary>

![image](https://github.com/OpenDreamProject/OpenDream/assets/6356337/05cc8b71-85af-4826-a856-b17cb1118320)

</details>