### PR TITLE
Implement world.params

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamObjectWorld.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectWorld.cs
@@ -2,13 +2,10 @@
 using System.Net.Sockets;
 using System.Text;
 using System.Web;
-
 using OpenDreamRuntime.Procs.Native;
 using OpenDreamRuntime.Resources;
-
 using OpenDreamShared;
 using OpenDreamShared.Dream;
-
 using Robust.Server;
 using Robust.Shared;
 using Robust.Shared.Configuration;

--- a/OpenDreamRuntime/Objects/Types/DreamObjectWorld.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectWorld.cs
@@ -1,7 +1,5 @@
 ﻿using System.Net;
 using System.Net.Sockets;
-using System.Text;
-using System.Web;
 using OpenDreamRuntime.Procs.Native;
 using OpenDreamRuntime.Resources;
 using OpenDreamShared;
@@ -36,18 +34,7 @@ public sealed class DreamObjectWorld : DreamObject {
         set => _gameTiming.TickRate = (byte)value;
     }
 
-    private DreamList? _paramsCache;
-
-    private DreamList Params {
-        set {
-            _paramsCache = value;
-            _cfg.SetCVar(OpenDreamCVars.WorldParams, DreamProcNativeRoot.list2params(value));
-        }
-        get {
-            _paramsCache ??= DreamProcNativeRoot.params2list(ObjectTree, _cfg.GetCVar(OpenDreamCVars.WorldParams));
-            return _paramsCache;
-        }
-    }
+    private DreamValue Params;
 
     /// <summary> Determines whether we try to show IPv6 or IPv4 to the user during .address and .internet_address queries.</summary>
     private bool DisplayIPv6 {
@@ -92,12 +79,19 @@ public sealed class DreamObjectWorld : DreamObject {
 
             _viewRange = new ViewRange(viewInt);
         }
+
+        var worldParams = _cfg.GetCVar(OpenDreamCVars.WorldParams);
+        Params = worldParams != string.Empty ?
+            new DreamValue(DreamProcNativeRoot.params2list(ObjectTree, worldParams)) :
+            new DreamValue(ObjectTree.CreateList());
     }
+
     protected override void HandleDeletion() {
         base.HandleDeletion();
 
         _server.Shutdown("world was deleted");
     }
+
     protected override bool TryGetVar(string varName, out DreamValue value) {
         switch (varName) {
             case "log":
@@ -105,7 +99,7 @@ public sealed class DreamObjectWorld : DreamObject {
                 return true;
 
             case "params":
-                value = new DreamValue(Params);
+                value = Params;
                 return true;
 
             case "status":
@@ -221,6 +215,7 @@ public sealed class DreamObjectWorld : DreamObject {
                 return base.TryGetVar(varName, out value);
         }
     }
+
     protected override void SetVar(string varName, DreamValue value) {
         switch (varName) {
             // Unimplemented writeable vars
@@ -243,14 +238,7 @@ public sealed class DreamObjectWorld : DreamObject {
                 break;
 
             case "params":
-                if (!value.TryGetValueAsDreamList(out var list))
-                    break;
-                if (list.GetLength() == 0) {
-                    Params.Cut();
-                    _cfg.SetCVar(OpenDreamCVars.WorldParams, "");
-                } else {
-                    Params = list;
-                }
+                Params = value;
                 break;
 
             case "tick_lag":
@@ -278,6 +266,7 @@ public sealed class DreamObjectWorld : DreamObject {
                 throw new Exception($"Cannot set var \"{varName}\" on world");
         }
     }
+
     public override void OperatorOutput(DreamValue b) {
         foreach (DreamConnection connection in DreamManager.Connections) {
             connection.OutputDreamValue(b);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1198,24 +1198,7 @@ namespace OpenDreamRuntime.Procs.Native {
         public static DreamValue NativeProc_list2params(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
             if (!bundle.GetArgument(0, "List").TryGetValueAsDreamList(out DreamList list))
                 return new DreamValue(string.Empty);
-
-            StringBuilder paramBuilder = new StringBuilder();
-
-            List<DreamValue> values = list.GetValues();
-            foreach (DreamValue entry in values) {
-                if (list.ContainsKey(entry)) {
-                    paramBuilder.Append(
-                        $"{HttpUtility.UrlEncode(entry.Stringify())}={HttpUtility.UrlEncode(list.GetValue(entry).Stringify())}");
-                } else {
-                    paramBuilder.Append(HttpUtility.UrlEncode(entry.Stringify()));
-                }
-
-                paramBuilder.Append('&');
-            }
-
-            //Remove trailing &
-            if (paramBuilder.Length > 0) paramBuilder.Remove(paramBuilder.Length - 1, 1);
-            return new DreamValue(paramBuilder.ToString());
+            return new DreamValue(list2params(list));
         }
 
         [DreamProc("log")]
@@ -1668,6 +1651,26 @@ namespace OpenDreamRuntime.Procs.Native {
             }
 
             return new DreamValue(view);
+        }
+
+        public static string list2params(DreamList list) {
+            StringBuilder paramBuilder = new StringBuilder();
+
+            List<DreamValue> values = list.GetValues();
+            foreach (DreamValue entry in values) {
+                if (list.ContainsKey(entry)) {
+                    paramBuilder.Append(
+                        $"{HttpUtility.UrlEncode(entry.Stringify())}={HttpUtility.UrlEncode(list.GetValue(entry).Stringify())}");
+                } else {
+                    paramBuilder.Append(HttpUtility.UrlEncode(entry.Stringify()));
+                }
+
+                paramBuilder.Append('&');
+            }
+
+            //Remove trailing &
+            if (paramBuilder.Length > 0) paramBuilder.Remove(paramBuilder.Length - 1, 1);
+            return paramBuilder.ToString();
         }
 
         public static DreamList params2list(DreamObjectTree objectTree, string queryString) {

--- a/OpenDreamShared/OpenDreamCVars.cs
+++ b/OpenDreamShared/OpenDreamCVars.cs
@@ -18,5 +18,8 @@ namespace OpenDreamShared {
 
         public static readonly CVarDef<bool> SpoofIEUserAgent =
             CVarDef.Create("opendream.spoof_ie_user_agent", true, CVar.CLIENTONLY);
+
+        public static readonly CVarDef<string> WorldParams =
+            CVarDef.Create("opendream.world_params", string.Empty, CVar.SERVERONLY);
     }
 }


### PR DESCRIPTION
Implements reading and writing to world.params.

To add them at ServerLaunch use `--cvar opendream.world_params="a=1;b=2;c=3"`

Closes https://github.com/OpenDreamProject/OpenDream/issues/1360