### PR TITLE
Fix invalid DreamValues in `DreamProc.GetField()`

### DIFF
--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -88,7 +88,7 @@ namespace DMCompiler.DM {
         public string? VerbName;
         public string? VerbCategory = string.Empty;
         public string? VerbDesc;
-        public sbyte? Invisibility;
+        public sbyte Invisibility;
 
         private DMObject _dmObject;
         private DMASTProcDefinition? _astDefinition;

--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -27,16 +27,18 @@ namespace OpenDreamRuntime {
 
         public readonly ProcAttributes Attributes;
 
-        public readonly List<String>? ArgumentNames;
+        public readonly List<string>? ArgumentNames;
 
         public readonly List<DMValueType>? ArgumentTypes;
 
-        public string? VerbName { get; }
-        public string? VerbCategory { get; } = string.Empty;
-        public string? VerbDesc { get; }
-        public sbyte? Invisibility { get; }
+        public string VerbName => _verbName ?? Name;
+        public readonly string? VerbCategory = string.Empty;
+        public readonly sbyte Invisibility;
 
-        protected DreamProc(int id, DreamPath owningType, string name, DreamProc? superProc, ProcAttributes attributes, List<string>? argumentNames, List<DMValueType>? argumentTypes, string? verbName, string? verbCategory, string? verbDesc, sbyte? invisibility, bool isVerb = false) {
+        private readonly string? _verbName;
+        private readonly string? _verbDesc;
+
+        protected DreamProc(int id, DreamPath owningType, string name, DreamProc? superProc, ProcAttributes attributes, List<string>? argumentNames, List<DMValueType>? argumentTypes, string? verbName, string? verbCategory, string? verbDesc, sbyte invisibility, bool isVerb = false) {
             Id = id;
             OwningType = owningType;
             Name = name;
@@ -46,14 +48,14 @@ namespace OpenDreamRuntime {
             ArgumentNames = argumentNames;
             ArgumentTypes = argumentTypes;
 
-            VerbName = verbName;
+            _verbName = verbName;
             if (verbCategory is not null) {
                 // (de)serialization meme to reduce JSON size
                 // It's string.Empty by default but we invert it to null to prevent serialization
                 // Explicit null becomes treated as string.Empty
                 VerbCategory = verbCategory == string.Empty ? null : verbCategory;
             }
-            VerbDesc = verbDesc;
+            _verbDesc = verbDesc;
             Invisibility = invisibility;
         }
 
@@ -73,11 +75,11 @@ namespace OpenDreamRuntime {
                 case "name":
                     return new DreamValue(VerbName);
                 case "category":
-                    return new DreamValue(VerbCategory);
+                    return (VerbCategory != null) ? new DreamValue(VerbCategory) : DreamValue.Null;
                 case "desc":
-                    return new DreamValue(VerbDesc);
+                    return (_verbDesc != null) ? new DreamValue(_verbDesc) : DreamValue.Null;
                 case "invisibility":
-                    return new DreamValue((int)Invisibility);
+                    return new DreamValue(Invisibility);
                 default:
                     throw new Exception($"Cannot get field \"{field}\" from {OwningType.ToString()}.{Name}()");
             }

--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -14,6 +14,7 @@ using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Validation;
 using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 using OpenDreamRuntime.Procs.Native;
+using Robust.Shared.Utility;
 
 namespace OpenDreamRuntime {
     [JsonConverter(typeof(DreamValueJsonConverter))]
@@ -71,6 +72,7 @@ namespace OpenDreamRuntime {
         private readonly float _floatValue;
 
         public DreamValue(string value) {
+            DebugTools.Assert(value != null);
             Type = DreamValueType.String;
             _refValue = value;
         }

--- a/OpenDreamRuntime/Procs/AsyncNativeProc.cs
+++ b/OpenDreamRuntime/Procs/AsyncNativeProc.cs
@@ -170,7 +170,7 @@ namespace OpenDreamRuntime.Procs {
         private readonly Func<State, Task<DreamValue>> _taskFunc;
 
         public AsyncNativeProc(int id, DreamPath owningType, string name, List<string> argumentNames, Dictionary<string, DreamValue> defaultArgumentValues, Func<State, Task<DreamValue>> taskFunc)
-            : base(id, owningType, name, null, ProcAttributes.None, argumentNames, null, null, null, null, null) {
+            : base(id, owningType, name, null, ProcAttributes.None, argumentNames, null, null, null, null, 0) {
             _defaultArgumentValues = defaultArgumentValues;
             _taskFunc = taskFunc;
         }

--- a/OpenDreamRuntime/Procs/NativeProc.cs
+++ b/OpenDreamRuntime/Procs/NativeProc.cs
@@ -82,7 +82,7 @@ public sealed unsafe class NativeProc : DreamProc {
     private readonly delegate*<Bundle, DreamObject?, DreamObject?, DreamValue> _handler;
 
     public NativeProc(int id, DreamPath owningType, string name, List<string> argumentNames, Dictionary<string, DreamValue> defaultArgumentValues, HandlerFn handler, DreamManager dreamManager, AtomManager atomManager, IDreamMapManager mapManager, DreamResourceManager resourceManager, DreamObjectTree objectTree)
-        : base(id, owningType, name, null, ProcAttributes.None, argumentNames, null, null, null, null, null) {
+        : base(id, owningType, name, null, ProcAttributes.None, argumentNames, null, null, null, null, 0) {
         _defaultArgumentValues = defaultArgumentValues;
         _handler = (delegate*<Bundle, DreamObject?, DreamObject?, DreamValue>)handler.Method.MethodHandle.GetFunctionPointer();
 

--- a/OpenDreamShared/Json/DreamProcJson.cs
+++ b/OpenDreamShared/Json/DreamProcJson.cs
@@ -16,7 +16,7 @@ namespace OpenDreamShared.Json {
         public string? VerbName { get; set; }
         public string? VerbCategory { get; set; } = null;
         public string? VerbDesc { get; set; }
-        public sbyte? Invisibility { get; set; }
+        public sbyte Invisibility { get; set; }
     }
 
     public sealed class ProcArgumentJson {


### PR DESCRIPTION
This method would create a string DreamValue with a null if the field didn't have a value.

I added a debug assert in the string constructor so this can be caught closer to the source in the future.