### PR TITLE
Fix `locate()` with a tag surrounded by brackets

### DIFF
--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -290,6 +290,7 @@ namespace OpenDreamRuntime {
 
             // Search for an object with this ref as its tag
             // Note that surrounding [] are stripped out at this point, this is intentional
+            // Doing locate("[abc]") is the same as locate("abc")
             if (Tags.TryGetValue(refString, out var tagList)) {
                 return new DreamValue(tagList.First());
             }

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -233,57 +233,69 @@ namespace OpenDreamRuntime {
         }
 
         public DreamValue LocateRef(string refString) {
-            if (!int.TryParse(refString.Substring(3).TrimEnd(']'), System.Globalization.NumberStyles.HexNumber, null, out var refId)) { //strip "[0x" and "]"
-                // If the ref is not an integer, it may be a tag
-                if (Tags.TryGetValue(refString, out var tagList)) {
-                    return new DreamValue(tagList.First());
-                }
+            bool canBePointer = false;
 
-                return DreamValue.Null;
+            if (refString.StartsWith('[') && refString.EndsWith(']')) {
+                // Strip the surrounding []
+                refString = refString.Substring(1, refString.Length - 2);
+
+                // This ref could possibly be a "pointer" (the hex number made up of an id and an index)
+                canBePointer = refString.StartsWith("0x");
             }
 
-            // The first one/two digits give the type, the last 6 give the index
-            var typeId = (RefType) (refId & 0xFF000000);
-            refId = (refId & 0x00FFFFFF); // The ref minus its ref type prefix
+            if (canBePointer && int.TryParse(refString.Substring(2), System.Globalization.NumberStyles.HexNumber, null, out var refId)) {
+                // The first one/two digits give the type, the last 6 give the index
+                var typeId = (RefType) (refId & 0xFF000000);
+                refId = (refId & 0x00FFFFFF); // The ref minus its ref type prefix
 
-            switch (typeId) {
-                case RefType.Null:
-                    return DreamValue.Null;
-                case RefType.DreamObjectArea:
-                case RefType.DreamObjectClient:
-                case RefType.DreamObjectDatum:
-                case RefType.DreamObjectImage:
-                case RefType.DreamObjectList:
-                case RefType.DreamObjectMob:
-                case RefType.DreamObjectTurf:
-                case RefType.DreamObject:
-                    if (ReferenceIDsToDreamObject.TryGetValue(refId, out var dreamObject))
-                        return new(dreamObject);
-
-                    return DreamValue.Null;
-                case RefType.String:
-                    return _objectTree.Strings.Count > refId
-                        ? new DreamValue(_objectTree.Strings[refId])
-                        : DreamValue.Null;
-                case RefType.DreamType:
-                    return _objectTree.Types.Length > refId
-                        ? new DreamValue(_objectTree.Types[refId])
-                        : DreamValue.Null;
-                case RefType.DreamResource:
-                    if (!_dreamResourceManager.TryLoadResource(refId, out var resource))
+                switch (typeId) {
+                    case RefType.Null:
                         return DreamValue.Null;
+                    case RefType.DreamObjectArea:
+                    case RefType.DreamObjectClient:
+                    case RefType.DreamObjectDatum:
+                    case RefType.DreamObjectImage:
+                    case RefType.DreamObjectList:
+                    case RefType.DreamObjectMob:
+                    case RefType.DreamObjectTurf:
+                    case RefType.DreamObject:
+                        if (ReferenceIDsToDreamObject.TryGetValue(refId, out var dreamObject))
+                            return new(dreamObject);
 
-                    return new DreamValue(resource);
-                case RefType.DreamAppearance:
-                    _appearanceSystem ??= _entitySystemManager.GetEntitySystem<ServerAppearanceSystem>();
-                    return _appearanceSystem.TryGetAppearance((uint)refId, out IconAppearance? appearance)
-                        ? new DreamValue(appearance)
-                        : DreamValue.Null;
-                case RefType.Proc:
-                    return new(_objectTree.Procs[refId]);
-                default:
-                    throw new Exception($"Invalid reference type for ref {refString}");
+                        return DreamValue.Null;
+                    case RefType.String:
+                        return _objectTree.Strings.Count > refId
+                            ? new DreamValue(_objectTree.Strings[refId])
+                            : DreamValue.Null;
+                    case RefType.DreamType:
+                        return _objectTree.Types.Length > refId
+                            ? new DreamValue(_objectTree.Types[refId])
+                            : DreamValue.Null;
+                    case RefType.DreamResource:
+                        if (!_dreamResourceManager.TryLoadResource(refId, out var resource))
+                            return DreamValue.Null;
+
+                        return new DreamValue(resource);
+                    case RefType.DreamAppearance:
+                        _appearanceSystem ??= _entitySystemManager.GetEntitySystem<ServerAppearanceSystem>();
+                        return _appearanceSystem.TryGetAppearance((uint)refId, out IconAppearance? appearance)
+                            ? new DreamValue(appearance)
+                            : DreamValue.Null;
+                    case RefType.Proc:
+                        return new(_objectTree.Procs[refId]);
+                    default:
+                        throw new Exception($"Invalid reference type for ref {refString}");
+                }
             }
+
+            // Search for an object with this ref as its tag
+            // Note that surrounding [] are stripped out at this point, this is intentional
+            if (Tags.TryGetValue(refString, out var tagList)) {
+                return new DreamValue(tagList.First());
+            }
+
+            // Nothing found
+            return DreamValue.Null;
         }
 
         public void HandleException(Exception e) {


### PR DESCRIPTION
Doing `locate("\[abc]")` is no different from doing `locate("abc")`