### PR TITLE
Several rendering fixes

### DIFF
--- a/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
+++ b/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
@@ -102,19 +102,8 @@ namespace OpenDreamClient.Rendering {
                 var protoManager = IoCManager.Resolve<IPrototypeManager>();
 
                 instance = protoManager.Index<ShaderPrototype>(filter.FilterType).InstanceUnique();
-                IRenderTexture renderSourceTexture;
                 switch (filter) {
                     case DreamFilterAlpha alpha:
-                        if(!String.IsNullOrEmpty(alpha.RenderSource) && renderSourceLookup.TryGetValue(alpha.RenderSource, out renderSourceTexture))
-                            instance.SetParameter("mask_texture", renderSourceTexture.Texture);
-                        else if(alpha.Icon != 0){
-                            _dreamResourceManager.LoadResourceAsync<DMIResource>(alpha.Icon, (DMIResource rsc) => {
-                                    instance.SetParameter("mask_texture", rsc.Texture);
-                                });
-                        }
-                        else{
-                            instance.SetParameter("mask_texture", Texture.Transparent);
-                        }
                         instance.SetParameter("x",alpha.X);
                         instance.SetParameter("y",alpha.Y);
                         instance.SetParameter("flags",alpha.Flags);
@@ -134,16 +123,6 @@ namespace OpenDreamClient.Rendering {
                         break;
                     }
                     case DreamFilterDisplace displace:
-                        if(!String.IsNullOrEmpty(displace.RenderSource) && renderSourceLookup.TryGetValue(displace.RenderSource, out renderSourceTexture))
-                            instance.SetParameter("displacement_map", renderSourceTexture.Texture);
-                        else if(displace.Icon != 0){
-                            _dreamResourceManager.LoadResourceAsync<DMIResource>(displace.Icon, (DMIResource rsc) => {
-                                    instance.SetParameter("displacement_map", rsc.Texture);
-                                });
-                        }
-                        else{
-                            instance.SetParameter("displacement_map", Texture.Transparent);
-                        }
                         instance.SetParameter("size", displace.Size);
                         instance.SetParameter("x", displace.X);
                         instance.SetParameter("y", displace.Y);
@@ -175,6 +154,34 @@ namespace OpenDreamClient.Rendering {
                     case DreamFilterGreyscale greyscale:
                         break;
                 }
+            }
+
+            // Texture parameters need reset because different render targets can be used each frame
+            switch (filter) {
+                case DreamFilterAlpha alpha:
+                    if (!string.IsNullOrEmpty(alpha.RenderSource) && renderSourceLookup.TryGetValue(alpha.RenderSource, out var renderSourceTexture))
+                        instance.SetParameter("mask_texture", renderSourceTexture.Texture);
+                    else if (alpha.Icon != 0) {
+                        _dreamResourceManager.LoadResourceAsync<DMIResource>(alpha.Icon, rsc => {
+                            instance.SetParameter("mask_texture", rsc.Texture);
+                        });
+                    } else {
+                        instance.SetParameter("mask_texture", Texture.Transparent);
+                    }
+
+                    break;
+                case DreamFilterDisplace displace:
+                    if (!string.IsNullOrEmpty(displace.RenderSource) && renderSourceLookup.TryGetValue(displace.RenderSource, out renderSourceTexture)) {
+                        instance.SetParameter("displacement_map", renderSourceTexture.Texture);
+                    } else if (displace.Icon != 0) {
+                        _dreamResourceManager.LoadResourceAsync<DMIResource>(displace.Icon, rsc => {
+                            instance.SetParameter("displacement_map", rsc.Texture);
+                        });
+                    } else {
+                        instance.SetParameter("displacement_map", Texture.Transparent);
+                    }
+
+                    break;
             }
 
             filter.Used = true;

--- a/OpenDreamClient/Rendering/DreamPlane.cs
+++ b/OpenDreamClient/Rendering/DreamPlane.cs
@@ -3,20 +3,41 @@
 namespace OpenDreamClient.Rendering;
 
 internal sealed class DreamPlane {
-    public IRenderTexture RenderTarget;
+    public IRenderTexture RenderTarget => _temporaryRenderTarget ?? _mainRenderTarget;
     public RendererMetaData? Master;
 
     public readonly List<Action> IconDrawActions = new();
     public readonly List<Action> MouseMapDrawActions = new();
 
+    private IRenderTexture _mainRenderTarget;
+    private IRenderTexture? _temporaryRenderTarget;
+
     public DreamPlane(IRenderTexture renderTarget) {
-        RenderTarget = renderTarget;
+        _mainRenderTarget = renderTarget;
     }
 
     public void Clear() {
         Master = null;
         IconDrawActions.Clear();
         MouseMapDrawActions.Clear();
+        _temporaryRenderTarget = null;
+    }
+
+    /// <summary>
+    /// Sets this plane's main render target<br/>
+    /// Persists through calls to <see cref="Clear()"/>
+    /// </summary>
+    public void SetMainRenderTarget(IRenderTexture renderTarget) {
+        _mainRenderTarget.Dispose();
+        _mainRenderTarget = renderTarget;
+    }
+
+    /// <summary>
+    /// Sets this plane's render target until the next <see cref="Clear()"/>
+    /// </summary>
+    public void SetTemporaryRenderTarget(IRenderTexture renderTarget) {
+        _temporaryRenderTarget?.Dispose();
+        _temporaryRenderTarget = renderTarget;
     }
 
     /// <summary>
@@ -24,10 +45,18 @@ internal sealed class DreamPlane {
     /// </summary>
     public void Draw(DrawingHandleWorld handle) {
         // Draw all icons
-        handle.RenderInRenderTarget(RenderTarget, () => {
+        handle.RenderInRenderTarget(_mainRenderTarget, () => {
             foreach (Action iconAction in IconDrawActions)
                 iconAction();
         }, new Color());
+
+        if (_temporaryRenderTarget != null) {
+            // Copy it over to the secondary render target if we have one
+            // We don't just render to it in the first place because this will flip it into the correct orientation
+            handle.RenderInRenderTarget(_temporaryRenderTarget, () => {
+                handle.DrawTextureRect(_mainRenderTarget.Texture, new(Vector2.Zero, _mainRenderTarget.Size));
+            }, new Color());
+        }
     }
 
     /// <summary>

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -195,8 +195,8 @@ internal sealed class DreamViewOverlay : Overlay {
                 current.ColorToApply = icon.Appearance.Color;
                 current.ColorMatrixToApply = icon.Appearance.ColorMatrix;
             } else {
-                current.ColorToApply = parentIcon.ColorToApply;
-                current.ColorMatrixToApply = parentIcon.ColorMatrixToApply;
+                current.ColorToApply = parentIcon.ColorToApply * icon.Appearance.Color;
+                ColorMatrix.Multiply(ref parentIcon.ColorMatrixToApply, ref icon.Appearance.ColorMatrix, out current.ColorMatrixToApply);
             }
 
             if ((icon.Appearance.AppearanceFlags & AppearanceFlags.ResetAlpha) != 0 || keepTogether) //RESET_ALPHA
@@ -524,9 +524,9 @@ internal sealed class DreamViewOverlay : Overlay {
             }
 
             if (icon.Appearance?.Filters.Count % 2 == 0) //if we have an even number of filters, we need to flip
-                tmpTranslation = Matrix3.CreateTranslation(-(pixelPosition.X+frame.Size.X/2), -(pixelPosition.Y+frame.Size.Y/2)) * //translate, apply transformation, un-translate
-                                    iconMetaData.TransformToApply * _flipMatrix *
-                                    Matrix3.CreateTranslation((pixelPosition.X+frame.Size.X/2), (pixelPosition.Y+frame.Size.Y/2));
+            tmpTranslation = Matrix3.CreateTranslation(-(pixelPosition.X+frame.Size.X/2), -(pixelPosition.Y+frame.Size.Y/2)) * //translate, apply transformation, un-translate
+                                iconMetaData.TransformToApply * _flipMatrix *
+                                Matrix3.CreateTranslation((pixelPosition.X+frame.Size.X/2), (pixelPosition.Y+frame.Size.Y/2));
 
             //then we return the Action that draws the actual icon with filters applied
             iconDrawAction = () => {
@@ -570,8 +570,7 @@ internal sealed class DreamViewOverlay : Overlay {
             _mouseMapRenderTarget = _clyde.CreateRenderTarget(size, new(RenderTargetColorFormat.Rgba8Srgb));
 
             foreach (var plane in _planes.Values) {
-                plane.RenderTarget.Dispose();
-                plane.RenderTarget = _clyde.CreateRenderTarget(size, new(RenderTargetColorFormat.Rgba8Srgb));
+                plane.SetMainRenderTarget(_clyde.CreateRenderTarget(size, new(RenderTargetColorFormat.Rgba8Srgb)));
             }
         } else {
             // Clear the mouse map lookup dictionary
@@ -624,7 +623,9 @@ internal sealed class DreamViewOverlay : Overlay {
                 }
 
                 if (sprite.IsPlaneMaster) { //if this is also a plane master
+                    sprite.Position = Vector2.Zero; //plane masters should not have a position offset
                     plane.Master = sprite;
+                    plane.SetTemporaryRenderTarget(tmpRenderTarget);
                 } else { //if not a plane master, draw the sprite to the render target
                     //note we don't draw this to the mouse-map because that's handled when the RenderTarget is used as a source later
                     DrawIconNow(handle, tmpRenderTarget, sprite, ((worldAABB.Size/2)-sprite.Position)-new Vector2(0.5f,0.5f), null, true); //draw the sprite centered on the RenderTarget
@@ -633,8 +634,8 @@ internal sealed class DreamViewOverlay : Overlay {
                 //if this is a plane master then we don't render it, we just set it as the plane's master
                 if (sprite.IsPlaneMaster) {
                     sprite.Position = Vector2.Zero; //plane masters should not have a position offset
-
                     plane.Master = sprite;
+
                     continue;
                 }
 
@@ -663,6 +664,10 @@ internal sealed class DreamViewOverlay : Overlay {
                     plane.Draw(handle);
 
                     if (plane.Master != null) {
+                        // Don't draw this to the base render target if it was rendered to another target
+                        if (!string.IsNullOrEmpty(plane.Master.RenderTarget))
+                            continue;
+
                         DrawIconNow(handle, null, plane.Master, Vector2.Zero, plane.RenderTarget.Texture, noMouseMap: true);
                     } else {
                         var renderBox = new Box2(

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -524,9 +524,9 @@ internal sealed class DreamViewOverlay : Overlay {
             }
 
             if (icon.Appearance?.Filters.Count % 2 == 0) //if we have an even number of filters, we need to flip
-            tmpTranslation = Matrix3.CreateTranslation(-(pixelPosition.X+frame.Size.X/2), -(pixelPosition.Y+frame.Size.Y/2)) * //translate, apply transformation, un-translate
-                                iconMetaData.TransformToApply * _flipMatrix *
-                                Matrix3.CreateTranslation((pixelPosition.X+frame.Size.X/2), (pixelPosition.Y+frame.Size.Y/2));
+                tmpTranslation = Matrix3.CreateTranslation(-(pixelPosition.X+frame.Size.X/2), -(pixelPosition.Y+frame.Size.Y/2)) * //translate, apply transformation, un-translate
+                                    iconMetaData.TransformToApply * _flipMatrix *
+                                    Matrix3.CreateTranslation((pixelPosition.X+frame.Size.X/2), (pixelPosition.Y+frame.Size.Y/2));
 
             //then we return the Action that draws the actual icon with filters applied
             iconDrawAction = () => {

--- a/OpenDreamRuntime/Objects/Types/DreamObjectFilter.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectFilter.cs
@@ -25,7 +25,7 @@ public sealed class DreamObjectFilter : DreamObject {
     protected override void SetVar(string varName, DreamValue value) {
         if (FilterAttachedTo.TryGetValue(Filter, out var attachedTo)) {
             int index = attachedTo.GetIndexOfFilter(Filter);
-            Type filterType = GetType();
+            Type filterType = Filter.GetType();
 
             // Create a new mapping with the modified value and replace the DreamFilter with it
             MappingDataNode mapping = (MappingDataNode)SerializationManager.WriteValue(filterType, Filter);

--- a/OpenDreamShared/Dream/ColorMatrix.cs
+++ b/OpenDreamShared/Dream/ColorMatrix.cs
@@ -1,12 +1,9 @@
 ﻿using Robust.Shared.Maths;
-using Robust.Shared.Physics.Dynamics.Joints;
 using Robust.Shared.Serialization;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace OpenDreamShared.Dream;
 /// <summary>
@@ -18,7 +15,6 @@ namespace OpenDreamShared.Dream;
 /// </remarks>
 [Serializable, NetSerializable, StructLayout(LayoutKind.Sequential)]
 public struct ColorMatrix {
-
     public float c11;
     public float c12;
     public float c13;
@@ -263,5 +259,66 @@ public struct ColorMatrix {
                c52 == other.c52 &&
                c53 == other.c53 &&
                c54 == other.c54;
+    }
+
+    /// <summary>
+    /// Multiplies two instances.
+    /// </summary>
+    /// <param name="left">The left operand of the multiplication.</param>
+    /// <param name="right">The right operand of the multiplication.</param>
+    /// <param name="result">A new instance that is the result of the multiplication</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Multiply(ref ColorMatrix left, ref ColorMatrix right, out ColorMatrix result) {
+        float lM11 = left.c11,
+            lM12 = left.c12,
+            lM13 = left.c13,
+            lM14 = left.c14,
+            lM21 = left.c21,
+            lM22 = left.c22,
+            lM23 = left.c23,
+            lM24 = left.c24,
+            lM31 = left.c31,
+            lM32 = left.c32,
+            lM33 = left.c33,
+            lM34 = left.c34,
+            lM41 = left.c41,
+            lM42 = left.c42,
+            lM43 = left.c43,
+            lM44 = left.c44,
+            rM11 = right.c11,
+            rM12 = right.c12,
+            rM13 = right.c13,
+            rM14 = right.c14,
+            rM21 = right.c21,
+            rM22 = right.c22,
+            rM23 = right.c23,
+            rM24 = right.c24,
+            rM31 = right.c31,
+            rM32 = right.c32,
+            rM33 = right.c33,
+            rM34 = right.c34,
+            rM41 = right.c41,
+            rM42 = right.c42,
+            rM43 = right.c43,
+            rM44 = right.c44;
+
+        result = new() {
+            c11 = lM11 * rM11 + lM12 * rM21 + lM13 * rM31 + lM14 * rM41,
+            c12 = lM11 * rM12 + lM12 * rM22 + lM13 * rM32 + lM14 * rM42,
+            c13 = lM11 * rM13 + lM12 * rM23 + lM13 * rM33 + lM14 * rM43,
+            c14 = lM11 * rM14 + lM12 * rM24 + lM13 * rM34 + lM14 * rM44,
+            c21 = lM21 * rM11 + lM22 * rM21 + lM23 * rM31 + lM24 * rM41,
+            c22 = lM21 * rM12 + lM22 * rM22 + lM23 * rM32 + lM24 * rM42,
+            c23 = lM21 * rM13 + lM22 * rM23 + lM23 * rM33 + lM24 * rM43,
+            c24 = lM21 * rM14 + lM22 * rM24 + lM23 * rM34 + lM24 * rM44,
+            c31 = lM31 * rM11 + lM32 * rM21 + lM33 * rM31 + lM34 * rM41,
+            c32 = lM31 * rM12 + lM32 * rM22 + lM33 * rM32 + lM34 * rM42,
+            c33 = lM31 * rM13 + lM32 * rM23 + lM33 * rM33 + lM34 * rM43,
+            c34 = lM31 * rM14 + lM32 * rM24 + lM33 * rM34 + lM34 * rM44,
+            c41 = lM41 * rM11 + lM42 * rM21 + lM43 * rM31 + lM44 * rM41,
+            c42 = lM41 * rM12 + lM42 * rM22 + lM43 * rM32 + lM44 * rM42,
+            c43 = lM41 * rM13 + lM42 * rM23 + lM43 * rM33 + lM44 * rM43,
+            c44 = lM41 * rM14 + lM42 * rM24 + lM43 * rM34 + lM44 * rM44
+        };
     }
 }

--- a/OpenDreamShared/Dream/DreamFilter.cs
+++ b/OpenDreamShared/Dream/DreamFilter.cs
@@ -1,7 +1,6 @@
 using Robust.Shared.Serialization;
 using Robust.Shared.ViewVariables;
 using System;
-using JetBrains.Annotations;
 using Robust.Shared.Maths;
 using Robust.Shared.Serialization.Manager.Attributes;
 

--- a/Resources/Shaders/alpha.swsl
+++ b/Resources/Shaders/alpha.swsl
@@ -23,12 +23,16 @@ void fragment() {
         ratio = input_size/mask_size;
         new_color = zTexture(UV);   
         mask_color = texture(mask_texture, (-ratio/2.0+0.5)+UV*ratio);
-    }  
+    }
+    
+    // The mask is the average of RGB multiplied by A
+    // Haven't actually tested this in BYOND, but it does give us behavior seen in SS13
+    highp float mask = (mask_color.r + mask_color.g + mask_color.b) / 3 * mask_color.a;
 
     if(mask_invert_flag){
-        new_color.a *= 1.0-mask_color.a;
+        new_color.a *= 1.0-mask;
     } else {
-        new_color.a *= mask_color.a;
+        new_color.a *= mask;
     }
 
     COLOR = new_color;


### PR DESCRIPTION
* Fix plane masters with a `render_target` value (actually render to the render target instead of ignoring it)
* Ignore positional offsets when rendering plane masters with a `render_target`
* Fix `/dm_filter` var setting
* Reset the texture shader parameters each frame since different render targets can be used between frames
* Make the alpha filter use the average of RGB multiplied by A instead of just A
* Mix an overlay's color with their parent if it doesn't have `RESET_COLOR`

Achieves working emissives in Paradise, and fixes rendering bugs in others

![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/f313825f-069d-43bd-8c7d-122be7ce2dd8)
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/9cd7ec11-6186-4c74-81f8-f3c9008f5c02)