### PR TITLE
Revert "Add Topic/Export capabilities (#1382)"

### DIFF
--- a/DMCompiler/DMStandard/Types/World.dm
+++ b/DMCompiler/DMStandard/Types/World.dm
@@ -82,6 +82,7 @@
 	proc/Import()
 		set opendream_unimplemented = TRUE
 	proc/Topic(T,Addr,Master,Keys)
+		set opendream_unimplemented = TRUE
 
 	proc/SetScores()
 		set opendream_unimplemented = TRUE

--- a/OpenDreamRuntime/DreamManager.Connections.cs
+++ b/OpenDreamRuntime/DreamManager.Connections.cs
@@ -1,9 +1,3 @@
-using System.Linq;
-using System.Net;
-using System.Net.Sockets;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using OpenDreamShared.Network.Messages;
 using Robust.Server.Player;
 using Robust.Shared.Enums;
@@ -11,20 +5,11 @@ using Robust.Shared.Network;
 
 namespace OpenDreamRuntime {
     public sealed partial class DreamManager {
-        public static readonly byte[] ByondTopicHeaderRaw = { 0x00, 0x83 };
-
-        public static readonly byte[] ByondTopicHeaderEncrypted = { 0x00, 0x15 };
-
         [Dependency] private readonly IServerNetManager _netManager = default!;
 
-        private readonly Dictionary<NetUserId, DreamConnection> _connections = new Dictionary<NetUserId, DreamConnection>();
+        private readonly Dictionary<NetUserId, DreamConnection> _connections = new();
 
         public IEnumerable<DreamConnection> Connections => _connections.Values;
-
-        private Socket? _worldTopicSocket;
-
-        private Task? _worldTopicListener;
-        private CancellationTokenSource? _worldTopicCancellationToken;
 
         private void InitializeConnectionManager() {
             _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
@@ -47,121 +32,6 @@ namespace OpenDreamRuntime {
             _netManager.RegisterNetMessage<MsgLoadInterface>();
             _netManager.RegisterNetMessage<MsgAckLoadInterface>(RxAckLoadInterface);
             _netManager.RegisterNetMessage<MsgSound>();
-
-            var worldTopicAddress = new IPEndPoint(IPAddress.Loopback, _netManager.Port);
-            _sawmill.Debug($"Binding World Topic at {worldTopicAddress}");
-            _worldTopicSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp) {
-                ReceiveTimeout = 5000,
-                SendTimeout = 5000,
-                ExclusiveAddressUse = false,
-            };
-            _worldTopicSocket.Bind(worldTopicAddress);
-            _worldTopicSocket.Listen();
-            _worldTopicCancellationToken = new CancellationTokenSource();
-            _worldTopicListener = WorldTopicListener(_worldTopicCancellationToken.Token);
-        }
-
-        private void ShutdownConnectionManager() {
-            _worldTopicSocket!.Dispose();
-            _worldTopicCancellationToken!.Cancel();
-        }
-
-        private async Task ConsumeAndHandleWorldTopicSocket(Socket remote, CancellationToken cancellationToken) {
-            try {
-                async Task<string?> ParseByondTopic(Socket from) {
-                    var buffer = new byte[2];
-                    await from.ReceiveAsync(buffer, cancellationToken);
-                    if (!buffer.SequenceEqual(ByondTopicHeaderRaw)) {
-                        if (buffer.SequenceEqual(ByondTopicHeaderEncrypted))
-                            _sawmill.Warning("Encrypted World Topic request is not implemented.");
-                        return null;
-                    }
-
-                    await from.ReceiveAsync(buffer, cancellationToken);
-                    if (BitConverter.IsLittleEndian)
-                        buffer = buffer.Reverse().ToArray();
-                    var length = BitConverter.ToUInt16(buffer);
-
-                    buffer = new byte[length];
-                    var read = await from.ReceiveAsync(buffer, cancellationToken);
-                    if (read != buffer.Length) {
-                        _sawmill.Warning("failed to parse byond topic due to insufficient data read");
-                        return null;
-                    }
-
-                    return Encoding.ASCII.GetString(buffer[5..^1]);
-                }
-
-                var topic = await ParseByondTopic(remote);
-                if (topic is null) {
-                    return;
-                }
-                var remoteAddress = (remote.RemoteEndPoint as IPEndPoint)!.Address.ToString();
-                _sawmill.Debug($"World Topic: '{remoteAddress}' -> '{topic}'");
-                var topicResponse = WorldInstance.SpawnProc("Topic", null, new DreamValue(topic), new DreamValue(remoteAddress));
-                if (topicResponse.IsNull) {
-                    return;
-                }
-
-                byte[] responseData;
-                byte responseType;
-                switch (topicResponse.Type) {
-                    case DreamValue.DreamValueType.Float:
-                        responseType = 0x2a;
-                        responseData = BitConverter.GetBytes(topicResponse.MustGetValueAsFloat());
-                        if (BitConverter.IsLittleEndian)
-                            responseData = responseData.Reverse().ToArray();
-                        break;
-
-                    case DreamValue.DreamValueType.String:
-                        responseType = 0x06;
-                        responseData = Encoding.ASCII.GetBytes(topicResponse.MustGetValueAsString().Replace("\0", "")).Append((byte)0x00).ToArray();
-                        break;
-
-                    case DreamValue.DreamValueType.DreamResource:
-                    case DreamValue.DreamValueType.DreamObject:
-                    case DreamValue.DreamValueType.DreamType:
-                    case DreamValue.DreamValueType.DreamProc:
-                    case DreamValue.DreamValueType.Appearance:
-                    case DreamValue.DreamValueType.ProcStub:
-                    case DreamValue.DreamValueType.VerbStub:
-                    default:
-                        _sawmill.Warning($"Unimplemented /world/Topic response type: {topicResponse.Type}");
-                        return;
-                }
-
-                var totalLength = (ushort)(responseData.Length + 1);
-                var lengthData = BitConverter.GetBytes(totalLength);
-                if (BitConverter.IsLittleEndian)
-                    lengthData = lengthData.Reverse().ToArray();
-
-                var responseBuffer = new List<byte>(ByondTopicHeaderRaw);
-                responseBuffer.AddRange(lengthData);
-                responseBuffer.Add(responseType);
-                responseBuffer.AddRange(responseData);
-                var responseActual = responseBuffer.ToArray();
-
-                var sent = await remote.SendAsync(responseActual, cancellationToken);
-                if (sent != responseActual.Length)
-                    _sawmill.Warning("Failed to reply to /world/Topic: response buffer not fully sent");
-
-            }
-            finally {
-                await remote.DisconnectAsync(false, cancellationToken);
-            }
-        }
-
-        private async Task WorldTopicListener(CancellationToken cancellationToken) {
-            if (_worldTopicSocket is null)
-                throw new InvalidOperationException("Attempted to start the World Topic Listener without a valid socket bind address.");
-
-            while (!cancellationToken.IsCancellationRequested) {
-                var pending = await _worldTopicSocket.AcceptAsync(cancellationToken);
-                _ = ConsumeAndHandleWorldTopicSocket(pending, cancellationToken);
-            }
-
-            _worldTopicSocket!.Dispose();
-            _worldTopicSocket = null!;
         }
 
         private void RxSelectStatPanel(MsgSelectStatPanel message) {
@@ -202,7 +72,6 @@ namespace OpenDreamRuntime {
 
                     e.Session.ConnectedClient.SendMessage(msgLoadInterface);
                     break;
-
                 case SessionStatus.InGame: {
                     if (!_connections.TryGetValue(e.Session.UserId, out var connection)) {
                         connection = new DreamConnection();
@@ -213,7 +82,6 @@ namespace OpenDreamRuntime {
                     connection.HandleConnection(e.Session);
                     break;
                 }
-
                 case SessionStatus.Disconnected: {
                     if (_connections.TryGetValue(e.Session.UserId, out var connection))
                         connection.HandleDisconnection();

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -84,9 +84,6 @@ namespace OpenDreamRuntime {
         }
 
         public void Shutdown() {
-            // TODO: Respect not calling parent and aborting shutdown
-            WorldInstance.Delete();
-            ShutdownConnectionManager();
             Initialized = false;
         }
 

--- a/OpenDreamRuntime/OpenDreamRuntime.csproj
+++ b/OpenDreamRuntime/OpenDreamRuntime.csproj
@@ -12,9 +12,6 @@
     <ProjectReference Include="..\OpenDreamShared\OpenDreamShared.csproj" />
     <ProjectReference Include="..\RobustToolbox\Robust.Server\Robust.Server.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Byond.TopicSender" Version="7.0.1" />
-  </ItemGroup>
 
   <Import Project="..\RobustToolbox\MSBuild\Robust.Properties.targets" />
   <Import Project="..\RobustToolbox\MSBuild\Robust.Analyzers.targets" />

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
@@ -1,8 +1,6 @@
-﻿using System.IO;
-using System.Linq;
+﻿using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Byond.TopicSender;
 using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Objects.Types;
 using Robust.Server;
@@ -20,36 +18,8 @@ namespace OpenDreamRuntime.Procs.Native {
             if (!Uri.TryCreate(addr, UriKind.RelativeOrAbsolute, out var uri))
                 throw new ArgumentException("Unable to parse URI.");
 
-            if (uri.Scheme is not ("http" or "https" or "byond"))
-                throw new NotSupportedException($"Unknown scheme for world.Export: '{uri.Scheme}'");
-
-            if (uri.Scheme is "byond") {
-                var tenSecondTimeout = TimeSpan.FromSeconds(10);
-                var topicClient = new TopicClient(new SocketParameters {
-                    ConnectTimeout = tenSecondTimeout,
-                    DisconnectTimeout = tenSecondTimeout,
-                    ReceiveTimeout = tenSecondTimeout,
-                    SendTimeout = tenSecondTimeout,
-                });
-
-                var topicResponse = await topicClient.SendTopic(uri.Host, uri.Query[1..], Convert.ToUInt16(uri.Port));
-                switch (topicResponse.ResponseType) {
-                    case TopicResponseType.FloatResponse:
-                        return new DreamValue(topicResponse.FloatData!.Value);
-
-                    case TopicResponseType.StringResponse:
-                        return new DreamValue(topicResponse.StringData!);
-
-                    case TopicResponseType.UnknownResponse:
-                        var byteList = state.ObjectTree.CreateList();
-                        foreach (var @byte in topicResponse.RawData)
-                            byteList.AddValue(new DreamValue(@byte));
-                        return new DreamValue(byteList);
-
-                    default:
-                        throw new IOException($"Topic returned an unknown response type: '{topicResponse.ResponseType}'");
-                }
-            }
+            if (uri.Scheme is not ("http" or "https"))
+                throw new NotSupportedException("non-HTTP world.Export is not supported.");
 
             // TODO: Maybe cache HttpClient.
             var client = new HttpClient();


### PR DESCRIPTION
This reverts commit 97c6f5225f1463159a36f577563622920026383a, which causes a fatal bug when running OpenDreamServer on Linux "[FATL] unhandled: SpaceWizards.HttpListener.HttpListenerException (98): Address already in use" in spite of no port being actually used.

(I don't know how to GitHub)