### PR TITLE
Misc DMF Parsing Fixes

### DIFF
--- a/OpenDreamClient/Interface/Controls/ControlChild.cs
+++ b/OpenDreamClient/Interface/Controls/ControlChild.cs
@@ -31,19 +31,25 @@ internal sealed class ControlChild : InterfaceControl {
         if (_rightElement != null) _grid.Children.Remove(_rightElement.UIElement);
 
         if (!string.IsNullOrEmpty(controlDescriptor.Left)) {
-            _leftElement = _dreamInterface.Windows[controlDescriptor.Left];
-            _leftElement.UIElement.HorizontalExpand = true;
-            _leftElement.UIElement.VerticalExpand = true;
-            _grid.Children.Add(_leftElement.UIElement);
+            if(!_dreamInterface.Windows.TryGetValue(controlDescriptor.Left, out _leftElement)){
+                Logger.Error($"Invalid ID given for {controlDescriptor.Name}.LEFT: {controlDescriptor.Left}");
+            } else {
+                _leftElement.UIElement.HorizontalExpand = true;
+                _leftElement.UIElement.VerticalExpand = true;
+                _grid.Children.Add(_leftElement.UIElement);
+            }
         } else {
             _leftElement = null;
         }
 
         if (!string.IsNullOrEmpty(controlDescriptor.Right)) {
-            _rightElement = _dreamInterface.Windows[controlDescriptor.Right];
-            _rightElement.UIElement.HorizontalExpand = true;
-            _rightElement.UIElement.VerticalExpand = true;
-            _grid.Children.Add(_rightElement.UIElement);
+            if(!_dreamInterface.Windows.TryGetValue(controlDescriptor.Right, out _rightElement)){
+                Logger.Error($"Invalid ID given for {controlDescriptor.Name}.RIGHT: {controlDescriptor.Right}");
+            } else {
+                _rightElement.UIElement.HorizontalExpand = true;
+                _rightElement.UIElement.VerticalExpand = true;
+                _grid.Children.Add(_rightElement.UIElement);
+            }
         } else {
             _rightElement = null;
         }

--- a/OpenDreamClient/Interface/Descriptors/ControlDescriptors.cs
+++ b/OpenDreamClient/Interface/Descriptors/ControlDescriptors.cs
@@ -98,7 +98,7 @@ public sealed class WindowDescriptor : ControlDescriptor {
     }
 
     public WindowDescriptor WithVisible(ISerializationManager serializationManager, bool visible) {
-        WindowDescriptor copy = (WindowDescriptor)CreateCopy(serializationManager, Name);
+        WindowDescriptor copy = (WindowDescriptor)CreateCopy(serializationManager, Id);
 
         copy.IsVisible = visible;
         return copy;

--- a/OpenDreamClient/Interface/Descriptors/InterfaceDescriptor.cs
+++ b/OpenDreamClient/Interface/Descriptors/InterfaceDescriptor.cs
@@ -33,7 +33,7 @@ public class ElementDescriptor {
     protected string? _name;
 
     public string Id {
-        get => _id;
+        get => string.IsNullOrEmpty(_id) ? _id = Guid.NewGuid().ToString() : _id; //ensure unique ID for all elements. Empty ID elements aren't addressible anyway.
         init => _id = value;
     }
 

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -222,7 +222,7 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
 
         ShowPrompt(prompt);
     }
-  
+
     private void RxBrowse(MsgBrowse pBrowse) {
         if (pBrowse.HtmlSource == null && pBrowse.Window != null) {
             //Closing a popup
@@ -560,7 +560,7 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
             case WindowDescriptor windowDescriptor:
                 ControlWindow window = new ControlWindow(windowDescriptor);
 
-                Windows.Add(windowDescriptor.Name, window);
+                Windows.Add(windowDescriptor.Id, window);
                 if (window.IsDefault) {
                     DefaultWindow = window;
                 }


### PR DESCRIPTION
Squashes some errors in DMF parsing for goonstation.

Major stumbling block remains `on-show` not being implemented.

Things fixed:
- bad ID in Left/Right on a Splitter would cause a dict key miss, now just prints an error.
- Accidentally using name instead of ID as a window key in `WithVisible()` was causing wincloned windows to duplicate ID
- Elements with empty IDs now get a random GUID instead. Not a perfect solution, but the chance of collision is miniscule.