### PR TITLE
Minimal `winget()` implementation

### DIFF
--- a/DMCompiler/DMStandard/UnsortedAdditions.dm
+++ b/DMCompiler/DMStandard/UnsortedAdditions.dm
@@ -42,8 +42,6 @@ proc/missile(Type, Start, End)
 	set opendream_unimplemented = TRUE
 /proc/walk_rand(Ref,Lag=0,Speed=0)
 	set opendream_unimplemented = TRUE
-/proc/winget(player, control_id, params)
-	set opendream_unimplemented = TRUE
 
 /database
 	parent_type = /datum

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -119,6 +119,7 @@ proc/walk(Ref, Dir, Lag = 0, Speed = 0)
 proc/walk_to(Ref, Trg, Min = 0, Lag = 0, Speed = 0)
 proc/winclone(player, window_name, clone_name)
 proc/winexists(player, control_id)
+proc/winget(player, control_id, params)
 proc/winset(player, control_id, params)
 
 #include "Defines.dm"

--- a/OpenDream.sln.DotSettings
+++ b/OpenDream.sln.DotSettings
@@ -22,7 +22,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fcopy/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=flist/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hwmode/@EntryIndexedValue">True</s:Boolean>
-	
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=isarea/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=isfile/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=isinf/@EntryIndexedValue">True</s:Boolean>

--- a/OpenDream.sln.DotSettings
+++ b/OpenDream.sln.DotSettings
@@ -58,5 +58,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=waitfor/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=winclone/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=winexists/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=winget/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=winset/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=xform/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/OpenDream.sln.DotSettings
+++ b/OpenDream.sln.DotSettings
@@ -21,6 +21,8 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=deciseconds/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fcopy/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=flist/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=hwmode/@EntryIndexedValue">True</s:Boolean>
+	
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=isarea/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=isfile/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=isinf/@EntryIndexedValue">True</s:Boolean>

--- a/OpenDreamClient/Interface/Controls/ControlChild.cs
+++ b/OpenDreamClient/Interface/Controls/ControlChild.cs
@@ -33,35 +33,35 @@ internal sealed class ControlChild : InterfaceControl {
             ? rightWindow.UIElement
             : null;
 
-        if (newLeftElement != _leftElement) {
+        if (newLeftElement != _leftElement || _grid.ChildCount == 0) {
             if (_leftElement != null)
                 _grid.Children.Remove(_leftElement);
 
             if (newLeftElement != null) {
                 _leftElement = newLeftElement;
-                _leftElement.HorizontalExpand = true;
-                _leftElement.VerticalExpand = true;
             } else {
                 // SplitContainer will have a size of 0x0 if there aren't 2 controls
                 _leftElement = new Control();
             }
 
+            _leftElement.HorizontalExpand = true;
+            _leftElement.VerticalExpand = true;
             _grid.Children.Add(_leftElement);
         }
 
-        if (newRightElement != _rightElement) {
+        if (newRightElement != _rightElement || _grid.ChildCount == 1) {
             if (_rightElement != null)
                 _grid.Children.Remove(_rightElement);
 
             if (newRightElement != null) {
                 _rightElement = newRightElement;
-                _rightElement.HorizontalExpand = true;
-                _rightElement.VerticalExpand = true;
             } else {
                 // SplitContainer will have a size of 0x0 if there aren't 2 controls
                 _rightElement = new Control();
             }
 
+            _rightElement.HorizontalExpand = true;
+            _rightElement.VerticalExpand = true;
             _grid.Children.Add(_rightElement);
         }
 

--- a/OpenDreamClient/Interface/Controls/ControlChild.cs
+++ b/OpenDreamClient/Interface/Controls/ControlChild.cs
@@ -10,11 +10,12 @@ internal sealed class ControlChild : InterfaceControl {
 
     [Dependency] private readonly IDreamInterfaceManager _dreamInterface = default!;
 
-    private SplitContainer _grid;
-    private ControlWindow? _leftElement, _rightElement;
+    private ControlDescriptorChild ChildDescriptor => (ControlDescriptorChild)ElementDescriptor;
 
-    public ControlChild(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor, window) {
-    }
+    private SplitContainer _grid;
+    private Control? _leftElement, _rightElement;
+
+    public ControlChild(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor, window) { }
 
     protected override Control CreateUIElement() {
         _grid = new SplitContainer();
@@ -25,40 +26,63 @@ internal sealed class ControlChild : InterfaceControl {
     protected override void UpdateElementDescriptor() {
         base.UpdateElementDescriptor();
 
-        ControlDescriptorChild controlDescriptor = (ControlDescriptorChild)ElementDescriptor;
+        var newLeftElement = !string.IsNullOrEmpty(ChildDescriptor.Left)
+            ? _dreamInterface.Windows[ChildDescriptor.Left].UIElement
+            : null;
+        var newRightElement = !string.IsNullOrEmpty(ChildDescriptor.Right)
+            ? _dreamInterface.Windows[ChildDescriptor.Right].UIElement
+            : null;
 
-        if (_leftElement != null) _grid.Children.Remove(_leftElement.UIElement);
-        if (_rightElement != null) _grid.Children.Remove(_rightElement.UIElement);
+        if (newLeftElement != _leftElement) {
+            if (_leftElement != null)
+                _grid.Children.Remove(_leftElement);
 
-        if (!string.IsNullOrEmpty(controlDescriptor.Left)) {
-            _leftElement = _dreamInterface.Windows[controlDescriptor.Left];
-            _leftElement.UIElement.HorizontalExpand = true;
-            _leftElement.UIElement.VerticalExpand = true;
-            _grid.Children.Add(_leftElement.UIElement);
-        } else {
-            _leftElement = null;
+            if (newLeftElement != null) {
+                _leftElement = newLeftElement;
+                _leftElement.HorizontalExpand = true;
+                _leftElement.VerticalExpand = true;
+            } else {
+                // SplitContainer will have a size of 0x0 if there aren't 2 controls
+                _leftElement = new Control();
+            }
+
+            _grid.Children.Add(_leftElement);
         }
 
-        if (!string.IsNullOrEmpty(controlDescriptor.Right)) {
-            _rightElement = _dreamInterface.Windows[controlDescriptor.Right];
-            _rightElement.UIElement.HorizontalExpand = true;
-            _rightElement.UIElement.VerticalExpand = true;
-            _grid.Children.Add(_rightElement.UIElement);
-        } else {
-            _rightElement = null;
+        if (newRightElement != _rightElement) {
+            if (_rightElement != null)
+                _grid.Children.Remove(_rightElement);
+
+            if (newRightElement != null) {
+                _rightElement = newRightElement;
+                _rightElement.HorizontalExpand = true;
+                _rightElement.VerticalExpand = true;
+            } else {
+                // SplitContainer will have a size of 0x0 if there aren't 2 controls
+                _rightElement = new Control();
+            }
+
+            _grid.Children.Add(_rightElement);
         }
 
-        UpdateGrid(controlDescriptor.IsVert);
+        UpdateGrid();
     }
 
     public override void Shutdown() {
-        _leftElement?.Shutdown();
-        _rightElement?.Shutdown();
+        if (ChildDescriptor.Left != null && _dreamInterface.Windows.TryGetValue(ChildDescriptor.Left, out var left))
+            left.Shutdown();
+        if (ChildDescriptor.Right != null && _dreamInterface.Windows.TryGetValue(ChildDescriptor.Right, out var right))
+            right.Shutdown();
     }
 
-    private void UpdateGrid(bool isVert) {
-        _grid.Orientation = isVert
+    private void UpdateGrid() {
+        _grid.Orientation = ChildDescriptor.IsVert
             ? SplitContainer.SplitOrientation.Horizontal
             : SplitContainer.SplitOrientation.Vertical;
+
+        if (_grid.Size == Vector2.Zero)
+            return;
+
+        _grid.SplitFraction = ChildDescriptor.Splitter / 100f;
     }
 }

--- a/OpenDreamClient/Interface/Controls/ControlChild.cs
+++ b/OpenDreamClient/Interface/Controls/ControlChild.cs
@@ -26,10 +26,10 @@ internal sealed class ControlChild : InterfaceControl {
     protected override void UpdateElementDescriptor() {
         base.UpdateElementDescriptor();
 
-        var newLeftElement = !_dreamInterface.Windows.TryGetValue(ChildDescriptor.Left, out var leftWindow)
+        var newLeftElement = ChildDescriptor.Left != null && _dreamInterface.Windows.TryGetValue(ChildDescriptor.Left, out var leftWindow)
             ? leftWindow.UIElement
             : null;
-        var newRightElement = !_dreamInterface.Windows.TryGetValue(ChildDescriptor.Right, out var rightWindow)
+        var newRightElement = ChildDescriptor.Right != null && _dreamInterface.Windows.TryGetValue(ChildDescriptor.Right, out var rightWindow)
             ? rightWindow.UIElement
             : null;
 

--- a/OpenDreamClient/Interface/Controls/InterfaceControl.cs
+++ b/OpenDreamClient/Interface/Controls/InterfaceControl.cs
@@ -60,6 +60,19 @@ public abstract class InterfaceControl : InterfaceElement {
         //UIControl.IsEnabled = !_controlDescriptor.IsDisabled;
     }
 
+    public override bool TryGetProperty(string property, out string value) {
+        switch (property) {
+            case "size":
+                value = $"{UIElement.Size.X}x{UIElement.Size.Y}";
+                return true;
+            case "is-disabled":
+                value = ControlDescriptor.IsDisabled.ToString();
+                return true;
+            default:
+                return base.TryGetProperty(property, out value);
+        }
+    }
+
     public virtual void Output(string value, string? data) {
 
     }

--- a/OpenDreamClient/Interface/Descriptors/ControlDescriptors.cs
+++ b/OpenDreamClient/Interface/Descriptors/ControlDescriptors.cs
@@ -112,6 +112,8 @@ public sealed class ControlDescriptorChild : ControlDescriptor {
     public string? Right;
     [DataField("is-vert")]
     public bool IsVert;
+    [DataField("splitter")]
+    public float Splitter = 50f;
 }
 
 public sealed class ControlDescriptorInput : ControlDescriptor {

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Text;
 using OpenDreamShared.Compiler;
 using OpenDreamShared.Dream.Procs;
 using OpenDreamShared.Network.Messages;
@@ -42,6 +43,7 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
     [Dependency] private readonly IInputManager _inputManager = default!;
     [Dependency] private readonly IUserInterfaceManager _uiManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly ITimerManager _timerManager = default!;
 
     private readonly ISawmill _sawmill = Logger.GetSawmill("opendream.interface");
 
@@ -122,6 +124,7 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
         _netManager.RegisterNetMessage<MsgWinSet>(RxWinSet);
         _netManager.RegisterNetMessage<MsgWinClone>(RxWinClone);
         _netManager.RegisterNetMessage<MsgWinExists>(RxWinExists);
+        _netManager.RegisterNetMessage<MsgWinGet>(RxWinGet);
         _netManager.RegisterNetMessage<MsgFtp>(RxFtp);
         _netManager.RegisterNetMessage<MsgLoadInterface>(RxLoadInterface);
         _netManager.RegisterNetMessage<MsgAckLoadInterface>();
@@ -279,6 +282,19 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
         };
 
         _netManager.ClientSendMessage(response);
+    }
+
+    private void RxWinGet(MsgWinGet message) {
+        // Run this later to ensure any pending UI measurements have occured
+        _timerManager.AddTimer(new Timer(100, false, () => {
+            MsgPromptResponse response = new() {
+                PromptId = message.PromptId,
+                Type = DMValueType.Text,
+                Value = WinGet(message.ControlId, message.QueryValue)
+            };
+
+            _netManager.ClientSendMessage(response);
+        }));
     }
 
     private void RxFtp(MsgFtp message) {
@@ -470,6 +486,47 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
                 _sawmill.Error($"Invalid element \"{controlId}\"");
             }
         }
+    }
+
+    public string WinGet(string controlId, string queryValue) {
+        string GetProperty(string elementId) {
+            var element = FindElementWithId(elementId);
+            if (element == null) {
+                _sawmill.Error($"Could not winget element {elementId} because it does not exist");
+                return string.Empty;
+            }
+
+            if (!element.TryGetProperty(queryValue, out var value))
+                _sawmill.Error($"Could not winget property {queryValue} on {element.Id}");
+
+            return value;
+        }
+
+        var elementIds = controlId.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        if (elementIds.Length == 0) {
+            _sawmill.Error($"Special winget \"{queryValue}\" is not implemented");
+            return string.Empty;
+        } else if (elementIds.Length == 1) {
+            return GetProperty(elementIds[0]);
+        }
+
+        var result = new StringBuilder(elementIds.Length * 6 - 1);
+
+        for (int i = 0; i < elementIds.Length; i++) {
+            var elementId = elementIds[i];
+
+            result.Append(elementId);
+            result.Append('.');
+            result.Append(queryValue);
+            result.Append('=');
+            result.Append(GetProperty(elementId));
+
+            if (i != elementIds.Length - 1)
+                result.Append(';');
+        }
+
+        return result.ToString();
     }
 
     public void WinClone(string controlId, string cloneId) {

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -525,8 +525,15 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
         var elementIds = controlId.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         if (elementIds.Length == 0) {
-            _sawmill.Error($"Special winget \"{queryValue}\" is not implemented");
-            return string.Empty;
+            switch (queryValue) {
+                // The server will actually never query this because it can predict the answer to be "true"
+                // But also have it here in case a local winget ever wants it
+                case "hwmode":
+                    return "true";
+                default:
+                    _sawmill.Error($"Special winget \"{queryValue}\" is not implemented");
+                    return string.Empty;
+            }
         } else if (elementIds.Length == 1) {
             return GetProperty(elementIds[0]);
         }

--- a/OpenDreamClient/Interface/InterfaceElement.cs
+++ b/OpenDreamClient/Interface/InterfaceElement.cs
@@ -26,6 +26,17 @@ public class InterfaceElement {
         UpdateElementDescriptor();
     }
 
+    /// <summary>
+    /// Attempt to get a DMF property
+    /// </summary>
+    /// <param name="property"></param>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public virtual bool TryGetProperty(string property, out string value) {
+        value = string.Empty;
+        return false;
+    }
+
     protected virtual void UpdateElementDescriptor() {
 
     }

--- a/OpenDreamClient/Interface/InterfaceElement.cs
+++ b/OpenDreamClient/Interface/InterfaceElement.cs
@@ -29,9 +29,6 @@ public class InterfaceElement {
     /// <summary>
     /// Attempt to get a DMF property
     /// </summary>
-    /// <param name="property"></param>
-    /// <param name="value"></param>
-    /// <returns></returns>
     public virtual bool TryGetProperty(string property, out string value) {
         value = string.Empty;
         return false;

--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -441,6 +441,19 @@ namespace OpenDreamRuntime {
             return task;
         }
 
+        public Task<DreamValue> WinGet(string controlId, string queryValue) {
+            var task = MakePromptTask(out var promptId);
+            var msg = new MsgWinGet() {
+                PromptId = promptId,
+                ControlId = controlId,
+                QueryValue = queryValue
+            };
+
+            Session.ConnectedClient.SendMessage(msg);
+
+            return task;
+        }
+
         public Task<DreamValue> Alert(String title, String message, String button1, String button2, String button3) {
             var task = MakePromptTask(out var promptId);
             var msg = new MsgAlert() {

--- a/OpenDreamRuntime/DreamManager.Connections.cs
+++ b/OpenDreamRuntime/DreamManager.Connections.cs
@@ -43,6 +43,7 @@ namespace OpenDreamRuntime {
             _netManager.RegisterNetMessage<MsgWinSet>();
             _netManager.RegisterNetMessage<MsgWinClone>();
             _netManager.RegisterNetMessage<MsgWinExists>();
+            _netManager.RegisterNetMessage<MsgWinGet>();
             _netManager.RegisterNetMessage<MsgFtp>();
             _netManager.RegisterNetMessage<MsgLoadInterface>();
             _netManager.RegisterNetMessage<MsgAckLoadInterface>(RxAckLoadInterface);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -118,6 +118,7 @@ namespace OpenDreamRuntime.Procs.Native {
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_walk_to);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_winclone);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_winexists);
+            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_winget);
             objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_winset);
 
             objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Add);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2968,6 +2968,30 @@ namespace OpenDreamRuntime.Procs.Native {
             return await connection.WinExists(controlId);
         }
 
+        [DreamProc("winget")]
+        [DreamProcParameter("player", Type = DreamValueTypeFlag.DreamObject)]
+        [DreamProcParameter("control_id", Type = DreamValueTypeFlag.String)]
+        [DreamProcParameter("params", Type = DreamValueTypeFlag.String)]
+        public static async Task<DreamValue> NativeProc_winget(AsyncNativeProc.State state) {
+            DreamValue player = state.GetArgument(0, "player");
+            state.GetArgument(1, "control_id").TryGetValueAsString(out var controlId);
+            if (!state.GetArgument(2, "params").TryGetValueAsString(out var paramsValue))
+                return new(string.Empty);
+
+            DreamConnection? connection = null;
+            if (player.TryGetValueAsDreamObject<DreamObjectMob>(out var mob)) {
+                connection = mob.Connection;
+            } else if (player.TryGetValueAsDreamObject<DreamObjectClient>(out var client)) {
+                connection = client.Connection;
+            }
+
+            if (connection == null) {
+                throw new Exception($"Invalid client {player}");
+            }
+
+            return await connection.WinGet(controlId, paramsValue);
+        }
+
         [DreamProc("winset")]
         [DreamProcParameter("player", Type = DreamValueTypeFlag.DreamObject)]
         [DreamProcParameter("control_id", Type = DreamValueTypeFlag.String)]

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2989,6 +2989,11 @@ namespace OpenDreamRuntime.Procs.Native {
                 throw new Exception($"Invalid client {player}");
             }
 
+            if (string.IsNullOrEmpty(controlId) && paramsValue == "hwmode") {
+                // Don't even bother querying the client, we don't have a non-hwmode
+                return new("true");
+            }
+
             return await connection.WinGet(controlId, paramsValue);
         }
 

--- a/OpenDreamShared/Network/Messages/MsgWinGet.cs
+++ b/OpenDreamShared/Network/Messages/MsgWinGet.cs
@@ -4,19 +4,22 @@ using Robust.Shared.Serialization;
 
 namespace OpenDreamShared.Network.Messages;
 
-public sealed class MsgWinExists : NetMessage {
+public sealed class MsgWinGet : NetMessage {
     public override MsgGroups MsgGroup => MsgGroups.EntityEvent;
 
     public int PromptId;
     public string ControlId = string.Empty;
+    public string QueryValue = string.Empty;
 
     public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer) {
         PromptId = buffer.ReadVariableInt32();
         ControlId = buffer.ReadString();
+        QueryValue = buffer.ReadString();
     }
 
     public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer) {
         buffer.WriteVariableInt32(PromptId);
         buffer.Write(ControlId);
+        buffer.Write(QueryValue);
     }
 }


### PR DESCRIPTION
Implements `winget()`. Currently only supports the `size` and `is-disabled` properties.

I didn't use RT's serialization manager to read the property because I want to move UI away from using it. It's not great for setting singular properties and reading properties that are constantly changing like `size` and `splitter`.

Also implemented the CHILD control's `splitter` property. This PR is enough to get the "Fit Viewport" verb working.

Fixes #192