### PR TITLE
Fix icon AABB calculation

### DIFF
--- a/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
+++ b/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
@@ -81,7 +81,11 @@ namespace OpenDreamClient.Rendering {
         }
 
         private void OnWorldAABB(EntityUid uid, DMISpriteComponent comp, ref WorldAABBEvent e) {
-            comp.GetAABB(_transformSystem, ref e);
+            Box2? aabb = null;
+
+            comp.Icon.GetWorldAABB(_transformSystem.GetWorldPosition(uid), ref aabb);
+            if (aabb != null)
+                e.AABB = aabb.Value;
         }
 
         public void ResetFilterUsageFlags() {

--- a/OpenDreamClient/Rendering/DMISpriteComponent.cs
+++ b/OpenDreamClient/Rendering/DMISpriteComponent.cs
@@ -18,13 +18,6 @@ namespace OpenDreamClient.Rendering {
             Icon.SizeChanged += OnIconSizeChanged;
         }
 
-        public void GetAABB(TransformSystem sys, ref WorldAABBEvent e) {
-            if (!_entityManager.TryGetComponent<TransformComponent>(Owner, out var transform)) {
-                return;
-            }
-            e.AABB = Icon.GetWorldAABB(sys.GetWorldPosition(transform));
-        }
-
         public bool IsVisible(bool checkWorld = true, int seeInvis = 0) {
             if (Icon.Appearance?.Invisibility > seeInvis) return false;
 

--- a/OpenDreamClient/Rendering/DreamIcon.cs
+++ b/OpenDreamClient/Rendering/DreamIcon.cs
@@ -89,32 +89,24 @@ namespace OpenDreamClient.Rendering {
             _appearanceAnimation = null;
         }
 
-        public Box2 GetWorldAABB(Vector2 worldPos) {
-            Box2? aabb = null;
-
+        public void GetWorldAABB(Vector2 worldPos, ref Box2? aabb) {
             if (DMI != null && Appearance != null) {
                 Vector2 size = DMI.IconSize / (float)EyeManager.PixelsPerMeter;
                 Vector2 pixelOffset = Appearance.PixelOffset / (float)EyeManager.PixelsPerMeter;
 
                 worldPos += pixelOffset;
-                aabb = Box2.CenteredAround(worldPos, size);
+
+                Box2 thisAABB = Box2.CenteredAround(worldPos, size);
+                aabb = aabb?.Union(thisAABB) ?? thisAABB;
             }
 
             foreach (DreamIcon underlay in Underlays) {
-                Box2 underlayAABB = underlay.GetWorldAABB(worldPos);
-
-                if (aabb == null) aabb = underlayAABB;
-                else aabb = aabb.Value.Union(underlayAABB);
+                underlay.GetWorldAABB(worldPos, ref aabb);
             }
 
             foreach (DreamIcon overlay in Overlays) {
-                Box2 overlayAABB = overlay.GetWorldAABB(worldPos);
-
-                if (aabb == null) aabb = overlayAABB;
-                else aabb = aabb.Value.Union(overlayAABB);
+                overlay.GetWorldAABB(worldPos, ref aabb);
             }
-
-            return aabb ?? Box2.FromDimensions(Vector2.Zero, Vector2.Zero);
         }
 
         private void UpdateAnimation() {
@@ -202,7 +194,8 @@ namespace OpenDreamClient.Rendering {
         }
 
         private void CheckSizeChange() {
-            Box2 aabb = GetWorldAABB(Vector2.Zero);
+            Box2? aabb = null;
+            GetWorldAABB(Vector2.Zero, ref aabb);
 
             if (aabb != _cachedAABB) {
                 _cachedAABB = aabb;


### PR DESCRIPTION
Fix the AABBs of some entities extending all the way to `(0, 0)`. This was the cause of airlocks/mobs/others appearing in the right click menu when they shouldn't.