### PR TITLE
Several interface fixes

### DIFF
--- a/OpenDream.sln.DotSettings
+++ b/OpenDream.sln.DotSettings
@@ -62,4 +62,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=winexists/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=winget/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=winset/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=winsets/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=xform/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/OpenDreamClient/Interface/Controls/ControlBrowser.cs
+++ b/OpenDreamClient/Interface/Controls/ControlBrowser.cs
@@ -67,44 +67,27 @@ internal sealed class ControlBrowser : InterfaceControl {
     }
 
     private void BeforeBrowseHandler(IBeforeBrowseContext context) {
-        if (string.IsNullOrEmpty(_webView.Url))
-            return;
+        // An exception in here will freeze up / crash CEF, so catch any
+        try {
+            if (string.IsNullOrEmpty(_webView.Url))
+                return;
 
-        Uri oldUri = new Uri(_webView.Url);
-        Uri newUri = new Uri(context.Url);
+            Uri oldUri = new Uri(_webView.Url);
+            Uri newUri = new Uri(context.Url);
 
-        if (newUri.Scheme == "byond" || (newUri.AbsolutePath == oldUri.AbsolutePath && newUri.Query != String.Empty)) {
-            context.DoCancel();
+            if (newUri.Scheme == "byond" || (newUri.AbsolutePath == oldUri.AbsolutePath && newUri.Query != string.Empty)) {
+                context.DoCancel();
 
-            if (newUri.Host == "winset") { // Embedded winset. Ex: usr << browse("<a href=\"byond://winset?command=.quit\">Quit</a>", "window=quitbutton")
-                // Strip the question mark out before parsing
-                var queryParams = HttpUtility.ParseQueryString(newUri.Query.Substring(1));
-
-                // We need to extract the control element (if one was included)
-                string? element = queryParams.Get("element");
-                queryParams.Remove("element");
-
-                // Wrap each parameter in quotes so the entire value is used
-                foreach (var paramKey in queryParams.AllKeys) {
-                    var paramValue = queryParams[paramKey];
-                    if (paramValue == null)
-                        continue;
-
-                    queryParams.Set(paramKey, $"\"{paramValue}\"");
+                if (newUri.Host == "winset") {
+                    HandleEmbeddedWinset(newUri.Query);
+                    return;
                 }
 
-                // Reassemble the query params without element then convert to winset syntax
-                var query = queryParams.ToString();
-                query = HttpUtility.UrlDecode(query);
-                query = query!.Replace('&', ';'); // TODO: More robust parsing
-
-                // We can finally call winset
-                _interfaceManager.WinSet(element, query);
-                return;
+                var msg = new MsgTopic() { Query = newUri.Query };
+                _netManager.ClientSendMessage(msg);
             }
-
-            var msg = new MsgTopic() { Query = newUri.Query };
-            _netManager.ClientSendMessage(msg);
+        } catch (Exception e) {
+            _sawmill.Error($"Exception in BeforeBrowseHandler: {e}");
         }
     }
 
@@ -131,8 +114,38 @@ internal sealed class ControlBrowser : InterfaceControl {
                 mimeType = "application/octet-stream";
 
             context.DoRespondStream(stream, mimeType, status);
-            return;
         }
+    }
+
+    /// <summary>
+    /// Handles an embedded winset
+    /// <code>byond://winset?command=.quit</code>
+    /// </summary>
+    /// <param name="query">The query portion of the embedded winset</param>
+    private void HandleEmbeddedWinset(string query) {
+        // Strip the question mark out before parsing
+        var queryParams = HttpUtility.ParseQueryString(query.Substring(1));
+
+        // We need to extract the control element (if one was included)
+        string? element = queryParams.Get("element");
+        queryParams.Remove("element");
+
+        // Wrap each parameter in quotes so the entire value is used
+        foreach (var paramKey in queryParams.AllKeys) {
+            var paramValue = queryParams[paramKey];
+            if (paramValue == null)
+                continue;
+
+            queryParams.Set(paramKey, $"\"{paramValue}\"");
+        }
+
+        // Reassemble the query params without element then convert to winset syntax
+        var modifiedQuery = queryParams.ToString();
+        modifiedQuery = HttpUtility.UrlDecode(modifiedQuery);
+        modifiedQuery = modifiedQuery!.Replace('&', ';'); // TODO: More robust parsing
+
+        // We can finally call winset
+        _interfaceManager.WinSet(element, modifiedQuery);
     }
 }
 

--- a/OpenDreamClient/Interface/Controls/ControlChild.cs
+++ b/OpenDreamClient/Interface/Controls/ControlChild.cs
@@ -39,13 +39,13 @@ internal sealed class ControlChild : InterfaceControl {
 
             if (newLeftElement != null) {
                 _leftElement = newLeftElement;
+                _leftElement.HorizontalExpand = true;
+                _leftElement.VerticalExpand = true;
             } else {
                 // SplitContainer will have a size of 0x0 if there aren't 2 controls
                 _leftElement = new Control();
             }
 
-            _leftElement.HorizontalExpand = true;
-            _leftElement.VerticalExpand = true;
             _grid.Children.Add(_leftElement);
         }
 
@@ -55,13 +55,13 @@ internal sealed class ControlChild : InterfaceControl {
 
             if (newRightElement != null) {
                 _rightElement = newRightElement;
+                _rightElement.HorizontalExpand = true;
+                _rightElement.VerticalExpand = true;
             } else {
                 // SplitContainer will have a size of 0x0 if there aren't 2 controls
                 _rightElement = new Control();
             }
 
-            _rightElement.HorizontalExpand = true;
-            _rightElement.VerticalExpand = true;
             _grid.Children.Add(_rightElement);
         }
 

--- a/OpenDreamClient/Interface/Controls/ControlWindow.cs
+++ b/OpenDreamClient/Interface/Controls/ControlWindow.cs
@@ -97,19 +97,19 @@ public sealed class ControlWindow : InterfaceControl {
             if (control.Size?.Y == 0) {
                 elementSize.Y = (windowSize.Y - elementPos.Y);
                 if (ChildControls.Count - 1 > i) {
-                    if (ChildControls[i + 1].Pos != null) {
+                    if (ChildControls[i + 1].Pos != null && ChildControls[i + 1].UIElement.Visible) {
                         var nextElementPos = ChildControls[i + 1].Pos.GetValueOrDefault();
                         elementSize.Y = nextElementPos.Y - elementPos.Y;
                     }
                 }
 
-                element.SetHeight = (elementSize.Y / windowSize.Y) * _canvas.Height;
+                element.SetHeight = ((float)elementSize.Y / windowSize.Y) * _canvas.Height;
             }
 
             if (control.Size?.X == 0) {
                 elementSize.X = (windowSize.X - elementPos.X);
                 if (ChildControls.Count - 1 > i) {
-                    if (ChildControls[i + 1].Pos != null) {
+                    if (ChildControls[i + 1].Pos != null && ChildControls[i + 1].UIElement.Visible) {
                         var nextElementPos = ChildControls[i + 1].Pos.GetValueOrDefault();
                         if (nextElementPos.X < (elementSize.X + elementPos.X) &&
                             nextElementPos.Y < (elementSize.Y + elementPos.Y))
@@ -117,7 +117,7 @@ public sealed class ControlWindow : InterfaceControl {
                     }
                 }
 
-                element.SetWidth = (elementSize.X / windowSize.X) * _canvas.Width;
+                element.SetWidth = ((float)elementSize.X / windowSize.X) * _canvas.Width;
             }
 
             if (control.Anchor1.HasValue) {

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -458,8 +458,13 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
             if (CheckParserErrors())
                 return;
 
+            // id=abc overrides the elements of other winsets without an element
+            string? elementOverride = winSets.FirstOrNull(winSet => winSet.Element == null && winSet.Attribute == "id")?.Value;
+
             foreach (DMFWinSet winSet in winSets) {
-                if (winSet.Element == null) {
+                string? elementId = winSet.Element ?? elementOverride;
+
+                if (elementId == null) {
                     if (winSet.Attribute == "command") {
                         DreamCommandSystem commandSystem = _entitySystemManager.GetEntitySystem<DreamCommandSystem>();
 
@@ -468,7 +473,7 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
                         _sawmill.Error($"Invalid global winset \"{winsetParams}\"");
                     }
                 } else {
-                    InterfaceElement? element = FindElementWithId(winSet.Element);
+                    InterfaceElement? element = FindElementWithId(elementId);
                     MappingDataNode node = new() {
                         {winSet.Attribute, winSet.Value}
                     };


### PR DESCRIPTION
Several interface fixes that get modern tgui-chat/tgui-panel working
* Try/Catch any exceptions in BeforeBrowseHandler because exceptions there freeze CEF
* Using `id` in a global winset will target a specific element
* Having only 1 pane in a CHILD control will have that pane take up the whole space (though the splitter can still be grabbed, this needs to be disabled later)
* Only care about visible controls when determining the available space for a control with size `0x0`

New state of [auxmos-removed BeeStation](https://github.com/itsmeowForks/BeeStation-Hornet/tree/db2b4b439a98af9b56cb75c9b8cce8f8493f2a7f):
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/b60fecef-d17e-4b6d-bba0-c7232c0e41e0)
