### PR TITLE
Fix `world.contents` order

### DIFF
--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -31,24 +31,28 @@ namespace OpenDreamRuntime {
         private ServerAppearanceSystem? _appearanceSystem;
 
         public DreamObject GetAtom(int index) {
+            // Order of world.contents:
+            //  Mobs + Movables + Areas + Turfs
+
+            if (index < Mobs.Count)
+                return Mobs[index];
+
+            // TODO: Movables and objects should be mixed together here
+            index -= Mobs.Count;
+            if (index < Objects.Count)
+                return Objects[index];
+
+            index -= Objects.Count;
+            if (index < Movables.Count)
+                return Movables[index];
+
+            index -= Movables.Count;
             if (index < Areas.Count)
                 return Areas[index];
 
             index -= Areas.Count;
             if (index < Turfs.Count)
                 return Turfs[index];
-
-            index -= Turfs.Count;
-            if (index < Movables.Count)
-                return Movables[index];
-
-            index -= Movables.Count;
-            if (index < Objects.Count)
-                return Objects[index];
-
-            index -= Objects.Count;
-            if (index < Mobs.Count)
-                return Mobs[index];
 
             throw new IndexOutOfRangeException($"Cannot get atom at index {index}. There are only {AtomCount} atoms.");
         }

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -854,11 +854,11 @@ namespace OpenDreamRuntime.Objects.Types {
         public override List<DreamValue> GetValues() {
             List<DreamValue> values = new(AtomManager.AtomCount);
 
-            values.AddRange(AtomManager.Areas.Select(area => new DreamValue(area)));
-            values.AddRange(AtomManager.Turfs.Select(turf => new DreamValue(turf)));
+            values.AddRange(AtomManager.Mobs.Select(mob => new DreamValue(mob)));
             values.AddRange(AtomManager.Movables.Select(movable => new DreamValue(movable)));
             values.AddRange(AtomManager.Objects.Select(obj => new DreamValue(obj)));
-            values.AddRange(AtomManager.Mobs.Select(mob => new DreamValue(mob)));
+            values.AddRange(AtomManager.Areas.Select(area => new DreamValue(area)));
+            values.AddRange(AtomManager.Turfs.Select(turf => new DreamValue(turf)));
             return values;
         }
 


### PR DESCRIPTION
`world.contents` should be in the order `Mobs + Movables + Areas + Turfs`

This fixes map init in BeeStation

![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/9f8ba032-e52d-49f4-aa18-39b6d4a3b769)
