### PR TITLE
Add some keywords to ScreenLocation's keywords list

### DIFF
--- a/OpenDreamShared/Dream/ScreenLocation.cs
+++ b/OpenDreamShared/Dream/ScreenLocation.cs
@@ -37,8 +37,8 @@ public sealed class ScreenLocation {
 
     private static string[] _keywords = {
         "CENTER",
-        "WEST", "EAST",
-        "NORTH", "SOUTH",
+        "WEST", "EAST", "LEFT", "RIGHT",
+        "NORTH", "SOUTH", "TOP", "BOTTOM",
         "TOPLEFT", "TOPRIGHT",
         "BOTTOMLEFT", "BOTTOMRIGHT"
     };


### PR DESCRIPTION
Important for preventing `TOP:-70,0` from treating the `TOP:` as a secondary control