### PR TITLE
Alpha applying to overlays properly

### DIFF
--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -203,7 +203,7 @@ internal sealed class DreamViewOverlay : Overlay {
             if ((icon.Appearance.AppearanceFlags & AppearanceFlags.ResetAlpha) != 0 || keepTogether) //RESET_ALPHA
                 current.AlphaToApply = icon.Appearance.Alpha/255.0f;
             else
-                current.AlphaToApply = parentIcon.AlphaToApply;
+                current.AlphaToApply = parentIcon.AlphaToApply * (icon.Appearance.Alpha / 255.0f);
 
             if ((icon.Appearance.AppearanceFlags & AppearanceFlags.ResetTransform) != 0 || keepTogether) //RESET_TRANSFORM
                 current.TransformToApply = iconAppearanceTransformMatrix;

--- a/TestGame/renderer_tests.dm
+++ b/TestGame/renderer_tests.dm
@@ -73,7 +73,9 @@
 	Crossed(var/atom/movable/AM)
 		src.loc = AM
 		AM << "You picked up [src]"
-		AM.overlays += image(src.icon, AM.loc, src.icon_state)	
+		var/mutable_appearance/ma = new(src.icon, src.icon_state)
+		ma.alpha = 50
+		AM.overlays += ma
 
 //simple underlay
 /obj/plaque/simple_underlay_test 

--- a/TestGame/renderer_tests.dm
+++ b/TestGame/renderer_tests.dm
@@ -74,7 +74,7 @@
 		src.loc = AM
 		AM << "You picked up [src]"
 		var/mutable_appearance/ma = new(src.icon, src.icon_state)
-		ma.alpha = 50
+		ma.alpha = 100
 		AM.overlays += ma
 
 //simple underlay

--- a/TestGame/renderer_tests.dm
+++ b/TestGame/renderer_tests.dm
@@ -73,9 +73,7 @@
 	Crossed(var/atom/movable/AM)
 		src.loc = AM
 		AM << "You picked up [src]"
-		var/mutable_appearance/ma = new(src.icon, src.icon_state)
-		ma.alpha = 100
-		AM.overlays += ma
+		AM.overlays += image(src.icon, AM.loc, src.icon_state)	
 
 //simple underlay
 /obj/plaque/simple_underlay_test 


### PR DESCRIPTION
Previously, unless you were using keep together or RESET_ALPHA, the overlay's alpha value was completely ignored. Now it will multiply the parent's alpha value by the provided alpha value. This is the behaviour that byond exhibits, as when I place an object sandwhiched between another object and its overlay, decreasing the alpha of the behind object will decrease the alpha of the overlay.

I noticed this was an issue when sent a screenshot of kilostation, as our decals on Beestation use an alpha of 50 which is set at the overlay object level rather than the sprite level.

**BYOND:**
<details>

![image](https://github.com/OpenDreamProject/OpenDream/assets/26465327/e1502e4f-83e6-44fb-a2b8-df032b78a0b0)

![image](https://github.com/OpenDreamProject/OpenDream/assets/26465327/1f06acfb-b9fb-4a4f-b3b3-c347ccdd0556)

![image](https://github.com/OpenDreamProject/OpenDream/assets/26465327/9f8942f1-1585-4224-b721-d58efe0866c0)

</details>

**OpenDream:**
Without the alpha variable set:
![image](https://github.com/OpenDreamProject/OpenDream/assets/26465327/37ce25d2-ebc6-4355-a1a3-18017855a7e6)
![image](https://github.com/OpenDreamProject/OpenDream/assets/26465327/daf55422-8ebf-4efc-85f2-5863f506c16d)


WIth the alpha variable set (Alpha of 50 was used):
![image](https://github.com/OpenDreamProject/OpenDream/assets/26465327/342396c3-ed1c-40fa-bca5-56421b6ba203)

Without the overlay alpha variable, but with the parent alpha:
![image](https://github.com/OpenDreamProject/OpenDream/assets/26465327/bf38ae6f-74ee-4251-9cc5-057677f62a83)

With the overlay alpha and parent alpha:
![image](https://github.com/OpenDreamProject/OpenDream/assets/26465327/b76b3915-fed3-49dd-aacc-489cb628ccb3)
