### PR TITLE
Adds compiler version metadata to the compiled json

### DIFF
--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -16,6 +16,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 using DMCompiler.Compiler;
+using OpenDreamShared.Dream.Procs;
 using Robust.Shared.Utility;
 
 namespace DMCompiler {
@@ -272,6 +273,7 @@ namespace DMCompiler {
         private static string SaveJson(List<DreamMapJson> maps, string interfaceFile, string outputFile) {
             var jsonRep = DMObjectTree.CreateJsonRepresentation();
             DreamCompiledJson compiledDream = new DreamCompiledJson {
+                Metadata = new DreamCompiledJsonMetadata { Version = OpcodeVerifier.GetOpcodesHash() },
                 Strings = DMObjectTree.StringTable,
                 Resources = DMObjectTree.Resources.ToArray(),
                 Maps = maps,

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -9,6 +9,7 @@ using OpenDreamRuntime.Rendering;
 using OpenDreamRuntime.Resources;
 using OpenDreamShared;
 using OpenDreamShared.Dream;
+using OpenDreamShared.Dream.Procs;
 using OpenDreamShared.Json;
 using Robust.Server;
 using Robust.Server.Player;
@@ -106,6 +107,10 @@ namespace OpenDreamRuntime {
             DreamCompiledJson? json = JsonSerializer.Deserialize<DreamCompiledJson>(jsonSource);
             if (json == null)
                 return false;
+
+            if (!json.Metadata.Version.Equals(OpcodeVerifier.GetOpcodesHash())) {
+                _sawmill.Warning("Compiler opcode version does not match the runtime version! This may cause issues!");
+            }
 
             if (json.Maps == null || json.Maps.Count == 0) throw new ArgumentException("No maps were given");
             if (json.Maps.Count > 1) {

--- a/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
+++ b/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace OpenDreamShared.Dream.Procs {
@@ -396,6 +397,22 @@ namespace OpenDreamShared.Dream.Procs {
                 bytePool.Add(usedInt);
             }
             return false;
+        }
+
+        /// <summary>
+        /// Calculates a hash of all the <c>DreamProcOpcode</c>s for warning on incompatibilities.
+        /// </summary>
+        /// <returns>A MD5 hash string</returns>
+        public static string GetOpcodesHash() {
+            Array allOpcodes = Enum.GetValues(typeof(DreamProcOpcode));
+            byte[] opcodesList = new byte[allOpcodes.Length];
+
+            for (int i = 0; i < allOpcodes.Length; i++) {
+                opcodesList[i] = (byte)allOpcodes.GetValue(i)!;
+            }
+
+            byte[] hashBytes = MD5.HashData(opcodesList);
+            return BitConverter.ToString(hashBytes).Replace("-", "");
         }
     }
 }

--- a/OpenDreamShared/Json/DreamCompiledJson.cs
+++ b/OpenDreamShared/Json/DreamCompiledJson.cs
@@ -1,15 +1,15 @@
 ﻿using System.Collections.Generic;
 
-namespace OpenDreamShared.Json {
-    public sealed class DreamCompiledJson {
-        public List<string>? Strings { get; set; }
-        public string[]? Resources { get; set; }
-        public int[]? GlobalProcs { get; set; }
-        public GlobalListJson? Globals { get; set; }
-        public ProcDefinitionJson? GlobalInitProc { get; set; }
-        public List<DreamMapJson>? Maps { get; set; }
-        public string? Interface { get; set; }
-        public DreamTypeJson[]? Types { get; set; }
-        public ProcDefinitionJson[]? Procs { get; set; }
-    }
+namespace OpenDreamShared.Json;
+
+public sealed class DreamCompiledJson {
+    public List<string>? Strings { get; set; }
+    public string[]? Resources { get; set; }
+    public int[]? GlobalProcs { get; set; }
+    public GlobalListJson? Globals { get; set; }
+    public ProcDefinitionJson? GlobalInitProc { get; set; }
+    public List<DreamMapJson>? Maps { get; set; }
+    public string? Interface { get; set; }
+    public DreamTypeJson[]? Types { get; set; }
+    public ProcDefinitionJson[]? Procs { get; set; }
 }

--- a/OpenDreamShared/Json/DreamCompiledJson.cs
+++ b/OpenDreamShared/Json/DreamCompiledJson.cs
@@ -3,6 +3,7 @@
 namespace OpenDreamShared.Json;
 
 public sealed class DreamCompiledJson {
+    public DreamCompiledJsonMetadata Metadata { get; set; }
     public List<string>? Strings { get; set; }
     public string[]? Resources { get; set; }
     public int[]? GlobalProcs { get; set; }
@@ -12,4 +13,11 @@ public sealed class DreamCompiledJson {
     public string? Interface { get; set; }
     public DreamTypeJson[]? Types { get; set; }
     public ProcDefinitionJson[]? Procs { get; set; }
+}
+
+public sealed class DreamCompiledJsonMetadata {
+    /// <summary>
+    ///  Hash of all the <c>DreamProcOpcode</c>s
+    /// </summary>
+    public string Version { get; set; }
 }


### PR DESCRIPTION
Title, hashes the DreamProcOpcodes and puts it in a metadata header in the json.

Fixes #1323 