### PR TITLE
Handle invalid dir/frame index in `/icon.Insert()`

### DIFF
--- a/OpenDreamRuntime/Objects/DreamIcon.cs
+++ b/OpenDreamRuntime/Objects/DreamIcon.cs
@@ -183,10 +183,12 @@ public sealed class DreamIcon {
 
         if (!States.TryGetValue(stateName, out var iconState)) {
             iconState = new IconState();
-            States.Add(stateName, iconState);
         }
 
         foreach (var insertingPair in insertingDirections) {
+            if (insertingPair.Value.Length == 0)
+                continue;
+
             List<IconFrame> iconFrames = new(insertingPair.Value.Length);
 
             foreach (var dmiFrame in insertingPair.Value) {
@@ -195,6 +197,11 @@ public sealed class DreamIcon {
 
             iconState.Directions[insertingPair.Key] = iconFrames;
             iconState.Frames = Math.Max(iconState.Frames, iconFrames.Count);
+        }
+
+        // Only add the state if it contains any frames
+        if (!States.ContainsKey(stateName) && iconState.Frames > 0) {
+            States.Add(stateName, iconState);
         }
 
         _cachedDMI = null;

--- a/OpenDreamShared/Resources/DMIParser.cs
+++ b/OpenDreamShared/Resources/DMIParser.cs
@@ -144,11 +144,12 @@ namespace OpenDreamShared.Resources {
             }
 
             /// <summary>
-            /// Get this state's frames
+            /// Get this state's frames<br/>
             /// </summary>
             /// <param name="dir">Which direction to get. Every direction if null.</param>
             /// <param name="frame">Which frame to get. Every frame if null.</param>
             /// <param name="asSouth">If dir isn't null, return the frames as facing south</param>
+            /// <remarks>Invalid dir/frame args will give empty arrays</remarks>
             /// <returns>A dictionary containing the specified frames for each specified direction</returns>
             public Dictionary<AtomDirection, ParsedDMIFrame[]> GetFrames(AtomDirection? dir = null, int? frame = null, bool asSouth = false) {
                 Dictionary<AtomDirection, ParsedDMIFrame[]> directions;
@@ -165,10 +166,12 @@ namespace OpenDreamShared.Resources {
 
                 if (frame != null) { // Only get a specified frame
                     foreach (var direction in directions) {
-                        ParsedDMIFrame[] newFrames = new ParsedDMIFrame[1];
-
-                        newFrames[0] = direction.Value[frame.Value];
-                        directions[direction.Key] = newFrames;
+                        if (direction.Value.Length > frame.Value) {
+                            directions[direction.Key] = new[] { direction.Value[frame.Value] };
+                        } else {
+                            // Frame doesn't exist
+                            directions[direction.Key] = Array.Empty<ParsedDMIFrame>();
+                        }
                     }
                 }
 

--- a/OpenDreamShared/Resources/DMIParser.cs
+++ b/OpenDreamShared/Resources/DMIParser.cs
@@ -144,7 +144,7 @@ namespace OpenDreamShared.Resources {
             }
 
             /// <summary>
-            /// Get this state's frames<br/>
+            /// Get this state's frames
             /// </summary>
             /// <param name="dir">Which direction to get. Every direction if null.</param>
             /// <param name="frame">Which frame to get. Every frame if null.</param>


### PR DESCRIPTION
Using an invalid dir/frame should just not insert an icon state