### PR TITLE
Fixed screen.Remove() - Fixes #1363

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -788,6 +788,10 @@ namespace OpenDreamRuntime.Objects.Types {
             _connection = connection;
         }
 
+        public override bool ContainsValue(DreamValue value) {
+            return _screenObjects.Contains(value);
+        }
+
         public override DreamValue GetValue(DreamValue key) {
             if (!key.TryGetValueAsInteger(out var screenIndex) || screenIndex < 1 || screenIndex > _screenObjects.Count)
                 throw new Exception($"Invalid index into screen list: {key}");


### PR DESCRIPTION
Fixes #1363

Implementing `ContainsValue` for `ClientScreenList` was necessary because the base implementation from `DreamList` searches the `_values` field, while `ClientScreenList` doesn't use that at all in favor of `_screenObjects`.