### PR TITLE
Basic implementation of `atom.vis_contents`

### DIFF
--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -12,7 +12,7 @@
 	var/list/overlays = null
 	var/list/underlays = null
 	var/list/vis_locs = null as opendream_unimplemented
-	var/list/vis_contents = null as opendream_unimplemented
+	var/list/vis_contents = null
 
 	var/atom/loc
 	var/dir = SOUTH

--- a/DMCompiler/DMStandard/Types/Client.dm
+++ b/DMCompiler/DMStandard/Types/Client.dm
@@ -1,7 +1,7 @@
 ﻿/client
 	var/list/verbs = null
 	var/list/screen = null
-	var/list/images = list() 
+	var/list/images = null
 	var/list/vars
 
 	var/atom/statobj

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -260,11 +260,6 @@ internal sealed class DreamViewOverlay : Overlay {
             result.Add(renderTargetPlaceholder);
         }
 
-
-        //TODO vis_contents
-        //click uid should be set to current.uid again
-        //dont forget the vis_flags
-
         //underlays - colour, alpha, and transform are inherited, but filters aren't
         foreach (DreamIcon underlay in icon.Underlays) {
             if (underlay.Appearance == null)
@@ -310,6 +305,16 @@ internal sealed class DreamViewOverlay : Overlay {
                 else
                     ProcessIconComponents(CI, current.Position, uid, isScreen, ref tieBreaker, result, current, false);
             }
+        }
+
+        foreach (var visContent in icon.Appearance.VisContents) {
+            if (!_spriteQuery.TryGetComponent(visContent, out var sprite))
+                continue;
+
+            ProcessIconComponents(sprite.Icon, position, visContent, false, ref tieBreaker, result, current, keepTogether);
+
+            // TODO: click uid should be set to current.uid again
+            // TODO: vis_flags
         }
 
         //TODO maptext - note colour + transform apply

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -7,6 +7,7 @@ using OpenDreamRuntime.Objects.Types;
 using OpenDreamRuntime.Rendering;
 using OpenDreamRuntime.Resources;
 using Robust.Server.GameObjects;
+using Robust.Server.GameStates;
 using Robust.Server.Player;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization.Manager;
@@ -34,6 +35,7 @@ namespace OpenDreamRuntime.Objects {
         protected ISerializationManager SerializationManager => ObjectDefinition.SerializationManager;
         protected ServerAppearanceSystem? AppearanceSystem => ObjectDefinition.AppearanceSystem;
         protected TransformSystem? TransformSystem => ObjectDefinition.TransformSystem;
+        protected PvsOverrideSystem? PvsOverrideSystem => ObjectDefinition.PvsOverrideSystem;
 
         protected Dictionary<string, DreamValue>? Variables;
 

--- a/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
@@ -5,6 +5,7 @@ using OpenDreamRuntime.Rendering;
 using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
 using Robust.Server.GameObjects;
+using Robust.Server.GameStates;
 using Robust.Server.Player;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization.Manager;
@@ -23,6 +24,7 @@ namespace OpenDreamRuntime.Objects {
         public readonly ISerializationManager SerializationManager;
         public readonly ServerAppearanceSystem? AppearanceSystem;
         public readonly TransformSystem? TransformSystem;
+        public readonly PvsOverrideSystem? PvsOverrideSystem;
 
         public readonly TreeEntry TreeEntry;
         public DreamPath Type => TreeEntry.Path;
@@ -59,6 +61,7 @@ namespace OpenDreamRuntime.Objects {
             SerializationManager = copyFrom.SerializationManager;
             AppearanceSystem = copyFrom.AppearanceSystem;
             TransformSystem = copyFrom.TransformSystem;
+            PvsOverrideSystem = copyFrom.PvsOverrideSystem;
 
             TreeEntry = copyFrom.TreeEntry;
             InitializationProc = copyFrom.InitializationProc;
@@ -71,7 +74,7 @@ namespace OpenDreamRuntime.Objects {
                 Verbs = new List<int>(copyFrom.Verbs);
         }
 
-        public DreamObjectDefinition(DreamManager dreamManager, DreamObjectTree objectTree, AtomManager atomManager, IDreamMapManager dreamMapManager, IMapManager mapManager, DreamResourceManager dreamResourceManager, IEntityManager entityManager, IPlayerManager playerManager, ISerializationManager serializationManager, ServerAppearanceSystem? appearanceSystem, TransformSystem? transformSystem, TreeEntry? treeEntry) {
+        public DreamObjectDefinition(DreamManager dreamManager, DreamObjectTree objectTree, AtomManager atomManager, IDreamMapManager dreamMapManager, IMapManager mapManager, DreamResourceManager dreamResourceManager, IEntityManager entityManager, IPlayerManager playerManager, ISerializationManager serializationManager, ServerAppearanceSystem? appearanceSystem, TransformSystem? transformSystem, PvsOverrideSystem  pvsOverrideSystem, TreeEntry? treeEntry) {
             DreamManager = dreamManager;
             ObjectTree = objectTree;
             AtomManager = atomManager;
@@ -83,6 +86,7 @@ namespace OpenDreamRuntime.Objects {
             SerializationManager = serializationManager;
             AppearanceSystem = appearanceSystem;
             TransformSystem = transformSystem;
+            PvsOverrideSystem = pvsOverrideSystem;
 
             TreeEntry = treeEntry;
 

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -9,11 +9,11 @@ using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Json;
 using Robust.Server.GameObjects;
+using Robust.Server.GameStates;
 using Robust.Server.Player;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Exceptions;
-using TreeEntry = OpenDreamRuntime.Objects.TreeEntry;
 
 namespace OpenDreamRuntime.Objects {
     public sealed class DreamObjectTree {
@@ -59,10 +59,12 @@ namespace OpenDreamRuntime.Objects {
         [Dependency] private readonly ProcScheduler _procScheduler = default!;
         private ServerAppearanceSystem? _appearanceSystem;
         private TransformSystem? _transformSystem;
+        private PvsOverrideSystem? _pvsOverrideSystem;
 
         public void LoadJson(DreamCompiledJson json) {
             _entitySystemManager.TryGetEntitySystem(out _appearanceSystem);
             _entitySystemManager.TryGetEntitySystem(out _transformSystem);
+            _entitySystemManager.TryGetEntitySystem(out _pvsOverrideSystem);
 
             Strings = json.Strings ?? new();
 
@@ -304,7 +306,7 @@ namespace OpenDreamRuntime.Objects {
             foreach (TreeEntry type in GetAllDescendants(Root)) {
                 int typeId = pathToTypeId[type.Path];
                 DreamTypeJson jsonType = types[typeId];
-                var definition = new DreamObjectDefinition(_dreamManager, this, _atomManager, _dreamMapManager, _mapManager, _dreamResourceManager, _entityManager, _playerManager, _serializationManager, _appearanceSystem, _transformSystem, type);
+                var definition = new DreamObjectDefinition(_dreamManager, this, _atomManager, _dreamMapManager, _mapManager, _dreamResourceManager, _entityManager, _playerManager, _serializationManager, _appearanceSystem, _transformSystem, _pvsOverrideSystem, type);
 
                 type.ObjectDefinition = definition;
                 type.TreeIndex = treeIndex++;

--- a/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
@@ -1,5 +1,4 @@
-﻿using OpenDreamRuntime.Procs;
-using OpenDreamShared.Dream;
+﻿using OpenDreamShared.Dream;
 
 namespace OpenDreamRuntime.Objects.Types;
 
@@ -9,10 +8,10 @@ public class DreamObjectAtom : DreamObject {
     public string? Desc;
     public readonly DreamOverlaysList Overlays;
     public readonly DreamOverlaysList Underlays;
+    public readonly DreamVisContentsList VisContents;
     public readonly VerbsList Verbs;
     public readonly DreamFilterList Filters;
     public DreamList? VisLocs; // TODO: Implement
-    public DreamList? VisContents; // TODO: Implement
 
     public DreamObjectAtom(DreamObjectDefinition objectDefinition) : base(objectDefinition) {
         ObjectDefinition.Variables["name"].TryGetValueAsString(out Name);
@@ -20,6 +19,7 @@ public class DreamObjectAtom : DreamObject {
 
         Overlays = new(ObjectTree.List.ObjectDefinition, this, AppearanceSystem, false);
         Underlays = new(ObjectTree.List.ObjectDefinition, this, AppearanceSystem, true);
+        VisContents = new(ObjectTree.List.ObjectDefinition, PvsOverrideSystem, this);
         Verbs = new(ObjectTree, this);
         Filters = new(ObjectTree.List.ObjectDefinition, this);
     }
@@ -75,7 +75,6 @@ public class DreamObjectAtom : DreamObject {
                 value = new(VisLocs);
                 return true;
             case "vis_contents":
-                VisContents ??= ObjectTree.CreateList();
                 value = new(VisContents);
                 return true;
 
@@ -130,6 +129,20 @@ public class DreamObjectAtom : DreamObject {
                     }
                 } else if (!value.IsNull) {
                     Underlays.AddValue(value);
+                }
+
+                break;
+            }
+            case "vis_contents": {
+                VisContents.Cut();
+
+                if (value.TryGetValueAsDreamList(out var valueList)) {
+                    // TODO: This should postpone UpdateAppearance until after everything is added
+                    foreach (DreamValue visContentsValue in valueList.GetValues()) {
+                        VisContents.AddValue(visContentsValue);
+                    }
+                } else if (!value.IsNull) {
+                    VisContents.AddValue(value);
                 }
 
                 break;

--- a/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
@@ -12,6 +12,7 @@ public sealed class DreamObjectClient : DreamObject {
     public readonly ClientImagesList Images;
     public readonly VerbsList Verbs;
     public ViewRange View { get; private set; }
+
     public DreamObjectClient(DreamObjectDefinition objectDefinition, DreamConnection connection, ServerScreenOverlaySystem? screenOverlaySystem, ServerClientImagesSystem? clientImagesSystem) : base(objectDefinition) {
         Connection = connection;
         Screen = new(ObjectTree, screenOverlaySystem, Connection);

--- a/OpenDreamShared/Dream/IconAppearance.cs
+++ b/OpenDreamShared/Dream/IconAppearance.cs
@@ -4,8 +4,10 @@ using Robust.Shared.ViewVariables;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.GameObjects;
 
 namespace OpenDreamShared.Dream {
+    // TODO: Wow this is huge! Probably look into splitting this by most used/least used to reduce the size of these
     [Serializable, NetSerializable]
     public sealed class IconAppearance : IEquatable<IconAppearance> {
         [ViewVariables] public int? Icon;
@@ -40,6 +42,7 @@ namespace OpenDreamShared.Dream {
         [ViewVariables] public MouseOpacity MouseOpacity = MouseOpacity.PixelOpaque;
         [ViewVariables] public List<uint> Overlays = new();
         [ViewVariables] public List<uint> Underlays = new();
+        [ViewVariables] public List<EntityUid> VisContents = new();
         [ViewVariables] public List<DreamFilter> Filters = new();
         /// <summary> The Transform property of this appearance, in [a,d,b,e,c,f] order</summary>
         [ViewVariables] public float[] Transform = new float[6] {   1, 0,   // a d
@@ -69,6 +72,7 @@ namespace OpenDreamShared.Dream {
             MouseOpacity = appearance.MouseOpacity;
             Overlays = new List<uint>(appearance.Overlays);
             Underlays = new List<uint>(appearance.Underlays);
+            VisContents = new List<EntityUid>(appearance.VisContents);
             Filters = new List<DreamFilter>(appearance.Filters);
             Override = appearance.Override;
 
@@ -77,9 +81,9 @@ namespace OpenDreamShared.Dream {
             }
         }
 
-        public override bool Equals(object obj) => obj is IconAppearance appearance && Equals(appearance);
+        public override bool Equals(object? obj) => obj is IconAppearance appearance && Equals(appearance);
 
-        public bool Equals(IconAppearance appearance) {
+        public bool Equals(IconAppearance? appearance) {
             if (appearance == null) return false;
 
             if (appearance.Icon != Icon) return false;
@@ -91,7 +95,7 @@ namespace OpenDreamShared.Dream {
             if (appearance.Alpha != Alpha) return false;
             if (appearance.GlideSize != GlideSize) return false;
             if (!appearance.ColorMatrix.Equals(ColorMatrix)) return false;
-            if (appearance.Layer != Layer) return false;
+            if (!appearance.Layer.Equals(Layer)) return false;
             if (appearance.Plane != Plane) return false;
             if (appearance.RenderSource != RenderSource) return false;
             if (appearance.RenderTarget != RenderTarget) return false;
@@ -102,6 +106,7 @@ namespace OpenDreamShared.Dream {
             if (appearance.MouseOpacity != MouseOpacity) return false;
             if (appearance.Overlays.Count != Overlays.Count) return false;
             if (appearance.Underlays.Count != Underlays.Count) return false;
+            if (appearance.VisContents.Count != VisContents.Count) return false;
             if (appearance.Filters.Count != Filters.Count) return false;
             if (appearance.Override != Override) return false;
 
@@ -117,8 +122,12 @@ namespace OpenDreamShared.Dream {
                 if (appearance.Underlays[i] != Underlays[i]) return false;
             }
 
+            for (int i = 0; i < VisContents.Count; i++) {
+                if (appearance.VisContents[i] != VisContents[i]) return false;
+            }
+
             for (int i = 0; i < 6; i++) {
-                if (appearance.Transform[i] != Transform[i]) return false;
+                if (!appearance.Transform[i].Equals(Transform[i])) return false;
             }
 
             return true;
@@ -180,6 +189,10 @@ namespace OpenDreamShared.Dream {
 
             foreach (int underlay in Underlays) {
                 hashCode.Add(underlay);
+            }
+
+            foreach (int visContent in VisContents) {
+                hashCode.Add(visContent);
             }
 
             foreach (DreamFilter filter in Filters) {


### PR DESCRIPTION
An implementation of vis_contents that does not much more than get them rendering.

vis_flags is currently ignored and clicking is incorrectly routed to the parent atom.

Gets BeeStation's airlocks rendering (though there's a bug with the alpha filter keeping them from masking when open):

![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/0271af2c-9b90-4a25-84c6-88aa7ce6ae33)

![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/387b73a4-1df8-449f-9c44-d2ba39081219)

Resolves #296