### PR TITLE
Always use forward slashes in compile-time resources

### DIFF
--- a/Content.Tests/DMProject/Tests/Expression/Constants/resource.dm
+++ b/Content.Tests/DMProject/Tests/Expression/Constants/resource.dm
@@ -1,3 +1,10 @@
 /proc/RunTest()
 	var/resource = 'data/test.txt'
 	ASSERT(file2text(resource) == "Test resource file's content")
+
+	// Compile-time resources always use a forward slash
+	// file() does not
+	ASSERT("['data/test.txt']" == "data/test.txt")
+	ASSERT("['data\\test.txt']" == "data/test.txt")
+	ASSERT("[file("data/test.txt")]" == "data/test.txt")
+	ASSERT("[file("data\\test.txt")]" == "data\\test.txt") // Note the backslash here

--- a/DMCompiler/DM/Expressions/Constant.cs
+++ b/DMCompiler/DM/Expressions/Constant.cs
@@ -361,6 +361,9 @@ namespace DMCompiler.DM.Expressions {
         private bool _isAmbiguous;
 
         public Resource(Location location, string filePath) : base(location) {
+            // Compile-time resources always use forward slashes
+            filePath = filePath.Replace('\\', '/');
+
             string? finalFilePath = null;
 
             var outputDir = System.IO.Path.GetDirectoryName(DMCompiler.Settings.Files[0]) ?? "/";
@@ -395,9 +398,6 @@ namespace DMCompiler.DM.Expressions {
                 DMCompiler.Emit(WarningCode.ItemDoesntExist, Location, $"Cannot find file '{filePath}'");
                 _filePath = filePath;
             }
-
-            // Compile-time resources always use forward slashes
-            _filePath = _filePath.Replace('\\', '/');
 
             DMObjectTree.Resources.Add(_filePath);
         }

--- a/DMCompiler/DM/Expressions/Constant.cs
+++ b/DMCompiler/DM/Expressions/Constant.cs
@@ -361,7 +361,7 @@ namespace DMCompiler.DM.Expressions {
         private bool _isAmbiguous;
 
         public Resource(Location location, string filePath) : base(location) {
-            // Compile-time resources always use forward slashes
+            // Treat backslashes as forward slashes on Linux
             filePath = filePath.Replace('\\', '/');
 
             string? finalFilePath = null;
@@ -398,6 +398,10 @@ namespace DMCompiler.DM.Expressions {
                 DMCompiler.Emit(WarningCode.ItemDoesntExist, Location, $"Cannot find file '{filePath}'");
                 _filePath = filePath;
             }
+
+            // Path operations give backslashes on Windows, so do this again
+            // Compile-time resources always use forward slashes
+            _filePath = _filePath.Replace('\\', '/');
 
             DMObjectTree.Resources.Add(_filePath);
         }

--- a/DMCompiler/DM/Expressions/Constant.cs
+++ b/DMCompiler/DM/Expressions/Constant.cs
@@ -396,6 +396,9 @@ namespace DMCompiler.DM.Expressions {
                 _filePath = filePath;
             }
 
+            // Compile-time resources always use forward slashes
+            _filePath = _filePath.Replace('\\', '/');
+
             DMObjectTree.Resources.Add(_filePath);
         }
 


### PR DESCRIPTION
Compile-time resources always use forward slashes in their paths

```dm
world.log << "[file("a/b.dmi")]"
world.log << "[file("a\\b.dmi")]"
world.log << "['a/b.dmi']"
world.log << "['a\\b.dmi']"
```
Outputs:
```
a/b.dmi
a\b.dmi
a/b.dmi
a/b.dmi
```