### PR TITLE
Adds a pragma for unsafe client accesses

### DIFF
--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -598,7 +598,6 @@ namespace DMCompiler.DM.Visitors {
                         _ => throw new InvalidOperationException(),
                     };
                 }
-
                 switch (operation.Kind) {
                     case DMASTDereference.OperationKind.Field:
                     case DMASTDereference.OperationKind.FieldSafe: {
@@ -618,6 +617,10 @@ namespace DMCompiler.DM.Visitors {
                                 operation.Identifier = field;
                                 operation.GlobalId = null;
                                 operation.Path = property.Type;
+                                if (operation.Kind == DMASTDereference.OperationKind.Field &&
+                                    dmObject.IsSubtypeOf(DreamPath.Client)) {
+                                    DMCompiler.Emit(WarningCode.UnsafeClientAccess, deref.Location,"Unsafe \"client\" access. Use the \"?.\" operator instead");
+                                }
                             } else {
                                 var globalId = dmObject.GetGlobalVariableId(field);
                                 if (globalId != null) {

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -30,3 +30,5 @@
 //3000-3999
 #pragma EmptyBlock notice
 #pragma EmptyProc disabled // NOTE: If you enable this in OD's default pragma config file, it will emit for OD's DMStandard. Put it in your codebase's pragma config file.
+#pragma UnsafeClientAccess disabled // NOTE: Only checks for unsafe accesses like "client.foobar" and doesn't consider if the client was already null-checked earlier in the proc
+

--- a/OpenDreamShared/Compiler/CompilerError.cs
+++ b/OpenDreamShared/Compiler/CompilerError.cs
@@ -54,7 +54,8 @@ namespace OpenDreamShared.Compiler {
 
         // 3000 - 3999 are reserved for stylistic configuration.
         EmptyBlock = 3100,
-        EmptyProc = 3101
+        EmptyProc = 3101,
+        UnsafeClientAccess = 3200
 
         // 4000 - 4999 are reserved for runtime configuration. (TODO: Runtime doesn't know about configs yet!)
     }


### PR DESCRIPTION
I didn't have time to revisit static typing so I did this instead.

Lints for `client.foo` and suggests `client?.foo`.

I consider this a stylistic pragma and a disabled-by-default pragma because it'll throw a lot of false positives since SS13 will nullcheck clients in various ways like `if(client && client.foo)` (even though `if(client?.foo)` is faster).

But with how often I've been seeing null client bugs in SS13 lately, I still consider this a useful lint.