### PR TITLE
Handle out-of-range `atom.dir` sets

### DIFF
--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -126,8 +126,13 @@ namespace OpenDreamRuntime {
                     value.TryGetValueAsString(out appearance.IconState);
                     break;
                 case "dir":
-                    //TODO figure out the weird inconsistencies with this being internally clamped
                     value.TryGetValueAsInteger(out var dir);
+
+                    if (dir <= 0) // Ignore any sets <= 0 or non-number
+                        break;
+
+                    if (dir > 0xFF) // Clamp to 1 byte
+                        dir = 0xFF;
 
                     appearance.Direction = (AtomDirection)dir;
                     break;

--- a/OpenDreamShared/Dream/AtomDirection.cs
+++ b/OpenDreamShared/Dream/AtomDirection.cs
@@ -1,19 +1,19 @@
 ﻿using Robust.Shared.Serialization;
 using System;
 
-namespace OpenDreamShared.Dream {
-    [Serializable, NetSerializable, Flags]
-    public enum AtomDirection {
-        None = 0,
+namespace OpenDreamShared.Dream;
 
-        North = 1,
-        South = 2,
-        East = 4,
-        West = 8,
+[Serializable, NetSerializable, Flags]
+public enum AtomDirection : byte {
+    None = 0,
 
-        Northeast = North | East,
-        Southeast = South | East,
-        Southwest = South | West,
-        Northwest = North | West
-    }
+    North = 1,
+    South = 2,
+    East = 4,
+    West = 8,
+
+    Northeast = North | East,
+    Southeast = South | East,
+    Southwest = South | West,
+    Northwest = North | West
 }


### PR DESCRIPTION
`atom.dir`'s maximum value is 255. Also, setting it to 0 or below/a non-number will ignore the assign entirely, keeping the current value.