### PR TITLE
Move `atom.transform` handling to the appearance var helpers

### DIFF
--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -100,13 +100,13 @@ namespace OpenDreamRuntime {
                 case "glide_size":
                 case "render_source":
                 case "render_target":
+                case "transform":
                     return true;
 
                 // Get/SetAppearanceVar doesn't handle these
                 case "overlays":
                 case "underlays":
                 case "filters":
-                case "transform":
                 default:
                     return false;
             }
@@ -193,7 +193,14 @@ namespace OpenDreamRuntime {
                 case "render_target":
                     value.TryGetValueAsString(out appearance.RenderTarget);
                     break;
-                // TODO: overlays, underlays, filters, transform
+                case "transform":
+                    float[] transformArray = value.TryGetValueAsDreamObject<DreamObjectMatrix>(out var transform)
+                        ? DreamObjectMatrix.MatrixToTransformFloatArray(transform)
+                        : DreamObjectMatrix.IdentityMatrixArray;
+
+                    appearance.Transform = transformArray;
+                    break;
+                // TODO: overlays, underlays, filters
                 //       Those are handled separately by whatever is calling SetAppearanceVar currently
                 default:
                     throw new ArgumentException($"Invalid appearance var {varName}");
@@ -259,7 +266,14 @@ namespace OpenDreamRuntime {
                     return (appearance.RenderTarget != null)
                         ? new DreamValue(appearance.RenderTarget)
                         : DreamValue.Null;
-                // TODO: overlays, underlays, filters, transform
+                case "transform":
+                    var transform = appearance.Transform;
+                    var matrix = DreamObjectMatrix.MakeMatrix(_objectTree,
+                        transform[0], transform[2], transform[4],
+                        transform[1], transform[3], transform[5]);
+
+                    return new(matrix);
+                // TODO: overlays, underlays, filters
                 //       Those are handled separately by whatever is calling GetAppearanceVar currently
                 default:
                     throw new ArgumentException($"Invalid appearance var {varName}");

--- a/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
@@ -47,17 +47,6 @@ public class DreamObjectAtom : DreamObject {
 
                 value = new(appearanceCopy);
                 return true;
-            case "transform":{
-                var appearance = AtomManager.MustGetAppearance(this)!;
-
-                var transform = appearance.Transform;
-                var matrix = DreamObjectMatrix.MakeMatrix(ObjectTree,
-                    transform[0], transform[2], transform[4],
-                    transform[1], transform[3], transform[5]);
-
-                value = new(matrix);
-                return true;
-            }
             case "overlays":
                 value = new(Overlays);
                 return true;
@@ -162,7 +151,7 @@ public class DreamObjectAtom : DreamObject {
                 break;
             }
             default:
-                if (AtomManager.IsValidAppearanceVar(varName) || varName == "transform") {
+                if (AtomManager.IsValidAppearanceVar(varName)) {
                     // Basically AtomManager.UpdateAppearance() but without the performance impact of using actions
                     var appearance = AtomManager.MustGetAppearance(this);
 
@@ -170,16 +159,7 @@ public class DreamObjectAtom : DreamObject {
                     // TODO: We can probably avoid cloning while the DMISpriteComponent is dirty
                     appearance = (appearance != null) ? new(appearance) : new();
 
-                    if (varName == "transform") {
-                        float[] matrixArray = value.TryGetValueAsDreamObject<DreamObjectMatrix>(out var matrix)
-                            ? DreamObjectMatrix.MatrixToTransformFloatArray(matrix)
-                            : DreamObjectMatrix.IdentityMatrixArray;
-
-                        appearance.Transform = matrixArray;
-                    } else {
-                        AtomManager.SetAppearanceVar(appearance, varName, value);
-                    }
-
+                    AtomManager.SetAppearanceVar(appearance, varName, value);
                     AtomManager.SetAtomAppearance(this, appearance);
                     break;
                 }


### PR DESCRIPTION
The behavior for this var in atoms and images is the same, so I moved the setter and getter to `SetAppearanceVar()` and `GetAppearanceVar()`

Makes the var work on images and appearance values.