### PR TITLE
Handle non-number `Start` and `End` args in `list.Find()`

### DIFF
--- a/Content.Tests/DMProject/Tests/List/ListFind.dm
+++ b/Content.Tests/DMProject/Tests/List/ListFind.dm
@@ -1,0 +1,20 @@
+/proc/RunTest()
+	var/list/L = list("a", "b", "c")
+	
+	ASSERT(L.Find("b") == 2)
+	
+	ASSERT(L.Find("b", 1) == 2)
+	ASSERT(L.Find("b", 2) == 2)
+	ASSERT(L.Find("b", 3) == 0)
+	
+	ASSERT(L.Find("b", 1, 0) == 2)
+	ASSERT(L.Find("b", 2, 0) == 2)
+	ASSERT(L.Find("b", 3, 0) == 0)
+	
+	ASSERT(L.Find("b", 1, 1) == 0)
+	ASSERT(L.Find("b", 1, 2) == 2)
+	ASSERT(L.Find("b", 1, 3) == 2)
+	
+	ASSERT(L.Find("b", new /datum) == 2)
+	ASSERT(L.Find("b", "c") == 2)
+	ASSERT(L.Find("b", 1, new /datum) == 2)

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeList.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeList.cs
@@ -53,8 +53,9 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("End", Type = DreamValueTypeFlag.Float, DefaultValue = 0)]
         public static DreamValue NativeProc_Find(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
             DreamValue element = bundle.GetArgument(0, "Elem");
-            int start = bundle.GetArgument(1, "Start").MustGetValueAsInteger(); //1-indexed
-            int end = bundle.GetArgument(2, "End").MustGetValueAsInteger(); //1-indexed
+            if (!bundle.GetArgument(1, "Start").TryGetValueAsInteger(out var start)) //1-indexed
+                start = 1; // 1 if non-number
+            bundle.GetArgument(2, "End").TryGetValueAsInteger(out var end); //1-indexed, 0 if non-number
             DreamList list = (DreamList)src!;
 
             return new(list.FindValue(element, start, end));


### PR DESCRIPTION
They are treated as their default values.