### PR TITLE
Don't register an appearance when removing an overlay

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -642,9 +642,10 @@ namespace OpenDreamRuntime.Objects.Types {
 
             _atomManager.UpdateAppearance(_atom, appearance => {
                 IconAppearance? overlayAppearance = CreateOverlayAppearance(_atomManager, value, appearance.Icon);
-                overlayAppearance ??= new IconAppearance();
+                if (overlayAppearance == null || !_appearanceSystem.TryGetAppearanceId(overlayAppearance, out var id))
+                    return;
 
-                GetOverlaysList(appearance).Remove(_appearanceSystem.AddAppearance(overlayAppearance));
+                GetOverlaysList(appearance).Remove(id);
             });
         }
 

--- a/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
+++ b/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
@@ -47,7 +47,7 @@ namespace OpenDreamRuntime.Rendering {
             return _idToAppearance.TryGetValue(appearanceId, out appearance);
         }
 
-        public bool TryGetAppearanceId(IconAppearance appearance, [NotNullWhen(true)] out uint appearanceId) {
+        public bool TryGetAppearanceId(IconAppearance appearance, out uint appearanceId) {
             return _appearanceToId.TryGetValue(appearance, out appearanceId);
         }
 


### PR DESCRIPTION
Avoid adding an appearance to the appearance list when trying to remove a nonexistent overlay from an overlays/underlays list. This cuts down on the amount of expensive operations done when dealing with appearances.