### PR TITLE
Bump RT

### DIFF
--- a/OpenDream.sln
+++ b/OpenDream.sln
@@ -95,6 +95,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Robust.Shared.CompNetworkGe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenDreamPackaging", "OpenDreamPackaging\OpenDreamPackaging.csproj", "{A86753A5-C9D8-4F3E-B030-BCFC64DF35D6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Robust.Serialization.Generator", "RobustToolbox\Robust.Serialization.Generator\Robust.Serialization.Generator.csproj", "{366AA569-0889-491B-AB00-F038EAEC5221}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -414,6 +416,16 @@ Global
 		{A86753A5-C9D8-4F3E-B030-BCFC64DF35D6}.Release|x64.Build.0 = Release|Any CPU
 		{A86753A5-C9D8-4F3E-B030-BCFC64DF35D6}.Tools|Any CPU.ActiveCfg = Debug|Any CPU
 		{A86753A5-C9D8-4F3E-B030-BCFC64DF35D6}.Tools|Any CPU.Build.0 = Debug|Any CPU
+		{366AA569-0889-491B-AB00-F038EAEC5221}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{366AA569-0889-491B-AB00-F038EAEC5221}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{366AA569-0889-491B-AB00-F038EAEC5221}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{366AA569-0889-491B-AB00-F038EAEC5221}.Debug|x64.Build.0 = Debug|Any CPU
+		{366AA569-0889-491B-AB00-F038EAEC5221}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{366AA569-0889-491B-AB00-F038EAEC5221}.Release|Any CPU.Build.0 = Release|Any CPU
+		{366AA569-0889-491B-AB00-F038EAEC5221}.Release|x64.ActiveCfg = Release|Any CPU
+		{366AA569-0889-491B-AB00-F038EAEC5221}.Release|x64.Build.0 = Release|Any CPU
+		{366AA569-0889-491B-AB00-F038EAEC5221}.Tools|Any CPU.ActiveCfg = Debug|Any CPU
+		{366AA569-0889-491B-AB00-F038EAEC5221}.Tools|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OpenDreamClient/Input/MouseInputSystem.cs
+++ b/OpenDreamClient/Input/MouseInputSystem.cs
@@ -56,7 +56,7 @@ namespace OpenDreamClient.Input {
                 mapCoords = new MapCoordinates(mapCoords.Position + new Vector2(0.5f), mapCoords.MapId);
 
                 if (_mapManager.TryFindGridAt(mapCoords, out _, out var grid)){
-                    Vector2i position = grid.CoordinatesToTile(mapCoords);
+                    Vector2i position = grid.CoordinatesToTile(grid.MapToGrid(mapCoords));
                     MapCoordinates worldPosition = grid.GridTileToWorld(position);
                     Vector2i turfIconPosition = (Vector2i) ((mapCoords.Position - position) * EyeManager.PixelsPerMeter);
                     RaiseNetworkEvent(new TurfClickedEvent(position, (int)worldPosition.MapId, screenLoc, middle, shift, ctrl, alt, turfIconPosition));

--- a/OpenDreamClient/Interface/Controls/ScalingViewport.cs
+++ b/OpenDreamClient/Interface/Controls/ScalingViewport.cs
@@ -16,6 +16,7 @@ namespace OpenDreamClient.Interface.Controls;
 public sealed class ScalingViewport : Control, IViewportControl {
     [Dependency] private readonly IClyde _clyde = default!;
     [Dependency] private readonly IInputManager _inputManager = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!;
 
     // Internal viewport creation is deferred.
     private IClydeViewport? _viewport;
@@ -220,6 +221,22 @@ public sealed class ScalingViewport : Control, IViewportControl {
         var matrix = Matrix3.Invert(LocalToScreenMatrix());
 
         return _viewport!.LocalToWorld(matrix.Transform(coords));
+    }
+
+    public MapCoordinates PixelToMap(Vector2 coords)
+    {
+        if (_eye == null)
+            return default;
+
+        EnsureViewportCreated();
+
+        var matrix = Matrix3.Invert(GetLocalToScreenMatrix());
+        coords = matrix.Transform(coords);
+
+        var ev = new PixelToMapEvent(coords, this, _viewport!);
+        _entityManager.EventBus.RaiseEvent(EventSource.Local, ref ev);
+
+        return _viewport!.LocalToWorld(ev.VisiblePosition);
     }
 
     public Vector2 WorldToScreen(Vector2 map) {

--- a/OpenDreamClient/Interface/Controls/ScalingViewport.cs
+++ b/OpenDreamClient/Interface/Controls/ScalingViewport.cs
@@ -223,8 +223,7 @@ public sealed class ScalingViewport : Control, IViewportControl {
         return _viewport!.LocalToWorld(matrix.Transform(coords));
     }
 
-    public MapCoordinates PixelToMap(Vector2 coords)
-    {
+    public MapCoordinates PixelToMap(Vector2 coords) {
         if (_eye == null)
             return default;
 

--- a/OpenDreamClient/Interface/Descriptors/ControlDescriptors.cs
+++ b/OpenDreamClient/Interface/Descriptors/ControlDescriptors.cs
@@ -9,7 +9,7 @@ using Robust.Shared.Serialization.TypeSerializers.Interfaces;
 namespace OpenDreamClient.Interface.Descriptors;
 
 [Virtual]
-public class ControlDescriptor : ElementDescriptor {
+public partial class ControlDescriptor : ElementDescriptor {
     [DataField("pos")]
     public Vector2i? Pos;
     [DataField("size")]
@@ -28,7 +28,7 @@ public class ControlDescriptor : ElementDescriptor {
     public bool IsDisabled;
 }
 
-public sealed class WindowDescriptor : ControlDescriptor {
+public sealed partial class WindowDescriptor : ControlDescriptor {
     [DataField("is-pane")]
     public bool IsPane;
     [DataField("icon")]
@@ -38,9 +38,9 @@ public sealed class WindowDescriptor : ControlDescriptor {
     [DataField("title")]
     public string? Title;
     [DataField("macro")]
-    public string? Macro { get; init; }
+    public string? Macro { get; private set; }
     [DataField("on-close")]
-    public string? OnClose { get; init; }
+    public string? OnClose { get; private set; }
 
     public readonly List<ControlDescriptor> ControlDescriptors;
 
@@ -108,7 +108,7 @@ public sealed class WindowDescriptor : ControlDescriptor {
     }
 }
 
-public sealed class ControlDescriptorChild : ControlDescriptor {
+public sealed partial class ControlDescriptorChild : ControlDescriptor {
     [DataField("left")]
     public string? Left;
     [DataField("right")]
@@ -119,39 +119,39 @@ public sealed class ControlDescriptorChild : ControlDescriptor {
     public float Splitter = 50f;
 }
 
-public sealed class ControlDescriptorInput : ControlDescriptor {
+public sealed partial class ControlDescriptorInput : ControlDescriptor {
 }
 
-public sealed class ControlDescriptorButton : ControlDescriptor {
+public sealed partial class ControlDescriptorButton : ControlDescriptor {
     [DataField("text")]
     public string? Text;
     [DataField("command")]
     public string? Command;
 }
 
-public sealed class ControlDescriptorOutput : ControlDescriptor {
+public sealed partial class ControlDescriptorOutput : ControlDescriptor {
 }
 
-public sealed class ControlDescriptorInfo : ControlDescriptor {
+public sealed partial class ControlDescriptorInfo : ControlDescriptor {
     [DataField("allow-html")]
     public bool AllowHtml = true; // Supposedly false by default, but it isn't if you're not using BYOND's default skin
 }
 
-public sealed class ControlDescriptorMap : ControlDescriptor {
+public sealed partial class ControlDescriptorMap : ControlDescriptor {
 }
 
-public sealed class ControlDescriptorBrowser : ControlDescriptor {
+public sealed partial class ControlDescriptorBrowser : ControlDescriptor {
 }
 
-public sealed class ControlDescriptorLabel : ControlDescriptor {
+public sealed partial class ControlDescriptorLabel : ControlDescriptor {
     [DataField("text")]
     public string? Text;
 }
 
-public sealed class ControlDescriptorGrid : ControlDescriptor {
+public sealed partial class ControlDescriptorGrid : ControlDescriptor {
 }
 
-public sealed class ControlDescriptorTab : ControlDescriptor {
+public sealed partial class ControlDescriptorTab : ControlDescriptor {
 }
 
 

--- a/OpenDreamClient/Interface/Descriptors/InterfaceDescriptor.cs
+++ b/OpenDreamClient/Interface/Descriptors/InterfaceDescriptor.cs
@@ -22,7 +22,7 @@ public sealed class InterfaceDescriptor {
 }
 
 [Virtual, ImplicitDataDefinitionForInheritors]
-public class ElementDescriptor {
+public partial class ElementDescriptor {
     [DataField("type")]
     public string _type;
 

--- a/OpenDreamClient/Interface/Descriptors/MacroDescriptors.cs
+++ b/OpenDreamClient/Interface/Descriptors/MacroDescriptors.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Serialization.Markdown.Mapping;
 
 namespace OpenDreamClient.Interface.Descriptors;
 
-public sealed class MacroSetDescriptor : ElementDescriptor {
+public sealed partial class MacroSetDescriptor : ElementDescriptor {
     private readonly List<MacroDescriptor> _macros = new();
     public IReadOnlyList<MacroDescriptor> Macros => _macros;
 
@@ -34,7 +34,7 @@ public sealed class MacroSetDescriptor : ElementDescriptor {
 }
 
 [UsedImplicitly]
-public sealed class MacroDescriptor : ElementDescriptor {
+public sealed partial class MacroDescriptor : ElementDescriptor {
     [DataField("command")]
-    public string Command  { get; init; }
+    public string Command  { get; private set; }
 }

--- a/OpenDreamClient/Interface/Descriptors/MenuDescriptors.cs
+++ b/OpenDreamClient/Interface/Descriptors/MenuDescriptors.cs
@@ -42,7 +42,7 @@ public sealed partial class MenuElementDescriptor : ElementDescriptor {
     [DataField("category")]
     public string? Category {
         get => _category;
-        private set { throw new NotImplementedException(); }
+        private set { _category = value; }
     }
 
     [DataField("can-check")]

--- a/OpenDreamClient/Interface/Descriptors/MenuDescriptors.cs
+++ b/OpenDreamClient/Interface/Descriptors/MenuDescriptors.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Serialization.Markdown.Mapping;
 
 namespace OpenDreamClient.Interface.Descriptors;
 
-public sealed class MenuDescriptor : ElementDescriptor {
+public sealed partial class MenuDescriptor : ElementDescriptor {
     private readonly List<MenuElementDescriptor> _elements = new();
     public IReadOnlyList<MenuElementDescriptor> Elements => _elements;
 
@@ -33,20 +33,20 @@ public sealed class MenuDescriptor : ElementDescriptor {
     }
 }
 
-public sealed class MenuElementDescriptor : ElementDescriptor {
+public sealed partial class MenuElementDescriptor : ElementDescriptor {
     private string? _category;
 
     [DataField("command")]
-    public string Command { get; init; }
+    public string Command { get; private set; }
 
     [DataField("category")]
     public string? Category {
         get => _category;
-        init => _category = value;
+        private set { throw new NotImplementedException(); }
     }
 
     [DataField("can-check")]
-    public bool CanCheck { get; init; }
+    public bool CanCheck { get; private set; }
 
     public MenuElementDescriptor WithCategory(ISerializationManager serialization, string category) {
         var copy = serialization.CreateCopy(this, notNullableOverride: true);

--- a/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
+++ b/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
@@ -8,9 +8,9 @@ using OpenDreamClient.Resources.ResourceTypes;
 
 namespace OpenDreamClient.Rendering {
     internal sealed class ClientAppearanceSystem : SharedAppearanceSystem {
-        private Dictionary<uint, IconAppearance> _appearances = new();
-        private readonly Dictionary<uint, List<Action<IconAppearance>>> _appearanceLoadCallbacks = new();
-        private readonly Dictionary<uint, DreamIcon> _turfIcons = new();
+        private Dictionary<int, IconAppearance> _appearances = new();
+        private readonly Dictionary<int, List<Action<IconAppearance>>> _appearanceLoadCallbacks = new();
+        private readonly Dictionary<int, DreamIcon> _turfIcons = new();
         private readonly Dictionary<DreamFilter, ShaderInstance> _filterShaders = new();
 
         [Dependency] private readonly IEntityManager _entityManager = default!;
@@ -30,7 +30,7 @@ namespace OpenDreamClient.Rendering {
             _turfIcons.Clear();
         }
 
-        public void LoadAppearance(uint appearanceId, Action<IconAppearance> loadCallback) {
+        public void LoadAppearance(int appearanceId, Action<IconAppearance> loadCallback) {
             if (_appearances.TryGetValue(appearanceId, out var appearance)) {
                 loadCallback(appearance);
             }
@@ -42,8 +42,8 @@ namespace OpenDreamClient.Rendering {
             _appearanceLoadCallbacks[appearanceId].Add(loadCallback);
         }
 
-        public DreamIcon GetTurfIcon(uint turfId) {
-            uint appearanceId = turfId - 1;
+        public DreamIcon GetTurfIcon(int turfId) {
+            int appearanceId = turfId - 1;
 
             if (!_turfIcons.TryGetValue(appearanceId, out var icon)) {
                 icon = new DreamIcon(appearanceId);
@@ -56,7 +56,7 @@ namespace OpenDreamClient.Rendering {
         private void OnAllAppearances(AllAppearancesEvent e, EntitySessionEventArgs session) {
             _appearances = e.Appearances;
 
-            foreach (KeyValuePair<uint, IconAppearance> pair in _appearances) {
+            foreach (KeyValuePair<int, IconAppearance> pair in _appearances) {
                 if (_appearanceLoadCallbacks.TryGetValue(pair.Key, out var callbacks)) {
                     foreach (var callback in callbacks) callback(pair.Value);
                 }

--- a/OpenDreamClient/Rendering/ClientImagesSystem.cs
+++ b/OpenDreamClient/Rendering/ClientImagesSystem.cs
@@ -6,9 +6,9 @@ using Vector3 = Robust.Shared.Maths.Vector3;
 
 namespace OpenDreamClient.Rendering;
 sealed class ClientImagesSystem : SharedClientImagesSystem {
-    private readonly Dictionary<Vector3, List<uint>> TurfClientImages = new();
-    private readonly Dictionary<EntityUid, List<uint>> AMClientImages = new();
-    private readonly Dictionary<uint, DreamIcon> _idToIcon = new();
+    private readonly Dictionary<Vector3, List<int>> TurfClientImages = new();
+    private readonly Dictionary<EntityUid, List<int>> AMClientImages = new();
+    private readonly Dictionary<int, DreamIcon> _idToIcon = new();
     [Dependency] private readonly ClientAppearanceSystem _clientAppearanceSystem = default!;
     [Dependency] private IEntityManager _entityManager = default!;
 
@@ -25,7 +25,7 @@ sealed class ClientImagesSystem : SharedClientImagesSystem {
 
     public bool TryGetClientImages(EntityUid entity, Vector3? tileCoords, [NotNullWhen(true)] out List<DreamIcon>? result){
         result = null;
-        List<uint>? resultIDs;
+        List<int>? resultIDs;
         if(entity == EntityUid.Invalid && tileCoords is not null) {
             if(!TurfClientImages.TryGetValue(tileCoords.Value, out resultIDs))
                 return false;
@@ -34,7 +34,7 @@ sealed class ClientImagesSystem : SharedClientImagesSystem {
                 return false;
         }
         result = new List<DreamIcon>();
-        foreach(uint distinctID in resultIDs)
+        foreach(int distinctID in resultIDs)
             if(_idToIcon.TryGetValue(distinctID, out DreamIcon? icon))
                 result.Add(icon);
         return result.Count > 0;
@@ -43,7 +43,7 @@ sealed class ClientImagesSystem : SharedClientImagesSystem {
     private void OnAddClientImage(AddClientImageEvent e) {
         if(e.AttachedEntity == EntityUid.Invalid) {
             if(!TurfClientImages.TryGetValue(e.TurfCoords, out var iconList))
-                iconList = new List<uint>();
+                iconList = new List<int>();
             if(!_idToIcon.ContainsKey(e.ImageAppearance)){
                 DreamIcon icon = new DreamIcon(e.ImageAppearance);
                 _idToIcon[e.ImageAppearance] = icon;
@@ -52,7 +52,7 @@ sealed class ClientImagesSystem : SharedClientImagesSystem {
             TurfClientImages[e.TurfCoords] = iconList;
         } else {
             if(!AMClientImages.TryGetValue(e.AttachedEntity, out var iconList))
-                iconList = new List<uint>();
+                iconList = new List<int>();
             if(!_idToIcon.ContainsKey(e.ImageAppearance)){
                 DreamIcon icon = new DreamIcon(e.ImageAppearance);
                 _idToIcon[e.ImageAppearance] = icon;

--- a/OpenDreamClient/Rendering/DMISpriteComponent.cs
+++ b/OpenDreamClient/Rendering/DMISpriteComponent.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Map;
 namespace OpenDreamClient.Rendering {
     [RegisterComponent]
     [ComponentReference(typeof(SharedDMISpriteComponent))]
-    internal sealed class DMISpriteComponent : SharedDMISpriteComponent {
+    internal sealed partial class DMISpriteComponent : SharedDMISpriteComponent {
         [ViewVariables] public DreamIcon Icon { get; set; } = new DreamIcon();
         [ViewVariables] public ScreenLocation? ScreenLocation { get; set; }
 

--- a/OpenDreamClient/Rendering/DreamIcon.cs
+++ b/OpenDreamClient/Rendering/DreamIcon.cs
@@ -49,11 +49,11 @@ namespace OpenDreamClient.Rendering {
 
         public DreamIcon() { }
 
-        public DreamIcon(uint appearanceId, AtomDirection? parentDir = null) {
+        public DreamIcon(int appearanceId, AtomDirection? parentDir = null) {
             SetAppearance(appearanceId, parentDir);
         }
 
-        public void SetAppearance(uint? appearanceId, AtomDirection? parentDir = null) {
+        public void SetAppearance(int? appearanceId, AtomDirection? parentDir = null) {
             // End any animations that are currently happening
             // Note that this isn't faithful to the original behavior
             EndAppearanceAnimation();
@@ -177,7 +177,7 @@ namespace OpenDreamClient.Rendering {
             }
 
             Overlays.Clear();
-            foreach (uint overlayId in Appearance.Overlays) {
+            foreach (int overlayId in Appearance.Overlays) {
                 DreamIcon overlay = new DreamIcon(overlayId, Appearance.Direction);
                 overlay.SizeChanged += CheckSizeChange;
 
@@ -185,7 +185,7 @@ namespace OpenDreamClient.Rendering {
             }
 
             Underlays.Clear();
-            foreach (uint underlayId in Appearance.Underlays) {
+            foreach (int underlayId in Appearance.Underlays) {
                 DreamIcon underlay = new DreamIcon(underlayId, Appearance.Direction);
                 underlay.SizeChanged += CheckSizeChange;
 

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -283,7 +283,7 @@ namespace OpenDreamRuntime {
                         return new DreamValue(resource);
                     case RefType.DreamAppearance:
                         _appearanceSystem ??= _entitySystemManager.GetEntitySystem<ServerAppearanceSystem>();
-                        return _appearanceSystem.TryGetAppearance((uint)refId, out IconAppearance? appearance)
+                        return _appearanceSystem.TryGetAppearance(refId, out IconAppearance? appearance)
                             ? new DreamValue(appearance)
                             : DreamValue.Null;
                     case RefType.Proc:

--- a/OpenDreamRuntime/DreamMapManager.cs
+++ b/OpenDreamRuntime/DreamMapManager.cs
@@ -154,14 +154,9 @@ namespace OpenDreamRuntime {
 
         public void SetTurfAppearance(DreamObjectTurf turf, IconAppearance appearance) {
             int appearanceId = _appearanceSystem.AddAppearance(appearance);
-            if (appearanceId > ushort.MaxValue - 1) {
-                // TODO: Maybe separate appearance IDs and turf IDs to prevent this possibility
-                _sawmill.Error($"Failed to set turf's appearance at ({turf.X}, {turf.Y}) because its appearance ID was greater than {ushort.MaxValue - 1}");
-                return;
-            }
 
             var level = _levels[turf.Z - 1];
-            ushort turfId = (ushort) (appearanceId + 1); // +1 because 0 is used for empty turfs
+            int turfId = (appearanceId + 1); // +1 because 0 is used for empty turfs
             level.QueuedTileUpdates[(turf.X, turf.Y)] = new Tile(turfId);
             turf.AppearanceId = appearanceId;
         }

--- a/OpenDreamRuntime/DreamMapManager.cs
+++ b/OpenDreamRuntime/DreamMapManager.cs
@@ -153,7 +153,7 @@ namespace OpenDreamRuntime {
         }
 
         public void SetTurfAppearance(DreamObjectTurf turf, IconAppearance appearance) {
-            uint appearanceId = _appearanceSystem.AddAppearance(appearance);
+            int appearanceId = _appearanceSystem.AddAppearance(appearance);
             if (appearanceId > ushort.MaxValue - 1) {
                 // TODO: Maybe separate appearance IDs and turf IDs to prevent this possibility
                 _sawmill.Error($"Failed to set turf's appearance at ({turf.X}, {turf.Y}) because its appearance ID was greater than {ushort.MaxValue - 1}");

--- a/OpenDreamRuntime/LocalHostConGroup.cs
+++ b/OpenDreamRuntime/LocalHostConGroup.cs
@@ -1,6 +1,10 @@
 using Robust.Server.Console;
 using Robust.Server.Player;
 using System.Net;
+using Robust.Shared.Network;
+using Robust.Shared.Players;
+using Robust.Shared.Toolshed;
+using Robust.Shared.Toolshed.Errors;
 
 namespace OpenDreamRuntime {
     #if DEBUG
@@ -32,6 +36,8 @@ namespace OpenDreamRuntime {
             return IsLocal(session);
         }
 
+
+
         private static bool IsLocal(IPlayerSession player) {
             var ep = player.ConnectedClient.RemoteEndPoint;
             var addr = ep.Address;
@@ -40,6 +46,23 @@ namespace OpenDreamRuntime {
             }
 
             return Equals(addr, IPAddress.Loopback) || Equals(addr, IPAddress.IPv6Loopback);
+        }
+
+        private static bool IsLocal(INetChannel client) {
+            var ep = client.RemoteEndPoint;
+            var addr = ep.Address;
+            if (addr.IsIPv4MappedToIPv6) {
+                addr = addr.MapToIPv4();
+            }
+
+            return Equals(addr, IPAddress.Loopback) || Equals(addr, IPAddress.IPv6Loopback);
+        }
+
+        public bool CheckInvokable(CommandSpec command, ICommonSession? user, out IConError? error)
+        {
+            error = null;
+            if (user is null) return false;
+            return IsLocal(user.ConnectedClient);
         }
 
         void IPostInjectInit.PostInject() {

--- a/OpenDreamRuntime/LocalHostConGroup.cs
+++ b/OpenDreamRuntime/LocalHostConGroup.cs
@@ -35,17 +35,9 @@ namespace OpenDreamRuntime {
         public bool CanAdminReloadPrototypes(IPlayerSession session) {
             return IsLocal(session);
         }
-
-
-
+        
         private static bool IsLocal(IPlayerSession player) {
-            var ep = player.ConnectedClient.RemoteEndPoint;
-            var addr = ep.Address;
-            if (addr.IsIPv4MappedToIPv6) {
-                addr = addr.MapToIPv4();
-            }
-
-            return Equals(addr, IPAddress.Loopback) || Equals(addr, IPAddress.IPv6Loopback);
+            return IsLocal(player.ConnectedClient);
         }
 
         private static bool IsLocal(INetChannel client) {

--- a/OpenDreamRuntime/LocalHostConGroup.cs
+++ b/OpenDreamRuntime/LocalHostConGroup.cs
@@ -50,8 +50,7 @@ namespace OpenDreamRuntime {
             return Equals(addr, IPAddress.Loopback) || Equals(addr, IPAddress.IPv6Loopback);
         }
 
-        public bool CheckInvokable(CommandSpec command, ICommonSession? user, out IConError? error)
-        {
+        public bool CheckInvokable(CommandSpec command, ICommonSession? user, out IConError? error) {
             error = null;
             if (user is null) return false;
             return IsLocal(user.ConnectedClient);

--- a/OpenDreamRuntime/LocalHostConGroup.cs
+++ b/OpenDreamRuntime/LocalHostConGroup.cs
@@ -52,7 +52,7 @@ namespace OpenDreamRuntime {
 
         public bool CheckInvokable(CommandSpec command, ICommonSession? user, out IConError? error) {
             error = null;
-            if (user is null) return false;
+            if (user is null) return true; // Server console
             return IsLocal(user.ConnectedClient);
         }
 

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -595,7 +595,7 @@ namespace OpenDreamRuntime.Objects.Types {
 
         public override void Cut(int start = 1, int end = 0) {
             _atomManager.UpdateAppearance(_atom, appearance => {
-                List<uint> overlaysList = GetOverlaysList(appearance);
+                List<int> overlaysList = GetOverlaysList(appearance);
                 int count = overlaysList.Count + 1;
                 if (end == 0 || end > count) end = count;
 
@@ -608,14 +608,14 @@ namespace OpenDreamRuntime.Objects.Types {
                 throw new Exception($"Invalid index into {(_isUnderlays ? "underlays" : "overlays")} list: {key}");
 
             IconAppearance appearance = GetAppearance();
-            List<uint> overlaysList = GetOverlaysList(appearance);
+            List<int> overlaysList = GetOverlaysList(appearance);
             if (overlayIndex > overlaysList.Count)
                 throw new Exception($"Atom only has {overlaysList.Count} {(_isUnderlays ? "underlay" : "overlay")}(s), cannot index {overlayIndex}");
 
             if (_appearanceSystem == null)
                 return DreamValue.Null;
 
-            uint overlayId = GetOverlaysList(appearance)[overlayIndex - 1];
+            int overlayId = GetOverlaysList(appearance)[overlayIndex - 1];
             IconAppearance overlayAppearance = _appearanceSystem.MustGetAppearance(overlayId);
             return new DreamValue(overlayAppearance);
         }
@@ -653,7 +653,7 @@ namespace OpenDreamRuntime.Objects.Types {
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private List<uint> GetOverlaysList(IconAppearance appearance) =>
+        private List<int> GetOverlaysList(IconAppearance appearance) =>
             _isUnderlays ? appearance.Underlays : appearance.Overlays;
 
         private IconAppearance GetAppearance() {

--- a/OpenDreamRuntime/Objects/Types/DreamObjectTurf.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectTurf.cs
@@ -4,7 +4,7 @@ public sealed class DreamObjectTurf : DreamObjectAtom {
     public readonly int X, Y, Z;
     public readonly IDreamMapManager.Cell Cell;
     public readonly TurfContentsList Contents;
-    public uint AppearanceId;
+    public int AppearanceId;
 
     public DreamObjectTurf(DreamObjectDefinition objectDefinition, int x, int y, int z, IDreamMapManager.Cell cell) : base(objectDefinition) {
         X = x;

--- a/OpenDreamRuntime/Rendering/DMISpriteComponent.cs
+++ b/OpenDreamRuntime/Rendering/DMISpriteComponent.cs
@@ -3,7 +3,7 @@ using OpenDreamShared.Rendering;
 
 namespace OpenDreamRuntime.Rendering {
     [RegisterComponent]
-    public sealed class DMISpriteComponent : SharedDMISpriteComponent {
+    public sealed partial class DMISpriteComponent : SharedDMISpriteComponent {
         [ViewVariables]
         public ScreenLocation? ScreenLocation {
             get => _screenLocation;

--- a/OpenDreamRuntime/Rendering/DMISpriteSystem.cs
+++ b/OpenDreamRuntime/Rendering/DMISpriteSystem.cs
@@ -11,7 +11,7 @@ public sealed class DMISpriteSystem : EntitySystem {
     }
 
     private void GetComponentState(EntityUid uid, DMISpriteComponent component, ref ComponentGetState args) {
-        uint? appearanceId = null;
+        int? appearanceId = null;
         if (component.Appearance != null) {
             appearanceId = _appearance.AddAppearance(component.Appearance);
         }

--- a/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
+++ b/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
@@ -6,9 +6,9 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace OpenDreamRuntime.Rendering {
     public sealed class ServerAppearanceSystem : SharedAppearanceSystem {
-        private readonly Dictionary<IconAppearance, uint> _appearanceToId = new();
-        private readonly Dictionary<uint, IconAppearance> _idToAppearance = new();
-        private uint _appearanceIdCounter;
+        private readonly Dictionary<IconAppearance, int> _appearanceToId = new();
+        private readonly Dictionary<int, IconAppearance> _idToAppearance = new();
+        private int _appearanceIdCounter;
 
         [Dependency] private readonly IPlayerManager _playerManager = default!;
 
@@ -28,8 +28,8 @@ namespace OpenDreamRuntime.Rendering {
             }
         }
 
-        public uint AddAppearance(IconAppearance appearance) {
-            if (!_appearanceToId.TryGetValue(appearance, out uint appearanceId)) {
+        public int AddAppearance(IconAppearance appearance) {
+            if (!_appearanceToId.TryGetValue(appearance, out int appearanceId)) {
                 appearanceId = _appearanceIdCounter++;
                 _appearanceToId.Add(appearance, appearanceId);
                 _idToAppearance.Add(appearanceId, appearance);
@@ -39,20 +39,20 @@ namespace OpenDreamRuntime.Rendering {
             return appearanceId;
         }
 
-        public IconAppearance MustGetAppearance(uint appearanceId) {
+        public IconAppearance MustGetAppearance(int appearanceId) {
             return _idToAppearance[appearanceId];
         }
 
-        public bool TryGetAppearance(uint appearanceId, [NotNullWhen(true)] out IconAppearance? appearance) {
+        public bool TryGetAppearance(int appearanceId, [NotNullWhen(true)] out IconAppearance? appearance) {
             return _idToAppearance.TryGetValue(appearanceId, out appearance);
         }
 
-        public bool TryGetAppearanceId(IconAppearance appearance, [NotNullWhen(true)] out uint appearanceId) {
+        public bool TryGetAppearanceId(IconAppearance appearance, [NotNullWhen(true)] out int appearanceId) {
             return _appearanceToId.TryGetValue(appearance, out appearanceId);
         }
 
         public void Animate(EntityUid entity, IconAppearance targetAppearance, TimeSpan duration) {
-            uint appearanceId = AddAppearance(targetAppearance);
+            int appearanceId = AddAppearance(targetAppearance);
 
             RaiseNetworkEvent(new AnimationEvent(entity, appearanceId, duration));
         }

--- a/OpenDreamRuntime/Rendering/ServerClientImagesSystem.cs
+++ b/OpenDreamRuntime/Rendering/ServerClientImagesSystem.cs
@@ -18,9 +18,9 @@ public sealed class ServerClientImagesSystem : SharedClientImagesSystem {
 
         EntityUid locEntity = EntityUid.Invalid;
         Vector3 turfCoords = Vector3.Zero;
-        uint locAppearanceID = 0;
+        int locAppearanceID = 0;
 
-        uint imageAppearanceID = _serverAppearanceSystem.AddAppearance(imageObject.Appearance!);
+        int imageAppearanceID = _serverAppearanceSystem.AddAppearance(imageObject.Appearance!);
 
         if(loc is DreamObjectMovable movable)
             locEntity = movable.Entity;
@@ -38,7 +38,7 @@ public sealed class ServerClientImagesSystem : SharedClientImagesSystem {
         EntityUid locEntity = EntityUid.Invalid;
         Vector3 turfCoords = Vector3.Zero;
 
-        uint imageAppearanceID = _serverAppearanceSystem.AddAppearance(imageObject.Appearance!);
+        int imageAppearanceID = _serverAppearanceSystem.AddAppearance(imageObject.Appearance!);
 
         if(loc is DreamObjectMovable)
             locEntity = ((DreamObjectMovable)loc).Entity;

--- a/OpenDreamShared/Dream/DreamFilter.cs
+++ b/OpenDreamShared/Dream/DreamFilter.cs
@@ -10,7 +10,7 @@ namespace OpenDreamShared.Dream;
 /// An object describing type and vars so the client doesn't have to make a ShaderInstance for shaders with the same params
 /// </summary>
 [Serializable, NetSerializable, ImplicitDataDefinitionForInheritors]
-public record DreamFilter {
+public partial record DreamFilter {
     /// <summary>
     /// Indicates this filter was used in the last render cycle, for shader caching purposes
     /// </summary>
@@ -42,7 +42,7 @@ public record DreamFilter {
 }
 
 [Serializable, NetSerializable]
-public sealed record DreamFilterAlpha : DreamFilter {
+public sealed partial record DreamFilterAlpha : DreamFilter {
     [ViewVariables, DataField("x")] public float X;
     [ViewVariables, DataField("y")] public float Y;
     [ViewVariables, DataField("icon")] public int Icon; // Icon resource ID
@@ -51,14 +51,14 @@ public sealed record DreamFilterAlpha : DreamFilter {
 }
 
 [Serializable, NetSerializable]
-public sealed record DreamFilterAngularBlur : DreamFilter {
+public sealed partial record DreamFilterAngularBlur : DreamFilter {
     [ViewVariables, DataField("x")] public float X;
     [ViewVariables, DataField("y")] public float Y;
     [ViewVariables, DataField("size")] public float Size = 1f;
 }
 
 [Serializable, NetSerializable]
-public sealed record DreamFilterBloom : DreamFilter {
+public sealed partial record DreamFilterBloom : DreamFilter {
     [ViewVariables, DataField("threshold")] public Color Threshold = Color.Black;
     [ViewVariables, DataField("size")] public float Size = 1f;
     [ViewVariables, DataField("offset")] public float Offset = 1f;
@@ -66,18 +66,18 @@ public sealed record DreamFilterBloom : DreamFilter {
 }
 
 [Serializable, NetSerializable]
-public sealed record DreamFilterBlur : DreamFilter {
+public sealed partial record DreamFilterBlur : DreamFilter {
     [ViewVariables, DataField("size")] public float Size = 1f;
 }
 
 [Serializable, NetSerializable]
-public sealed record DreamFilterColor : DreamFilter {
+public sealed partial record DreamFilterColor : DreamFilter {
     [ViewVariables, DataField("color", required: true)] public ColorMatrix Color;
     [ViewVariables, DataField("space")] public float Space; // Default is FILTER_COLOR_RGB = 0
 }
 
 [Serializable, NetSerializable]
-public sealed record DreamFilterDisplace : DreamFilter {
+public sealed partial record DreamFilterDisplace : DreamFilter {
     [ViewVariables, DataField("x")] public float X;
     [ViewVariables, DataField("y")] public float Y;
     [ViewVariables, DataField("size")] public float Size = 1f;
@@ -86,7 +86,7 @@ public sealed record DreamFilterDisplace : DreamFilter {
 }
 
 [Serializable, NetSerializable]
-public sealed record DreamFilterDropShadow : DreamFilter {
+public sealed partial record DreamFilterDropShadow : DreamFilter {
     [ViewVariables, DataField("x")] public float X = 1f;
     [ViewVariables, DataField("y")] public float Y = -1f;
     [ViewVariables, DataField("size")] public float Size = 1f;
@@ -95,7 +95,7 @@ public sealed record DreamFilterDropShadow : DreamFilter {
 }
 
 [Serializable, NetSerializable]
-public sealed record DreamFilterLayer : DreamFilter {
+public sealed partial record DreamFilterLayer : DreamFilter {
     [ViewVariables, DataField("x")] public float X;
     [ViewVariables, DataField("y")] public float Y;
     [ViewVariables, DataField("icon")] public int Icon; // Icon resource ID
@@ -107,27 +107,27 @@ public sealed record DreamFilterLayer : DreamFilter {
 }
 
 [Serializable, NetSerializable]
-public sealed record DreamFilterMotionBlur : DreamFilter {
+public sealed partial record DreamFilterMotionBlur : DreamFilter {
     [ViewVariables, DataField("x")] public float X;
     [ViewVariables, DataField("y")] public float Y;
 }
 
 [Serializable, NetSerializable]
-public sealed record DreamFilterOutline : DreamFilter {
+public sealed partial record DreamFilterOutline : DreamFilter {
     [ViewVariables, DataField("size")] public float Size = 1f;
     [ViewVariables, DataField("color")] public Color Color = Color.Black;
     [ViewVariables, DataField("flags")] public float Flags;
 }
 
 [Serializable, NetSerializable]
-public sealed record DreamFilterRadialBlur : DreamFilter {
+public sealed partial record DreamFilterRadialBlur : DreamFilter {
     [ViewVariables, DataField("x")] public float X;
     [ViewVariables, DataField("y")] public float Y;
     [ViewVariables, DataField("size")] public float Size = 0.01f;
 }
 
 [Serializable, NetSerializable]
-public sealed record DreamFilterRays : DreamFilter {
+public sealed partial record DreamFilterRays : DreamFilter {
     [ViewVariables, DataField("x")] public float X;
     [ViewVariables, DataField("y")] public float Y;
     [ViewVariables, DataField("size")] public float Size = 16f; // Defaults to half tile width
@@ -140,7 +140,7 @@ public sealed record DreamFilterRays : DreamFilter {
 }
 
 [Serializable, NetSerializable]
-public sealed record DreamFilterRipple : DreamFilter {
+public sealed partial record DreamFilterRipple : DreamFilter {
     [ViewVariables, DataField("x")] public float X;
     [ViewVariables, DataField("y")] public float Y;
     [ViewVariables, DataField("size")] public float Size = 1f;
@@ -151,7 +151,7 @@ public sealed record DreamFilterRipple : DreamFilter {
 }
 
 [Serializable, NetSerializable]
-public sealed record DreamFilterWave : DreamFilter {
+public sealed partial record DreamFilterWave : DreamFilter {
     [ViewVariables, DataField("x")] public float X;
     [ViewVariables, DataField("y")] public float Y;
     [ViewVariables, DataField("size")] public float Size = 1f;
@@ -160,4 +160,4 @@ public sealed record DreamFilterWave : DreamFilter {
 }
 
 [Serializable, NetSerializable]
-public sealed record DreamFilterGreyscale : DreamFilter;
+public sealed partial record DreamFilterGreyscale : DreamFilter;

--- a/OpenDreamShared/Dream/IconAppearance.cs
+++ b/OpenDreamShared/Dream/IconAppearance.cs
@@ -40,8 +40,8 @@ namespace OpenDreamShared.Dream {
         [ViewVariables] public string? RenderSource;
         [ViewVariables] public string? RenderTarget;
         [ViewVariables] public MouseOpacity MouseOpacity = MouseOpacity.PixelOpaque;
-        [ViewVariables] public List<uint> Overlays = new();
-        [ViewVariables] public List<uint> Underlays = new();
+        [ViewVariables] public List<int> Overlays = new();
+        [ViewVariables] public List<int> Underlays = new();
         [ViewVariables] public List<EntityUid> VisContents = new();
         [ViewVariables] public List<DreamFilter> Filters = new();
         /// <summary> The Transform property of this appearance, in [a,d,b,e,c,f] order</summary>
@@ -70,8 +70,8 @@ namespace OpenDreamShared.Dream {
             Invisibility = appearance.Invisibility;
             Opacity = appearance.Opacity;
             MouseOpacity = appearance.MouseOpacity;
-            Overlays = new List<uint>(appearance.Overlays);
-            Underlays = new List<uint>(appearance.Underlays);
+            Overlays = new List<int>(appearance.Overlays);
+            Underlays = new List<int>(appearance.Underlays);
             VisContents = new List<EntityUid>(appearance.VisContents);
             Filters = new List<DreamFilter>(appearance.Filters);
             Override = appearance.Override;

--- a/OpenDreamShared/Rendering/DreamMobSightComponent.cs
+++ b/OpenDreamShared/Rendering/DreamMobSightComponent.cs
@@ -6,7 +6,7 @@ using Robust.Shared.GameStates;
 namespace OpenDreamShared.Rendering {
     [RegisterComponent]
     [NetworkedComponent]
-    public sealed class DreamMobSightComponent : Component {
+    public sealed partial class DreamMobSightComponent : Component {
         //this would be a good place for:
         //see_in_dark
         //see_infrared

--- a/OpenDreamShared/Rendering/SharedAppearanceSystem.cs
+++ b/OpenDreamShared/Rendering/SharedAppearanceSystem.cs
@@ -8,19 +8,19 @@ namespace OpenDreamShared.Rendering {
     public abstract class SharedAppearanceSystem : EntitySystem {
         [Serializable, NetSerializable]
         public sealed class AllAppearancesEvent : EntityEventArgs {
-            public Dictionary<uint, IconAppearance> Appearances = new();
+            public Dictionary<int, IconAppearance> Appearances = new();
 
-            public AllAppearancesEvent(Dictionary<uint, IconAppearance> appearances) {
+            public AllAppearancesEvent(Dictionary<int, IconAppearance> appearances) {
               Appearances = appearances;
             }
         }
 
         [Serializable, NetSerializable]
         public sealed class NewAppearanceEvent : EntityEventArgs {
-            public uint AppearanceId { get; }
+            public int AppearanceId { get; }
             public IconAppearance Appearance { get; }
 
-            public NewAppearanceEvent(uint appearanceID, IconAppearance appearance) {
+            public NewAppearanceEvent(int appearanceID, IconAppearance appearance) {
                 AppearanceId = appearanceID;
                 Appearance = appearance;
             }
@@ -29,10 +29,10 @@ namespace OpenDreamShared.Rendering {
         [Serializable, NetSerializable]
         public sealed class AnimationEvent : EntityEventArgs {
             public EntityUid Entity;
-            public uint TargetAppearanceId;
+            public int TargetAppearanceId;
             public TimeSpan Duration;
 
-            public AnimationEvent(EntityUid entity, uint targetAppearanceId, TimeSpan duration) {
+            public AnimationEvent(EntityUid entity, int targetAppearanceId, TimeSpan duration) {
                 Entity = entity;
                 TargetAppearanceId = targetAppearanceId;
                 Duration = duration;

--- a/OpenDreamShared/Rendering/SharedClientImagesSystem.cs
+++ b/OpenDreamShared/Rendering/SharedClientImagesSystem.cs
@@ -13,9 +13,9 @@ public class SharedClientImagesSystem : EntitySystem {
     public sealed class AddClientImageEvent : EntityEventArgs {
         public Vector3 TurfCoords;
         public EntityUid AttachedEntity; //if this is EntityUid.Invalid (ie, a turf) use the TurfCoords instead
-        public uint ImageAppearance;
+        public int ImageAppearance;
 
-        public AddClientImageEvent(EntityUid attachedEntity, Vector3 turfCoords, uint imageAppearance) {
+        public AddClientImageEvent(EntityUid attachedEntity, Vector3 turfCoords, int imageAppearance) {
             TurfCoords = turfCoords;
             ImageAppearance = imageAppearance;
             AttachedEntity = attachedEntity;
@@ -26,9 +26,9 @@ public class SharedClientImagesSystem : EntitySystem {
     public sealed class RemoveClientImageEvent : EntityEventArgs {
         public Vector3 TurfCoords;
         public EntityUid AttachedEntity; //if this is EntityUid.Invalid (ie, a turf) use the TurfCoords instead
-        public uint ImageAppearance;
+        public int ImageAppearance;
 
-        public RemoveClientImageEvent(EntityUid attachedEntity, Vector3 turfCoords, uint imageAppearance) {
+        public RemoveClientImageEvent(EntityUid attachedEntity, Vector3 turfCoords, int imageAppearance) {
             TurfCoords = turfCoords;
             ImageAppearance = imageAppearance;
             AttachedEntity = attachedEntity;

--- a/OpenDreamShared/Rendering/SharedDMISpriteComponent.cs
+++ b/OpenDreamShared/Rendering/SharedDMISpriteComponent.cs
@@ -6,13 +6,13 @@ using OpenDreamShared.Dream;
 
 namespace OpenDreamShared.Rendering {
     [NetworkedComponent]
-    public abstract class SharedDMISpriteComponent : Component {
+    public abstract partial class SharedDMISpriteComponent : Component {
         [Serializable, NetSerializable]
         public sealed class DMISpriteComponentState : ComponentState {
-            public readonly uint? AppearanceId;
+            public readonly int? AppearanceId;
             public readonly ScreenLocation ScreenLocation;
 
-            public DMISpriteComponentState(uint? appearanceId, ScreenLocation screenLocation) {
+            public DMISpriteComponentState(int? appearanceId, ScreenLocation screenLocation) {
                 AppearanceId = appearanceId;
                 ScreenLocation = screenLocation;
             }


### PR DESCRIPTION
Bumps RT to latest. Main thing for us is that tile IDs are now an `int` instead of `ushort`.

Paradise doesn't explode:

![image](https://github.com/OpenDreamProject/OpenDream/assets/5714543/48bbea1f-4434-4610-aa71-316fa5f620e8)
