### PR TITLE
Use `EnsureCapacity()` instead of `Capacity` when resizing lists

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -183,7 +183,7 @@ namespace OpenDreamRuntime.Objects.Types {
 
         public void Resize(int size) {
             if (size > _values.Count) {
-                _values.Capacity = size;
+                _values.EnsureCapacity(size);
 
                 for (int i = _values.Count; i < size; i++) {
                     AddValue(DreamValue.Null);


### PR DESCRIPTION
This doubles the internal array's size instead of setting the size exactly. This means doing `list.len++` repeatedly does not lead to lots of unnecessary array allocations and copies.

Cuts tg's total init allocations in half.

Before:
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/5b8970ba-dd2d-4e18-8a1d-a9b416380ff2)

After:
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/72bcee5d-9a62-4399-bae1-2441a78f460a)