### PR TITLE
Remove allocations in `DMIParser.GetExportedDirectionCount()`

### DIFF
--- a/OpenDreamRuntime/Objects/DreamIcon.cs
+++ b/OpenDreamRuntime/Objects/DreamIcon.cs
@@ -25,7 +25,7 @@ public sealed class DreamIcon {
 
     private IconResource? _cachedDMI;
 
-    private int FrameCount => States.Values.Sum(state => state.Frames * DMIParser.GetExportedDirectionCount(state.Directions.Keys));
+    private int FrameCount => States.Values.Sum(state => state.Frames * DMIParser.GetExportedDirectionCount(state.Directions));
 
     /// <summary>
     /// A list of operations to be applied when generating the DMI, along with what frames to apply them on
@@ -102,7 +102,7 @@ public sealed class DreamIcon {
 
             dmiStates.Add(newState.Name, newState);
 
-            int exportedDirectionCount = DMIParser.GetExportedDirectionCount(iconState.Directions.Keys);
+            int exportedDirectionCount = DMIParser.GetExportedDirectionCount(iconState.Directions);
             for (int directionIndex = 0; directionIndex < exportedDirectionCount; directionIndex++) {
                 AtomDirection direction = DMIParser.DMIFrameDirections[directionIndex];
                 int firstFrame = currentFrame;

--- a/OpenDreamShared/Resources/DMIParser.cs
+++ b/OpenDreamShared/Resources/DMIParser.cs
@@ -114,7 +114,7 @@ namespace OpenDreamShared.Resources {
                 text.AppendLine("\"");
 
                 text.Append("\tdirs = ");
-                text.Append(GetExportedDirectionCount(Directions.Keys));
+                text.Append(GetExportedDirectionCount(Directions));
                 text.AppendLine();
 
                 text.Append("\tframes = ");
@@ -188,26 +188,17 @@ namespace OpenDreamShared.Resources {
         /// The total directions present in an exported DMI.<br/>
         /// An icon state in a DMI must contain either 1, 4, or 8 directions.
         /// </summary>
-        public static int GetExportedDirectionCount(IEnumerable<AtomDirection> directions) {
+        public static int GetExportedDirectionCount<T>(Dictionary<AtomDirection, T> directions) {
             // If we have any of these directions then we export 8 directions
-            foreach (var direction in directions) {
-                switch (direction) {
-                    case AtomDirection.Northeast:
-                    case AtomDirection.Southeast:
-                    case AtomDirection.Southwest:
-                    case AtomDirection.Northwest:
-                        return 8;
-                }
+            if (directions.ContainsKey(AtomDirection.Northeast) || directions.ContainsKey(AtomDirection.Southeast) ||
+                directions.ContainsKey(AtomDirection.Southwest) || directions.ContainsKey(AtomDirection.Northwest)) {
+                return 8;
             }
 
-            // Any of these means 4 directions
-            foreach (var direction in directions) {
-                switch (direction) {
-                    case AtomDirection.North:
-                    case AtomDirection.East:
-                    case AtomDirection.West:
-                        return 4;
-                }
+            // Any of these (without the above) means 4 directions
+            if (directions.ContainsKey(AtomDirection.North) || directions.ContainsKey(AtomDirection.East) ||
+                directions.ContainsKey(AtomDirection.West)) {
+                return 4;
             }
 
             // Otherwise, 1 direction (just south)


### PR DESCRIPTION
This was allocating huge amounts on tg

Before:
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/222adf3e-1713-46bb-b993-fd297f38eaae)
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/c24f6d09-e1d8-449a-86e3-9650f6081c4b)


After:
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/88cb7283-65ba-4f2c-9324-3ab748c08b91)
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/93ee7501-d2b4-46cd-b067-af1e5f20442e)

Spending 20 seconds on this is still crazy, this will need changing later.