### PR TITLE
Fix global init order

### DIFF
--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using OpenDreamShared.Compiler;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Dream.Procs;
@@ -187,6 +188,10 @@ namespace DMCompiler.Compiler.DM {
         }
 
         public void VisitList(DMASTList list) {
+            throw new NotImplementedException();
+        }
+
+        public void VisitDimensionalList(DMASTDimensionalList list) {
             throw new NotImplementedException();
         }
 
@@ -1293,6 +1298,28 @@ namespace DMCompiler.Compiler.DM {
 
         public override void Visit(DMASTVisitor visitor) {
             visitor.VisitList(this);
+        }
+
+        public bool AllValuesConstant() {
+            return Values.All(value => value is {
+                Key: DMASTExpressionConstant,
+                Value: DMASTExpressionConstant
+            });
+        }
+    }
+
+    /// <summary>
+    /// Represents the value of a var defined as <code>var/list/L[1][2][3]</code>
+    /// </summary>
+    public sealed class DMASTDimensionalList : DMASTExpression {
+        public readonly List<DMASTExpression> Sizes;
+
+        public DMASTDimensionalList(Location location, List<DMASTExpression> sizes) : base(location) {
+            Sizes = sizes;
+        }
+
+        public override void Visit(DMASTVisitor visitor) {
+            visitor.VisitDimensionalList(this);
         }
     }
 

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -275,7 +275,7 @@ namespace DMCompiler.Compiler.DM {
                     while (true) {
                         Whitespace();
 
-                        var value = PathArray(ref varPath);
+                        DMASTExpression? value = PathArray(ref varPath);
 
                         if (Check(TokenType.DM_Equals)) {
                             if (value != null) Warning("List doubly initialized");
@@ -410,7 +410,7 @@ namespace DMCompiler.Compiler.DM {
             }
         }
 
-        public DMASTExpression? PathArray(ref DreamPath path) {
+        public DMASTDimensionalList? PathArray(ref DreamPath path) {
             if (Current().Type == TokenType.DM_LeftBracket || Current().Type == TokenType.DM_DoubleSquareBracket) {
                 var loc = Current().Location;
 
@@ -421,7 +421,7 @@ namespace DMCompiler.Compiler.DM {
                     path = new DreamPath("/" + String.Join("/", elements));
                 }
 
-                List<DMASTCallParameter> sizes = new(2); // Most common is 1D or 2D lists
+                List<DMASTExpression> sizes = new(2); // Most common is 1D or 2D lists
 
                 while (true) {
                     if(Check(TokenType.DM_DoubleSquareBracket))
@@ -430,18 +430,17 @@ namespace DMCompiler.Compiler.DM {
                         Whitespace();
                         var size = Expression();
                         if (size is not null) {
-                            sizes.Add(new DMASTCallParameter(size.Location, size));
+                            sizes.Add(size);
                         }
 
                         ConsumeRightBracket();
                         Whitespace();
-                    }
-                    else
+                    } else
                         break;
                 }
 
                 if (sizes.Count > 0) {
-                    return new DMASTNewPath(loc, new DMASTPath(loc, DreamPath.List), sizes.ToArray());
+                    return new DMASTDimensionalList(loc, sizes);
                 }
             }
 

--- a/DMCompiler/DM/DMObjectTree.cs
+++ b/DMCompiler/DM/DMObjectTree.cs
@@ -27,7 +27,7 @@ namespace DMCompiler.DM {
         public static DMObject Root => GetDMObject(DreamPath.Root)!;
 
         private static readonly Dictionary<string, int> StringToStringId = new();
-        private static readonly Dictionary<DreamPath, List<(int GlobalId, DMExpression Value)>> _globalInitAssigns = new();
+        private static readonly List<(int GlobalId, DMExpression Value)> _globalInitAssigns = new();
 
         private static Dictionary<DreamPath, int> _pathToTypeId = new();
         private static int _dmObjectIdCounter = 0;
@@ -182,29 +182,21 @@ namespace DMCompiler.DM {
             GlobalProcs[name] = id; // Said in this way so it clobbers previous definitions of this global proc (the ..() stuff doesn't work with glob procs)
         }
 
-        public static void AddGlobalInitAssign(DMObject owningType, int globalId, DMExpression value) {
-            if (!_globalInitAssigns.TryGetValue(owningType.Path, out var list)) {
-                list = new List<(int GlobalId, DMExpression Value)>();
-
-                _globalInitAssigns.Add(owningType.Path, list);
-            }
-
-            list.Add( (globalId, value) );
+        public static void AddGlobalInitAssign(int globalId, DMExpression value) {
+            _globalInitAssigns.Add( (globalId, value) );
         }
 
         public static void CreateGlobalInitProc() {
             if (_globalInitAssigns.Count == 0) return;
 
-            foreach (var globals in _globalInitAssigns.Values) {
-                foreach (var assign in globals) {
-                    try {
-                        GlobalInitProc.DebugSource(assign.Value.Location);
+            foreach (var assign in _globalInitAssigns) {
+                try {
+                    GlobalInitProc.DebugSource(assign.Value.Location);
 
-                        assign.Value.EmitPushValue(Root, GlobalInitProc);
-                        GlobalInitProc.Assign(DMReference.CreateGlobal(assign.GlobalId));
-                    } catch (CompileErrorException e) {
-                        DMCompiler.Emit(e.Error);
-                    }
+                    assign.Value.EmitPushValue(Root, GlobalInitProc);
+                    GlobalInitProc.Assign(DMReference.CreateGlobal(assign.GlobalId));
+                } catch (CompileErrorException e) {
+                    DMCompiler.Emit(e.Error);
                 }
             }
 

--- a/DMCompiler/DM/Expressions/Binary.cs
+++ b/DMCompiler/DM/Expressions/Binary.cs
@@ -428,11 +428,6 @@ namespace DMCompiler.DM.Expressions {
                 return true;
             }
 
-            if (RHS.TryAsConstant(out var rhs)) {
-                constant = rhs;
-                return true;
-            }
-
             constant = null;
             return false;
         }

--- a/DMCompiler/DM/Expressions/Builtins.cs
+++ b/DMCompiler/DM/Expressions/Builtins.cs
@@ -473,6 +473,31 @@ namespace DMCompiler.DM.Expressions {
         }
     }
 
+    // Value of var/list/L[1][2][3]
+    internal sealed class DimensionalList : DMExpression {
+        private readonly DMExpression[] _sizes;
+
+        public DimensionalList(Location location, DMExpression[] sizes) : base(location) {
+            _sizes = sizes;
+        }
+
+        public override void EmitPushValue(DMObject dmObject, DMProc proc) {
+            // This basically emits new /list(1, 2, 3)
+
+            if (!DMObjectTree.TryGetTypeId(DreamPath.List, out var listTypeId)) {
+                DMCompiler.Emit(WarningCode.ItemDoesntExist, Location, "Could not get type ID of /list");
+                return;
+            }
+
+            foreach (var size in _sizes) {
+                size.EmitPushValue(dmObject, proc);
+            }
+
+            proc.PushType(listTypeId);
+            proc.CreateObject(DMCallArgumentsType.FromStack, _sizes.Length);
+        }
+    }
+
     // newlist(...)
     sealed class NewList : DMExpression {
         private readonly DMExpression[] _parameters;

--- a/DMCompiler/DM/Visitors/DMObjectBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMObjectBuilder.cs
@@ -19,7 +19,10 @@ namespace DMCompiler.DM.Visitors {
             VarDefinitions.Clear();
             VarOverrides.Clear();
             ProcDefinitions.Clear();
+            StaticObjectVars.Clear();
             StaticProcVars.Clear();
+
+            _firstProcGlobal = -1;
         }
 
         public static void BuildObjectTree(DMASTFile astFile) {

--- a/DMCompiler/DM/Visitors/DMObjectBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMObjectBuilder.cs
@@ -53,7 +53,7 @@ namespace DMCompiler.DM.Visitors {
                             DMExpression expression = DMExpression.Create(procStatic.DMObject, procStatic.Proc,
                                 procStatic.VarDecl.Value, procStatic.VarDecl.Type);
 
-                            DMObjectTree.AddGlobalInitAssign(procStatic.DMObject, procStatic.Id, expression);
+                            DMObjectTree.AddGlobalInitAssign(procStatic.Id, expression);
                         } catch (UnknownIdentifierException e) {
                             // For step 5
                             lateProcVarDefs.Add((procStatic.DMObject, procStatic.Proc, procStatic.VarDecl, procStatic.Id, e));
@@ -115,7 +115,7 @@ namespace DMCompiler.DM.Visitors {
                         DMExpression expression =
                             DMExpression.Create(varDef.Item1, varDef.Item2, varDecl.Value!, varDecl.Type);
 
-                        DMObjectTree.AddGlobalInitAssign(varDef.Item1, varDef.Item4, expression);
+                        DMObjectTree.AddGlobalInitAssign(varDef.Item4, expression);
 
                         // Success! Remove this one from the list
                         lateProcVarDefs.RemoveAt(i--);
@@ -507,7 +507,7 @@ namespace DMCompiler.DM.Visitors {
                 int? globalId = currentObject.GetGlobalVariableId(variable.Name);
                 if (globalId == null) throw new CompileAbortException(expression?.Location ?? Location.Unknown, $"Invalid global {currentObject.Path}.{variable.Name}");
 
-                DMObjectTree.AddGlobalInitAssign(currentObject, globalId.Value, expression);
+                DMObjectTree.AddGlobalInitAssign(globalId.Value, expression);
             } else {
                 var initLoc = expression.Location;
                 Expressions.Field field = new Expressions.Field(initLoc, variable);

--- a/DMCompiler/DM/Visitors/DMObjectBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMObjectBuilder.cs
@@ -178,7 +178,12 @@ namespace DMCompiler.DM.Visitors {
                     var dmObject = DMObjectTree.GetDMObject(varDefinition.ObjectPath)!;
 
                     if (varDefinition.IsGlobal) {
-                        StaticObjectVars.Add((dmObject, varDefinition));
+                        // var/static/list/L[1][2][3] and list() both come first in global init order
+                        if (varDefinition.Value is DMASTDimensionalList ||
+                            (varDefinition.Value is DMASTList list && list.AllValuesConstant()))
+                            StaticObjectVars.Insert(0, (dmObject, varDefinition));
+                        else
+                            StaticObjectVars.Add((dmObject, varDefinition));
                     } else {
                         VarDefinitions.Add((dmObject, varDefinition));
                     }
@@ -493,6 +498,7 @@ namespace DMCompiler.DM.Visitors {
                 },
 
                 Expressions.List => true,
+                Expressions.DimensionalList => true,
                 Expressions.NewList => true,
                 Expressions.NewPath => true,
                 // TODO: Check for circular reference loops here

--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -14,7 +14,7 @@ namespace DMCompiler.DM.Visitors {
             // Only global vars and procs available
             Static,
 
-            // Only constant global vars and global procs available
+            // Only global procs available
             FirstPassStatic
         }
 

--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -14,7 +14,7 @@ namespace DMCompiler.DM.Visitors {
             // Only global vars and procs available
             Static,
 
-            // Only global procs available
+            // Only constant global vars and global procs available
             FirstPassStatic
         }
 
@@ -131,15 +131,12 @@ namespace DMCompiler.DM.Visitors {
                     }
 
                     if (CurrentScopeMode != ScopeMode.FirstPassStatic) {
-                        int? procGlobalId = _proc?.GetGlobalVariableId(name);
-                        if (procGlobalId != null) {
-                            Result = new Expressions.GlobalField(identifier.Location, DMObjectTree.Globals[procGlobalId.Value].Type, procGlobalId.Value);
-                            return;
-                        }
+                        int? globalId = _proc?.GetGlobalVariableId(name) ?? _dmObject?.GetGlobalVariableId(name);
 
-                        int? globalId = _dmObject?.GetGlobalVariableId(name);
                         if (globalId != null) {
-                            Result = new Expressions.GlobalField(identifier.Location, DMObjectTree.Globals[globalId.Value].Type, globalId.Value);
+                            var global = new Expressions.GlobalField(identifier.Location, DMObjectTree.Globals[globalId.Value].Type, globalId.Value);
+
+                            Result = global;
                             return;
                         }
                     }

--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -6,14 +6,24 @@ using OpenDreamShared.Dream;
 using Robust.Shared.Utility;
 
 namespace DMCompiler.DM.Visitors {
-    sealed class DMVisitorExpression : DMASTVisitor {
+    internal sealed class DMVisitorExpression : DMASTVisitor {
+        public enum ScopeMode {
+            // All in-scope procs and vars available
+            Normal,
+
+            // Only global vars and procs available
+            Static,
+
+            // Only global procs available
+            FirstPassStatic
+        }
+
+        public static ScopeMode CurrentScopeMode = ScopeMode.Normal;
+        public DMExpression Result { get; private set; }
+
         private readonly DMObject _dmObject;
         private readonly DMProc _proc;
         private readonly DreamPath? _inferredPath;
-        internal DMExpression Result { get; private set; }
-
-        // NOTE This needs to be turned into a Stack of modes if more complicated scope changes are added in the future
-        public static string _scopeMode = "normal";
 
         internal DMVisitorExpression(DMObject dmObject, DMProc proc, DreamPath? inferredPath) {
             _dmObject = dmObject;
@@ -106,28 +116,32 @@ namespace DMCompiler.DM.Visitors {
                     Result = new Expressions.Global(identifier.Location);
                     break;
                 default: {
-                    DMProc.LocalVariable localVar = _proc?.GetLocalVariable(name);
-                    if (localVar != null && _scopeMode == "normal") {
-                        Result = new Expressions.Local(identifier.Location, localVar);
-                        return;
+                    if (CurrentScopeMode == ScopeMode.Normal) {
+                        DMProc.LocalVariable localVar = _proc?.GetLocalVariable(name);
+                        if (localVar != null) {
+                            Result = new Expressions.Local(identifier.Location, localVar);
+                            return;
+                        }
+
+                        var field = _dmObject?.GetVariable(name);
+                        if (field != null) {
+                            Result = new Expressions.Field(identifier.Location, field);
+                            return;
+                        }
                     }
 
-                    int? procGlobalId = _proc?.GetGlobalVariableId(name);
-                    if (procGlobalId != null) {
-                        Result = new Expressions.GlobalField(identifier.Location, DMObjectTree.Globals[procGlobalId.Value].Type, procGlobalId.Value);
-                        return;
-                    }
+                    if (CurrentScopeMode != ScopeMode.FirstPassStatic) {
+                        int? procGlobalId = _proc?.GetGlobalVariableId(name);
+                        if (procGlobalId != null) {
+                            Result = new Expressions.GlobalField(identifier.Location, DMObjectTree.Globals[procGlobalId.Value].Type, procGlobalId.Value);
+                            return;
+                        }
 
-                    var field = _dmObject?.GetVariable(name);
-                    if (field != null && _scopeMode == "normal") {
-                        Result = new Expressions.Field(identifier.Location, field);
-                        return;
-                    }
-
-                    int? globalId = _dmObject?.GetGlobalVariableId(name);
-                    if (globalId != null) {
-                        Result = new Expressions.GlobalField(identifier.Location, DMObjectTree.Globals[globalId.Value].Type, globalId.Value);
-                        return;
+                        int? globalId = _dmObject?.GetGlobalVariableId(name);
+                        if (globalId != null) {
+                            Result = new Expressions.GlobalField(identifier.Location, DMObjectTree.Globals[globalId.Value].Type, globalId.Value);
+                            return;
+                        }
                     }
 
                     throw new UnknownIdentifierException(identifier.Location, name);
@@ -142,14 +156,16 @@ namespace DMCompiler.DM.Visitors {
         public void VisitGlobalIdentifier(DMASTGlobalIdentifier globalIdentifier) {
             string name = globalIdentifier.Identifier;
 
-            int? globalId = _dmObject?.GetGlobalVariableId(name);
-            if (globalId != null) {
-                Result = new Expressions.GlobalField(globalIdentifier.Location, DMObjectTree.Globals[globalId.Value].Type, globalId.Value);
-                return;
-            } else if (name == "vars")
-            {
-                Result = new Expressions.GlobalVars(globalIdentifier.Location);
-                return;
+            if (CurrentScopeMode != ScopeMode.FirstPassStatic) {
+                int? globalId = _dmObject?.GetGlobalVariableId(name);
+                if (globalId != null) {
+                    Result = new Expressions.GlobalField(globalIdentifier.Location,
+                        DMObjectTree.Globals[globalId.Value].Type, globalId.Value);
+                    return;
+                } else if (name == "vars") {
+                    Result = new Expressions.GlobalVars(globalIdentifier.Location);
+                    return;
+                }
             }
 
             throw new CompileErrorException(globalIdentifier.Location, $"Unknown global \"{name}\"");
@@ -164,7 +180,7 @@ namespace DMCompiler.DM.Visitors {
         }
 
         public void VisitCallableProcIdentifier(DMASTCallableProcIdentifier procIdentifier) {
-            if (_scopeMode == "static") {
+            if (CurrentScopeMode is ScopeMode.Static or ScopeMode.FirstPassStatic) {
                 Result = new Expressions.GlobalProc(procIdentifier.Location, procIdentifier.Identifier);
             } else {
                 if (_dmObject.HasProc(procIdentifier.Identifier)) {

--- a/DMCompiler/DM/Visitors/DMVisitorExpression.cs
+++ b/DMCompiler/DM/Visitors/DMVisitorExpression.cs
@@ -864,6 +864,17 @@ namespace DMCompiler.DM.Visitors {
             Result = new Expressions.List(list.Location, values);
         }
 
+        public void VisitDimensionalList(DMASTDimensionalList list) {
+            var sizes = new DMExpression[list.Sizes.Count];
+            for (int i = 0; i < sizes.Length; i++) {
+                var sizeExpr = DMExpression.Create(_dmObject, _proc, list.Sizes[i], _inferredPath);
+
+                sizes[i] = sizeExpr;
+            }
+
+            Result = new DimensionalList(list.Location, sizes);
+        }
+
         public void VisitNewList(DMASTNewList newList) {
             DMExpression[] expressions = new DMExpression[newList.Parameters.Length];
 


### PR DESCRIPTION
Two important changes to global var init order:

1. All global vars (except lists) are initialized in the order they appear in the code, except globals inside procs are all lumped together and start at the appearance of the first one.
2. Proc global vars that reference other global vars are moved to the end of init. I achieved this by making global vars not available on the first pass, which makes them handled by the late-var-def system.