### PR TITLE
Make menu elements addressable with `winget()`

### DIFF
--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -374,6 +374,9 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
                 window = Windows[windowId];
             } else if (_popupWindows.TryGetValue(windowId, out var popup)) {
                 window = popup.WindowElement;
+            } else if (Menus.TryGetValue(windowId, out var menu)) {
+                if(menu.MenuElements.TryGetValue(elementId, out var menuElement))
+                    return menuElement;
             }
 
             if (window != null) {


### PR DESCRIPTION
Doesn't seem to be documented, but you can refer to elements in a menu with the same format as elements of a window.