### PR TITLE
Fix `\a` on strings

### DIFF
--- a/Content.Tests/DMProject/Tests/Text/StringInterpolation9.dm
+++ b/Content.Tests/DMProject/Tests/Text/StringInterpolation9.dm
@@ -1,0 +1,39 @@
+﻿/datum/thing
+	var/name = "thing"
+
+/datum/Thing
+	var/name = "Thing"
+
+/datum/proper_thing
+	var/name = "\proper thing"
+
+/datum/plural_things
+	var/name = "things"
+	var/gender = PLURAL
+
+/proc/RunTest()
+	// Lowercase \a on datums
+	ASSERT("\a [new /datum/thing]" == "a thing")
+	ASSERT("\a [new /datum/Thing]" == "Thing")
+	ASSERT("\a [new /datum/proper_thing]" == "thing")
+	ASSERT("\a [new /datum/plural_things]" == "some things")
+	
+	// Uppercase \A on datums
+	ASSERT("\A [new /datum/thing]" == "A thing")
+	ASSERT("\A [new /datum/Thing]" == "Thing")
+	ASSERT("\A [new /datum/proper_thing]" == "thing")
+	ASSERT("\A [new /datum/plural_things]" == "Some things")
+	
+	// Lowercase \a on strings
+	ASSERT("\a ["thing"]" == "a thing")
+	ASSERT("\a ["Thing"]" == "Thing")
+	ASSERT("\a ["\proper thing"]" == "thing")
+	
+	// Uppercase \A on strings
+	ASSERT("\A ["thing"]" == "A thing")
+	ASSERT("\A ["Thing"]" == "Thing")
+	ASSERT("\A ["\proper thing"]" == "thing")
+
+	// Invalid \a
+	ASSERT("\a [123]" == "")
+	ASSERT("\A [123]" == "")

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -276,8 +276,6 @@ namespace OpenDreamRuntime.Objects {
                         return true;
                     case StringFormatEncoder.FormatSuffix.Improper:
                         return false;
-                    default:
-                        break;
                 }
             }
 
@@ -312,9 +310,7 @@ namespace OpenDreamRuntime.Objects {
             if (this is DreamObjectClient client)
                 return client.Connection.Session!.Name;
 
-            if (!TryGetVariable("name", out DreamValue nameVar) || !nameVar.TryGetValueAsString(out string? name))
-                return ObjectDefinition.Type.ToString();
-
+            var name = GetRawName();
             bool isProper = StringIsProper(name);
             name = StringFormatEncoder.RemoveFormatting(name); // TODO: Care about other formatting macros for obj names beyond \proper & \improper
             if(!isProper) {
@@ -335,9 +331,18 @@ namespace OpenDreamRuntime.Objects {
         /// Similar to <see cref="GetDisplayName"/> except it just returns the name as plaintext, with formatting removed. No article or anything.
         /// </summary>
         public string GetNameUnformatted() {
+            return StringFormatEncoder.RemoveFormatting(GetRawName());
+        }
+
+        /// <summary>
+        /// Returns the name of this object with no formatting evaluated
+        /// </summary>
+        /// <returns></returns>
+        public string GetRawName() {
             if (!TryGetVariable("name", out DreamValue nameVar) || !nameVar.TryGetValueAsString(out string? name))
-                return ObjectDefinition?.Type.ToString() ?? String.Empty;
-            return StringFormatEncoder.RemoveFormatting(name);
+                return ObjectDefinition.Type.ToString();
+
+            return name;
         }
         #endregion Name Helpers
 

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -376,7 +376,7 @@ namespace OpenDreamRuntime.Procs {
                         if (interps[nextInterpIndex].TryGetValueAsDreamObject<DreamObject>(out var dreamObject)) {
                             formattedString.Append(dreamObject.GetNameUnformatted());
                         } else if (interps[nextInterpIndex].TryGetValueAsString(out var interpStr)) {
-                            formattedString.Append(interpStr);
+                            formattedString.Append(StringFormatEncoder.RemoveFormatting(interpStr));
                         }
 
                         // NOTE probably should put this above the TryGetAsDreamObject function and continue if formatting has occured


### PR DESCRIPTION
```dm
world.log << "\a ["thing"]"
world.log << "\a ["Thing"]"
```
Outputs:
```
[INFO] world.log: a thing
[INFO] world.log: Thing
```