### PR TITLE
Improved `range` support in `view()` procs

### DIFF
--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
@@ -154,16 +154,11 @@ internal static partial class DreamProcNativeHelpers {
             } else if (arg.TryGetValueAsString(out var distString)) {
                 range = new ViewRange(distString);
             } else if (!arg.IsNull) { // null range arg is handled by DefaultView above
-                ThrowBadViewArg(arg);
+                throw new Exception($"Invalid argument: {arg}");
             }
         }
 
         return (center, range);
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private static void ThrowBadViewArg(DreamValue arg) {
-        throw new Exception($"Invalid argument: {arg}");
     }
 
     public static ViewAlgorithm.Tile?[,] CollectViewData(AtomManager atomManager, IDreamMapManager mapManager, (int X, int Y, int Z) eyePos, ViewRange range) {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
@@ -136,12 +136,13 @@ internal static partial class DreamProcNativeHelpers {
     /// If a range argument is passed, like "11x4", then THAT is what we have to deal with.
     /// </remarks>
     /// <returns>The center (which may not be the turf), the distance along the x-axis, and the distance along the y-axis to iterate.</returns>
-    public static (DreamObjectAtom?, ViewRange) ResolveViewArguments(DreamObjectAtom? usr, ReadOnlySpan<DreamValue> arguments) {
+    public static (DreamObjectAtom?, ViewRange) ResolveViewArguments(DreamManager dreamMan, DreamObjectAtom? usr, ReadOnlySpan<DreamValue> arguments) {
+        ViewRange range = dreamMan.WorldInstance.DefaultView;
+
         if(arguments.Length == 0) {
-            return (usr, new ViewRange(5,5));
+            return (usr, range);
         }
 
-        ViewRange range = new ViewRange(5,5);
         DreamObjectAtom? center = usr;
 
         foreach (var arg in arguments) {
@@ -149,8 +150,10 @@ internal static partial class DreamProcNativeHelpers {
                 center = centerObject;
             } else if(arg.TryGetValueAsInteger(out int distValue)) {
                 range = new ViewRange(distValue);
-            } else if(arg.TryGetValueAsString(out var distString)) {
+            } else if (arg.TryGetValueAsString(out var distString)) {
                 range = new ViewRange(distString);
+            } else if (arg.IsNull) {
+                range = dreamMan.WorldInstance.DefaultView;
             } else {
                 throw new Exception($"Invalid argument: {arg}");
             }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
@@ -1,4 +1,5 @@
-﻿using OpenDreamRuntime.Objects;
+﻿using System.Runtime.CompilerServices;
+using OpenDreamRuntime.Objects;
 using OpenDreamShared.Dream;
 using System.Text.RegularExpressions;
 using OpenDreamRuntime.Objects.Types;
@@ -152,14 +153,17 @@ internal static partial class DreamProcNativeHelpers {
                 range = new ViewRange(distValue);
             } else if (arg.TryGetValueAsString(out var distString)) {
                 range = new ViewRange(distString);
-            } else if (arg.IsNull) {
-                range = dreamMan.WorldInstance.DefaultView;
-            } else {
-                throw new Exception($"Invalid argument: {arg}");
+            } else if (!arg.IsNull) { // null range arg is handled by DefaultView above
+                ThrowBadViewArg(arg);
             }
         }
 
         return (center, range);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowBadViewArg(DreamValue arg) {
+        throw new Exception($"Invalid argument: {arg}");
     }
 
     public static ViewAlgorithm.Tile?[,] CollectViewData(AtomManager atomManager, IDreamMapManager mapManager, (int X, int Y, int Z) eyePos, ViewRange range) {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1642,7 +1642,7 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("Dist", Type = DreamValueTypeFlag.Float, DefaultValue = 5)]
         [DreamProcParameter("Center", Type = DreamValueTypeFlag.DreamObject)]
         public static DreamValue NativeProc_orange(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-            (DreamObjectAtom? center, ViewRange range) = DreamProcNativeHelpers.ResolveViewArguments(usr as DreamObjectAtom, bundle.Arguments);
+            (DreamObjectAtom? center, ViewRange range) = DreamProcNativeHelpers.ResolveViewArguments(bundle.DreamManager, usr as DreamObjectAtom, bundle.Arguments);
             if (center is null)
                 return DreamValue.Null; // NOTE: Not sure if parity
             DreamList rangeList = bundle.ObjectTree.CreateList(range.Height * range.Width);
@@ -1661,7 +1661,7 @@ namespace OpenDreamRuntime.Procs.Native {
         public static DreamValue NativeProc_oview(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
             DreamList view = bundle.ObjectTree.CreateList();
 
-            (DreamObjectAtom? center, ViewRange range) = DreamProcNativeHelpers.ResolveViewArguments(usr as DreamObjectAtom, bundle.Arguments);
+            (DreamObjectAtom? center, ViewRange range) = DreamProcNativeHelpers.ResolveViewArguments(bundle.DreamManager, usr as DreamObjectAtom, bundle.Arguments);
             if (center is null)
                 return new(view);
 
@@ -1833,7 +1833,7 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("Dist", Type = DreamValueTypeFlag.Float, DefaultValue = 5)]
         [DreamProcParameter("Center", Type = DreamValueTypeFlag.DreamObject)]
         public static DreamValue NativeProc_range(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-            (DreamObjectAtom? center, ViewRange range) = DreamProcNativeHelpers.ResolveViewArguments(usr as DreamObjectAtom, bundle.Arguments);
+            (DreamObjectAtom? center, ViewRange range) = DreamProcNativeHelpers.ResolveViewArguments(bundle.DreamManager, usr as DreamObjectAtom, bundle.Arguments);
             if (center is null)
                 return DreamValue.Null; // NOTE: Not sure if parity
             DreamList rangeList = bundle.ObjectTree.CreateList(range.Height * range.Width);
@@ -2883,7 +2883,7 @@ namespace OpenDreamRuntime.Procs.Native {
         public static DreamValue NativeProc_view(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
             DreamList view = bundle.ObjectTree.CreateList();
 
-            (DreamObjectAtom? center, ViewRange range) = DreamProcNativeHelpers.ResolveViewArguments(usr as DreamObjectAtom, bundle.Arguments);
+            (DreamObjectAtom? center, ViewRange range) = DreamProcNativeHelpers.ResolveViewArguments(bundle.DreamManager, usr as DreamObjectAtom, bundle.Arguments);
             if (center is null)
                 return new(view);
 


### PR DESCRIPTION
Closes #1456 

Implements null arg support and non-default `world.view` size support.