### PR TITLE
Set default atom names

### DIFF
--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -1,7 +1,7 @@
 ﻿/atom
 	parent_type = /datum
 
-	var/name = "atom"
+	var/name = null
 	var/text = null
 	var/desc = null
 	var/suffix = null as opendream_unimplemented

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -342,10 +342,13 @@ namespace OpenDreamRuntime.Objects {
                     type.ParentEntry.ChildCount += type.ChildCount + 1;
             }
 
-            //Fifth pass: Set atom's text
+            //Fifth pass: Set atom's name and text
             foreach (TreeEntry type in GetAllDescendants(Atom)) {
-                if (type.ObjectDefinition.Variables["text"].Equals(DreamValue.Null) && type.ObjectDefinition.Variables["name"].TryGetValueAsString(out var name)) {
-                    type.ObjectDefinition.SetVariableDefinition("text", new DreamValue(String.IsNullOrEmpty(name) ? String.Empty : name[..1]));
+                if (type.ObjectDefinition.Variables["name"].IsNull)
+                    type.ObjectDefinition.Variables["name"] = new(type.Path.LastElement!.Replace("_", " "));
+
+                if (type.ObjectDefinition.Variables["text"].IsNull && type.ObjectDefinition.Variables["name"].TryGetValueAsString(out var name)) {
+                    type.ObjectDefinition.Variables["text"] = new DreamValue(string.IsNullOrEmpty(name) ? string.Empty : name[..1]);
                 }
             }
         }


### PR DESCRIPTION
Descendants of `/atom` have their name var set to their type name (with spaces instead of underscores) by default.