### PR TITLE
Use a for loop in `DreamList.ContainsValue()`

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -142,7 +142,12 @@ namespace OpenDreamRuntime.Objects.Types {
 
         //Does not include associations
         public virtual bool ContainsValue(DreamValue value) {
-            return _values.Contains(value);
+            for (int i = 0; i < _values.Count; i++) {
+                if (_values[i].Equals(value))
+                    return true;
+            }
+
+            return false;
         }
 
         public virtual bool ContainsKey(DreamValue value) {


### PR DESCRIPTION
C#'s list `Contains()` method usies a `GenericEqualityComparer` which allocates. This removes ~600MB total allocations during BeeStation init bringing it down to 7.3GB.