### PR TITLE
Upgrade RobustToolbox to v158

### DIFF
--- a/OpenDreamClient/Input/MouseInputSystem.cs
+++ b/OpenDreamClient/Input/MouseInputSystem.cs
@@ -18,6 +18,7 @@ namespace OpenDreamClient.Input {
         [Dependency] private readonly IMapManager _mapManager = default!;
         [Dependency] private readonly IOverlayManager _overlayManager = default!;
         [Dependency] private readonly EntityLookupSystem _lookupSystem = default!;
+        [Dependency] private IEntityManager _entityManager = default!;
 
         private DreamViewOverlay? _dreamViewOverlay;
         private ContextMenuPopup _contextMenu = default!;
@@ -87,7 +88,8 @@ namespace OpenDreamClient.Input {
 
             // TODO: Take icon transformations into account
             Vector2i iconPosition = (Vector2i) ((mapCoords.Position - entity.Position) * EyeManager.PixelsPerMeter);
-            RaiseNetworkEvent(new EntityClickedEvent(entity.ClickUid, screenLoc, middle, shift, ctrl, alt, iconPosition));
+            NetEntity ent = _entityManager.GetNetEntity(entity.ClickUid);
+            RaiseNetworkEvent(new EntityClickedEvent(ent, screenLoc, middle, shift, ctrl, alt, iconPosition));
             return true;
         }
 

--- a/OpenDreamClient/Interface/Controls/ScalingViewport.cs
+++ b/OpenDreamClient/Interface/Controls/ScalingViewport.cs
@@ -2,6 +2,7 @@
 using Robust.Client.Input;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared.Graphics;
 using Robust.Shared.Map;
 using Robust.Shared.Utility;
 using SixLabors.ImageSharp.PixelFormats;

--- a/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
+++ b/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
@@ -72,7 +72,8 @@ namespace OpenDreamClient.Rendering {
         }
 
         private void OnAnimation(AnimationEvent e) {
-            if (!_entityManager.TryGetComponent<DMISpriteComponent>(e.Entity, out var sprite))
+            EntityUid ent = _entityManager.GetEntity(e.Entity);
+            if (!_entityManager.TryGetComponent<DMISpriteComponent>(ent, out var sprite))
                 return;
 
             LoadAppearance(e.TargetAppearanceId, targetAppearance => {

--- a/OpenDreamClient/Rendering/ClientImagesSystem.cs
+++ b/OpenDreamClient/Rendering/ClientImagesSystem.cs
@@ -41,7 +41,8 @@ sealed class ClientImagesSystem : SharedClientImagesSystem {
     }
 
     private void OnAddClientImage(AddClientImageEvent e) {
-        if(e.AttachedEntity == EntityUid.Invalid) {
+        EntityUid ent = _entityManager.GetEntity(e.AttachedEntity);
+        if(ent == EntityUid.Invalid) {
             if(!TurfClientImages.TryGetValue(e.TurfCoords, out var iconList))
                 iconList = new List<int>();
             if(!_idToIcon.ContainsKey(e.ImageAppearance)){
@@ -51,30 +52,31 @@ sealed class ClientImagesSystem : SharedClientImagesSystem {
             iconList.Add(e.ImageAppearance);
             TurfClientImages[e.TurfCoords] = iconList;
         } else {
-            if(!AMClientImages.TryGetValue(e.AttachedEntity, out var iconList))
+            if(!AMClientImages.TryGetValue(ent, out var iconList))
                 iconList = new List<int>();
             if(!_idToIcon.ContainsKey(e.ImageAppearance)){
                 DreamIcon icon = new DreamIcon(e.ImageAppearance);
                 _idToIcon[e.ImageAppearance] = icon;
             }
             iconList.Add(e.ImageAppearance);
-            AMClientImages[e.AttachedEntity] = iconList;
+            AMClientImages[ent] = iconList;
         }
 
     }
 
     private void OnRemoveClientImage(RemoveClientImageEvent e) {
-        if(e.AttachedEntity == EntityUid.Invalid) {
+        EntityUid ent = _entityManager.GetEntity(e.AttachedEntity);
+        if(ent == EntityUid.Invalid) {
                 if(!TurfClientImages.TryGetValue(e.TurfCoords, out var iconList))
                     return;
                 iconList.Remove(e.ImageAppearance);
                 TurfClientImages[e.TurfCoords] = iconList;
                 _idToIcon.Remove(e.ImageAppearance);
         } else {
-            if(!AMClientImages.TryGetValue(e.AttachedEntity, out var iconList))
+            if(!AMClientImages.TryGetValue(ent, out var iconList))
                 return;
             iconList.Remove(e.ImageAppearance);
-            AMClientImages[e.AttachedEntity] = iconList;
+            AMClientImages[ent] = iconList;
             _idToIcon.Remove(e.ImageAppearance);
         }
     }

--- a/OpenDreamClient/Rendering/ClientScreenOverlaySystem.cs
+++ b/OpenDreamClient/Rendering/ClientScreenOverlaySystem.cs
@@ -16,11 +16,13 @@ namespace OpenDreamClient.Rendering {
         }
 
         private void OnAddScreenObject(AddScreenObjectEvent e) {
-            ScreenObjects.Add(e.ScreenObject);
+            EntityUid ent = _entityManager.GetEntity(e.ScreenObject);
+            ScreenObjects.Add(ent);
         }
 
         private void OnRemoveScreenObject(RemoveScreenObjectEvent e) {
-            ScreenObjects.Remove(e.ScreenObject);
+            EntityUid ent = _entityManager.GetEntity(e.ScreenObject);
+            ScreenObjects.Remove(ent);
         }
     }
 }

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -304,10 +304,11 @@ internal sealed class DreamViewOverlay : Overlay {
         }
 
         foreach (var visContent in icon.Appearance.VisContents) {
-            if (!_spriteQuery.TryGetComponent(visContent, out var sprite))
+            EntityUid visContentEntity = _entityManager.GetEntity(visContent);
+            if (!_spriteQuery.TryGetComponent(visContentEntity, out var sprite))
                 continue;
 
-            ProcessIconComponents(sprite.Icon, position, visContent, false, ref tieBreaker, result, current, keepTogether);
+            ProcessIconComponents(sprite.Icon, position, visContentEntity, false, ref tieBreaker, result, current, keepTogether);
 
             // TODO: click uid should be set to current.uid again
             // TODO: vis_flags

--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -344,7 +344,9 @@ namespace OpenDreamRuntime {
             // Don't send the updated appearance to clients, they will animate it
             movable.SpriteComponent.SetAppearance(appearance, dirty: false);
 
-            AppearanceSystem.Animate(movable.Entity, appearance, duration);
+            NetEntity ent = _entityManager.GetNetEntity(movable.Entity);
+
+            AppearanceSystem.Animate(ent, appearance, duration);
         }
 
         public bool TryCreateAppearanceFrom(DreamValue value, [NotNullWhen(true)] out IconAppearance? appearance) {

--- a/OpenDreamRuntime/Input/MouseInputSystem.cs
+++ b/OpenDreamRuntime/Input/MouseInputSystem.cs
@@ -10,6 +10,7 @@ namespace OpenDreamRuntime.Input {
         [Dependency] private readonly AtomManager _atomManager = default!;
         [Dependency] private readonly DreamManager _dreamManager = default!;
         [Dependency] private readonly IDreamMapManager _dreamMapManager = default!;
+        [Dependency] private IEntityManager _entityManager = default!;
 
         public override void Initialize() {
             base.Initialize();
@@ -20,7 +21,8 @@ namespace OpenDreamRuntime.Input {
         }
 
         private void OnEntityClicked(EntityClickedEvent e, EntitySessionEventArgs sessionEvent) {
-            if (!_atomManager.TryGetMovableFromEntity(e.EntityUid, out var atom))
+            EntityUid ent = _entityManager.GetEntity(e.NetEntity);
+            if (!_atomManager.TryGetMovableFromEntity(ent, out var atom))
                 return;
 
             HandleAtomClick(e, atom, sessionEvent);

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -692,6 +692,7 @@ namespace OpenDreamRuntime.Objects.Types {
     // Operates on an atom's appearance
     public sealed class DreamVisContentsList : DreamList {
         [Dependency] private readonly AtomManager _atomManager = default!;
+        [Dependency] private IEntityManager _entityManager = default!;
         private readonly PvsOverrideSystem? _pvsOverrideSystem;
 
         private readonly List<DreamObjectAtom> _visContents = new();
@@ -755,7 +756,7 @@ namespace OpenDreamRuntime.Objects.Types {
 
             _atomManager.UpdateAppearance(_atom, appearance => {
                 // Add even an invalid UID to keep this and _visContents in sync
-                appearance.VisContents.Add(entity);
+                appearance.VisContents.Add(_entityManager.GetNetEntity(entity));
             });
         }
 
@@ -765,7 +766,7 @@ namespace OpenDreamRuntime.Objects.Types {
 
             _visContents.Remove(movable);
             _atomManager.UpdateAppearance(_atom, appearance => {
-                appearance.VisContents.Remove(movable.Entity);
+                appearance.VisContents.Remove(_entityManager.GetNetEntity(movable.Entity));
             });
         }
 

--- a/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
+++ b/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
@@ -51,7 +51,7 @@ namespace OpenDreamRuntime.Rendering {
             return _appearanceToId.TryGetValue(appearance, out appearanceId);
         }
 
-        public void Animate(EntityUid entity, IconAppearance targetAppearance, TimeSpan duration) {
+        public void Animate(NetEntity entity, IconAppearance targetAppearance, TimeSpan duration) {
             int appearanceId = AddAppearance(targetAppearance);
 
             RaiseNetworkEvent(new AnimationEvent(entity, appearanceId, duration));

--- a/OpenDreamRuntime/Rendering/ServerClientImagesSystem.cs
+++ b/OpenDreamRuntime/Rendering/ServerClientImagesSystem.cs
@@ -27,7 +27,8 @@ public sealed class ServerClientImagesSystem : SharedClientImagesSystem {
         else if(loc is DreamObjectTurf turf)
             turfCoords = new Vector3(turf.X, turf.Y, turf.Z);
 
-        RaiseNetworkEvent(new AddClientImageEvent(locEntity, turfCoords, imageAppearanceID), connection.Session.ConnectedClient);
+        NetEntity ent = GetNetEntity(locEntity);
+        RaiseNetworkEvent(new AddClientImageEvent(ent, turfCoords, imageAppearanceID), connection.Session.ConnectedClient);
     }
 
     public void RemoveImageObject(DreamConnection connection, DreamObjectImage imageObject) {
@@ -46,6 +47,7 @@ public sealed class ServerClientImagesSystem : SharedClientImagesSystem {
             turfCoords = new Vector3(turf.X, turf.Y, turf.Z);
 
 
-        RaiseNetworkEvent(new RemoveClientImageEvent(locEntity, turfCoords, imageAppearanceID), connection.Session.ConnectedClient);
+        NetEntity ent = GetNetEntity(locEntity);
+        RaiseNetworkEvent(new RemoveClientImageEvent(ent, turfCoords, imageAppearanceID), connection.Session.ConnectedClient);
     }
 }

--- a/OpenDreamRuntime/Rendering/ServerScreenOverlaySystem.cs
+++ b/OpenDreamRuntime/Rendering/ServerScreenOverlaySystem.cs
@@ -6,6 +6,7 @@ using Robust.Server.Player;
 namespace OpenDreamRuntime.Rendering {
     public sealed class ServerScreenOverlaySystem : SharedScreenOverlaySystem {
         private readonly Dictionary<IPlayerSession, HashSet<EntityUid>> _sessionToScreenObjects = new();
+        [Dependency] private IEntityManager _entityManager = default!;
 
         public override void Initialize() {
             SubscribeLocalEvent<ExpandPvsEvent>(HandleExpandPvsEvent);
@@ -18,12 +19,14 @@ namespace OpenDreamRuntime.Rendering {
             }
 
             objects.Add(screenObject.Entity);
-            RaiseNetworkEvent(new AddScreenObjectEvent(screenObject.Entity), connection.Session.ConnectedClient);
+            NetEntity ent = _entityManager.GetNetEntity(screenObject.Entity);
+            RaiseNetworkEvent(new AddScreenObjectEvent(ent), connection.Session.ConnectedClient);
         }
 
         public void RemoveScreenObject(DreamConnection connection, DreamObjectMovable screenObject) {
             _sessionToScreenObjects[connection.Session].Remove(screenObject.Entity);
-            RaiseNetworkEvent(new RemoveScreenObjectEvent(screenObject.Entity), connection.Session.ConnectedClient);
+            NetEntity ent = _entityManager.GetNetEntity(screenObject.Entity);
+            RaiseNetworkEvent(new RemoveScreenObjectEvent(ent), connection.Session.ConnectedClient);
         }
 
         private void HandleExpandPvsEvent(ref ExpandPvsEvent e) {

--- a/OpenDreamShared/Dream/IconAppearance.cs
+++ b/OpenDreamShared/Dream/IconAppearance.cs
@@ -42,7 +42,7 @@ namespace OpenDreamShared.Dream {
         [ViewVariables] public MouseOpacity MouseOpacity = MouseOpacity.PixelOpaque;
         [ViewVariables] public List<int> Overlays = new();
         [ViewVariables] public List<int> Underlays = new();
-        [ViewVariables] public List<EntityUid> VisContents = new();
+        [ViewVariables] public List<NetEntity> VisContents = new();
         [ViewVariables] public List<DreamFilter> Filters = new();
         /// <summary> The Transform property of this appearance, in [a,d,b,e,c,f] order</summary>
         [ViewVariables] public float[] Transform = new float[6] {   1, 0,   // a d
@@ -72,7 +72,7 @@ namespace OpenDreamShared.Dream {
             MouseOpacity = appearance.MouseOpacity;
             Overlays = new List<int>(appearance.Overlays);
             Underlays = new List<int>(appearance.Underlays);
-            VisContents = new List<EntityUid>(appearance.VisContents);
+            VisContents = new List<NetEntity>(appearance.VisContents);
             Filters = new List<DreamFilter>(appearance.Filters);
             Override = appearance.Override;
 

--- a/OpenDreamShared/Input/SharedMouseInputSystem.cs
+++ b/OpenDreamShared/Input/SharedMouseInputSystem.cs
@@ -21,7 +21,7 @@ public class SharedMouseInputSystem : EntitySystem {
 
     [Serializable, NetSerializable]
     public sealed class EntityClickedEvent : EntityEventArgs, IAtomClickedEvent {
-        public EntityUid EntityUid { get; }
+        public NetEntity NetEntity { get; }
         public ScreenLocation ScreenLoc { get; }
         public bool Middle { get; }
         public bool Shift { get; }
@@ -30,8 +30,8 @@ public class SharedMouseInputSystem : EntitySystem {
         public int IconX { get; }
         public int IconY { get; }
 
-        public EntityClickedEvent(EntityUid entityUid, ScreenLocation screenLoc, bool middle, bool shift, bool ctrl, bool alt, Vector2i iconPos) {
-            EntityUid = entityUid;
+        public EntityClickedEvent(NetEntity netEntity, ScreenLocation screenLoc, bool middle, bool shift, bool ctrl, bool alt, Vector2i iconPos) {
+            NetEntity = netEntity;
             ScreenLoc = screenLoc;
             Middle = middle;
             Shift = shift;

--- a/OpenDreamShared/Rendering/SharedAppearanceSystem.cs
+++ b/OpenDreamShared/Rendering/SharedAppearanceSystem.cs
@@ -28,11 +28,11 @@ namespace OpenDreamShared.Rendering {
 
         [Serializable, NetSerializable]
         public sealed class AnimationEvent : EntityEventArgs {
-            public EntityUid Entity;
+            public NetEntity Entity;
             public int TargetAppearanceId;
             public TimeSpan Duration;
 
-            public AnimationEvent(EntityUid entity, int targetAppearanceId, TimeSpan duration) {
+            public AnimationEvent(NetEntity entity, int targetAppearanceId, TimeSpan duration) {
                 Entity = entity;
                 TargetAppearanceId = targetAppearanceId;
                 Duration = duration;

--- a/OpenDreamShared/Rendering/SharedClientImagesSystem.cs
+++ b/OpenDreamShared/Rendering/SharedClientImagesSystem.cs
@@ -12,10 +12,10 @@ public class SharedClientImagesSystem : EntitySystem {
     [Serializable, NetSerializable]
     public sealed class AddClientImageEvent : EntityEventArgs {
         public Vector3 TurfCoords;
-        public EntityUid AttachedEntity; //if this is EntityUid.Invalid (ie, a turf) use the TurfCoords instead
+        public NetEntity AttachedEntity; //if this is NetEntity.Invalid (ie, a turf) use the TurfCoords instead
         public int ImageAppearance;
 
-        public AddClientImageEvent(EntityUid attachedEntity, Vector3 turfCoords, int imageAppearance) {
+        public AddClientImageEvent(NetEntity attachedEntity, Vector3 turfCoords, int imageAppearance) {
             TurfCoords = turfCoords;
             ImageAppearance = imageAppearance;
             AttachedEntity = attachedEntity;
@@ -25,10 +25,10 @@ public class SharedClientImagesSystem : EntitySystem {
     [Serializable, NetSerializable]
     public sealed class RemoveClientImageEvent : EntityEventArgs {
         public Vector3 TurfCoords;
-        public EntityUid AttachedEntity; //if this is EntityUid.Invalid (ie, a turf) use the TurfCoords instead
+        public NetEntity AttachedEntity; //if this is NetEntity.Invalid (ie, a turf) use the TurfCoords instead
         public int ImageAppearance;
 
-        public RemoveClientImageEvent(EntityUid attachedEntity, Vector3 turfCoords, int imageAppearance) {
+        public RemoveClientImageEvent(NetEntity attachedEntity, Vector3 turfCoords, int imageAppearance) {
             TurfCoords = turfCoords;
             ImageAppearance = imageAppearance;
             AttachedEntity = attachedEntity;

--- a/OpenDreamShared/Rendering/SharedScreenOverlaySystem.cs
+++ b/OpenDreamShared/Rendering/SharedScreenOverlaySystem.cs
@@ -8,18 +8,18 @@ namespace OpenDreamShared.Rendering {
     public class SharedScreenOverlaySystem : EntitySystem {
         [Serializable, NetSerializable]
         public sealed class AddScreenObjectEvent : EntityEventArgs {
-            public EntityUid ScreenObject;
+            public NetEntity ScreenObject;
 
-            public AddScreenObjectEvent(EntityUid screenObject) {
+            public AddScreenObjectEvent(NetEntity screenObject) {
                 ScreenObject = screenObject;
             }
         }
 
         [Serializable, NetSerializable]
         public sealed class RemoveScreenObjectEvent : EntityEventArgs {
-            public EntityUid ScreenObject;
+            public NetEntity ScreenObject;
 
-            public RemoveScreenObjectEvent(EntityUid screenObject) {
+            public RemoveScreenObjectEvent(NetEntity screenObject) {
                 ScreenObject = screenObject;
             }
         }


### PR DESCRIPTION
This handles the server-client EntityUid separation. Basically just needed to change everything in OpenDreamShared.

The one thing I didn't change but it seems to work fine is `DreamMobSightSystem` - the `SubscribeLocalEvent` complains if I change the unused `EntityUid` argument to a `NetEntity`.

This is right before v159 where some render handle stuff got moved and I got bored of fixing stuff. There's also the removal of ComponentReference in v160.

This upgrades us to last week though, which I see as a win.
TestGame runs fine, ditto for Paradise.
![image](https://github.com/OpenDreamProject/OpenDream/assets/4741640/d2012c50-9107-4d86-993b-5f81ddc4e296)
