### PR TITLE
fix #warn choking on apostrophe

### DIFF
--- a/Content.Tests/DMProject/Tests/Preprocessor/Pragma/warning_quote.dm
+++ b/Content.Tests/DMProject/Tests/Preprocessor/Pragma/warning_quote.dm
@@ -1,0 +1,10 @@
+#define CONDITION_TRUE
+
+#ifdef CONDITION_TRUE
+#warn Oh no you're gonna have a bad time
+#endif
+
+/proc/RunTest()
+	return
+
+#warn end of file

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -581,28 +581,11 @@ namespace DMCompiler.Compiler.DMPreprocessor {
         private void HandleErrorOrWarningDirective(Token token) {
             if (!VerifyDirectiveUsage(token))
                 return;
-            Token whitespace = GetNextToken();
-            if(whitespace.Type != TokenType.DM_Preproc_Whitespace) {
-                DMCompiler.Emit(WarningCode.BadDirective, token.Location, "Expected whitespace after #error or #warning");
-                return;
-            }
 
-            StringBuilder messageBuilder = new StringBuilder();
-
-            //get raw tokens because #warn/#error messages should not be preprocessed at all - no macro replacements, no string processing
-            Token messageToken = _lexerStack.Peek().GetNextRawToken();
-            while (messageToken.Type != TokenType.EndOfFile) {
-                if (messageToken.Type == TokenType.Newline) break;
-
-                messageBuilder.Append(messageToken.Text);
-                messageToken = _lexerStack.Peek().GetNextRawToken();
-            }
-
-            string message = messageBuilder.ToString();
             if (token.Type == TokenType.DM_Preproc_Error) {
-                DMCompiler.Emit(WarningCode.ErrorDirective, token.Location, message);
+                DMCompiler.Emit(WarningCode.ErrorDirective, token.Location, token.Text);
             } else {
-                DMCompiler.Emit(WarningCode.WarningDirective, token.Location, message);
+                DMCompiler.Emit(WarningCode.WarningDirective, token.Location, token.Text);
             }
         }
 

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -581,15 +581,21 @@ namespace DMCompiler.Compiler.DMPreprocessor {
         private void HandleErrorOrWarningDirective(Token token) {
             if (!VerifyDirectiveUsage(token))
                 return;
+            Token whitespace = GetNextToken();
+            if(whitespace.Type != TokenType.DM_Preproc_Whitespace) {
+                DMCompiler.Emit(WarningCode.BadDirective, token.Location, "Expected whitespace after #error or #warning");
+                return;
+            }
 
             StringBuilder messageBuilder = new StringBuilder();
 
-            Token messageToken = GetNextToken(true);
+            //get raw tokens because #warn/#error messages should not be preprocessed at all - no macro replacements, no string processing
+            Token messageToken = _lexerStack.Peek().GetNextRawToken();
             while (messageToken.Type != TokenType.EndOfFile) {
                 if (messageToken.Type == TokenType.Newline) break;
 
                 messageBuilder.Append(messageToken.Text);
-                messageToken = GetNextToken();
+                messageToken = _lexerStack.Peek().GetNextRawToken();
             }
 
             string message = messageBuilder.ToString();

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -428,7 +428,28 @@ namespace DMCompiler.Compiler.DMPreprocessor {
         private bool TryMacroKeyword(string text, out Token token) {
             switch (text) {
                 case "warn":
-                case "warning": token = CreateToken(TokenType.DM_Preproc_Warning, "#warn"); break;
+                case "warning": {
+                    StringBuilder message = new StringBuilder();
+
+                    while (GetCurrent() is not '\0' and not '\n') {
+                        message.Append(GetCurrent());
+                        Advance();
+                    }
+
+                    token = CreateToken(TokenType.DM_Preproc_Warning, "#warn" + message.ToString());
+                    break;
+                }
+                case "error": {
+                    StringBuilder message = new StringBuilder();
+
+                    while (GetCurrent() is not '\0' and not '\n') {
+                        message.Append(GetCurrent());
+                        Advance();
+                    }
+
+                    token = CreateToken(TokenType.DM_Preproc_Error, "#error" + message.ToString());
+                    break;
+                }
                 case "include": token = CreateToken(TokenType.DM_Preproc_Include, "#include"); break;
                 case "define": token = CreateToken(TokenType.DM_Preproc_Define, "#define"); break;
                 case "undef": token = CreateToken(TokenType.DM_Preproc_Undefine, "#undef"); break;
@@ -438,7 +459,6 @@ namespace DMCompiler.Compiler.DMPreprocessor {
                 case "elif": token = CreateToken(TokenType.DM_Preproc_Elif, "#elif"); break;
                 case "else": token = CreateToken(TokenType.DM_Preproc_Else, "#else"); break;
                 case "endif": token = CreateToken(TokenType.DM_Preproc_EndIf, "#endif"); break;
-                case "error": token = CreateToken(TokenType.DM_Preproc_Error, "#error"); break;
                 //OD-specific directives
                 case "pragma": token = CreateToken(TokenType.DM_Preproc_Pragma, "#pragma"); break;
                 default:

--- a/OpenDreamShared/Compiler/Lexer.cs
+++ b/OpenDreamShared/Compiler/Lexer.cs
@@ -40,18 +40,6 @@ namespace OpenDreamShared.Compiler {
             }
         }
 
-        public Token GetNextRawToken() {
-            if(AtEndOfSource)
-                return CreateToken(TokenType.EndOfFile, String.Empty);
-            SourceType current = GetCurrent();
-            if(current?.ToString() == "\n") {
-                Advance();
-                return CreateToken(TokenType.Newline, current?.ToString() ?? String.Empty);
-            }
-            Advance();
-            return CreateToken(TokenType.Unknown, current?.ToString() ?? String.Empty);
-        }
-
         protected virtual Token ParseNextToken() {
             return CreateToken(TokenType.Unknown, GetCurrent()?.ToString() ?? String.Empty);
         }

--- a/OpenDreamShared/Compiler/Lexer.cs
+++ b/OpenDreamShared/Compiler/Lexer.cs
@@ -40,6 +40,18 @@ namespace OpenDreamShared.Compiler {
             }
         }
 
+        public Token GetNextRawToken() {
+            if(AtEndOfSource)
+                return CreateToken(TokenType.EndOfFile, String.Empty);
+            SourceType current = GetCurrent();
+            if(current?.ToString() == "\n") {
+                Advance();
+                return CreateToken(TokenType.Newline, current?.ToString() ?? String.Empty);
+            }
+            Advance();
+            return CreateToken(TokenType.Unknown, current?.ToString() ?? String.Empty);
+        }
+
         protected virtual Token ParseNextToken() {
             return CreateToken(TokenType.Unknown, GetCurrent()?.ToString() ?? String.Empty);
         }


### PR DESCRIPTION
`#warn` directives shouldn't try to process the tokens. Fixes #1439 and adds test