### PR TITLE
Stop image overlays with null/blank icon state from inheriting icons

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -678,13 +678,13 @@ public sealed class DreamOverlaysList : DreamList {
             overlay = new IconAppearance() {
                 IconState = iconState
             };
+            overlay.Icon ??= defaultIcon;
         } else if (atomManager.TryCreateAppearanceFrom(value, out var overlayAppearance)) {
             overlay = overlayAppearance;
         } else {
             return null; // Not a valid overlay
         }
 
-        overlay.Icon ??= defaultIcon;
         return overlay;
     }
 }


### PR DESCRIPTION
As far as I know, a blank image `new /image` added as an overlay shouldn't inherit the parent's icon. It should only do that if you add a raw icon state as an overlay, like `"foo"`.