### PR TITLE
Add a performance warning when OpenDream is compiled in Debug

### DIFF
--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -42,6 +42,10 @@ namespace DMCompiler {
 
             _compileStartTime = DateTime.Now;
 
+#if DEBUG
+            ForcedWarning("This compiler was compiled in the Debug .NET configuration. This will impact compile speed.");
+#endif
+
             if (settings.SuppressUnimplementedWarnings) {
                 ForcedWarning("Unimplemented proc & var warnings are currently suppressed");
             }
@@ -83,7 +87,7 @@ namespace DMCompiler {
 
         public static void AddResourceDirectory(string dir) {
             dir = dir.Replace('\\', Path.DirectorySeparatorChar);
-            
+
             _resourceDirectories.Add(dir);
         }
 

--- a/DMCompiler/Program.cs
+++ b/DMCompiler/Program.cs
@@ -1,24 +1,19 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
-using OpenDreamShared.Compiler;
 using Robust.Shared.Utility;
 
 namespace DMCompiler {
-
-    struct Argument {
+    internal struct Argument {
         /// <summary> The text we found that's in the '--whatever' format. May be null if no such text was present.</summary>
         public string? Name;
         /// <summary> The value, either set in a '--whatever=whoever' format or just left by itself anonymously. May be null.</summary>
         public string? Value;
     }
 
-
-
-    class Program {
-        static void Main(string[] args) {
+    internal static class Program {
+        private static void Main(string[] args) {
             if (!TryParseArguments(args, out DMCompilerSettings settings)) {
                 Environment.Exit(1);
                 return;

--- a/OpenDreamClient/States/Connecting/ConnectingControl.xaml.cs
+++ b/OpenDreamClient/States/Connecting/ConnectingControl.xaml.cs
@@ -6,37 +6,33 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.XAML;
 using Robust.Shared.Configuration;
 
-namespace OpenDreamClient.States.Connecting
-{
-    [GenerateTypedNameReferences]
-    public sealed partial class ConnectingControl : Control
-    {
-        public ConnectingControl(IResourceCache resCache, IConfigurationManager configMan)
-        {
+namespace OpenDreamClient.States.Connecting;
 
-            RobustXamlLoader.Load(this);
+[GenerateTypedNameReferences]
+public sealed partial class ConnectingControl : Control {
+    public ConnectingControl(IResourceCache resCache, IConfigurationManager configMan) {
+        RobustXamlLoader.Load(this);
 
-            Panel.PanelOverride = new StyleBoxFlat(Color.Black);
+        Panel.PanelOverride = new StyleBoxFlat(Color.Black);
 
-            ConnectingLabel.FontOverride = new VectorFont(resCache.GetResource<FontResource>("/Fonts/NotoSans-Regular.ttf"), 24);
-            WIPLabel.FontOverride = new VectorFont(resCache.GetResource<FontResource>("/Fonts/NotoSans-Bold.ttf"), 32);
+        ConnectingLabel.FontOverride = new VectorFont(resCache.GetResource<FontResource>("/Fonts/NotoSans-Regular.ttf"), 24);
+        WIPLabel.FontOverride = new VectorFont(resCache.GetResource<FontResource>("/Fonts/NotoSans-Bold.ttf"), 32);
 
-            LayoutContainer.SetAnchorPreset(this, LayoutContainer.LayoutPreset.Wide);
+        LayoutContainer.SetAnchorPreset(this, LayoutContainer.LayoutPreset.Wide);
 
-            LayoutContainer.SetAnchorPreset(VBox, LayoutContainer.LayoutPreset.Center);
-            LayoutContainer.SetGrowHorizontal(VBox, LayoutContainer.GrowDirection.Both);
-            LayoutContainer.SetGrowVertical(VBox, LayoutContainer.GrowDirection.Both);
+        LayoutContainer.SetAnchorPreset(VBox, LayoutContainer.LayoutPreset.Center);
+        LayoutContainer.SetGrowHorizontal(VBox, LayoutContainer.GrowDirection.Both);
+        LayoutContainer.SetGrowVertical(VBox, LayoutContainer.GrowDirection.Both);
 
-            LayoutContainer.SetAnchorPreset(ConnectingLabel, LayoutContainer.LayoutPreset.Center);
-            LayoutContainer.SetGrowHorizontal(ConnectingLabel, LayoutContainer.GrowDirection.Both);
-            LayoutContainer.SetGrowVertical(ConnectingLabel, LayoutContainer.GrowDirection.Both);
+        LayoutContainer.SetAnchorPreset(ConnectingLabel, LayoutContainer.LayoutPreset.Center);
+        LayoutContainer.SetGrowHorizontal(ConnectingLabel, LayoutContainer.GrowDirection.Both);
+        LayoutContainer.SetGrowVertical(ConnectingLabel, LayoutContainer.GrowDirection.Both);
 
-            LayoutContainer.SetAnchorPreset(WIP, LayoutContainer.LayoutPreset.VerticalCenterWide);
-            LayoutContainer.SetGrowHorizontal(WIP, LayoutContainer.GrowDirection.Both);
-            LayoutContainer.SetGrowVertical(WIP, LayoutContainer.GrowDirection.Both);
+        LayoutContainer.SetAnchorPreset(WIP, LayoutContainer.LayoutPreset.VerticalCenterWide);
+        LayoutContainer.SetGrowHorizontal(WIP, LayoutContainer.GrowDirection.Both);
+        LayoutContainer.SetGrowVertical(WIP, LayoutContainer.GrowDirection.Both);
 
-            var logoTexture = resCache.GetResource<TextureResource>("/OpenDream/Logo/logo.png");
-            Logo.Texture = logoTexture;
-        }
+        var logoTexture = resCache.GetResource<TextureResource>("/OpenDream/Logo/logo.png");
+        Logo.Texture = logoTexture;
     }
 }

--- a/OpenDreamClient/States/Connecting/ConnectingState.cs
+++ b/OpenDreamClient/States/Connecting/ConnectingState.cs
@@ -3,25 +3,21 @@ using Robust.Client.State;
 using Robust.Client.UserInterface;
 using Robust.Shared.Configuration;
 
-namespace OpenDreamClient.States.Connecting
-{
-    public sealed class ConnectingState : State
-    {
-        [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;
-        [Dependency] private readonly IResourceCache _resourceCache = default!;
-        [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+namespace OpenDreamClient.States.Connecting;
 
-        private ConnectingControl _connectingControl = default!;
+public sealed class ConnectingState : State {
+    [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;
+    [Dependency] private readonly IResourceCache _resourceCache = default!;
+    [Dependency] private readonly IConfigurationManager _configurationManager = default!;
 
-        protected override void Startup()
-        {
-            _connectingControl = new ConnectingControl(_resourceCache, _configurationManager);
-            _userInterfaceManager.StateRoot.AddChild(_connectingControl);
-        }
+    private ConnectingControl _connectingControl = default!;
 
-        protected override void Shutdown()
-        {
-            _connectingControl.Dispose();
-        }
+    protected override void Startup() {
+        _connectingControl = new ConnectingControl(_resourceCache, _configurationManager);
+        _userInterfaceManager.StateRoot.AddChild(_connectingControl);
+    }
+
+    protected override void Shutdown() {
+        _connectingControl.Dispose();
     }
 }

--- a/OpenDreamClient/States/DreamUserInterfaceStateManager.cs
+++ b/OpenDreamClient/States/DreamUserInterfaceStateManager.cs
@@ -4,51 +4,45 @@ using OpenDreamClient.States.MainMenu;
 using Robust.Client;
 using Robust.Client.State;
 
-namespace OpenDreamClient.States
-{
-    /// <summary>
-    ///     Handles changing the UI state depending on connection status.
-    /// </summary>
-    [UsedImplicitly]
-    public sealed class DreamUserInterfaceStateManager
-    {
-        [Dependency] private readonly IGameController _gameController = default!;
-        [Dependency] private readonly IBaseClient _client = default!;
-        [Dependency] private readonly IStateManager _stateManager = default!;
+namespace OpenDreamClient.States;
 
-        public void Initialize()
-        {
-            _client.RunLevelChanged += ((_, args) =>
-            {
-                switch (args.NewLevel)
-                {
-                    case ClientRunLevel.InGame:
-                    case ClientRunLevel.Connected:
-                    case ClientRunLevel.SinglePlayerGame:
-                        _stateManager.RequestStateChange<InGameState>();
-                        break;
+/// <summary>
+///     Handles changing the UI state depending on connection status.
+/// </summary>
+[UsedImplicitly]
+public sealed class DreamUserInterfaceStateManager {
+    [Dependency] private readonly IGameController _gameController = default!;
+    [Dependency] private readonly IBaseClient _client = default!;
+    [Dependency] private readonly IStateManager _stateManager = default!;
 
-                    case ClientRunLevel.Initialize when args.OldLevel < ClientRunLevel.Connected:
-                        _stateManager.RequestStateChange<MainMenuState>();
-                        break;
+    public void Initialize() {
+        _client.RunLevelChanged += ((_, args) => {
+            switch (args.NewLevel) {
+                case ClientRunLevel.InGame:
+                case ClientRunLevel.Connected:
+                case ClientRunLevel.SinglePlayerGame:
+                    _stateManager.RequestStateChange<InGameState>();
+                    break;
 
-                    // When we disconnect from the server:
-                    case ClientRunLevel.Error:
-                    case ClientRunLevel.Initialize when args.OldLevel >= ClientRunLevel.Connected:
-                        if (_gameController.LaunchState.FromLauncher)
-                        {
-                            _stateManager.RequestStateChange<ConnectingState>();
-                            break;
-                        }
+                case ClientRunLevel.Initialize when args.OldLevel < ClientRunLevel.Connected:
+                    _stateManager.RequestStateChange<MainMenuState>();
+                    break;
 
-                        _stateManager.RequestStateChange<MainMenuState>();
-                        break;
-
-                    case ClientRunLevel.Connecting:
+                // When we disconnect from the server:
+                case ClientRunLevel.Error:
+                case ClientRunLevel.Initialize when args.OldLevel >= ClientRunLevel.Connected:
+                    if (_gameController.LaunchState.FromLauncher) {
                         _stateManager.RequestStateChange<ConnectingState>();
                         break;
-                }
-            });
-        }
+                    }
+
+                    _stateManager.RequestStateChange<MainMenuState>();
+                    break;
+
+                case ClientRunLevel.Connecting:
+                    _stateManager.RequestStateChange<ConnectingState>();
+                    break;
+            }
+        });
     }
 }

--- a/OpenDreamClient/States/InGameState.cs
+++ b/OpenDreamClient/States/InGameState.cs
@@ -1,15 +1,11 @@
 using Robust.Client.State;
 
-namespace OpenDreamClient.States
-{
-    public sealed class InGameState : State
-    {
-        protected override void Startup()
-        {
-        }
+namespace OpenDreamClient.States;
 
-        protected override void Shutdown()
-        {
-        }
+public sealed class InGameState : State {
+    protected override void Startup() {
+    }
+
+    protected override void Shutdown() {
     }
 }

--- a/OpenDreamClient/States/MainMenu/MainMenuControl.xaml
+++ b/OpenDreamClient/States/MainMenu/MainMenuControl.xaml
@@ -6,33 +6,45 @@
                           Orientation="Vertical">
                 <TextureRect Name="Logo"
                              Stretch="KeepCentered" />
-                <BoxContainer Orientation="Horizontal"
-                              SeparationOverride="4">
-                    <Label Text="Username: " FontColorOverride="#FFFFFF"/>
-                    <LineEdit Name="UsernameBoxProtected"
-                              PlaceHolder="JoeGenero"
-                              HorizontalExpand="True" />
+                <BoxContainer Orientation="Vertical"
+                              SetWidth="371"
+                              HorizontalAlignment="Center">
+                    <BoxContainer Orientation="Horizontal"
+                                  SeparationOverride="4">
+                        <Label Text="Username: " FontColorOverride="#FFFFFF"/>
+                        <LineEdit Name="UsernameBoxProtected"
+                                  PlaceHolder="JoeGenero"
+                                  HorizontalExpand="True" />
+                    </BoxContainer>
+                    <Control MinSize="0 2" />
+                    <BoxContainer Orientation="Horizontal"
+                                  SeparationOverride="4">
+                        <Label Text="Address: " FontColorOverride="#FFFFFF"/>
+                        <LineEdit Name="AddressBoxProtected"
+                                  PlaceHolder="127.0.0.1:25566"
+                                  HorizontalExpand="True" />
+                    </BoxContainer>
+                    <Control MinSize="0 2" />
+                    <Button Name="ConnectButtonProtected"
+                            Text="Connect"
+                            TextAlign="Center" />
+                    <Control MinSize="0 2" />
+                    <Button Name="QuitButtonProtected"
+                            Text="Quit"
+                            TextAlign="Center" />
                 </BoxContainer>
-                <Control MinSize="0 2" />
-                <BoxContainer Orientation="Horizontal"
-                                          SeparationOverride="4">
-                                <Label Text="Address: " FontColorOverride="#FFFFFF"/>
-                                <LineEdit Name="AddressBoxProtected"
-                                          PlaceHolder="127.0.0.1:25566"
-                                          HorizontalExpand="True" />
-                </BoxContainer>
-                <Control MinSize="0 2" />
-                <Button Name="ConnectButtonProtected"
-                        Text="Connect"
-                        TextAlign="Center" />
-                <Control MinSize="0 2" />
-                <Button Name="QuitButtonProtected"
-                        Text="Quit"
-                        TextAlign="Center" />
                 <Control MinHeight="128"></Control>
-                <BoxContainer Name="WIP" Orientation="Horizontal"
+                <BoxContainer Name="Notices" Orientation="Vertical"
                               SeparationOverride="4">
-                    <Label Name="WIPLabel" Text="Work In Progress" FontColorOverride="#FFFFFF"/>
+                    <Label Name="WIPLabel"
+                           Text="Work In Progress"
+                           FontColorOverride="#FFFFFF"
+                           HorizontalAlignment="Center"/>
+                    <Label Name="DebugWarningLabel"
+                           Text="OpenDream was compiled in the Debug .NET configuration. This will heavily impact performance!"
+                           FontColorOverride="#FF1111"
+                           HorizontalAlignment="Center"
+                           Visible="False"/>
                 </BoxContainer>
             </BoxContainer>
 

--- a/OpenDreamClient/States/MainMenu/MainMenuControl.xaml.cs
+++ b/OpenDreamClient/States/MainMenu/MainMenuControl.xaml.cs
@@ -7,40 +7,37 @@ using Robust.Client.UserInterface.XAML;
 using Robust.Shared;
 using Robust.Shared.Configuration;
 
-namespace OpenDreamClient.States.MainMenu
-{
-    [GenerateTypedNameReferences]
-    public sealed partial class MainMenuControl : Control
-    {
-        public LineEdit UserNameBox => UsernameBoxProtected;
-        public LineEdit AddressBox => AddressBoxProtected;
-        public Button ConnectButton => ConnectButtonProtected;
-        public Button QuitButton => QuitButtonProtected;
+namespace OpenDreamClient.States.MainMenu;
 
-        public MainMenuControl(IResourceCache resCache, IConfigurationManager configMan)
-        {
-            RobustXamlLoader.Load(this);
+[GenerateTypedNameReferences]
+public sealed partial class MainMenuControl : Control {
+    public LineEdit UserNameBox => UsernameBoxProtected;
+    public LineEdit AddressBox => AddressBoxProtected;
+    public Button ConnectButton => ConnectButtonProtected;
+    public Button QuitButton => QuitButtonProtected;
 
-            Panel.PanelOverride = new StyleBoxFlat(Color.Black);
-            WIPLabel.FontOverride = new VectorFont(resCache.GetResource<FontResource>("/Fonts/NotoSans-Bold.ttf"), 32);
+    public MainMenuControl(IResourceCache resCache, IConfigurationManager configMan) {
+        RobustXamlLoader.Load(this);
 
-            LayoutContainer.SetAnchorPreset(this, LayoutContainer.LayoutPreset.Wide);
+        Panel.PanelOverride = new StyleBoxFlat(Color.Black);
+        WIPLabel.FontOverride = new VectorFont(resCache.GetResource<FontResource>("/Fonts/NotoSans-Bold.ttf"), 32);
 
-            LayoutContainer.SetAnchorPreset(VBox, LayoutContainer.LayoutPreset.Center);
-            LayoutContainer.SetGrowHorizontal(VBox, LayoutContainer.GrowDirection.Both);
-            LayoutContainer.SetGrowVertical(VBox, LayoutContainer.GrowDirection.Both);
+        LayoutContainer.SetAnchorPreset(this, LayoutContainer.LayoutPreset.Wide);
 
-            var logoTexture = resCache.GetResource<TextureResource>("/OpenDream/Logo/logo.png");
-            Logo.Texture = logoTexture;
+        LayoutContainer.SetAnchorPreset(VBox, LayoutContainer.LayoutPreset.Center);
+        LayoutContainer.SetGrowHorizontal(VBox, LayoutContainer.GrowDirection.Both);
+        LayoutContainer.SetGrowVertical(VBox, LayoutContainer.GrowDirection.Both);
 
-            var currentUserName = configMan.GetCVar(CVars.PlayerName);
-            UserNameBox.Text = currentUserName;
+        var logoTexture = resCache.GetResource<TextureResource>("/OpenDream/Logo/logo.png");
+        Logo.Texture = logoTexture;
 
-            AddressBoxProtected.Text = "127.0.0.1:25566";
+        var currentUserName = configMan.GetCVar(CVars.PlayerName);
+        UserNameBox.Text = currentUserName;
+
+        AddressBoxProtected.Text = "127.0.0.1:25566";
 
 #if DEBUG
-            DebugWarningLabel.Visible = true;
+        DebugWarningLabel.Visible = true;
 #endif
-        }
     }
 }

--- a/OpenDreamClient/States/MainMenu/MainMenuControl.xaml.cs
+++ b/OpenDreamClient/States/MainMenu/MainMenuControl.xaml.cs
@@ -37,6 +37,10 @@ namespace OpenDreamClient.States.MainMenu
             UserNameBox.Text = currentUserName;
 
             AddressBoxProtected.Text = "127.0.0.1:25566";
+
+#if DEBUG
+            DebugWarningLabel.Visible = true;
+#endif
         }
     }
 }

--- a/OpenDreamClient/States/MainMenu/MainMenuState.cs
+++ b/OpenDreamClient/States/MainMenu/MainMenuState.cs
@@ -10,163 +10,137 @@ using Robust.Shared.Configuration;
 using Robust.Shared.Network;
 using Robust.Shared.Utility;
 
-namespace OpenDreamClient.States.MainMenu
-{
-    public sealed class MainMenuState : State
-    {
-        [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;
-        [Dependency] private readonly IBaseClient _client = default!;
-        [Dependency] private readonly IClientNetManager _netManager = default!;
-        [Dependency] private readonly IResourceCache _resourceCache = default!;
-        [Dependency] private readonly IConfigurationManager _configurationManager = default!;
-        [Dependency] private readonly IGameController _controllerProxy = default!;
+namespace OpenDreamClient.States.MainMenu;
 
-        private MainMenuControl _mainMenuControl = default!;
-        private bool _isConnecting;
+public sealed class MainMenuState : State {
+    [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;
+    [Dependency] private readonly IBaseClient _client = default!;
+    [Dependency] private readonly IClientNetManager _netManager = default!;
+    [Dependency] private readonly IResourceCache _resourceCache = default!;
+    [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+    [Dependency] private readonly IGameController _controllerProxy = default!;
 
-        // ReSharper disable once InconsistentNaming
-        private static readonly Regex IPv6Regex = new(@"\[(.*:.*:.*)](?::(\d+))?");
+    private MainMenuControl _mainMenuControl = default!;
+    private bool _isConnecting;
 
-        protected override void Startup()
-        {
+    // ReSharper disable once InconsistentNaming
+    private static readonly Regex IPv6Regex = new(@"\[(.*:.*:.*)](?::(\d+))?");
 
-            _mainMenuControl = new MainMenuControl(_resourceCache, _configurationManager);
-            _userInterfaceManager.StateRoot.AddChild(_mainMenuControl);
+    protected override void Startup() {
+        _mainMenuControl = new MainMenuControl(_resourceCache, _configurationManager);
+        _userInterfaceManager.StateRoot.AddChild(_mainMenuControl);
 
-            _mainMenuControl.QuitButton.OnPressed += QuitButtonPressed;
-            _mainMenuControl.ConnectButton.OnPressed += ConnectButtonPressed;
-            _mainMenuControl.AddressBox.OnTextEntered += AddressBoxEntered;
-            _mainMenuControl.UserNameBox.OnTextChanged += UsernameBoxChanged;
+        _mainMenuControl.QuitButton.OnPressed += QuitButtonPressed;
+        _mainMenuControl.ConnectButton.OnPressed += ConnectButtonPressed;
+        _mainMenuControl.AddressBox.OnTextEntered += AddressBoxEntered;
+        _mainMenuControl.UserNameBox.OnTextChanged += UsernameBoxChanged;
 
-            _client.RunLevelChanged += RunLevelChanged;
+        _client.RunLevelChanged += RunLevelChanged;
+    }
 
-        }
+    protected override void Shutdown() {
+        _client.RunLevelChanged -= RunLevelChanged;
+        _netManager.ConnectFailed -= _onConnectFailed;
 
-        protected override void Shutdown()
-        {
-            _client.RunLevelChanged -= RunLevelChanged;
+        _mainMenuControl.Dispose();
+    }
+
+    private void UsernameBoxChanged(LineEdit.LineEditEventArgs args) {
+        _configurationManager.SetCVar(CVars.PlayerName, _mainMenuControl.UserNameBox.Text);
+    }
+
+    private void RunLevelChanged(object? obj, RunLevelChangedEventArgs args) {
+        if (args.NewLevel == ClientRunLevel.Initialize) {
+            _setConnectingState(false);
             _netManager.ConnectFailed -= _onConnectFailed;
+        }
+    }
 
-            _mainMenuControl.Dispose();
+    private void QuitButtonPressed(BaseButton.ButtonEventArgs args) {
+        _controllerProxy.Shutdown();
+    }
+
+    private void ConnectButtonPressed(BaseButton.ButtonEventArgs args) {
+        var input = _mainMenuControl.AddressBox;
+        TryConnect(input.Text);
+    }
+
+    private void AddressBoxEntered(LineEdit.LineEditEventArgs args) {
+        if (_isConnecting) {
+            return;
         }
 
-        private void UsernameBoxChanged(LineEdit.LineEditEventArgs args)
-        {
-            _configurationManager.SetCVar(CVars.PlayerName, _mainMenuControl.UserNameBox.Text);
+        TryConnect(args.Text);
+    }
+
+    private void TryConnect(string address) {
+        var inputName = _mainMenuControl.UserNameBox.Text.Trim();
+        if (!UsernameHelpers.IsNameValid(inputName, out var reason)) {
+            var invalidReason = Loc.GetString(reason.ToText());
+            _userInterfaceManager.Popup(
+                Loc.GetString("main-menu-invalid-username-with-reason", ("invalidReason", invalidReason)),
+                Loc.GetString("main-menu-invalid-username"));
+            return;
         }
 
-        private void RunLevelChanged(object? obj, RunLevelChangedEventArgs args)
-        {
-            if (args.NewLevel == ClientRunLevel.Initialize)
-            {
-                _setConnectingState(false);
-                _netManager.ConnectFailed -= _onConnectFailed;
-            }
+        var configName = _configurationManager.GetCVar(CVars.PlayerName);
+        if (_mainMenuControl.UserNameBox.Text != configName) {
+            _configurationManager.SetCVar(CVars.PlayerName, inputName);
+            _configurationManager.SaveToFile();
         }
 
-        private void QuitButtonPressed(BaseButton.ButtonEventArgs args)
-        {
-            _controllerProxy.Shutdown();
-        }
-
-        private void ConnectButtonPressed(BaseButton.ButtonEventArgs args)
-        {
-            var input = _mainMenuControl.AddressBox;
-            TryConnect(input.Text);
-        }
-
-        private void AddressBoxEntered(LineEdit.LineEditEventArgs args)
-        {
-            if (_isConnecting)
-            {
-                return;
-            }
-
-            TryConnect(args.Text);
-        }
-
-        private void TryConnect(string address)
-        {
-            var inputName = _mainMenuControl.UserNameBox.Text.Trim();
-            if (!UsernameHelpers.IsNameValid(inputName, out var reason))
-            {
-                var invalidReason = Loc.GetString(reason.ToText());
-                _userInterfaceManager.Popup(
-                    Loc.GetString("main-menu-invalid-username-with-reason", ("invalidReason", invalidReason)),
-                    Loc.GetString("main-menu-invalid-username"));
-                return;
-            }
-
-            var configName = _configurationManager.GetCVar(CVars.PlayerName);
-            if (_mainMenuControl.UserNameBox.Text != configName)
-            {
-                _configurationManager.SetCVar(CVars.PlayerName, inputName);
-                _configurationManager.SaveToFile();
-            }
-
-            _setConnectingState(true);
-            _netManager.ConnectFailed += _onConnectFailed;
-            try {
-                ParseAddress(address, out var ip, out var port);
-                _client.ConnectToServer(ip, port);
-            } catch (ArgumentException e) {
-                _userInterfaceManager.Popup($"Unable to connect: {e.Message}", "Connection error.");
-                Logger.GetSawmill("opendream").Warning(e.ToString());
-                _netManager.ConnectFailed -= _onConnectFailed;
-                _setConnectingState(false);
-            }
-        }
-
-        private void ParseAddress(string address, out string ip, out ushort port)
-        {
-            var match6 = IPv6Regex.Match(address);
-            if (match6 != Match.Empty)
-            {
-                ip = match6.Groups[1].Value;
-                if (!match6.Groups[2].Success)
-                {
-                    port = _client.DefaultPort;
-                }
-                else if (!ushort.TryParse(match6.Groups[2].Value, out port))
-                {
-                    throw new ArgumentException("Not a valid port.");
-                }
-
-                return;
-            }
-
-            // See if the IP includes a port.
-            var split = address.Split(':');
-            ip = address;
-            port = _client.DefaultPort;
-            if (split.Length > 2)
-            {
-                throw new ArgumentException("Not a valid Address.");
-            }
-
-            // IP:port format.
-            if (split.Length == 2)
-            {
-                ip = split[0];
-                if (!ushort.TryParse(split[1], out port))
-                {
-                    throw new ArgumentException("Not a valid port.");
-                }
-            }
-        }
-
-
-        private void _onConnectFailed(object? _, NetConnectFailArgs args)
-        {
-            _userInterfaceManager.Popup($"Failed to connect: {args.Reason}");
+        _setConnectingState(true);
+        _netManager.ConnectFailed += _onConnectFailed;
+        try {
+            ParseAddress(address, out var ip, out var port);
+            _client.ConnectToServer(ip, port);
+        } catch (ArgumentException e) {
+            _userInterfaceManager.Popup($"Unable to connect: {e.Message}", "Connection error.");
+            Logger.GetSawmill("opendream").Warning(e.ToString());
             _netManager.ConnectFailed -= _onConnectFailed;
             _setConnectingState(false);
         }
+    }
 
-        private void _setConnectingState(bool state)
-        {
-            _isConnecting = state;
-            _mainMenuControl.ConnectButton.Disabled = state;
+    private void ParseAddress(string address, out string ip, out ushort port) {
+        var match6 = IPv6Regex.Match(address);
+        if (match6 != Match.Empty) {
+            ip = match6.Groups[1].Value;
+            if (!match6.Groups[2].Success) {
+                port = _client.DefaultPort;
+            } else if (!ushort.TryParse(match6.Groups[2].Value, out port)) {
+                throw new ArgumentException("Not a valid port.");
+            }
+
+            return;
         }
+
+        // See if the IP includes a port.
+        var split = address.Split(':');
+        ip = address;
+        port = _client.DefaultPort;
+        if (split.Length > 2) {
+            throw new ArgumentException("Not a valid Address.");
+        }
+
+        // IP:port format.
+        if (split.Length == 2) {
+            ip = split[0];
+            if (!ushort.TryParse(split[1], out port)) {
+                throw new ArgumentException("Not a valid port.");
+            }
+        }
+    }
+
+
+    private void _onConnectFailed(object? _, NetConnectFailArgs args) {
+        _userInterfaceManager.Popup($"Failed to connect: {args.Reason}");
+        _netManager.ConnectFailed -= _onConnectFailed;
+        _setConnectingState(false);
+    }
+
+    private void _setConnectingState(bool state) {
+        _isConnecting = state;
+        _mainMenuControl.ConnectButton.Disabled = state;
     }
 }

--- a/OpenDreamServer/Program.cs
+++ b/OpenDreamServer/Program.cs
@@ -1,12 +1,11 @@
 ﻿using Robust.Server;
 
-namespace OpenDreamServer {
-    class Program {
-        static void Main(string[] args) {
-            ContentStart.StartLibrary(args, new ServerOptions
-            {
-                ContentModulePrefix = "OpenDream",
-            });
-        }
+namespace OpenDreamServer;
+
+internal sealed class Program {
+    private static void Main(string[] args) {
+        ContentStart.StartLibrary(args, new ServerOptions {
+            ContentModulePrefix = "OpenDream",
+        });
     }
 }


### PR DESCRIPTION
When the client is compiled in Debug:
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/9b13ea08-85d3-46cd-a8c8-4b993bc61ae5)

And the compiler:
`Warning OD0000 at <internal>: This compiler was compiled in the Debug .NET configuration. This will impact compile speed.`

Nothing for the server because there's nowhere to obviously place it, and the people this targets likely aren't compiling the server in Debug and client in Release.