### PR TITLE
Move DMCompiler's build output path

### DIFF
--- a/.github/workflows/compiler-test.yml
+++ b/.github/workflows/compiler-test.yml
@@ -33,14 +33,14 @@ jobs:
     - name: Build
       run: dotnet build main/OpenDream.sln --configuration Release --no-restore /m
     - name: Compile TestGame
-      run: main\DMCompiler\bin\Release\net7.0\DMCompiler.exe main\TestGame\environment.dme
+      run: main\bin\DMCompiler\DMCompiler.exe main\TestGame\environment.dme
     - name: Checkout Modified /tg/station
       uses: actions/checkout@v2
       with:
         repository: wixoaGit/tgstation
         path: tg
     - name: Compile Modified /tg/station
-      run: main\DMCompiler\bin\Release\net7.0\DMCompiler.exe tg\tgstation.dme 
+      run: main\bin\DMCompiler\DMCompiler.exe tg\tgstation.dme 
     - name: Checkout 64-bit Paradise
       uses: actions/checkout@v2
       with:
@@ -48,4 +48,4 @@ jobs:
         ref: rustg_64
         path: para
     - name: Compile 64-bit Paradise
-      run: main\DMCompiler\bin\Release\net7.0\DMCompiler.exe para\paradise.dme
+      run: main\bin\DMCompiler\DMCompiler.exe para\paradise.dme

--- a/DMCompiler/DMCompiler.csproj
+++ b/DMCompiler/DMCompiler.csproj
@@ -6,6 +6,8 @@
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;Tools</Configurations>
     <Platforms>AnyCPU</Platforms>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath>..\bin\DMCompiler\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Move DMCompiler's build path to be beside the server and client.