### PR TITLE
Don't throw `WarningCode.EmptyBlock` on semicolon bodies

### DIFF
--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -618,6 +618,12 @@ namespace DMCompiler.Compiler.DM {
         /// </remarks>
         public readonly DMASTProcStatement[] SetStatements;
 
+        /// <summary>
+        /// This is used to determine if we should flag for <c>WarningCode.EmptyBlock</c>,
+        /// which we don't do if there was a manually entered semicolon within.
+        /// </summary>
+        public bool NotCompletelyEmpty;
+
         /// <summary> Initializes an empty block. </summary>
         public DMASTProcBlockInner(Location location) : base(location) {
             Statements = Array.Empty<DMASTProcStatement>();

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -85,7 +85,7 @@ namespace DMCompiler.DM.Visitors {
                     DMCompiler.Emit(e.Error);
                 }
             }
-            if(!silenceEmptyBlockWarning && block.Statements.Length == 0) { // If this block has no real statements
+            if(!silenceEmptyBlockWarning && block.Statements.Length == 0 && !block.NotCompletelyEmpty) { // If this block has no real statements
                 // Not an error in BYOND, but we do have an emission for this!
                 if(block.SetStatements.Length != 0) { // Give a more articulate message about this, since it's kinda weird
                     DMCompiler.Emit(WarningCode.EmptyBlock,block.Location,"Empty block detected - set statements are executed outside of, before, and unconditional to, this block");


### PR DESCRIPTION
Essentially, throw `WarningCode.EmptyBlock` on
```cs
if(xyz)
	// :(
else
	...
```
but not 
```cs
if(xyz)
	; // <--
else
	...
```
This way, developers can insert a semicolon to denote that they intentionally want to write a statement a certain way.

----
this is pretty cursed code, but it's the only really viable way i could see how to do this