### PR TITLE
Handle lone-carriage-return line endings

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -325,7 +325,7 @@ namespace DMCompiler.Compiler.DM {
                     statement = new DMASTObjectDefinition(loc, _currentPath, null);
                 }
 
-                if (requireDelimiter && !PeekDelimiter() && Current().Type != TokenType.DM_Dedent && Current().Type != TokenType.DM_RightCurlyBracket) {
+                if (requireDelimiter && !PeekDelimiter() && Current().Type != TokenType.DM_Dedent && Current().Type != TokenType.DM_RightCurlyBracket && Current().Type != TokenType.EndOfFile) {
                     Error("Expected end of object statement");
                 }
 

--- a/DMCompiler/Compiler/DM/DMParserHelper.cs
+++ b/DMCompiler/Compiler/DM/DMParserHelper.cs
@@ -135,7 +135,7 @@ namespace DMCompiler.Compiler.DM {
                                 List<Token> preprocTokens = new();
                                 Token preprocToken;
                                 do {
-                                    preprocToken = preprocLexer.GetNextToken();
+                                    preprocToken = preprocLexer.NextToken();
                                     preprocToken.Location = constantToken.Location;
                                     preprocTokens.Add(preprocToken);
                                 } while (preprocToken.Type != TokenType.EndOfFile);

--- a/DMCompiler/Compiler/DMM/DMMParser.cs
+++ b/DMCompiler/Compiler/DMM/DMMParser.cs
@@ -1,4 +1,5 @@
-﻿using OpenDreamShared.Compiler;
+﻿using System;
+using OpenDreamShared.Compiler;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Json;
 using DMCompiler.DM;
@@ -121,8 +122,7 @@ namespace DMCompiler.Compiler.DMM {
                 Consume(TokenType.DM_String, "Expected a string");
 
                 string blockString = (string)blockStringToken.Value;
-                List<string> lines = new(blockString.Split("\n"));
-                lines.RemoveAll(string.IsNullOrEmpty);
+                List<string> lines = new(blockString.Split("\n", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries));
 
                 mapBlock.Height = lines.Count;
                 for (int y = 1; y <= lines.Count; y++) {

--- a/DMCompiler/Compiler/DMPreprocessor/DMMacro.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMMacro.cs
@@ -3,183 +3,183 @@ using System.Collections.Generic;
 using System.Text;
 using OpenDreamShared.Compiler;
 
-namespace DMCompiler.Compiler.DMPreprocessor {
-    internal class DMMacro {
-        private readonly List<string> _parameters;
-        private readonly List<Token> _tokens;
-        private readonly string _overflowParameter;
-        private readonly int _overflowParameterIndex;
+namespace DMCompiler.Compiler.DMPreprocessor;
 
-        public DMMacro(List<string> parameters, List<Token> tokens) {
-            _parameters = parameters;
-            _tokens = tokens;
+internal class DMMacro {
+    private readonly List<string> _parameters;
+    private readonly List<Token> _tokens;
+    private readonly string _overflowParameter;
+    private readonly int _overflowParameterIndex;
 
-            if (_parameters != null) {
-                for (int i = 0; i < _parameters.Count; i++) {
-                    string parameter = _parameters[i];
+    public DMMacro(List<string> parameters, List<Token> tokens) {
+        _parameters = parameters;
+        _tokens = tokens;
 
-                    if (parameter.EndsWith("...")) {
-                        _overflowParameter = parameter.Substring(0, parameter.Length - 3);
-                        _overflowParameterIndex = i;
+        if (_parameters != null) {
+            for (int i = 0; i < _parameters.Count; i++) {
+                string parameter = _parameters[i];
 
-                        break;
-                    }
-                }
-            }
+                if (parameter.EndsWith("...")) {
+                    _overflowParameter = parameter.Substring(0, parameter.Length - 3);
+                    _overflowParameterIndex = i;
 
-            if (_tokens != null) {
-                // Concat tokens cause any whitespace directly before them to be ignored
-                for (int i = 1; i < _tokens.Count; i++) {
-                    Token token = _tokens[i];
-                    Token lastToken = _tokens[i - 1];
-
-                    if (token.Type == TokenType.DM_Preproc_TokenConcat &&
-                        lastToken.Type == TokenType.DM_Preproc_Whitespace) {
-                        _tokens.RemoveAt(--i);
-                    }
+                    break;
                 }
             }
         }
 
-        public bool HasParameters() {
-            return _parameters != null;
+        if (_tokens != null) {
+            // Concat tokens cause any whitespace directly before them to be ignored
+            for (int i = 1; i < _tokens.Count; i++) {
+                Token token = _tokens[i];
+                Token lastToken = _tokens[i - 1];
+
+                if (token.Type == TokenType.DM_Preproc_TokenConcat &&
+                    lastToken.Type == TokenType.DM_Preproc_Whitespace) {
+                    _tokens.RemoveAt(--i);
+                }
+            }
         }
+    }
 
-        /// <summary>
-        /// Takes given parameters and creates a list of tokens representing the expanded macro
-        /// </summary>
-        /// <param name="replacing">The identifier being replaced with this macro</param>
-        /// <param name="parameters">Parameters for macro expansion. Null if none given.</param>
-        /// <returns>A list of tokens replacing the identifier</returns>
-        /// <exception cref="ArgumentException">Thrown if no parameters were given but are required</exception>
-        // TODO: Convert this to an IEnumerator<Token>? Could cut down on allocations.
-        public virtual List<Token> Expand(Token replacing, List<List<Token>> parameters) {
-            // If this macro has no parameters then we can just return our list of tokens
-            if (!HasParameters())
-                return _tokens;
+    public bool HasParameters() {
+        return _parameters != null;
+    }
 
-            // If we have parameters but weren't given any, throw an exception
-            if (parameters == null)
-                throw new ArgumentException("This macro requires parameters");
+    /// <summary>
+    /// Takes given parameters and creates a list of tokens representing the expanded macro
+    /// </summary>
+    /// <param name="replacing">The identifier being replaced with this macro</param>
+    /// <param name="parameters">Parameters for macro expansion. Null if none given.</param>
+    /// <returns>A list of tokens replacing the identifier</returns>
+    /// <exception cref="ArgumentException">Thrown if no parameters were given but are required</exception>
+    // TODO: Convert this to an IEnumerator<Token>? Could cut down on allocations.
+    public virtual List<Token> Expand(Token replacing, List<List<Token>> parameters) {
+        // If this macro has no parameters then we can just return our list of tokens
+        if (!HasParameters())
+            return _tokens;
 
-            List<Token> expandedTokens = new(_tokens.Count);
-            foreach (Token token in _tokens) {
-                string parameterName =
-                    token.Type is TokenType.DM_Preproc_TokenConcat or TokenType.DM_Preproc_ParameterStringify
-                        ? (string) token.Value
-                        : token.Text;
-                int parameterIndex = _parameters.IndexOf(parameterName);
+        // If we have parameters but weren't given any, throw an exception
+        if (parameters == null)
+            throw new ArgumentException("This macro requires parameters");
 
-                if (parameterIndex != -1 && parameters.Count > parameterIndex) {
-                    List<Token> parameter = parameters[parameterIndex];
+        List<Token> expandedTokens = new(_tokens.Count);
+        foreach (Token token in _tokens) {
+            string parameterName =
+                token.Type is TokenType.DM_Preproc_TokenConcat or TokenType.DM_Preproc_ParameterStringify
+                    ? (string) token.Value
+                    : token.Text;
+            int parameterIndex = _parameters.IndexOf(parameterName);
 
-                    if (token.Type == TokenType.DM_Preproc_ParameterStringify) {
-                        StringBuilder tokenTextBuilder = new StringBuilder();
+            if (parameterIndex != -1 && parameters.Count > parameterIndex) {
+                List<Token> parameter = parameters[parameterIndex];
 
-                        // Use a raw string. Use '#' because that can't appear in an expression.
-                        // this does mean, however, that a '#' inside the string will make the preprocessor dump produce invalid code
-                        tokenTextBuilder.Append("@#");
-                        foreach (Token parameterToken in parameter) {
-                            tokenTextBuilder.Append(parameterToken.Text);
-                        }
+                if (token.Type == TokenType.DM_Preproc_ParameterStringify) {
+                    StringBuilder tokenTextBuilder = new StringBuilder();
 
-                        tokenTextBuilder.Append('#');
-
-                        string tokenText = tokenTextBuilder.ToString();
-                        expandedTokens.Add(new Token(TokenType.DM_Preproc_ConstantString, tokenText,
-                            Location.Unknown, tokenText.Substring(2, tokenText.Length - 3)));
-                    } else {
-                        foreach (var parameterToken in parameter) {
-                            switch (parameterToken.Type) {
-                                case TokenType.DM_Preproc_Identifier:
-                                case TokenType.DM_Preproc_Number:
-                                    if (expandedTokens.Count == 0)
-                                        goto default;
-
-                                    // If the last token was an identifier, we need to combine the two
-                                    var lastToken = expandedTokens[^1];
-                                    if (lastToken.Type != TokenType.DM_Preproc_Identifier)
-                                        goto default;
-
-                                    // A new identifier made up of the last one and this identifier/number
-                                    expandedTokens[^1] = new Token(TokenType.DM_Preproc_Identifier,
-                                        lastToken.Text + parameterToken.Text, lastToken.Location, null);
-                                    break;
-                                default:
-                                    expandedTokens.Add(parameterToken);
-                                    break;
-                            }
-                        }
+                    // Use a raw string. Use '#' because that can't appear in an expression.
+                    // this does mean, however, that a '#' inside the string will make the preprocessor dump produce invalid code
+                    tokenTextBuilder.Append("@#");
+                    foreach (Token parameterToken in parameter) {
+                        tokenTextBuilder.Append(parameterToken.Text);
                     }
-                } else if (_overflowParameter != null && parameterName == _overflowParameter) {
-                    for (int i = _overflowParameterIndex; i < parameters.Count; i++) {
-                        expandedTokens.AddRange(parameters[i]);
 
-                        if(i < parameters.Count-1)
-                            expandedTokens.Add(new Token(TokenType.DM_Preproc_Punctuator_Comma, ",", Location.Unknown, null));
-                    }
+                    tokenTextBuilder.Append('#');
+
+                    string tokenText = tokenTextBuilder.ToString();
+                    expandedTokens.Add(new Token(TokenType.DM_Preproc_ConstantString, tokenText,
+                        Location.Unknown, tokenText.Substring(2, tokenText.Length - 3)));
                 } else {
-                    if (token.Type == TokenType.DM_Preproc_ParameterStringify) {
-                        expandedTokens.Add(new Token(TokenType.DM_Preproc_ConstantString, $"@#{parameterName}#",
-                            Location.Unknown, parameterName));
-                    } else if (token.Type == TokenType.DM_Preproc_TokenConcat) {
-                        expandedTokens.Add(new Token(TokenType.DM_Preproc_Identifier, parameterName,
-                            Location.Unknown, null));
-                    } else {
-                        expandedTokens.Add(token);
+                    foreach (var parameterToken in parameter) {
+                        switch (parameterToken.Type) {
+                            case TokenType.DM_Preproc_Identifier:
+                            case TokenType.DM_Preproc_Number:
+                                if (expandedTokens.Count == 0)
+                                    goto default;
+
+                                // If the last token was an identifier, we need to combine the two
+                                var lastToken = expandedTokens[^1];
+                                if (lastToken.Type != TokenType.DM_Preproc_Identifier)
+                                    goto default;
+
+                                // A new identifier made up of the last one and this identifier/number
+                                expandedTokens[^1] = new Token(TokenType.DM_Preproc_Identifier,
+                                    lastToken.Text + parameterToken.Text, lastToken.Location, null);
+                                break;
+                            default:
+                                expandedTokens.Add(parameterToken);
+                                break;
+                        }
                     }
                 }
+            } else if (_overflowParameter != null && parameterName == _overflowParameter) {
+                for (int i = _overflowParameterIndex; i < parameters.Count; i++) {
+                    expandedTokens.AddRange(parameters[i]);
+
+                    if(i < parameters.Count-1)
+                        expandedTokens.Add(new Token(TokenType.DM_Preproc_Punctuator_Comma, ",", Location.Unknown, null));
+                }
+            } else {
+                if (token.Type == TokenType.DM_Preproc_ParameterStringify) {
+                    expandedTokens.Add(new Token(TokenType.DM_Preproc_ConstantString, $"@#{parameterName}#",
+                        Location.Unknown, parameterName));
+                } else if (token.Type == TokenType.DM_Preproc_TokenConcat) {
+                    expandedTokens.Add(new Token(TokenType.DM_Preproc_Identifier, parameterName,
+                        Location.Unknown, null));
+                } else {
+                    expandedTokens.Add(token);
+                }
             }
-
-            return expandedTokens;
         }
+
+        return expandedTokens;
     }
+}
 
-    // __LINE__
-    sealed class DMMacroLine : DMMacro {
-        public DMMacroLine() : base(null, null) { }
+// __LINE__
+internal sealed class DMMacroLine : DMMacro {
+    public DMMacroLine() : base(null, null) { }
 
-        public override List<Token> Expand(Token replacing, List<List<Token>> parameters) {
-            return new(1) {
-                new Token(TokenType.DM_Preproc_Number, replacing.Location.Line.ToString(), replacing.Location, null)
-            };
-        }
+    public override List<Token> Expand(Token replacing, List<List<Token>> parameters) {
+        return new(1) {
+            new Token(TokenType.DM_Preproc_Number, replacing.Location.Line.ToString(), replacing.Location, null)
+        };
     }
+}
 
-    // __FILE__
-    sealed class DMMacroFile : DMMacro {
-        public DMMacroFile() : base(null, null) { }
+// __FILE__
+internal sealed class DMMacroFile : DMMacro {
+    public DMMacroFile() : base(null, null) { }
 
-        public override List<Token> Expand(Token replacing, List<List<Token>> parameters) {
-            string path = replacing.Location.SourceFile.Replace(@"\", @"\\"); //Escape any backwards slashes
+    public override List<Token> Expand(Token replacing, List<List<Token>> parameters) {
+        string path = replacing.Location.SourceFile.Replace(@"\", @"\\"); //Escape any backwards slashes
 
-            return new(1) {
-                new Token(TokenType.DM_Preproc_ConstantString, $"\"{path}\"", replacing.Location, path)
-            };
-        }
+        return new(1) {
+            new Token(TokenType.DM_Preproc_ConstantString, $"\"{path}\"", replacing.Location, path)
+        };
     }
+}
 
-    // DM_VERSION
+// DM_VERSION
 
-    sealed class DMMacroVersion : DMMacro {
-        public DMMacroVersion() : base(null, null) { }
+internal sealed class DMMacroVersion : DMMacro {
+    public DMMacroVersion() : base(null, null) { }
 
-        public override List<Token> Expand(Token replacing, List<List<Token>> parameters) {
-            return new(1) {
-                new Token(TokenType.DM_Preproc_Number, DMCompiler.Settings.DMVersion, replacing.Location, null)
-            };
-        }
+    public override List<Token> Expand(Token replacing, List<List<Token>> parameters) {
+        return new(1) {
+            new Token(TokenType.DM_Preproc_Number, DMCompiler.Settings.DMVersion, replacing.Location, null)
+        };
     }
+}
 
-    // DM_BUILD
+// DM_BUILD
 
-    sealed class DMMacroBuild : DMMacro {
-        public DMMacroBuild() : base(null, null) { }
+internal sealed class DMMacroBuild : DMMacro {
+    public DMMacroBuild() : base(null, null) { }
 
-        public override List<Token> Expand(Token replacing, List<List<Token>> parameters) {
-            return new(1) {
-                new Token(TokenType.DM_Preproc_Number, DMCompiler.Settings.DMBuild, replacing.Location, null)
-            };
-        }
+    public override List<Token> Expand(Token replacing, List<List<Token>> parameters) {
+        return new(1) {
+            new Token(TokenType.DM_Preproc_Number, DMCompiler.Settings.DMBuild, replacing.Location, null)
+        };
     }
 }

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -15,7 +15,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
     /// </summary>
     public sealed class DMPreprocessor : IEnumerable<Token> {
         public readonly List<string> IncludedMaps = new(8);
-        public string IncludedInterface;
+        public string? IncludedInterface;
 
         //Every include pushes a new lexer that gets popped once the included file is finished
         private readonly Stack<DMPreprocessorLexer> _lexerStack =  new(8); // Capacity Note: TG peaks at 4 at time of writing
@@ -235,6 +235,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
                             DMCompiler.Emit(WarningCode.FileAlreadyIncluded, includedFrom ?? Location.Internal, $"Interface \"{filePath}\" was already included");
                             break;
                         }
+
                         DMCompiler.Emit(WarningCode.InvalidInclusion, includedFrom ?? Location.Internal, $"Attempted to include a second interface file ({filePath}) while one was already included ({IncludedInterface})");
                         break;
                     }
@@ -252,9 +253,9 @@ namespace DMCompiler.Compiler.DMPreprocessor {
         }
 
         public void PreprocessFile(string includeDir, string file) {
-            string filePath = Path.Combine(includeDir, file).Replace('\\', Path.DirectorySeparatorChar);
+            file = file.Replace('\\', '/');
 
-            _lexerStack.Push(new DMPreprocessorLexer(includeDir, filePath));
+            _lexerStack.Push(new DMPreprocessorLexer(includeDir, file));
         }
 
         private bool VerifyDirectiveUsage(Token token) {

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -7,804 +7,801 @@ using DMCompiler.Compiler.DM;
 using OpenDreamShared.Compiler;
 using Robust.Shared.Utility;
 
-namespace DMCompiler.Compiler.DMPreprocessor {
+namespace DMCompiler.Compiler.DMPreprocessor;
 
+/// <summary>
+/// The master class for handling DM preprocessing.
+/// This is an <see cref="IEnumerable"/>, and is usually accessed via its <see cref="Token"/> output in a for-loop.
+/// </summary>
+public sealed class DMPreprocessor : IEnumerable<Token> {
+    public readonly List<string> IncludedMaps = new(8);
+    public string? IncludedInterface;
+
+    //Every include pushes a new lexer that gets popped once the included file is finished
+    private readonly Stack<DMPreprocessorLexer> _lexerStack =  new(8); // Capacity Note: TG peaks at 4 at time of writing
+
+    private readonly Stack<Token> _bufferedWhitespace = new();
+    private bool _currentLineContainsNonWhitespace = false;
+    private bool _canUseDirective = true;
+    private readonly HashSet<string> _includedFiles = new(5120); // Capacity Note: TG peaks at 4860 at time of writing
+    private readonly Stack<Token> _unprocessedTokens = new(8192); // Capacity Note: TG peaks at 6802 at time of writing
+    private readonly bool _enableDirectives;
+    private readonly Dictionary<string, DMMacro> _defines = new(12288) { // Capacity Note: TG peaks at 9827 at time of writing. Current value is arbitrarily 4096 * 3.
+        { "__LINE__", new DMMacroLine() },
+        { "__FILE__", new DMMacroFile() },
+        { "DM_VERSION", new DMMacroVersion() },
+        { "DM_BUILD", new DMMacroBuild() }
+    };
     /// <summary>
-    /// The master class for handling DM preprocessing.
-    /// This is an <see cref="IEnumerable"/>, and is usually accessed via its <see cref="Token"/> output in a for-loop.
+    /// This stores previous evaluations of if-directives that have yet to find their #endif.<br/>
+    /// We do this so that we can A.) Detect whether an #else or #endif is valid and B.) Remember what to do when we find that #else.
+    /// A null value indicates the last directive found was an #else that's waiting for an #endif.
     /// </summary>
-    public sealed class DMPreprocessor : IEnumerable<Token> {
-        public readonly List<string> IncludedMaps = new(8);
-        public string? IncludedInterface;
+    private readonly Stack<bool?> _lastIfEvaluations = new(16);
+    private Location _lastSeenIf = Location.Unknown; // used by the errors emitted for when the above var isn't empty at exit
 
-        //Every include pushes a new lexer that gets popped once the included file is finished
-        private readonly Stack<DMPreprocessorLexer> _lexerStack =  new(8); // Capacity Note: TG peaks at 4 at time of writing
+    private static readonly TokenType[] DirectiveTypes = {
+        TokenType.DM_Preproc_Include,
+        TokenType.DM_Preproc_Define,
+        TokenType.DM_Preproc_Undefine,
+        TokenType.DM_Preproc_If,
+        TokenType.DM_Preproc_Ifdef,
+        TokenType.DM_Preproc_Ifndef,
+        TokenType.DM_Preproc_Elif,
+        TokenType.DM_Preproc_Else,
+        TokenType.DM_Preproc_Warning,
+        TokenType.DM_Preproc_Error,
+        TokenType.DM_Preproc_EndIf,
+        TokenType.DM_Preproc_Pragma
+    };
 
-        private Stack<Token> _bufferedWhitespace = new();
-        private bool _currentLineContainsNonWhitespace = false;
-        private bool _canUseDirective = true;
-        private readonly HashSet<string> _includedFiles = new(5120); // Capacity Note: TG peaks at 4860 at time of writing
-        private readonly Stack<Token> _unprocessedTokens = new(8192); // Capacity Note: TG peaks at 6802 at time of writing
-        private readonly bool _enableDirectives;
-        private readonly Dictionary<string, DMMacro> _defines = new(12288) { // Capacity Note: TG peaks at 9827 at time of writing. Current value is arbitrarily 4096 * 3.
-            { "__LINE__", new DMMacroLine() },
-            { "__FILE__", new DMMacroFile() },
-            { "DM_VERSION", new DMMacroVersion() },
-            { "DM_BUILD", new DMMacroBuild() }
-        };
-        /// <summary>
-        /// This stores previous evaluations of if-directives that have yet to find their #endif.<br/>
-        /// We do this so that we can A.) Detect whether an #else or #endif is valid and B.) Remember what to do when we find that #else.
-        /// A null value indicates the last directive found was an #else that's waiting for an #endif.
-        /// </summary>
-        private readonly Stack<bool?> _lastIfEvaluations = new(16);
-        private Location _lastSeenIf = Location.Unknown; // used by the errors emitted for when the above var isn't empty at exit
+    public DMPreprocessor(bool enableDirectives) {
+        _enableDirectives = enableDirectives;
+    }
 
-        private static readonly TokenType[] DirectiveTypes = {
-            TokenType.DM_Preproc_Include,
-            TokenType.DM_Preproc_Define,
-            TokenType.DM_Preproc_Undefine,
-            TokenType.DM_Preproc_If,
-            TokenType.DM_Preproc_Ifdef,
-            TokenType.DM_Preproc_Ifndef,
-            TokenType.DM_Preproc_Elif,
-            TokenType.DM_Preproc_Else,
-            TokenType.DM_Preproc_Warning,
-            TokenType.DM_Preproc_Error,
-            TokenType.DM_Preproc_EndIf,
-            TokenType.DM_Preproc_Pragma
-        };
+    public IEnumerator<Token> GetEnumerator() {
+        while (_lexerStack.Count > 0) {
+            Token token = GetNextToken();
 
-        public DMPreprocessor(bool enableDirectives) {
-            _enableDirectives = enableDirectives;
-        }
-
-        public IEnumerator<Token> GetEnumerator() {
-            while (_lexerStack.Count > 0) {
-                Token token = GetNextToken();
-
-                switch (token.Type) {
-                    case TokenType.DM_Preproc_Whitespace:
-                        if (_currentLineContainsNonWhitespace) {
-                            yield return token;
-                            break;
-                        }
-
-                        _bufferedWhitespace.Push(token);
-                        break;
-                    case TokenType.EndOfFile:
-                        _lexerStack.Pop();
-                        break;
-                    case TokenType.Newline:
-                        _canUseDirective = true;
-
-                        if (!_currentLineContainsNonWhitespace) {
-                            _bufferedWhitespace.Clear();
-                            break;
-                        }
-
-                        // All buffered whitespace should have been written out by this point
-                        if (_bufferedWhitespace.Count > 0) {
-                            throw new InvalidOperationException();
-                        }
-
-                        _currentLineContainsNonWhitespace = false;
-                        yield return token;
-                        break;
-                    case TokenType.DM_Preproc_LineSplice:
-                        do {
-                            token = GetNextToken(true);
-                        } while (token.Type == TokenType.Newline);
-
-                        // Preprocessor directives can be used once we reach a line-splice
-                        _canUseDirective = true;
-                        PushToken(token);
-                        break;
-
-                    case TokenType.DM_Preproc_Include:
-                        if (!_currentLineContainsNonWhitespace) {
-                            _bufferedWhitespace.Clear();
-                        }
-                        HandleIncludeDirective(token);
-                        break;
-                    case TokenType.DM_Preproc_Define:
-                        HandleDefineDirective(token);
-                        break;
-                    case TokenType.DM_Preproc_Undefine:
-                        HandleUndefineDirective(token);
-                        break;
-                    case TokenType.DM_Preproc_If:
-                        HandleIfDirective(token);
-                        break;
-                    case TokenType.DM_Preproc_Ifdef:
-                        HandleIfDefDirective(token);
-                        break;
-                    case TokenType.DM_Preproc_Ifndef:
-                        HandleIfNDefDirective(token);
-                        break;
-                    case TokenType.DM_Preproc_Elif:
-                        HandleElifDirective(token);
-                        break;
-                    case TokenType.DM_Preproc_Else:
-                        if (!_lastIfEvaluations.TryPop(out bool? wasTruthy) || wasTruthy is null)
-                            DMCompiler.Emit(WarningCode.BadDirective, token.Location, "Unexpected #else");
-                        if (wasTruthy.Value)
-                            SkipIfBody(true);
-                        else
-                            _lastIfEvaluations.Push((bool?)null);
-                        break;
-                    case TokenType.DM_Preproc_Warning:
-                    case TokenType.DM_Preproc_Error:
-                        HandleErrorOrWarningDirective(token);
-                        break;
-                    case TokenType.DM_Preproc_Pragma:
-                        HandlePragmaDirective(token);
-                        break;
-                    case TokenType.DM_Preproc_EndIf:
-                        if (!_lastIfEvaluations.TryPop(out var _))
-                            DMCompiler.Emit(WarningCode.BadDirective, token.Location, "Unexpected #endif");
-                        break;
-                    case TokenType.DM_Preproc_Identifier: {
-                        if (TryMacro(token)) {
-                            break;
-                        }
-
-                        // Otherwise treat it like any other normal token
-                        goto case TokenType.DM_Preproc_Number;
-                    }
-                    case TokenType.DM_Preproc_Punctuator:
-                    case TokenType.DM_Preproc_Number:
-                    case TokenType.DM_Preproc_String:
-                    case TokenType.DM_Preproc_ConstantString:
-                    case TokenType.DM_Preproc_Punctuator_Comma:
-                    case TokenType.DM_Preproc_Punctuator_Period:
-                    case TokenType.DM_Preproc_Punctuator_Colon:
-                    case TokenType.DM_Preproc_Punctuator_Question:
-                    case TokenType.DM_Preproc_Punctuator_LeftParenthesis:
-                    case TokenType.DM_Preproc_Punctuator_LeftBracket:
-                    case TokenType.DM_Preproc_Punctuator_RightBracket:
-                    case TokenType.DM_Preproc_Punctuator_Semicolon:
-                    case TokenType.DM_Preproc_Punctuator_RightParenthesis: {
-                        while (_bufferedWhitespace.TryPop(out var whitespace)) {
-                            yield return whitespace;
-                        }
-                        _currentLineContainsNonWhitespace = true;
-                        _canUseDirective = (token.Type == TokenType.DM_Preproc_Punctuator_Semicolon);
-
+            switch (token.Type) {
+                case TokenType.DM_Preproc_Whitespace:
+                    if (_currentLineContainsNonWhitespace) {
                         yield return token;
                         break;
                     }
 
-                    case TokenType.Error:
-                        DMCompiler.Emit(WarningCode.ErrorDirective, token.Location, (string)token.Value);
-                        break;
+                    _bufferedWhitespace.Push(token);
+                    break;
+                case TokenType.EndOfFile:
+                    _lexerStack.Pop();
+                    break;
+                case TokenType.Newline:
+                    _canUseDirective = true;
 
-                    default:
-                        DMCompiler.Emit(WarningCode.BadToken, token.Location,
-                            $"Invalid token encountered while preprocessing: {token.PrintableText} ({token.Type})");
+                    if (!_currentLineContainsNonWhitespace) {
+                        _bufferedWhitespace.Clear();
                         break;
+                    }
+
+                    // All buffered whitespace should have been written out by this point
+                    if (_bufferedWhitespace.Count > 0) {
+                        throw new InvalidOperationException();
+                    }
+
+                    _currentLineContainsNonWhitespace = false;
+                    yield return token;
+                    break;
+                case TokenType.DM_Preproc_LineSplice:
+                    do {
+                        token = GetNextToken(true);
+                    } while (token.Type == TokenType.Newline);
+
+                    // Preprocessor directives can be used once we reach a line-splice
+                    _canUseDirective = true;
+                    PushToken(token);
+                    break;
+
+                case TokenType.DM_Preproc_Include:
+                    if (!_currentLineContainsNonWhitespace) {
+                        _bufferedWhitespace.Clear();
+                    }
+                    HandleIncludeDirective(token);
+                    break;
+                case TokenType.DM_Preproc_Define:
+                    HandleDefineDirective(token);
+                    break;
+                case TokenType.DM_Preproc_Undefine:
+                    HandleUndefineDirective(token);
+                    break;
+                case TokenType.DM_Preproc_If:
+                    HandleIfDirective(token);
+                    break;
+                case TokenType.DM_Preproc_Ifdef:
+                    HandleIfDefDirective(token);
+                    break;
+                case TokenType.DM_Preproc_Ifndef:
+                    HandleIfNDefDirective(token);
+                    break;
+                case TokenType.DM_Preproc_Elif:
+                    HandleElifDirective(token);
+                    break;
+                case TokenType.DM_Preproc_Else:
+                    if (!_lastIfEvaluations.TryPop(out bool? wasTruthy) || wasTruthy is null)
+                        DMCompiler.Emit(WarningCode.BadDirective, token.Location, "Unexpected #else");
+                    if (wasTruthy.Value)
+                        SkipIfBody(true);
+                    else
+                        _lastIfEvaluations.Push((bool?)null);
+                    break;
+                case TokenType.DM_Preproc_Warning:
+                case TokenType.DM_Preproc_Error:
+                    HandleErrorOrWarningDirective(token);
+                    break;
+                case TokenType.DM_Preproc_Pragma:
+                    HandlePragmaDirective(token);
+                    break;
+                case TokenType.DM_Preproc_EndIf:
+                    if (!_lastIfEvaluations.TryPop(out var _))
+                        DMCompiler.Emit(WarningCode.BadDirective, token.Location, "Unexpected #endif");
+                    break;
+                case TokenType.DM_Preproc_Identifier: {
+                    if (TryMacro(token)) {
+                        break;
+                    }
+
+                    // Otherwise treat it like any other normal token
+                    goto case TokenType.DM_Preproc_Number;
                 }
-            }
-            if(_lastIfEvaluations.Any())
-                DMCompiler.Emit(WarningCode.BadDirective, _lastSeenIf, $"Missing {_lastIfEvaluations.Count} #endif directive{(_lastIfEvaluations.Count != 1 ? 's' : "")}");
-            DMCompiler.CheckAllPragmasWereSet();
-        }
+                case TokenType.DM_Preproc_Punctuator:
+                case TokenType.DM_Preproc_Number:
+                case TokenType.DM_Preproc_String:
+                case TokenType.DM_Preproc_ConstantString:
+                case TokenType.DM_Preproc_Punctuator_Comma:
+                case TokenType.DM_Preproc_Punctuator_Period:
+                case TokenType.DM_Preproc_Punctuator_Colon:
+                case TokenType.DM_Preproc_Punctuator_Question:
+                case TokenType.DM_Preproc_Punctuator_LeftParenthesis:
+                case TokenType.DM_Preproc_Punctuator_LeftBracket:
+                case TokenType.DM_Preproc_Punctuator_RightBracket:
+                case TokenType.DM_Preproc_Punctuator_Semicolon:
+                case TokenType.DM_Preproc_Punctuator_RightParenthesis: {
+                    while (_bufferedWhitespace.TryPop(out var whitespace)) {
+                        yield return whitespace;
+                    }
+                    _currentLineContainsNonWhitespace = true;
+                    _canUseDirective = (token.Type == TokenType.DM_Preproc_Punctuator_Semicolon);
 
-        IEnumerator IEnumerable.GetEnumerator() {
-            return GetEnumerator();
-        }
-
-        public void DefineMacro(string key, string value) {
-            var lexer = new DMPreprocessorLexer(null, "<command line>", value);
-            var list = new List<Token>();
-
-            while (lexer.NextToken() is { Type: not TokenType.EndOfFile } token) {
-                list.Add(token);
-            }
-
-            _defines.Add(key, new DMMacro(null, list));
-        }
-
-        // NB: Pushes files to a stack, so call in reverse order if you are
-        // including multiple files.
-        public void IncludeFile(string includeDir, string file, Location? includedFrom = null) {
-            string filePath = Path.Combine(includeDir, file);
-            filePath = filePath.Replace('\\', Path.DirectorySeparatorChar);
-
-            if (_includedFiles.Contains(filePath)) {
-                DMCompiler.Emit(WarningCode.FileAlreadyIncluded, includedFrom ?? Location.Internal, $"File \"{filePath}\" was already included");
-                return;
-            }
-
-            if (!File.Exists(filePath)) {
-                DMCompiler.Emit(WarningCode.MissingIncludedFile, includedFrom ?? Location.Internal, $"Could not find included file \"{filePath}\"");
-                return;
-            }
-
-            DMCompiler.VerbosePrint($"Including {file}");
-            _includedFiles.Add(filePath);
-
-            switch (Path.GetExtension(filePath)) {
-                case ".dmp":
-                case ".dmm":
-                    IncludedMaps.Add(filePath);
+                    yield return token;
                     break;
-                case ".dmf":
-                    if (IncludedInterface != null) {
-                        if(IncludedInterface == filePath) {
-                            DMCompiler.Emit(WarningCode.FileAlreadyIncluded, includedFrom ?? Location.Internal, $"Interface \"{filePath}\" was already included");
-                            break;
-                        }
+                }
 
-                        DMCompiler.Emit(WarningCode.InvalidInclusion, includedFrom ?? Location.Internal, $"Attempted to include a second interface file ({filePath}) while one was already included ({IncludedInterface})");
+                case TokenType.Error:
+                    DMCompiler.Emit(WarningCode.ErrorDirective, token.Location, (string)token.Value);
+                    break;
+
+                default:
+                    DMCompiler.Emit(WarningCode.BadToken, token.Location,
+                        $"Invalid token encountered while preprocessing: {token.PrintableText} ({token.Type})");
+                    break;
+            }
+        }
+        if(_lastIfEvaluations.Any())
+            DMCompiler.Emit(WarningCode.BadDirective, _lastSeenIf, $"Missing {_lastIfEvaluations.Count} #endif directive{(_lastIfEvaluations.Count != 1 ? 's' : "")}");
+        DMCompiler.CheckAllPragmasWereSet();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() {
+        return GetEnumerator();
+    }
+
+    public void DefineMacro(string key, string value) {
+        var lexer = new DMPreprocessorLexer(null, "<command line>", value);
+        var list = new List<Token>();
+
+        while (lexer.NextToken() is { Type: not TokenType.EndOfFile } token) {
+            list.Add(token);
+        }
+
+        _defines.Add(key, new DMMacro(null, list));
+    }
+
+    // NB: Pushes files to a stack, so call in reverse order if you are
+    // including multiple files.
+    public void IncludeFile(string includeDir, string file, Location? includedFrom = null) {
+        string filePath = Path.Combine(includeDir, file);
+        filePath = filePath.Replace('\\', Path.DirectorySeparatorChar);
+
+        if (_includedFiles.Contains(filePath)) {
+            DMCompiler.Emit(WarningCode.FileAlreadyIncluded, includedFrom ?? Location.Internal, $"File \"{filePath}\" was already included");
+            return;
+        }
+
+        if (!File.Exists(filePath)) {
+            DMCompiler.Emit(WarningCode.MissingIncludedFile, includedFrom ?? Location.Internal, $"Could not find included file \"{filePath}\"");
+            return;
+        }
+
+        DMCompiler.VerbosePrint($"Including {file}");
+        _includedFiles.Add(filePath);
+
+        switch (Path.GetExtension(filePath)) {
+            case ".dmp":
+            case ".dmm":
+                IncludedMaps.Add(filePath);
+                break;
+            case ".dmf":
+                if (IncludedInterface != null) {
+                    if(IncludedInterface == filePath) {
+                        DMCompiler.Emit(WarningCode.FileAlreadyIncluded, includedFrom ?? Location.Internal, $"Interface \"{filePath}\" was already included");
                         break;
                     }
 
-                    IncludedInterface = filePath;
+                    DMCompiler.Emit(WarningCode.InvalidInclusion, includedFrom ?? Location.Internal, $"Attempted to include a second interface file ({filePath}) while one was already included ({IncludedInterface})");
                     break;
-                case ".dms":
-                    // Webclient interface file. Probably never gonna be supported.
-                    DMCompiler.UnimplementedWarning(includedFrom ?? Location.Internal, "DMS files are not supported");
-                    break;
-                default:
-                    PreprocessFile(includeDir, file);
-                    break;
-            }
+                }
+
+                IncludedInterface = filePath;
+                break;
+            case ".dms":
+                // Webclient interface file. Probably never gonna be supported.
+                DMCompiler.UnimplementedWarning(includedFrom ?? Location.Internal, "DMS files are not supported");
+                break;
+            default:
+                PreprocessFile(includeDir, file);
+                break;
+        }
+    }
+
+    public void PreprocessFile(string includeDir, string file) {
+        file = file.Replace('\\', '/');
+
+        _lexerStack.Push(new DMPreprocessorLexer(includeDir, file));
+    }
+
+    private bool VerifyDirectiveUsage(Token token) {
+        if (!_enableDirectives) {
+            DMCompiler.Emit(WarningCode.MisplacedDirective, token.Location, "Cannot use a preprocessor directive here");
+            return false;
         }
 
-        public void PreprocessFile(string includeDir, string file) {
-            file = file.Replace('\\', '/');
-
-            _lexerStack.Push(new DMPreprocessorLexer(includeDir, file));
+        if (!_canUseDirective) {
+            DMCompiler.Emit(WarningCode.MisplacedDirective, token.Location, "There can only be whitespace before a preprocessor directive");
+            return false;
         }
 
-        private bool VerifyDirectiveUsage(Token token) {
-            if (!_enableDirectives) {
-                DMCompiler.Emit(WarningCode.MisplacedDirective, token.Location, "Cannot use a preprocessor directive here");
-                return false;
-            }
+        return true;
+    }
 
-            if (!_canUseDirective) {
-                DMCompiler.Emit(WarningCode.MisplacedDirective, token.Location, "There can only be whitespace before a preprocessor directive");
-                return false;
-            }
+    private void HandleIncludeDirective(Token includeToken) {
+        if (!VerifyDirectiveUsage(includeToken))
+            return;
 
-            return true;
+        Token includedFileToken = GetNextToken(true);
+        if (includedFileToken.Type != TokenType.DM_Preproc_ConstantString) {
+            DMCompiler.Emit(WarningCode.InvalidInclusion, includeToken.Location, $"\"{includedFileToken.Text}\" is not a valid include path");
+            return;
         }
 
-        private void HandleIncludeDirective(Token includeToken) {
-            if (!VerifyDirectiveUsage(includeToken))
-                return;
+        DMPreprocessorLexer currentLexer = _lexerStack.Peek();
+        string file = Path.Combine(Path.GetDirectoryName(currentLexer.File.Replace('\\', Path.DirectorySeparatorChar)), (string)includedFileToken.Value);
+        string directory = currentLexer.IncludeDirectory;
 
-            Token includedFileToken = GetNextToken(true);
-            if (includedFileToken.Type != TokenType.DM_Preproc_ConstantString) {
-                DMCompiler.Emit(WarningCode.InvalidInclusion, includeToken.Location, $"\"{includedFileToken.Text}\" is not a valid include path");
+        IncludeFile(directory, file, includedFrom: includeToken.Location);
+    }
+
+    private void HandleDefineDirective(Token defineToken) {
+        if (!VerifyDirectiveUsage(defineToken))
+            return;
+
+        Token defineIdentifier = GetNextToken(true);
+        if (defineIdentifier.Type != TokenType.DM_Preproc_Identifier) {
+            DMCompiler.Emit(WarningCode.BadDirective, defineIdentifier.Location, "Unexpected token, identifier expected for #define directive");
+            GetLineOfTokens(); // consume what's on this line and leave
+            return;
+        }
+
+        // #define FILE_DIR is a little special
+        // Every define will add to a list of directories to check for resource files
+        if (defineIdentifier.Text == "FILE_DIR") {
+            Token dirToken = GetNextToken(true);
+            string? dirTokenValue = dirToken.Type switch {
+                TokenType.DM_Preproc_ConstantString => (string?)dirToken.Value,
+                TokenType.DM_Preproc_Punctuator_Period => ".",
+                _ => null
+            };
+
+            if (dirTokenValue is null) {
+                DMCompiler.Emit(WarningCode.BadDirective, dirToken.Location, $"\"{dirToken.Text}\" is not a valid directory");
                 return;
             }
 
             DMPreprocessorLexer currentLexer = _lexerStack.Peek();
-            string file = Path.Combine(Path.GetDirectoryName(currentLexer.File.Replace('\\', Path.DirectorySeparatorChar)), (string)includedFileToken.Value);
-            string directory = currentLexer.IncludeDirectory;
+            string dir = Path.Combine(currentLexer.IncludeDirectory, dirTokenValue);
+            DMCompiler.AddResourceDirectory(dir);
 
-            IncludeFile(directory, file, includedFrom: includeToken.Location);
+            // In BYOND it goes on to set the FILE_DIR macro's value to the added directory
+            // I don't see any reason to do that
+            return;
+        } else if (defineIdentifier.Text == "defined") {
+            DMCompiler.Emit(WarningCode.SoftReservedKeyword, defineIdentifier.Location, "Reserved keyword 'defined' cannot be used as macro name");
         }
 
-        private void HandleDefineDirective(Token defineToken) {
-            if (!VerifyDirectiveUsage(defineToken))
-                return;
+        List<string> parameters = null;
+        List<Token> macroTokens = new(1);
 
-            Token defineIdentifier = GetNextToken(true);
-            if (defineIdentifier.Type != TokenType.DM_Preproc_Identifier) {
-                DMCompiler.Emit(WarningCode.BadDirective, defineIdentifier.Location, "Unexpected token, identifier expected for #define directive");
-                GetLineOfTokens(); // consume what's on this line and leave
-                return;
-            }
-
-            // #define FILE_DIR is a little special
-            // Every define will add to a list of directories to check for resource files
-            if (defineIdentifier.Text == "FILE_DIR") {
-                Token dirToken = GetNextToken(true);
-                string? dirTokenValue = dirToken.Type switch {
-                    TokenType.DM_Preproc_ConstantString => (string?)dirToken.Value,
-                    TokenType.DM_Preproc_Punctuator_Period => ".",
-                    _ => null
-                };
-
-                if (dirTokenValue is null) {
-                    DMCompiler.Emit(WarningCode.BadDirective, dirToken.Location, $"\"{dirToken.Text}\" is not a valid directory");
-                    return;
-                }
-
-                DMPreprocessorLexer currentLexer = _lexerStack.Peek();
-                string dir = Path.Combine(currentLexer.IncludeDirectory, dirTokenValue);
-                DMCompiler.AddResourceDirectory(dir);
-
-                // In BYOND it goes on to set the FILE_DIR macro's value to the added directory
-                // I don't see any reason to do that
-                return;
-            } else if (defineIdentifier.Text == "defined") {
-                DMCompiler.Emit(WarningCode.SoftReservedKeyword, defineIdentifier.Location, "Reserved keyword 'defined' cannot be used as macro name");
-            }
-
-            List<string> parameters = null;
-            List<Token> macroTokens = new(1);
-
-            Token macroToken = GetNextToken();
-            if (macroToken.Type == TokenType.DM_Preproc_Punctuator_LeftParenthesis) { // We're a macro function!
-                parameters = new List<string>(1);
-                //Read in the parameters
-                bool canConsumeComma = false;
-                bool foundVariadic = false;
-                while(true) {
-                    var parameterToken = GetNextToken(true);
-                    switch(parameterToken.Type) {
-                        case TokenType.DM_Preproc_Identifier:
-                            canConsumeComma = true;
-                            if (foundVariadic) {
-                                DMCompiler.Emit(WarningCode.BadDirective, parameterToken.Location, $"Variadic argument '{parameters.Last()}' must be the last argument");
-                                foundVariadic = false; // Reduces error spam if there's several arguments after it
-                                continue;
-                            }
-                            if(Check(TokenType.DM_Preproc_Punctuator_Period)) { // Check for a variadic
-                                if (!Check(TokenType.DM_Preproc_Punctuator_Period) || !Check(TokenType.DM_Preproc_Punctuator_Period)) {
-                                    DMCompiler.Emit(WarningCode.BadDirective, parameterToken.Location, $"Invalid macro parameter, '{parameterToken.Text}...' expected");
-                                }
-                                parameters.Add($"{parameterToken.Text}...");
-                                foundVariadic = true;
-                                // Consciously not setting canConsumeComma to false here. Users can have a little dangling comma, as a treat :o)
-                                continue;
-                            }
-                            parameters.Add(parameterToken.Text);
-
+        Token macroToken = GetNextToken();
+        if (macroToken.Type == TokenType.DM_Preproc_Punctuator_LeftParenthesis) { // We're a macro function!
+            parameters = new List<string>(1);
+            //Read in the parameters
+            bool canConsumeComma = false;
+            bool foundVariadic = false;
+            while(true) {
+                var parameterToken = GetNextToken(true);
+                switch(parameterToken.Type) {
+                    case TokenType.DM_Preproc_Identifier:
+                        canConsumeComma = true;
+                        if (foundVariadic) {
+                            DMCompiler.Emit(WarningCode.BadDirective, parameterToken.Location, $"Variadic argument '{parameters.Last()}' must be the last argument");
+                            foundVariadic = false; // Reduces error spam if there's several arguments after it
                             continue;
-                        case TokenType.DM_Preproc_Punctuator_Period: // One of those "..." things, maybe?
+                        }
+                        if(Check(TokenType.DM_Preproc_Punctuator_Period)) { // Check for a variadic
                             if (!Check(TokenType.DM_Preproc_Punctuator_Period) || !Check(TokenType.DM_Preproc_Punctuator_Period)) {
-                                DMCompiler.Emit(WarningCode.BadDirective, parameterToken.Location, "Invalid macro parameter, '...' expected");
+                                DMCompiler.Emit(WarningCode.BadDirective, parameterToken.Location, $"Invalid macro parameter, '{parameterToken.Text}...' expected");
                             }
-                            canConsumeComma = true;
-                            if (foundVariadic) { // Placed here so we properly consume this bogus '...' parameter if need be
-                                DMCompiler.Emit(WarningCode.BadDirective, parameterToken.Location, $"Variadic argument '{parameters.Last()}' must be the last argument");
-                                foundVariadic = false; // Reduces error spam if there's several arguments after it
-                                continue;
-                            }
-                            parameters.Add($"...");
+                            parameters.Add($"{parameterToken.Text}...");
+                            foundVariadic = true;
+                            // Consciously not setting canConsumeComma to false here. Users can have a little dangling comma, as a treat :o)
                             continue;
-                        case TokenType.DM_Preproc_Punctuator_Comma:
-                            if(!canConsumeComma)
-                                DMCompiler.Emit(WarningCode.BadDirective, parameterToken.Location, "Unexpected ',' in macro parameter list");
-                            canConsumeComma = false;
+                        }
+                        parameters.Add(parameterToken.Text);
+
+                        continue;
+                    case TokenType.DM_Preproc_Punctuator_Period: // One of those "..." things, maybe?
+                        if (!Check(TokenType.DM_Preproc_Punctuator_Period) || !Check(TokenType.DM_Preproc_Punctuator_Period)) {
+                            DMCompiler.Emit(WarningCode.BadDirective, parameterToken.Location, "Invalid macro parameter, '...' expected");
+                        }
+                        canConsumeComma = true;
+                        if (foundVariadic) { // Placed here so we properly consume this bogus '...' parameter if need be
+                            DMCompiler.Emit(WarningCode.BadDirective, parameterToken.Location, $"Variadic argument '{parameters.Last()}' must be the last argument");
+                            foundVariadic = false; // Reduces error spam if there's several arguments after it
                             continue;
-                        case TokenType.DM_Preproc_Punctuator_RightParenthesis:
-                            break;
-                        case TokenType.EndOfFile:
-                            DMCompiler.Emit(WarningCode.BadDirective, macroToken.Location, "Missing ')' in macro definition"); // Location points to the left paren!
-                            PushToken(parameterToken);
-                            break;
-                        default:
-                            DMCompiler.Emit(WarningCode.BadDirective, parameterToken.Location, "Expected a macro parameter");
-                            return;
-                    }
-                    break; // If the switch gets here, the loop ends.
+                        }
+                        parameters.Add($"...");
+                        continue;
+                    case TokenType.DM_Preproc_Punctuator_Comma:
+                        if(!canConsumeComma)
+                            DMCompiler.Emit(WarningCode.BadDirective, parameterToken.Location, "Unexpected ',' in macro parameter list");
+                        canConsumeComma = false;
+                        continue;
+                    case TokenType.DM_Preproc_Punctuator_RightParenthesis:
+                        break;
+                    case TokenType.EndOfFile:
+                        DMCompiler.Emit(WarningCode.BadDirective, macroToken.Location, "Missing ')' in macro definition"); // Location points to the left paren!
+                        PushToken(parameterToken);
+                        break;
+                    default:
+                        DMCompiler.Emit(WarningCode.BadDirective, parameterToken.Location, "Expected a macro parameter");
+                        return;
                 }
-                macroToken = GetNextToken(true);
-            } else if (macroToken.Type == TokenType.DM_Preproc_Whitespace) { // Whitespace between the identifier and a left-paren turns it into a non-function macro.
+                break; // If the switch gets here, the loop ends.
+            }
+            macroToken = GetNextToken(true);
+        } else if (macroToken.Type == TokenType.DM_Preproc_Whitespace) { // Whitespace between the identifier and a left-paren turns it into a non-function macro.
+            macroToken = GetNextToken();
+        }
+
+        while (macroToken.Type != TokenType.Newline && macroToken.Type != TokenType.EndOfFile) {
+            // A line splice followed by another new line will end the macro without inserting the line splice
+            if (macroToken.Type == TokenType.DM_Preproc_LineSplice) {
+                var nextToken = GetNextToken(true);
+
+                // If the next token is another newline, immediately stop adding new tokens
+                if (nextToken.Type == TokenType.Newline) {
+                    break;
+                }
+                macroTokens.Add(macroToken);
+                macroToken = nextToken;
+            } else {
+                macroTokens.Add(macroToken);
                 macroToken = GetNextToken();
             }
-
-            while (macroToken.Type != TokenType.Newline && macroToken.Type != TokenType.EndOfFile) {
-                // A line splice followed by another new line will end the macro without inserting the line splice
-                if (macroToken.Type == TokenType.DM_Preproc_LineSplice) {
-                    var nextToken = GetNextToken(true);
-
-                    // If the next token is another newline, immediately stop adding new tokens
-                    if (nextToken.Type == TokenType.Newline) {
-                        break;
-                    }
-                    macroTokens.Add(macroToken);
-                    macroToken = nextToken;
-                } else {
-                    macroTokens.Add(macroToken);
-                    macroToken = GetNextToken();
-                }
-            }
-
-            if (macroTokens.Count > 0 && macroTokens[^1].Type == TokenType.DM_Preproc_Whitespace) {
-                //Remove trailing whitespace
-                macroTokens.Pop();
-            }
-
-            _defines[defineIdentifier.Text] = new DMMacro(parameters, macroTokens);
-            PushToken(macroToken);
         }
 
-        private void HandleUndefineDirective(Token undefToken) {
-            if (!VerifyDirectiveUsage(undefToken))
-                return;
-
-            Token defineIdentifier = GetNextToken(true);
-            if (defineIdentifier.Type != TokenType.DM_Preproc_Identifier) {
-                DMCompiler.Emit(WarningCode.BadDirective, defineIdentifier.Location, "Invalid macro identifier");
-                return;
-            } else if (!_defines.ContainsKey(defineIdentifier.Text)) {
-                DMCompiler.Emit(WarningCode.UndefineMissingDirective, defineIdentifier.Location, $"No macro named \"{defineIdentifier.PrintableText}\"");
-                return;
-            }
-
-            _defines.Remove(defineIdentifier.Text);
+        if (macroTokens.Count > 0 && macroTokens[^1].Type == TokenType.DM_Preproc_Whitespace) {
+            //Remove trailing whitespace
+            macroTokens.Pop();
         }
 
-        /// <summary>
-        /// Reads in <see cref="Token"/>s to a List until it reads a grammatical line of them,
-        /// handling newlines, macros, the preproc's wonky line-splicing.
-        /// These are DM tokens, not DM_Preproc ones!!
-        /// </summary>
-        private List<Token> GetLineOfTokens()
-        {
-            List<Token> tokens = new List<Token>();
-            bool tryIdentifiersAsMacros = true;
-            for(Token token = GetNextToken(true); token.Type != TokenType.Newline; token = GetNextToken(true)) {
-                switch(token.Type) {
-                    case TokenType.DM_Preproc_LineSplice:
+        _defines[defineIdentifier.Text] = new DMMacro(parameters, macroTokens);
+        PushToken(macroToken);
+    }
+
+    private void HandleUndefineDirective(Token undefToken) {
+        if (!VerifyDirectiveUsage(undefToken))
+            return;
+
+        Token defineIdentifier = GetNextToken(true);
+        if (defineIdentifier.Type != TokenType.DM_Preproc_Identifier) {
+            DMCompiler.Emit(WarningCode.BadDirective, defineIdentifier.Location, "Invalid macro identifier");
+            return;
+        } else if (!_defines.ContainsKey(defineIdentifier.Text)) {
+            DMCompiler.Emit(WarningCode.UndefineMissingDirective, defineIdentifier.Location, $"No macro named \"{defineIdentifier.PrintableText}\"");
+            return;
+        }
+
+        _defines.Remove(defineIdentifier.Text);
+    }
+
+    /// <summary>
+    /// Reads in <see cref="Token"/>s to a List until it reads a grammatical line of them,
+    /// handling newlines, macros, the preproc's wonky line-splicing.
+    /// These are DM tokens, not DM_Preproc ones!!
+    /// </summary>
+    private List<Token> GetLineOfTokens()
+    {
+        List<Token> tokens = new List<Token>();
+        bool tryIdentifiersAsMacros = true;
+        for(Token token = GetNextToken(true); token.Type != TokenType.Newline; token = GetNextToken(true)) {
+            switch(token.Type) {
+                case TokenType.DM_Preproc_LineSplice:
+                    continue;
+                case TokenType.DM_Preproc_Identifier:
+                    if(token.Text == "defined") // need to be careful here to prevent macros in defined() expressions from being clobbered
+                        tryIdentifiersAsMacros = false;
+                    else if (tryIdentifiersAsMacros && TryMacro(token)) // feeding any novel macro tokens back into the pipeline here
                         continue;
-                    case TokenType.DM_Preproc_Identifier:
-                        if(token.Text == "defined") // need to be careful here to prevent macros in defined() expressions from being clobbered
-                            tryIdentifiersAsMacros = false;
-                        else if (tryIdentifiersAsMacros && TryMacro(token)) // feeding any novel macro tokens back into the pipeline here
-                            continue;
-                        goto default; // Fallthrough!
-                    case TokenType.DM_Preproc_Punctuator_RightParenthesis:
-                        tryIdentifiersAsMacros = true; // may be ending a defined() sequence
-                        goto default; // Fallthrough!
-                    default:
-                        tokens.Add(token);
-                        break;
-                }
-            }
-            tokens.Add(new Token(TokenType.Newline, "\n", Location.Unknown, null));
-            DMLexer lexer = new(_lexerStack.Peek().File, tokens);
-            List<Token> newTokens = new List<Token>();
-            for(Token token = lexer.GetNextToken(); !lexer.AtEndOfSource; token = lexer.GetNextToken()) {
-                newTokens.Add(token);
-            }
-            return newTokens;
-        }
-
-        /// <summary>If this <see cref="TokenType.DM_Preproc_Identifier"/> Token is a macro, pushes all of its tokens onto the queue.</summary>
-        /// <returns>true if the Token ended up meaning a macro sequence.</returns>
-        private bool TryMacro(Token token) {
-            DebugTools.Assert(token.Type == TokenType.DM_Preproc_Identifier); // Check this before passing anything to this function.
-            if (!_defines.TryGetValue(token.Text, out DMMacro macro)) {
-                return false;
-            }
-
-            List<List<Token>> parameters = null;
-            if (macro.HasParameters() && !TryGetMacroParameters(out parameters)) {
-                return false;
-            }
-
-            List<Token> expandedTokens = macro.Expand(token, parameters);
-            for (int i = expandedTokens.Count - 1; i >= 0; i--) {
-                Token expandedToken = expandedTokens[i];
-                expandedToken.Location = token.Location;
-
-                // These tokens are pushed so that nested macros get processed
-                PushToken(expandedToken);
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Tiny helper that handles what to do when an #if or #ifdef or whatever is not well-formed. <br/>
-        /// Doing this stuff helps make the compiler errors a bit clearer.
-        /// </summary>
-        private void HandleDegenerateIf() {
-            _lastIfEvaluations.Push(false); // Doing this to help reduce weird #else errors
-            SkipIfBody();
-        }
-
-        /// <remarks> NOTE: This is called by <see cref="HandleElifDirective(Token)"/> once it finishes doing its else-y behaviour. </remarks>
-        private void HandleIfDirective(Token ifToken) {
-            _lastSeenIf = ifToken.Location;
-            if (!VerifyDirectiveUsage(ifToken))
-                return;
-
-            var tokens = GetLineOfTokens();
-            if (!tokens.Any()) { // If empty
-                DMCompiler.Emit(WarningCode.BadDirective, ifToken.Location, "Expression expected for #if");
-                HandleDegenerateIf();
-                return;
-            }
-            float? expr = DMPreprocessorParser.ExpressionFromTokens(tokens, _defines);
-            if(expr is null) {
-                DMCompiler.Emit(WarningCode.BadDirective, ifToken.Location, "Expression is invalid");
-                HandleDegenerateIf();
-                return;
-            }
-            bool result = expr != 0.0f;
-            _lastIfEvaluations.Push(result);
-            if (!result)
-                SkipIfBody();
-        }
-
-        private void HandleIfDefDirective(Token ifDefToken) {
-            _lastSeenIf = ifDefToken.Location;
-            if (!VerifyDirectiveUsage(ifDefToken))
-                return;
-
-            Token define = GetNextToken(true);
-            if (define.Type != TokenType.DM_Preproc_Identifier) {
-                DMCompiler.Emit(WarningCode.BadDirective, ifDefToken.Location, "Expected a define identifier");
-                HandleDegenerateIf();
-                return;
-            }
-            bool result = _defines.ContainsKey(define.Text);
-            if (!result) {
-                SkipIfBody();
-            }
-            _lastIfEvaluations.Push(result);
-        }
-
-        private void HandleIfNDefDirective(Token ifNDefToken) {
-            _lastSeenIf = ifNDefToken.Location;
-            if (!VerifyDirectiveUsage(ifNDefToken))
-                return;
-
-            Token define = GetNextToken(true);
-            if (define.Type != TokenType.DM_Preproc_Identifier) {
-                DMCompiler.Emit(WarningCode.BadDirective, ifNDefToken.Location, "Expected a define identifier");
-                HandleDegenerateIf();
-                return;
-            }
-
-            bool result = _defines.ContainsKey(define.Text);
-            if (result) {
-                SkipIfBody();
-            }
-            _lastIfEvaluations.Push(!result);
-        }
-
-        private void HandleElifDirective(Token elifToken) {
-            if (!_lastIfEvaluations.TryPeek(out bool? wasTruthy))
-                DMCompiler.Emit(WarningCode.BadDirective, elifToken.Location, "Unexpected #elif");
-            if (wasTruthy is null) {
-                DMCompiler.Emit(WarningCode.BadDirective, elifToken.Location, "Directive #elif cannot appear after #else in its flow control");
-                SkipIfBody();
-            } else if (wasTruthy.Value)
-                SkipIfBody();
-            else {
-                _lastIfEvaluations.Pop(); // There's a new evaluation in town
-                HandleIfDirective(elifToken);
-            }
-        }
-
-        private void HandleErrorOrWarningDirective(Token token) {
-            if (!VerifyDirectiveUsage(token))
-                return;
-
-            if (token.Type == TokenType.DM_Preproc_Error) {
-                DMCompiler.Emit(WarningCode.ErrorDirective, token.Location, token.Text);
-            } else {
-                DMCompiler.Emit(WarningCode.WarningDirective, token.Location, token.Text);
-            }
-        }
-
-        private void PushToken(Token token) {
-            _unprocessedTokens.Push(token);
-        }
-
-        /// <remarks>
-        /// WARNING: Do not call this with the <see langword="true"/> argument <br/>
-        /// unless you are completely sure that the clobbered whitespace will NEVER have any grammatical significance <br/>
-        /// neither here in the preprocessor, nor in any other parsing pass! <br/><br/>
-        /// If whitespace may be important later, use <see cref="CheckForTokenIgnoringWhitespace(TokenType, out Token)"/>.
-        /// </remarks>
-        private Token GetNextToken(bool ignoreWhitespace = false) {
-            if (_unprocessedTokens.TryPop(out Token? nextToken)) {
-                if (ignoreWhitespace && nextToken.Type == TokenType.DM_Preproc_Whitespace) { // This doesn't need to be a loop since whitespace tokens should never occur next to each other
-                    nextToken = GetNextToken(true);
-                }
-
-                return nextToken;
-            } else {
-                return _lexerStack.Peek().NextToken(ignoreWhitespace);
-            }
-        }
-
-        private void HandlePragmaDirective(Token pragmaDirective) {
-            Token warningNameToken = GetNextToken(true);
-            WarningCode warningCode;
-            switch(warningNameToken.Type) {
-                case TokenType.DM_Preproc_Identifier: {
-                    if(!Enum.TryParse<WarningCode>(warningNameToken.Text, out warningCode)) {
-                        DMCompiler.Emit(WarningCode.BadDirective, warningNameToken.Location, $"Warning '{warningNameToken.PrintableText}' does not exist");
-                        GetLineOfTokens(); // consume what's on this line and leave
-                        return;
-                    }
-                    break;
-                }
-                case TokenType.DM_Preproc_Number: {
-                    if(!Int32.TryParse(warningNameToken.Text, out var intValue)) {
-                        DMCompiler.Emit(WarningCode.BadDirective, warningNameToken.Location, $"Warning OD{warningNameToken.PrintableText} does not exist");
-                        GetLineOfTokens();
-                        return;
-                    }
-                    warningCode = (WarningCode)intValue;
-                    break;
-                }
-                default: {
-                    DMCompiler.Emit(WarningCode.BadDirective, warningNameToken.Location, $"Invalid warning identifier '{warningNameToken.PrintableText}'");
-                    GetLineOfTokens();
-                    return;
-                }
-            }
-            DebugTools.AssertNotNull(warningCode);
-            if((int)warningCode < 1000) {
-                DMCompiler.Emit(WarningCode.BadDirective, warningNameToken.Location, $"Warning OD{(int)warningCode:d4} cannot be set - it must always be an error");
-                GetLineOfTokens();
-                return;
-            }
-
-            Token warningTypeToken = GetNextToken(true);
-            if (warningTypeToken.Type != TokenType.DM_Preproc_Identifier) {
-                DMCompiler.Emit(WarningCode.BadDirective, warningNameToken.Location, $"Warnings can only be set to disabled, notice, warning, or error");
-                return;
-            }
-            switch(warningTypeToken.Text.ToLower()) {
-                case "disabled":
-                case "disable":
-                    DMCompiler.SetPragma(warningCode, ErrorLevel.Disabled);
-                    break;
-                case "notice":
-                case "pedantic":
-                case "info":
-                    DMCompiler.SetPragma(warningCode, ErrorLevel.Notice);
-                    break;
-                case "warning":
-                case "warn":
-                    DMCompiler.SetPragma(warningCode, ErrorLevel.Warning);
-                    break;
-                case "error":
-                case "err":
-                    DMCompiler.SetPragma(warningCode, ErrorLevel.Error);
-                    break;
+                    goto default; // Fallthrough!
+                case TokenType.DM_Preproc_Punctuator_RightParenthesis:
+                    tryIdentifiersAsMacros = true; // may be ending a defined() sequence
+                    goto default; // Fallthrough!
                 default:
-                    DMCompiler.Emit(WarningCode.BadDirective, warningNameToken.Location, $"Warnings can only be set to disabled, notice, warning, or error");
-                    return;
+                    tokens.Add(token);
+                    break;
             }
         }
+        tokens.Add(new Token(TokenType.Newline, "\n", Location.Unknown, null));
+        DMLexer lexer = new(_lexerStack.Peek().File, tokens);
+        List<Token> newTokens = new List<Token>();
+        for(Token token = lexer.GetNextToken(); !lexer.AtEndOfSource; token = lexer.GetNextToken()) {
+            newTokens.Add(token);
+        }
+        return newTokens;
+    }
 
-        private bool Check(TokenType tokenType) {
-            Token received = GetNextToken();
-            if(received.Type == tokenType)
-                return true;
-            PushToken(received);
+    /// <summary>If this <see cref="TokenType.DM_Preproc_Identifier"/> Token is a macro, pushes all of its tokens onto the queue.</summary>
+    /// <returns>true if the Token ended up meaning a macro sequence.</returns>
+    private bool TryMacro(Token token) {
+        DebugTools.Assert(token.Type == TokenType.DM_Preproc_Identifier); // Check this before passing anything to this function.
+        if (!_defines.TryGetValue(token.Text, out DMMacro macro)) {
             return false;
         }
 
-        /// <summary>
-        /// The alternative to <see cref="GetNextToken(bool)"/> if you don't know whether you'll consume the whitespace or not.
-        /// </summary>
-        private bool CheckForTokenIgnoringWhitespace(TokenType type, out Token result) {
-            Token firstToken = GetNextToken();
-            if (firstToken.Type == TokenType.DM_Preproc_Whitespace) { // This doesn't need to be a loop since whitespace tokens should never occur next to each other
-                Token secondToken = GetNextToken();
-                if (secondToken.Type != type) { //Rollback!
-                    PushToken(secondToken);
-                    PushToken(firstToken);
-                    result = null;
-                    return false;
+        List<List<Token>> parameters = null;
+        if (macro.HasParameters() && !TryGetMacroParameters(out parameters)) {
+            return false;
+        }
+
+        List<Token> expandedTokens = macro.Expand(token, parameters);
+        for (int i = expandedTokens.Count - 1; i >= 0; i--) {
+            Token expandedToken = expandedTokens[i];
+            expandedToken.Location = token.Location;
+
+            // These tokens are pushed so that nested macros get processed
+            PushToken(expandedToken);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Tiny helper that handles what to do when an #if or #ifdef or whatever is not well-formed. <br/>
+    /// Doing this stuff helps make the compiler errors a bit clearer.
+    /// </summary>
+    private void HandleDegenerateIf() {
+        _lastIfEvaluations.Push(false); // Doing this to help reduce weird #else errors
+        SkipIfBody();
+    }
+
+    /// <remarks> NOTE: This is called by <see cref="HandleElifDirective(Token)"/> once it finishes doing its else-y behaviour. </remarks>
+    private void HandleIfDirective(Token ifToken) {
+        _lastSeenIf = ifToken.Location;
+        if (!VerifyDirectiveUsage(ifToken))
+            return;
+
+        var tokens = GetLineOfTokens();
+        if (!tokens.Any()) { // If empty
+            DMCompiler.Emit(WarningCode.BadDirective, ifToken.Location, "Expression expected for #if");
+            HandleDegenerateIf();
+            return;
+        }
+        float? expr = DMPreprocessorParser.ExpressionFromTokens(tokens, _defines);
+        if(expr is null) {
+            DMCompiler.Emit(WarningCode.BadDirective, ifToken.Location, "Expression is invalid");
+            HandleDegenerateIf();
+            return;
+        }
+        bool result = expr != 0.0f;
+        _lastIfEvaluations.Push(result);
+        if (!result)
+            SkipIfBody();
+    }
+
+    private void HandleIfDefDirective(Token ifDefToken) {
+        _lastSeenIf = ifDefToken.Location;
+        if (!VerifyDirectiveUsage(ifDefToken))
+            return;
+
+        Token define = GetNextToken(true);
+        if (define.Type != TokenType.DM_Preproc_Identifier) {
+            DMCompiler.Emit(WarningCode.BadDirective, ifDefToken.Location, "Expected a define identifier");
+            HandleDegenerateIf();
+            return;
+        }
+        bool result = _defines.ContainsKey(define.Text);
+        if (!result) {
+            SkipIfBody();
+        }
+        _lastIfEvaluations.Push(result);
+    }
+
+    private void HandleIfNDefDirective(Token ifNDefToken) {
+        _lastSeenIf = ifNDefToken.Location;
+        if (!VerifyDirectiveUsage(ifNDefToken))
+            return;
+
+        Token define = GetNextToken(true);
+        if (define.Type != TokenType.DM_Preproc_Identifier) {
+            DMCompiler.Emit(WarningCode.BadDirective, ifNDefToken.Location, "Expected a define identifier");
+            HandleDegenerateIf();
+            return;
+        }
+
+        bool result = _defines.ContainsKey(define.Text);
+        if (result) {
+            SkipIfBody();
+        }
+        _lastIfEvaluations.Push(!result);
+    }
+
+    private void HandleElifDirective(Token elifToken) {
+        if (!_lastIfEvaluations.TryPeek(out bool? wasTruthy))
+            DMCompiler.Emit(WarningCode.BadDirective, elifToken.Location, "Unexpected #elif");
+        if (wasTruthy is null) {
+            DMCompiler.Emit(WarningCode.BadDirective, elifToken.Location, "Directive #elif cannot appear after #else in its flow control");
+            SkipIfBody();
+        } else if (wasTruthy.Value)
+            SkipIfBody();
+        else {
+            _lastIfEvaluations.Pop(); // There's a new evaluation in town
+            HandleIfDirective(elifToken);
+        }
+    }
+
+    private void HandleErrorOrWarningDirective(Token token) {
+        if (!VerifyDirectiveUsage(token))
+            return;
+
+        DMCompiler.Emit(
+            token.Type == TokenType.DM_Preproc_Error ? WarningCode.ErrorDirective : WarningCode.WarningDirective,
+            token.Location, token.Text);
+    }
+
+    private void PushToken(Token token) {
+        _unprocessedTokens.Push(token);
+    }
+
+    /// <remarks>
+    /// WARNING: Do not call this with the <see langword="true"/> argument <br/>
+    /// unless you are completely sure that the clobbered whitespace will NEVER have any grammatical significance <br/>
+    /// neither here in the preprocessor, nor in any other parsing pass! <br/><br/>
+    /// If whitespace may be important later, use <see cref="CheckForTokenIgnoringWhitespace(TokenType, out Token)"/>.
+    /// </remarks>
+    private Token GetNextToken(bool ignoreWhitespace = false) {
+        if (_unprocessedTokens.TryPop(out Token? nextToken)) {
+            if (ignoreWhitespace && nextToken.Type == TokenType.DM_Preproc_Whitespace) { // This doesn't need to be a loop since whitespace tokens should never occur next to each other
+                nextToken = GetNextToken(true);
+            }
+
+            return nextToken;
+        } else {
+            return _lexerStack.Peek().NextToken(ignoreWhitespace);
+        }
+    }
+
+    private void HandlePragmaDirective(Token pragmaDirective) {
+        Token warningNameToken = GetNextToken(true);
+        WarningCode warningCode;
+        switch(warningNameToken.Type) {
+            case TokenType.DM_Preproc_Identifier: {
+                if(!Enum.TryParse<WarningCode>(warningNameToken.Text, out warningCode)) {
+                    DMCompiler.Emit(WarningCode.BadDirective, warningNameToken.Location, $"Warning '{warningNameToken.PrintableText}' does not exist");
+                    GetLineOfTokens(); // consume what's on this line and leave
+                    return;
                 }
-                result = secondToken;
-                return true;
+                break;
             }
-            else if (firstToken.Type == type) {
-                result = firstToken;
-                return true;
+            case TokenType.DM_Preproc_Number: {
+                if(!int.TryParse(warningNameToken.Text, out var intValue)) {
+                    DMCompiler.Emit(WarningCode.BadDirective, warningNameToken.Location, $"Warning OD{warningNameToken.PrintableText} does not exist");
+                    GetLineOfTokens();
+                    return;
+                }
+                warningCode = (WarningCode)intValue;
+                break;
             }
-            else {
+            default: {
+                DMCompiler.Emit(WarningCode.BadDirective, warningNameToken.Location, $"Invalid warning identifier '{warningNameToken.PrintableText}'");
+                GetLineOfTokens();
+                return;
+            }
+        }
+        DebugTools.AssertNotNull(warningCode);
+        if((int)warningCode < 1000) {
+            DMCompiler.Emit(WarningCode.BadDirective, warningNameToken.Location, $"Warning OD{(int)warningCode:d4} cannot be set - it must always be an error");
+            GetLineOfTokens();
+            return;
+        }
+
+        Token warningTypeToken = GetNextToken(true);
+        if (warningTypeToken.Type != TokenType.DM_Preproc_Identifier) {
+            DMCompiler.Emit(WarningCode.BadDirective, warningNameToken.Location, $"Warnings can only be set to disabled, notice, warning, or error");
+            return;
+        }
+        switch(warningTypeToken.Text.ToLower()) {
+            case "disabled":
+            case "disable":
+                DMCompiler.SetPragma(warningCode, ErrorLevel.Disabled);
+                break;
+            case "notice":
+            case "pedantic":
+            case "info":
+                DMCompiler.SetPragma(warningCode, ErrorLevel.Notice);
+                break;
+            case "warning":
+            case "warn":
+                DMCompiler.SetPragma(warningCode, ErrorLevel.Warning);
+                break;
+            case "error":
+            case "err":
+                DMCompiler.SetPragma(warningCode, ErrorLevel.Error);
+                break;
+            default:
+                DMCompiler.Emit(WarningCode.BadDirective, warningNameToken.Location, $"Warnings can only be set to disabled, notice, warning, or error");
+                return;
+        }
+    }
+
+    private bool Check(TokenType tokenType) {
+        Token received = GetNextToken();
+        if(received.Type == tokenType)
+            return true;
+        PushToken(received);
+        return false;
+    }
+
+    /// <summary>
+    /// The alternative to <see cref="GetNextToken(bool)"/> if you don't know whether you'll consume the whitespace or not.
+    /// </summary>
+    private bool CheckForTokenIgnoringWhitespace(TokenType type, out Token result) {
+        Token firstToken = GetNextToken();
+        if (firstToken.Type == TokenType.DM_Preproc_Whitespace) { // This doesn't need to be a loop since whitespace tokens should never occur next to each other
+            Token secondToken = GetNextToken();
+            if (secondToken.Type != type) { //Rollback!
+                PushToken(secondToken);
                 PushToken(firstToken);
                 result = null;
                 return false;
             }
+            result = secondToken;
+            return true;
+        }
+        else if (firstToken.Type == type) {
+            result = firstToken;
+            return true;
+        }
+        else {
+            PushToken(firstToken);
+            result = null;
+            return false;
+        }
+    }
+
+    /// <summary>Also used by #else sometimes to skip its body.</summary>
+    /// <remarks>WARNING: DOES NOT CONSUME any #elif, #else, or #endif it finds.</remarks>
+    /// <param name="noElseAllowed">This is used so that #else can operate this function while also forbidding it having its own #elses.</param>
+    /// <returns>true if it stopped on an #else, false if it stopped in an #endif.</returns>
+    private bool SkipIfBody(bool calledByElseDirective = false) {
+        int ifStack = 1; // how many "ifs" deep we seem to be. We end when we reach 0.
+        for (Token token = GetNextToken(true); token.Type != TokenType.EndOfFile; token = GetNextToken(true)) {
+            switch (token.Type) {
+                case TokenType.DM_Preproc_If:
+                case TokenType.DM_Preproc_Ifdef:
+                case TokenType.DM_Preproc_Ifndef:
+                    ifStack++;
+                    break;
+                case TokenType.DM_Preproc_EndIf:
+                    ifStack--;
+                    break;
+                case TokenType.DM_Preproc_Else:
+                case TokenType.DM_Preproc_Elif:
+                    if (ifStack != 1)
+                        break;
+                    if (calledByElseDirective)
+                        DMCompiler.Emit(WarningCode.BadDirective, token.Location, $"Unexpected {token.PrintableText} directive");
+                    _unprocessedTokens.Push(token); // Push it back onto the stack so we can interpret this later
+                    return true;
+                default:
+                    continue; // Don't need to do the ifStack check since it has not changed as a result of this token
+            }
+            if (ifStack == 0) {
+                if (!calledByElseDirective) {
+                    _unprocessedTokens.Push(token); // Push it back onto the stack so we can interpret the entry in _lastIfEvaluations correctly.
+                }
+
+                return false;
+            }
+        }
+        DMCompiler.Emit(WarningCode.BadDirective, Location.Unknown, "Missing #endif directive");
+        return false;
+    }
+
+    private bool TryGetMacroParameters(out List<List<Token>> parameters) {
+        if (!CheckForTokenIgnoringWhitespace(TokenType.DM_Preproc_Punctuator_LeftParenthesis, out var leftParenToken)) {
+            parameters = null;
+            return false;
+        }
+        parameters = new();
+        List<Token> currentParameter = new();
+
+        Token parameterToken = GetNextToken(true);
+        while (parameterToken.Type == TokenType.Newline) { // Skip newlines after the left parenthesis
+            parameterToken = GetNextToken(true);
         }
 
-        /// <summary>Also used by #else sometimes to skip its body.</summary>
-        /// <remarks>WARNING: DOES NOT CONSUME any #elif, #else, or #endif it finds.</remarks>
-        /// <param name="noElseAllowed">This is used so that #else can operate this function while also forbidding it having its own #elses.</param>
-        /// <returns>true if it stopped on an #else, false if it stopped in an #endif.</returns>
-        private bool SkipIfBody(bool calledByElseDirective = false) {
-            int ifStack = 1; // how many "ifs" deep we seem to be. We end when we reach 0.
-            for (Token token = GetNextToken(true); token.Type != TokenType.EndOfFile; token = GetNextToken(true)) {
-                switch (token.Type) {
-                    case TokenType.DM_Preproc_If:
-                    case TokenType.DM_Preproc_Ifdef:
-                    case TokenType.DM_Preproc_Ifndef:
-                        ifStack++;
-                        break;
-                    case TokenType.DM_Preproc_EndIf:
-                        ifStack--;
-                        break;
-                    case TokenType.DM_Preproc_Else:
-                    case TokenType.DM_Preproc_Elif:
-                        if (ifStack != 1)
-                            break;
-                        if (calledByElseDirective)
-                            DMCompiler.Emit(WarningCode.BadDirective, token.Location, $"Unexpected {token.PrintableText} directive");
-                        _unprocessedTokens.Push(token); // Push it back onto the stack so we can interpret this later
-                        return true;
-                    default:
-                        continue; // Don't need to do the ifStack check since it has not changed as a result of this token
-                }
-                if (ifStack == 0) {
-                    if (!calledByElseDirective) {
-                        _unprocessedTokens.Push(token); // Push it back onto the stack so we can interpret the entry in _lastIfEvaluations correctly.
+        int parenthesisNesting = 1;
+        while(true) {
+            switch (parameterToken.Type) {
+                case TokenType.DM_Preproc_Punctuator_Comma when parenthesisNesting == 1:
+                    parameters.Add(currentParameter);
+                    currentParameter = new List<Token>();
+                    parameterToken = GetNextToken(true);
+                    while(parameterToken.Type == TokenType.Newline) {
+                        currentParameter.Add(new Token(TokenType.DM_Preproc_LineSplice, "", parameterToken.Location, null));
+                        parameterToken = GetNextToken(true);
                     }
-
-                    return false;
-                }
+                    continue;
+                case TokenType.DM_Preproc_Punctuator_LeftParenthesis:
+                    parenthesisNesting++;
+                    currentParameter.Add(parameterToken);
+                    parameterToken = GetNextToken();
+                    continue;
+                case TokenType.DM_Preproc_Punctuator_RightParenthesis:
+                    parenthesisNesting--;
+                    if (parenthesisNesting == 0) // if that's our paren
+                        break; // break out
+                    //otherwise, add it as another token for this parameter
+                    currentParameter.Add(parameterToken);
+                    parameterToken = GetNextToken();
+                    continue;
+                case TokenType.EndOfFile:
+                    PushToken(parameterToken);
+                    break;
+                default:
+                    currentParameter.Add(parameterToken);
+                    parameterToken = GetNextToken();
+                    continue;
             }
-            DMCompiler.Emit(WarningCode.BadDirective, Location.Unknown, "Missing #endif directive");
+            break; // If it manages to escape the switch, the loop breaks
+        }
+
+        parameters.Add(currentParameter);
+        if (parameterToken.Type != TokenType.DM_Preproc_Punctuator_RightParenthesis) {
+            DMCompiler.Emit(WarningCode.BadDirective, leftParenToken.Location, "Missing ')' in macro call");
+
             return false;
         }
 
-        private bool TryGetMacroParameters(out List<List<Token>> parameters) {
-            if (!CheckForTokenIgnoringWhitespace(TokenType.DM_Preproc_Punctuator_LeftParenthesis, out var leftParenToken)) {
-                parameters = null;
-                return false;
-            }
-            parameters = new();
-            List<Token> currentParameter = new();
-
-            Token parameterToken = GetNextToken(true);
-            while (parameterToken.Type == TokenType.Newline) { // Skip newlines after the left parenthesis
-                parameterToken = GetNextToken(true);
-            }
-
-            int parenthesisNesting = 1;
-            while(true) {
-                switch (parameterToken.Type) {
-                    case TokenType.DM_Preproc_Punctuator_Comma when parenthesisNesting == 1:
-                        parameters.Add(currentParameter);
-                        currentParameter = new List<Token>();
-                        parameterToken = GetNextToken(true);
-                        while(parameterToken.Type == TokenType.Newline) {
-                            currentParameter.Add(new Token(TokenType.DM_Preproc_LineSplice, "", parameterToken.Location, null));
-                            parameterToken = GetNextToken(true);
-                        }
-                        continue;
-                    case TokenType.DM_Preproc_Punctuator_LeftParenthesis:
-                        parenthesisNesting++;
-                        currentParameter.Add(parameterToken);
-                        parameterToken = GetNextToken();
-                        continue;
-                    case TokenType.DM_Preproc_Punctuator_RightParenthesis:
-                        parenthesisNesting--;
-                        if (parenthesisNesting == 0) // if that's our paren
-                            break; // break out
-                        //otherwise, add it as another token for this parameter
-                        currentParameter.Add(parameterToken);
-                        parameterToken = GetNextToken();
-                        continue;
-                    case TokenType.EndOfFile:
-                        PushToken(parameterToken);
-                        break;
-                    default:
-                        currentParameter.Add(parameterToken);
-                        parameterToken = GetNextToken();
-                        continue;
-                }
-                break; // If it manages to escape the switch, the loop breaks
-            }
-
-            parameters.Add(currentParameter);
-            if (parameterToken.Type != TokenType.DM_Preproc_Punctuator_RightParenthesis) {
-                DMCompiler.Emit(WarningCode.BadDirective, leftParenToken.Location, "Missing ')' in macro call");
-
-                return false;
-            }
-
-            return true;
-        }
+        return true;
     }
 }

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -253,6 +253,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
             string filePath = Path.Combine(includeDir, file).Replace('\\', Path.DirectorySeparatorChar);
             string source = File.ReadAllText(filePath);
             source = source.Replace("\r\n", "\n");
+            source = source.Replace('\r', '\n'); // Lone carriage returns are treated as newlines
             source += '\n';
 
             _lexerStack.Push(new DMPreprocessorLexer(includeDir, file.Replace('\\', Path.DirectorySeparatorChar), source));

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -253,10 +253,8 @@ namespace DMCompiler.Compiler.DMPreprocessor {
 
         public void PreprocessFile(string includeDir, string file) {
             string filePath = Path.Combine(includeDir, file).Replace('\\', Path.DirectorySeparatorChar);
-            string source = File.ReadAllText(filePath);
-            source += '\n';
 
-            _lexerStack.Push(new DMPreprocessorLexer(includeDir, file.Replace('\\', Path.DirectorySeparatorChar), source));
+            _lexerStack.Push(new DMPreprocessorLexer(includeDir, filePath));
         }
 
         private bool VerifyDirectiveUsage(Token token) {

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -5,622 +5,622 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using OpenDreamShared.Compiler;
 
-namespace DMCompiler.Compiler.DMPreprocessor {
-    /// <summary>
-    /// This class acts as the first layer of digestion for the compiler, <br/>
-    /// taking in raw text and outputting vague tokens descriptive enough for the preprocessor to run on them.
-    /// </summary>
-    internal sealed class DMPreprocessorLexer {
-        public readonly string IncludeDirectory;
-        public readonly string File;
+namespace DMCompiler.Compiler.DMPreprocessor;
 
-        private readonly StreamReader _source;
-        private char _current;
-        private int _currentLine = 1, _currentColumn;
-        private readonly Queue<Token> _pendingTokenQueue = new(); // TODO: Possible to remove this?
+/// <summary>
+/// This class acts as the first layer of digestion for the compiler, <br/>
+/// taking in raw text and outputting vague tokens descriptive enough for the preprocessor to run on them.
+/// </summary>
+internal sealed class DMPreprocessorLexer {
+    public readonly string IncludeDirectory;
+    public readonly string File;
 
-        public DMPreprocessorLexer(string includeDirectory, string file, string source) {
-            IncludeDirectory = includeDirectory;
-            File = file;
+    private readonly StreamReader _source;
+    private char _current;
+    private int _currentLine = 1, _currentColumn;
+    private readonly Queue<Token> _pendingTokenQueue = new(); // TODO: Possible to remove this?
 
-            _source = new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(source)), Encoding.UTF8);
-            Advance();
-        }
+    public DMPreprocessorLexer(string includeDirectory, string file, string source) {
+        IncludeDirectory = includeDirectory;
+        File = file;
 
-        public DMPreprocessorLexer(string includeDirectory, string file) {
-            IncludeDirectory = includeDirectory;
-            File = file;
+        _source = new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(source)), Encoding.UTF8);
+        Advance();
+    }
 
-            _source = new StreamReader(Path.Combine(includeDirectory, file), Encoding.UTF8);
-            Advance();
-        }
+    public DMPreprocessorLexer(string includeDirectory, string file) {
+        IncludeDirectory = includeDirectory;
+        File = file;
 
-        public Token NextToken(bool ignoreWhitespace = false) {
-            if (_pendingTokenQueue.Count > 0) {
-                Token token = _pendingTokenQueue.Dequeue();
-                if (ignoreWhitespace) {
-                    do {
-                        if (token.Type != TokenType.DM_Preproc_Whitespace)
-                            return token;
+        _source = new StreamReader(Path.Combine(includeDirectory, file), Encoding.UTF8);
+        Advance();
+    }
 
-                        if (_pendingTokenQueue.Count == 0)
-                            break;
+    public Token NextToken(bool ignoreWhitespace = false) {
+        if (_pendingTokenQueue.Count > 0) {
+            Token token = _pendingTokenQueue.Dequeue();
+            if (ignoreWhitespace) {
+                do {
+                    if (token.Type != TokenType.DM_Preproc_Whitespace)
+                        return token;
 
-                        token = _pendingTokenQueue.Dequeue();
-                    } while (true);
-                } else {
-                    return token;
-                }
+                    if (_pendingTokenQueue.Count == 0)
+                        break;
+
+                    token = _pendingTokenQueue.Dequeue();
+                } while (true);
+            } else {
+                return token;
             }
+        }
 
-            char c = GetCurrent();
+        char c = GetCurrent();
 
-            switch (c) {
-                case '\0':
-                    return CreateToken(TokenType.EndOfFile, c);
-                case '\r':
-                case '\n':
-                    HandleLineEnd();
+        switch (c) {
+            case '\0':
+                return CreateToken(TokenType.EndOfFile, c);
+            case '\r':
+            case '\n':
+                HandleLineEnd();
 
-                    return CreateToken(TokenType.Newline, "\n");
-                case ' ':
-                case '\t':
-                    int whitespaceLength = 1;
-                    while (Advance() is ' ' or '\t')
-                        whitespaceLength++;
+                return CreateToken(TokenType.Newline, "\n");
+            case ' ':
+            case '\t':
+                int whitespaceLength = 1;
+                while (Advance() is ' ' or '\t')
+                    whitespaceLength++;
 
-                    return ignoreWhitespace
-                        ? NextToken()
-                        : CreateToken(TokenType.DM_Preproc_Whitespace, new string(c, whitespaceLength));
-                case '}': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, c);
-                case ';': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_Semicolon, c);
-                case '.': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_Period, c);
-                case ':':
+                return ignoreWhitespace
+                    ? NextToken()
+                    : CreateToken(TokenType.DM_Preproc_Whitespace, new string(c, whitespaceLength));
+            case '}': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, c);
+            case ';': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_Semicolon, c);
+            case '.': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_Period, c);
+            case ':':
+                if (Advance() == '=') {
+                    Advance();
+                    return CreateToken(TokenType.DM_Preproc_Punctuator, ":=");
+                }
+
+                return CreateToken(TokenType.DM_Preproc_Punctuator_Colon, c);
+            case ',': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_Comma, c);
+            case '(': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_LeftParenthesis, c);
+            case ')': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_RightParenthesis, c);
+            case '[': {
+                if (Advance() == ']') {
                     if (Advance() == '=') {
                         Advance();
-                        return CreateToken(TokenType.DM_Preproc_Punctuator, ":=");
+                        return CreateToken(TokenType.DM_Preproc_Punctuator, "[]=");
                     }
 
-                    return CreateToken(TokenType.DM_Preproc_Punctuator_Colon, c);
-                case ',': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_Comma, c);
-                case '(': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_LeftParenthesis, c);
-                case ')': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_RightParenthesis, c);
-                case '[': {
-                    if (Advance() == ']') {
+                    return CreateToken(TokenType.DM_Preproc_Punctuator, "[]");
+                }
+
+                return CreateToken(TokenType.DM_Preproc_Punctuator_LeftBracket, c);
+            }
+            case ']': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_RightBracket, c);
+            case '?': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_Question, c);
+            case '\\': {
+                c = Advance();
+
+                if (HandleLineEnd()) {
+                    return CreateToken(TokenType.DM_Preproc_LineSplice, c);
+                }
+
+                //An escaped identifier.
+                //The next character turns into an identifier.
+                Advance();
+                return CreateToken(TokenType.DM_Preproc_Identifier, c);
+            }
+            case '>': {
+                switch (Advance()) {
+                    case '>': {
                         if (Advance() == '=') {
                             Advance();
-                            return CreateToken(TokenType.DM_Preproc_Punctuator, "[]=");
+
+                            return CreateToken(TokenType.DM_Preproc_Punctuator, ">>=");
                         }
 
-                        return CreateToken(TokenType.DM_Preproc_Punctuator, "[]");
+                        return CreateToken(TokenType.DM_Preproc_Punctuator, ">>");
                     }
-
-                    return CreateToken(TokenType.DM_Preproc_Punctuator_LeftBracket, c);
+                    case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, ">=");
+                    default: return CreateToken(TokenType.DM_Preproc_Punctuator, '>');
                 }
-                case ']': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_RightBracket, c);
-                case '?': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_Question, c);
-                case '\\': {
-                    c = Advance();
-
-                    if (HandleLineEnd()) {
-                        return CreateToken(TokenType.DM_Preproc_LineSplice, c);
-                    }
-
-                    //An escaped identifier.
-                    //The next character turns into an identifier.
-                    Advance();
-                    return CreateToken(TokenType.DM_Preproc_Identifier, c);
-                }
-                case '>': {
-                    switch (Advance()) {
-                        case '>': {
-                            if (Advance() == '=') {
-                                Advance();
-
-                                return CreateToken(TokenType.DM_Preproc_Punctuator, ">>=");
-                            }
-
-                            return CreateToken(TokenType.DM_Preproc_Punctuator, ">>");
-                        }
-                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, ">=");
-                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '>');
-                    }
-                }
-                case '<': {
-                    switch (Advance()) {
-                        case '<': {
-                            if (Advance() == '=') {
-                                Advance();
-
-                                return CreateToken(TokenType.DM_Preproc_Punctuator, "<<=");
-                            }
-
-                            return CreateToken(TokenType.DM_Preproc_Punctuator, "<<");
-                        }
-                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "<=");
-                        case '>': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "<>");
-                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '<');
-                    }
-                }
-                case '|': {
-                    switch (Advance()) {
-                        case '|': {
-                            switch (Advance()) {
-                                case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "||=");
-                                default: return CreateToken(TokenType.DM_Preproc_Punctuator, "||");
-                            }
-                        }
-                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "|=");
-                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '|');
-                    }
-                }
-                case '*': {
-                    switch (Advance()) {
-                        case '*': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "**");
-                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "*=");
-                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '*');
-                    }
-                }
-                case '+': {
-                    switch (Advance()) {
-                        case '+': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "++");
-                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "+=");
-                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '+');
-                    }
-                }
-                case '&': {
-                    switch (Advance()) {
-                        case '&': {
-                            switch (Advance()) {
-                                case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "&&=");
-                                default: return CreateToken(TokenType.DM_Preproc_Punctuator, "&&");
-                            }
-                        }
-                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "&=");
-                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '&');
-                    }
-                }
-                case '~': {
-                    switch (Advance()) {
-                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "~=");
-                        case '!': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "~!");
-                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '~');
-                    }
-                }
-                case '%': {
-                    switch (Advance()) {
-                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "%=");
-                        case '%': {
-                            if (Advance() == '=') {
-                                Advance();
-                                return CreateToken(TokenType.DM_Preproc_Punctuator, "%%=");
-                            }
-
-                            return CreateToken(TokenType.DM_Preproc_Punctuator, "%%");
-                        }
-                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '%');
-                    }
-                }
-                case '^': {
-                    switch (Advance()) {
-                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "^=");
-                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '^');
-                    }
-                }
-                case '!': {
-                    switch (Advance()) {
-                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "!=");
-                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '!');
-                    }
-                }
-                case '=': {
-                    switch (Advance()) {
-                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "==");
-                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '=');
-                    }
-                }
-                case '-': {
-                    switch (Advance()) {
-                        case '-': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "--");
-                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "-=");
-                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '-');
-                    }
-                }
-                case '/': {
-                    switch (Advance()) {
-                        case '/': {
-                            do {
-                                Advance();
-
-                                if (c == '\\') {
-                                    Advance();
-
-                                    if (HandleLineEnd()) { //Line splice within a comment
-                                        do {
-                                            Advance();
-                                        } while (GetCurrent() is ' ' or '\t' || HandleLineEnd());
-                                    }
-                                }
-                            } while (!AtLineEnd() && !AtEndOfSource());
-
-                            return NextToken(ignoreWhitespace);
-                        }
-                        case '*': {
-                            //Skip everything up to the "*/"
+            }
+            case '<': {
+                switch (Advance()) {
+                    case '<': {
+                        if (Advance() == '=') {
                             Advance();
-                            var commentDepth = 1;
-                            while (commentDepth > 0) {
-                                if (GetCurrent() == '/') {
-                                    if (Advance() == '*') {
-                                        // We found another comment - up the nest count
-                                        commentDepth++;
+
+                            return CreateToken(TokenType.DM_Preproc_Punctuator, "<<=");
+                        }
+
+                        return CreateToken(TokenType.DM_Preproc_Punctuator, "<<");
+                    }
+                    case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "<=");
+                    case '>': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "<>");
+                    default: return CreateToken(TokenType.DM_Preproc_Punctuator, '<');
+                }
+            }
+            case '|': {
+                switch (Advance()) {
+                    case '|': {
+                        switch (Advance()) {
+                            case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "||=");
+                            default: return CreateToken(TokenType.DM_Preproc_Punctuator, "||");
+                        }
+                    }
+                    case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "|=");
+                    default: return CreateToken(TokenType.DM_Preproc_Punctuator, '|');
+                }
+            }
+            case '*': {
+                switch (Advance()) {
+                    case '*': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "**");
+                    case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "*=");
+                    default: return CreateToken(TokenType.DM_Preproc_Punctuator, '*');
+                }
+            }
+            case '+': {
+                switch (Advance()) {
+                    case '+': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "++");
+                    case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "+=");
+                    default: return CreateToken(TokenType.DM_Preproc_Punctuator, '+');
+                }
+            }
+            case '&': {
+                switch (Advance()) {
+                    case '&': {
+                        switch (Advance()) {
+                            case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "&&=");
+                            default: return CreateToken(TokenType.DM_Preproc_Punctuator, "&&");
+                        }
+                    }
+                    case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "&=");
+                    default: return CreateToken(TokenType.DM_Preproc_Punctuator, '&');
+                }
+            }
+            case '~': {
+                switch (Advance()) {
+                    case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "~=");
+                    case '!': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "~!");
+                    default: return CreateToken(TokenType.DM_Preproc_Punctuator, '~');
+                }
+            }
+            case '%': {
+                switch (Advance()) {
+                    case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "%=");
+                    case '%': {
+                        if (Advance() == '=') {
+                            Advance();
+                            return CreateToken(TokenType.DM_Preproc_Punctuator, "%%=");
+                        }
+
+                        return CreateToken(TokenType.DM_Preproc_Punctuator, "%%");
+                    }
+                    default: return CreateToken(TokenType.DM_Preproc_Punctuator, '%');
+                }
+            }
+            case '^': {
+                switch (Advance()) {
+                    case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "^=");
+                    default: return CreateToken(TokenType.DM_Preproc_Punctuator, '^');
+                }
+            }
+            case '!': {
+                switch (Advance()) {
+                    case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "!=");
+                    default: return CreateToken(TokenType.DM_Preproc_Punctuator, '!');
+                }
+            }
+            case '=': {
+                switch (Advance()) {
+                    case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "==");
+                    default: return CreateToken(TokenType.DM_Preproc_Punctuator, '=');
+                }
+            }
+            case '-': {
+                switch (Advance()) {
+                    case '-': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "--");
+                    case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "-=");
+                    default: return CreateToken(TokenType.DM_Preproc_Punctuator, '-');
+                }
+            }
+            case '/': {
+                switch (Advance()) {
+                    case '/': {
+                        do {
+                            Advance();
+
+                            if (c == '\\') {
+                                Advance();
+
+                                if (HandleLineEnd()) { //Line splice within a comment
+                                    do {
                                         Advance();
-                                    } else if (GetCurrent() == '/') {
-                                        // Encountered a line comment - skip to end of line
-                                        do {
-                                            Advance();
-                                        } while (!AtLineEnd() && !AtEndOfSource());
-                                    }
-                                } else if (GetCurrent() == '*') {
-                                    if (Advance() == '/') {
-                                        // End of comment - decrease nest count
-                                        commentDepth--;
-                                        Advance();
-                                    }
-                                } else if (AtEndOfSource()) {
-                                    return CreateToken(TokenType.Error, string.Empty,
-                                        "Expected \"*/\" to end multiline comment");
-                                } else if (!HandleLineEnd()) {
-                                    Advance();
+                                    } while (GetCurrent() is ' ' or '\t' || HandleLineEnd());
                                 }
                             }
+                        } while (!AtLineEnd() && !AtEndOfSource());
 
-                            while (GetCurrent() == ' ' || GetCurrent() == '\t') {
+                        return NextToken(ignoreWhitespace);
+                    }
+                    case '*': {
+                        //Skip everything up to the "*/"
+                        Advance();
+                        var commentDepth = 1;
+                        while (commentDepth > 0) {
+                            if (GetCurrent() == '/') {
+                                if (Advance() == '*') {
+                                    // We found another comment - up the nest count
+                                    commentDepth++;
+                                    Advance();
+                                } else if (GetCurrent() == '/') {
+                                    // Encountered a line comment - skip to end of line
+                                    do {
+                                        Advance();
+                                    } while (!AtLineEnd() && !AtEndOfSource());
+                                }
+                            } else if (GetCurrent() == '*') {
+                                if (Advance() == '/') {
+                                    // End of comment - decrease nest count
+                                    commentDepth--;
+                                    Advance();
+                                }
+                            } else if (AtEndOfSource()) {
+                                return CreateToken(TokenType.Error, string.Empty,
+                                    "Expected \"*/\" to end multiline comment");
+                            } else if (!HandleLineEnd()) {
                                 Advance();
                             }
-
-                            return NextToken(ignoreWhitespace);
                         }
-                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "/=");
-                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, c);
+
+                        while (GetCurrent() == ' ' || GetCurrent() == '\t') {
+                            Advance();
+                        }
+
+                        return NextToken(ignoreWhitespace);
                     }
+                    case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "/=");
+                    default: return CreateToken(TokenType.DM_Preproc_Punctuator, c);
                 }
-                case '@': { //Raw string
-                    char delimiter = Advance();
-                    StringBuilder textBuilder = new StringBuilder();
+            }
+            case '@': { //Raw string
+                char delimiter = Advance();
+                StringBuilder textBuilder = new StringBuilder();
 
-                    textBuilder.Append('@');
-                    textBuilder.Append(delimiter);
+                textBuilder.Append('@');
+                textBuilder.Append(delimiter);
 
-                    bool isLong = false;
-                    c = Advance();
-                    if (delimiter == '{') {
-                        textBuilder.Append(c);
-
-                        if (c == '"') isLong = true;
-                    }
-
-                    if (isLong) {
-                        bool nextCharCanTerm = false;
-                        do {
-                            c = Advance();
-
-                            if(nextCharCanTerm && c == '}')
-                                break;
-                            else {
-                                textBuilder.Append(c);
-                                nextCharCanTerm = false;
-                            }
-
-                            if (c == '"')
-                                nextCharCanTerm = true;
-
-                        } while (!AtEndOfSource());
-                    } else {
-                        while (c != delimiter && !AtLineEnd() && !AtEndOfSource()) {
-                            textBuilder.Append(c);
-                            c = Advance();
-                        }
-                    }
-
+                bool isLong = false;
+                c = Advance();
+                if (delimiter == '{') {
                     textBuilder.Append(c);
-                    if (!HandleLineEnd())
-                        Advance();
 
-                    string text = textBuilder.ToString();
-                    string value = isLong ? text.Substring(3, text.Length - 5) : text.Substring(2, text.Length - 3);
-                    return CreateToken(TokenType.DM_Preproc_ConstantString, text, value);
+                    if (c == '"') isLong = true;
                 }
-                case '\'':
-                case '"':
-                    return LexString(false);
-                case '{':
-                    return Advance() == '"' ?
-                        LexString(true) :
-                        CreateToken(TokenType.DM_Preproc_Punctuator, c);
-                case '#': {
-                    bool isConcat = (Advance() == '#');
-                    if (isConcat) Advance();
 
-                    // Whitespace after '#' is ignored
-                    while (GetCurrent() is ' ' or '\t') {
-                        Advance();
-                    }
+                if (isLong) {
+                    bool nextCharCanTerm = false;
+                    do {
+                        c = Advance();
 
-                    StringBuilder textBuilder = new StringBuilder();
-                    while (char.IsAsciiLetter(GetCurrent()) || GetCurrent() == '_') {
-                        textBuilder.Append(GetCurrent());
-                        Advance();
-                    }
-
-                    string text = textBuilder.ToString();
-                    if (text == string.Empty) {
-                        return NextToken(ignoreWhitespace); // Skip this token
-                    } else if (isConcat) {
-                        return CreateToken(TokenType.DM_Preproc_TokenConcat, $"##{text}", text);
-                    }
-
-                    if (TryMacroKeyword(text, out var macroKeyword))
-                        return macroKeyword;
-
-                    string macroAttempt = text.ToLower();
-                    if (TryMacroKeyword(macroAttempt, out var attemptKeyword)) { // if they mis-capitalized the keyword
-                        DMCompiler.Emit(WarningCode.MiscapitalizedDirective, attemptKeyword.Location,
-                            $"#{text} is not a valid macro keyword. Did you mean '#{macroAttempt}'?");
-                    }
-
-                    return CreateToken(TokenType.DM_Preproc_ParameterStringify, $"#{text}", text);
-                }
-                default: {
-                    if (char.IsAsciiLetter(c) || c == '_') {
-                        StringBuilder textBuilder = new StringBuilder(char.ToString(c));
-                        while ((char.IsAsciiLetterOrDigit(Advance()) || GetCurrent() == '_') && !AtEndOfSource())
-                            textBuilder.Append(GetCurrent());
-
-                        return CreateToken(TokenType.DM_Preproc_Identifier, textBuilder.ToString());
-                    } else if (char.IsAsciiDigit(c)) {
-                        StringBuilder textBuilder = new StringBuilder(char.ToString(c));
-                        bool error = false;
-
-                        while (!AtEndOfSource()) {
-                            char next = Advance();
-                            if ((c == 'e' || c == 'E') && (next == '-' || next == '+')) { //1e-10 or 1e+10
-                                textBuilder.Append(next);
-                                next = Advance();
-                            } else if (c == '#' && next == 'I') { //1.#INF and 1.#IND
-                                if (Advance() != 'N' || Advance() != 'F' && GetCurrent() != 'D') {
-                                    error = true;
-
-                                    break;
-                                }
-
-                                textBuilder.Append("IN");
-                                textBuilder.Append(GetCurrent());
-                                next = Advance();
-                            }
-
-                            c = next;
-                            if (char.IsAsciiHexDigit(c) || c == '.' || c == 'x' || c == '#' || c == 'e' || c == 'E' || c == 'p' || c == 'P') {
-                                textBuilder.Append(c);
-                            } else {
-                                break;
-                            }
+                        if(nextCharCanTerm && c == '}')
+                            break;
+                        else {
+                            textBuilder.Append(c);
+                            nextCharCanTerm = false;
                         }
 
-                        return error
-                            ? CreateToken(TokenType.Error, string.Empty, "Invalid number")
-                            : CreateToken(TokenType.DM_Preproc_Number, textBuilder.ToString());
-                    }
+                        if (c == '"')
+                            nextCharCanTerm = true;
 
-                    Advance();
-                    return CreateToken(TokenType.Error, string.Empty, $"Unknown character: {c.ToString()}");
+                    } while (!AtEndOfSource());
+                } else {
+                    while (c != delimiter && !AtLineEnd() && !AtEndOfSource()) {
+                        textBuilder.Append(c);
+                        c = Advance();
+                    }
                 }
+
+                textBuilder.Append(c);
+                if (!HandleLineEnd())
+                    Advance();
+
+                string text = textBuilder.ToString();
+                string value = isLong ? text.Substring(3, text.Length - 5) : text.Substring(2, text.Length - 3);
+                return CreateToken(TokenType.DM_Preproc_ConstantString, text, value);
             }
-        }
+            case '\'':
+            case '"':
+                return LexString(false);
+            case '{':
+                return Advance() == '"' ?
+                    LexString(true) :
+                    CreateToken(TokenType.DM_Preproc_Punctuator, c);
+            case '#': {
+                bool isConcat = (Advance() == '#');
+                if (isConcat) Advance();
 
-        /// <returns>True if token was successfully set to a macro keyword token, false if not.</returns>
-        private bool TryMacroKeyword(string text, [NotNullWhen(true)] out Token? token) {
-            switch (text) {
-                case "warn":
-                case "warning": {
-                    StringBuilder message = new StringBuilder();
-
-                    while (!AtEndOfSource() && !AtLineEnd()) {
-                        message.Append(GetCurrent());
-                        Advance();
-                    }
-
-                    token = CreateToken(TokenType.DM_Preproc_Warning, "#warn" + message);
-                    break;
+                // Whitespace after '#' is ignored
+                while (GetCurrent() is ' ' or '\t') {
+                    Advance();
                 }
-                case "error": {
-                    StringBuilder message = new StringBuilder();
 
-                    while (!AtEndOfSource() && !AtLineEnd()) {
-                        message.Append(GetCurrent());
-                        Advance();
-                    }
-
-                    token = CreateToken(TokenType.DM_Preproc_Error, "#error" + message);
-                    break;
+                StringBuilder textBuilder = new StringBuilder();
+                while (char.IsAsciiLetter(GetCurrent()) || GetCurrent() == '_') {
+                    textBuilder.Append(GetCurrent());
+                    Advance();
                 }
-                case "include": token = CreateToken(TokenType.DM_Preproc_Include, "#include"); break;
-                case "define": token = CreateToken(TokenType.DM_Preproc_Define, "#define"); break;
-                case "undef": token = CreateToken(TokenType.DM_Preproc_Undefine, "#undef"); break;
-                case "if": token = CreateToken(TokenType.DM_Preproc_If, "#if"); break;
-                case "ifdef": token = CreateToken(TokenType.DM_Preproc_Ifdef, "#ifdef"); break;
-                case "ifndef": token = CreateToken(TokenType.DM_Preproc_Ifndef, "#ifndef"); break;
-                case "elif": token = CreateToken(TokenType.DM_Preproc_Elif, "#elif"); break;
-                case "else": token = CreateToken(TokenType.DM_Preproc_Else, "#else"); break;
-                case "endif": token = CreateToken(TokenType.DM_Preproc_EndIf, "#endif"); break;
-                //OD-specific directives
-                case "pragma": token = CreateToken(TokenType.DM_Preproc_Pragma, "#pragma"); break;
-                default:
-                    token = null; // maybe should use ref instead of out?
-                    return false;
+
+                string text = textBuilder.ToString();
+                if (text == string.Empty) {
+                    return NextToken(ignoreWhitespace); // Skip this token
+                } else if (isConcat) {
+                    return CreateToken(TokenType.DM_Preproc_TokenConcat, $"##{text}", text);
+                }
+
+                if (TryMacroKeyword(text, out var macroKeyword))
+                    return macroKeyword;
+
+                string macroAttempt = text.ToLower();
+                if (TryMacroKeyword(macroAttempt, out var attemptKeyword)) { // if they mis-capitalized the keyword
+                    DMCompiler.Emit(WarningCode.MiscapitalizedDirective, attemptKeyword.Location,
+                        $"#{text} is not a valid macro keyword. Did you mean '#{macroAttempt}'?");
+                }
+
+                return CreateToken(TokenType.DM_Preproc_ParameterStringify, $"#{text}", text);
             }
-            return true;
-        }
-
-
-        ///<summary>
-        /// Lex a string <br/>
-        ///</summary>
-        ///<remarks>
-        /// If it contains string interpolations, it splits the string tokens into parts and lex the expressions as normal <br/>
-        /// For example, "There are [amount] of them" becomes: <br/>
-        ///    DM_Preproc_String("There are "), DM_Preproc_Identifier(amount), DM_Preproc_String(" of them") <br/>
-        /// If there is no string interpolation, it outputs a DM_Preproc_ConstantString token instead
-        /// </remarks>
-        private Token LexString(bool isLong) {
-            char terminator = GetCurrent();
-            StringBuilder textBuilder = new StringBuilder(isLong ? "{" + terminator : char.ToString(terminator));
-            Queue<Token> stringTokens = new();
-
-            Advance();
-            while (!(!isLong && AtLineEnd()) && !AtEndOfSource()) {
-                char stringC = GetCurrent();
-
-                textBuilder.Append(stringC);
-                if (stringC == '[') {
-                    stringTokens.Enqueue(CreateToken(TokenType.DM_Preproc_String, textBuilder.ToString()));
-                    textBuilder.Clear();
-
-                    Advance();
-
-                    Token exprToken = NextToken();
-                    int bracketNesting = 0;
-                    while (!(bracketNesting == 0 && exprToken.Type == TokenType.DM_Preproc_Punctuator_RightBracket) && !AtEndOfSource()) {
-                        stringTokens.Enqueue(exprToken);
-
-                        if (exprToken.Type == TokenType.DM_Preproc_Punctuator_LeftBracket) bracketNesting++;
-                        if (exprToken.Type == TokenType.DM_Preproc_Punctuator_RightBracket) bracketNesting--;
-                        exprToken = NextToken();
-                    }
-
-                    if (exprToken.Type != TokenType.DM_Preproc_Punctuator_RightBracket)
-                        return CreateToken(TokenType.Error, string.Empty, "Expected ']' to end expression");
-                    textBuilder.Append(']');
-                } else if (stringC == '\\') {
-                    Advance();
-
-                    if (AtLineEnd()) { //Line splice
-                        //Remove the '\' from textBuilder and ignore newlines & all incoming whitespace
-                        textBuilder.Remove(textBuilder.Length - 1, 1);
-                        do {
-                            Advance();
-                        } while (AtLineEnd() || GetCurrent() == ' ' || GetCurrent() == '\t');
-                    } else {
+            default: {
+                if (char.IsAsciiLetter(c) || c == '_') {
+                    StringBuilder textBuilder = new StringBuilder(char.ToString(c));
+                    while ((char.IsAsciiLetterOrDigit(Advance()) || GetCurrent() == '_') && !AtEndOfSource())
                         textBuilder.Append(GetCurrent());
-                        Advance();
-                    }
-                } else if (stringC == terminator) {
-                    if (isLong) {
-                        stringC = Advance();
 
-                        if (stringC == '}') {
-                            textBuilder.Append('}');
+                    return CreateToken(TokenType.DM_Preproc_Identifier, textBuilder.ToString());
+                } else if (char.IsAsciiDigit(c)) {
+                    StringBuilder textBuilder = new StringBuilder(char.ToString(c));
+                    bool error = false;
 
+                    while (!AtEndOfSource()) {
+                        char next = Advance();
+                        if ((c == 'e' || c == 'E') && (next == '-' || next == '+')) { //1e-10 or 1e+10
+                            textBuilder.Append(next);
+                            next = Advance();
+                        } else if (c == '#' && next == 'I') { //1.#INF and 1.#IND
+                            if (Advance() != 'N' || Advance() != 'F' && GetCurrent() != 'D') {
+                                error = true;
+
+                                break;
+                            }
+
+                            textBuilder.Append("IN");
+                            textBuilder.Append(GetCurrent());
+                            next = Advance();
+                        }
+
+                        c = next;
+                        if (char.IsAsciiHexDigit(c) || c == '.' || c == 'x' || c == '#' || c == 'e' || c == 'E' || c == 'p' || c == 'P') {
+                            textBuilder.Append(c);
+                        } else {
                             break;
                         }
-                    } else {
+                    }
+
+                    return error
+                        ? CreateToken(TokenType.Error, string.Empty, "Invalid number")
+                        : CreateToken(TokenType.DM_Preproc_Number, textBuilder.ToString());
+                }
+
+                Advance();
+                return CreateToken(TokenType.Error, string.Empty, $"Unknown character: {c.ToString()}");
+            }
+        }
+    }
+
+    /// <returns>True if token was successfully set to a macro keyword token, false if not.</returns>
+    private bool TryMacroKeyword(string text, [NotNullWhen(true)] out Token? token) {
+        switch (text) {
+            case "warn":
+            case "warning": {
+                StringBuilder message = new StringBuilder();
+
+                while (!AtEndOfSource() && !AtLineEnd()) {
+                    message.Append(GetCurrent());
+                    Advance();
+                }
+
+                token = CreateToken(TokenType.DM_Preproc_Warning, "#warn" + message);
+                break;
+            }
+            case "error": {
+                StringBuilder message = new StringBuilder();
+
+                while (!AtEndOfSource() && !AtLineEnd()) {
+                    message.Append(GetCurrent());
+                    Advance();
+                }
+
+                token = CreateToken(TokenType.DM_Preproc_Error, "#error" + message);
+                break;
+            }
+            case "include": token = CreateToken(TokenType.DM_Preproc_Include, "#include"); break;
+            case "define": token = CreateToken(TokenType.DM_Preproc_Define, "#define"); break;
+            case "undef": token = CreateToken(TokenType.DM_Preproc_Undefine, "#undef"); break;
+            case "if": token = CreateToken(TokenType.DM_Preproc_If, "#if"); break;
+            case "ifdef": token = CreateToken(TokenType.DM_Preproc_Ifdef, "#ifdef"); break;
+            case "ifndef": token = CreateToken(TokenType.DM_Preproc_Ifndef, "#ifndef"); break;
+            case "elif": token = CreateToken(TokenType.DM_Preproc_Elif, "#elif"); break;
+            case "else": token = CreateToken(TokenType.DM_Preproc_Else, "#else"); break;
+            case "endif": token = CreateToken(TokenType.DM_Preproc_EndIf, "#endif"); break;
+            //OD-specific directives
+            case "pragma": token = CreateToken(TokenType.DM_Preproc_Pragma, "#pragma"); break;
+            default:
+                token = null; // maybe should use ref instead of out?
+                return false;
+        }
+        return true;
+    }
+
+
+    ///<summary>
+    /// Lex a string <br/>
+    ///</summary>
+    ///<remarks>
+    /// If it contains string interpolations, it splits the string tokens into parts and lex the expressions as normal <br/>
+    /// For example, "There are [amount] of them" becomes: <br/>
+    ///    DM_Preproc_String("There are "), DM_Preproc_Identifier(amount), DM_Preproc_String(" of them") <br/>
+    /// If there is no string interpolation, it outputs a DM_Preproc_ConstantString token instead
+    /// </remarks>
+    private Token LexString(bool isLong) {
+        char terminator = GetCurrent();
+        StringBuilder textBuilder = new StringBuilder(isLong ? "{" + terminator : char.ToString(terminator));
+        Queue<Token> stringTokens = new();
+
+        Advance();
+        while (!(!isLong && AtLineEnd()) && !AtEndOfSource()) {
+            char stringC = GetCurrent();
+
+            textBuilder.Append(stringC);
+            if (stringC == '[') {
+                stringTokens.Enqueue(CreateToken(TokenType.DM_Preproc_String, textBuilder.ToString()));
+                textBuilder.Clear();
+
+                Advance();
+
+                Token exprToken = NextToken();
+                int bracketNesting = 0;
+                while (!(bracketNesting == 0 && exprToken.Type == TokenType.DM_Preproc_Punctuator_RightBracket) && !AtEndOfSource()) {
+                    stringTokens.Enqueue(exprToken);
+
+                    if (exprToken.Type == TokenType.DM_Preproc_Punctuator_LeftBracket) bracketNesting++;
+                    if (exprToken.Type == TokenType.DM_Preproc_Punctuator_RightBracket) bracketNesting--;
+                    exprToken = NextToken();
+                }
+
+                if (exprToken.Type != TokenType.DM_Preproc_Punctuator_RightBracket)
+                    return CreateToken(TokenType.Error, string.Empty, "Expected ']' to end expression");
+                textBuilder.Append(']');
+            } else if (stringC == '\\') {
+                Advance();
+
+                if (AtLineEnd()) { //Line splice
+                    //Remove the '\' from textBuilder and ignore newlines & all incoming whitespace
+                    textBuilder.Remove(textBuilder.Length - 1, 1);
+                    do {
+                        Advance();
+                    } while (AtLineEnd() || GetCurrent() == ' ' || GetCurrent() == '\t');
+                } else {
+                    textBuilder.Append(GetCurrent());
+                    Advance();
+                }
+            } else if (stringC == terminator) {
+                if (isLong) {
+                    stringC = Advance();
+
+                    if (stringC == '}') {
+                        textBuilder.Append('}');
+
                         break;
                     }
                 } else {
-                    Advance();
+                    break;
                 }
-            }
-
-            if (!AtEndOfSource() && !HandleLineEnd())
-                Advance();
-
-            string text = textBuilder.ToString();
-            if (!isLong && !(text.EndsWith(terminator) && text.Length != 1))
-                return CreateToken(TokenType.Error, string.Empty, "Expected '" + terminator + "' to end string");
-            if (isLong && !text.EndsWith("}"))
-                return CreateToken(TokenType.Error, string.Empty, "Expected '}' to end long string");
-
-            if (stringTokens.Count == 0) {
-                string stringValue = isLong ? text.Substring(2, text.Length - 4) : text.Substring(1, text.Length - 2);
-
-                return CreateToken(TokenType.DM_Preproc_ConstantString, text, stringValue);
             } else {
-                stringTokens.Enqueue(CreateToken(TokenType.DM_Preproc_String, textBuilder.ToString()));
-
-                foreach (Token stringToken in stringTokens) {
-                    _pendingTokenQueue.Enqueue(stringToken);
-                }
-
-                return _pendingTokenQueue.Dequeue();
+                Advance();
             }
         }
 
-        /// <summary>
-        /// Checks if the current position is at the end of a line (carriage return or newline)
-        /// </summary>
-        private bool AtLineEnd() {
-            return GetCurrent() is '\r' or '\n';
-        }
+        if (!AtEndOfSource() && !HandleLineEnd())
+            Advance();
 
-        /// <summary>
-        /// Handles the end of a line by consuming all carriage returns before a newline or the absence of a newline
-        /// </summary>
-        /// <remarks>If you skip a line ending without using this, the line counter will be incorrect</remarks>
-        /// <returns>True if this handled a line ending, otherwise false</returns>
-        private bool HandleLineEnd() {
-            char c = GetCurrent();
+        string text = textBuilder.ToString();
+        if (!isLong && !(text.EndsWith(terminator) && text.Length != 1))
+            return CreateToken(TokenType.Error, string.Empty, "Expected '" + terminator + "' to end string");
+        if (isLong && !text.EndsWith("}"))
+            return CreateToken(TokenType.Error, string.Empty, "Expected '}' to end long string");
 
-            switch (c) {
-                case '\r':
-                    while (c == '\r')
-                        c = Advance();
+        if (stringTokens.Count == 0) {
+            string stringValue = isLong ? text.Substring(2, text.Length - 4) : text.Substring(1, text.Length - 2);
 
-                    goto case '\n';
-                case '\n':
-                    _currentLine++;
-                    _currentColumn = 1;
+            return CreateToken(TokenType.DM_Preproc_ConstantString, text, stringValue);
+        } else {
+            stringTokens.Enqueue(CreateToken(TokenType.DM_Preproc_String, textBuilder.ToString()));
 
-                    if (c == '\n') // This line could have ended with only \r
-                        Advance();
-
-                    return true;
-                default:
-                    return false; // No line ending
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private char GetCurrent() {
-            return _current;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private char Advance() {
-            int value = _source.Read();
-
-            if (value == -1) {
-                _current = '\0';
-            }  else {
-                _currentColumn++;
-                _current = (char)value;
+            foreach (Token stringToken in stringTokens) {
+                _pendingTokenQueue.Enqueue(stringToken);
             }
 
-            return GetCurrent();
+            return _pendingTokenQueue.Dequeue();
+        }
+    }
+
+    /// <summary>
+    /// Checks if the current position is at the end of a line (carriage return or newline)
+    /// </summary>
+    private bool AtLineEnd() {
+        return GetCurrent() is '\r' or '\n';
+    }
+
+    /// <summary>
+    /// Handles the end of a line by consuming all carriage returns before a newline or the absence of a newline
+    /// </summary>
+    /// <remarks>If you skip a line ending without using this, the line counter will be incorrect</remarks>
+    /// <returns>True if this handled a line ending, otherwise false</returns>
+    private bool HandleLineEnd() {
+        char c = GetCurrent();
+
+        switch (c) {
+            case '\r':
+                while (c == '\r')
+                    c = Advance();
+
+                goto case '\n';
+            case '\n':
+                _currentLine++;
+                _currentColumn = 1;
+
+                if (c == '\n') // This line could have ended with only \r
+                    Advance();
+
+                return true;
+            default:
+                return false; // No line ending
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private char GetCurrent() {
+        return _current;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private char Advance() {
+        int value = _source.Read();
+
+        if (value == -1) {
+            _current = '\0';
+        }  else {
+            _currentColumn++;
+            _current = (char)value;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool AtEndOfSource() {
-            return _current == '\0';
-        }
+        return GetCurrent();
+    }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private Token CreateToken(TokenType type, string text, object? value = null) {
-            return new Token(type, text, new Location(File, _currentLine, _currentColumn), value);
-        }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool AtEndOfSource() {
+        return _current == '\0';
+    }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private Token CreateToken(TokenType type, char text, object? value = null) {
-            return new Token(type, text.ToString(), new Location(File, _currentLine, _currentColumn), value);
-        }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private Token CreateToken(TokenType type, string text, object? value = null) {
+        return new Token(type, text, new Location(File, _currentLine, _currentColumn), value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private Token CreateToken(TokenType type, char text, object? value = null) {
+        return new Token(type, text.ToString(), new Location(File, _currentLine, _currentColumn), value);
     }
 }

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -23,7 +23,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
             IncludeDirectory = includeDirectory;
             File = file;
 
-            _source = new StreamReader(new MemoryStream(Encoding.ASCII.GetBytes(source)), Encoding.ASCII);
+            _source = new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(source)), Encoding.UTF8);
             Advance();
         }
 
@@ -31,7 +31,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
             IncludeDirectory = includeDirectory;
             File = file;
 
-            _source = new StreamReader(Path.Combine(includeDirectory, file), Encoding.ASCII);
+            _source = new StreamReader(Path.Combine(includeDirectory, file), Encoding.UTF8);
             Advance();
         }
 
@@ -241,7 +241,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
                                         } while (GetCurrent() is ' ' or '\t' || HandleLineEnd());
                                     }
                                 }
-                            } while (!AtLineEnd());
+                            } while (!AtLineEnd() && !AtEndOfSource());
 
                             return NextToken(ignoreWhitespace);
                         }

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -1,5 +1,6 @@
-using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text;
 using OpenDreamShared.Compiler;
 
@@ -8,446 +9,411 @@ namespace DMCompiler.Compiler.DMPreprocessor {
     /// This class acts as the first layer of digestion for the compiler, <br/>
     /// taking in raw text and outputting vague tokens descriptive enough for the preprocessor to run on them.
     /// </summary>
-    internal sealed class DMPreprocessorLexer : TextLexer {
-        public string IncludeDirectory;
+    internal sealed class DMPreprocessorLexer {
+        public readonly string IncludeDirectory;
+        public readonly string File;
 
-        public DMPreprocessorLexer(string includeDirectory, string sourceName, string source) : base(sourceName, source) {
+        private readonly string _source;
+        private int _currentIndex, _currentLine = 1, _currentColumn = 1;
+        private readonly Queue<Token> _pendingTokenQueue = new(); // TODO: Possible to remove this?
+
+        public DMPreprocessorLexer(string includeDirectory, string file, string source) {
             IncludeDirectory = includeDirectory;
+            File = file;
+            _source = source;
         }
 
-        public Token GetNextTokenIgnoringWhitespace() {
-            Token nextToken = GetNextToken();
-            if (nextToken.Type == TokenType.DM_Preproc_Whitespace) nextToken = GetNextToken();
+        public Token NextToken(bool ignoreWhitespace = false) {
+            if (_pendingTokenQueue.Count > 0)
+                return _pendingTokenQueue.Dequeue();
 
-            return nextToken;
-        }
+            char c = GetCurrent();
 
-        protected override Token ParseNextToken() {
-            Token token = base.ParseNextToken();
+            switch (c) {
+                case '\0':
+                    return CreateToken(TokenType.EndOfFile, c);
+                case '\r':
+                case '\n':
+                    HandleLineEnd();
 
-            if (token.Type == TokenType.Unknown) {
-                char c = GetCurrent();
+                    return CreateToken(TokenType.Newline, "\n");
+                case ' ':
+                case '\t':
+                    int whitespaceLength = 1;
+                    while (Advance() is ' ' or '\t')
+                        whitespaceLength++;
 
-                switch (c) {
-                    case ' ':
-                    case '\t':
-                        int whitespaceLength = 1;
-                        while (Advance() is ' ' or '\t')
-                            whitespaceLength++;
-
-                        token = CreateToken(TokenType.DM_Preproc_Whitespace, new string(c, whitespaceLength));
-                        break;
-                    case '}': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, c); break;
-                    case ';': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator_Semicolon, c); break;
-                    case '.': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator_Period, c); break;
-                    case ':':
-                        if(Advance() == '=') {
-                            Advance();
-                            token = CreateToken(TokenType.DM_Preproc_Punctuator, ":=");
-                        } else
-                            token = CreateToken(TokenType.DM_Preproc_Punctuator_Colon, c);
-                        break;
-                    case ',': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator_Comma, c); break;
-                    case '(': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator_LeftParenthesis, c); break;
-                    case ')': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator_RightParenthesis, c); break;
-                    case '[': {
-                        if(Advance() == ']'){
-                            if(Advance() == '=') {
-                                Advance();
-                                token = CreateToken(TokenType.DM_Preproc_Punctuator, "[]=");
-                            } else
-                                token = CreateToken(TokenType.DM_Preproc_Punctuator, "[]");
-                        } else {
-                            token = CreateToken(TokenType.DM_Preproc_Punctuator_LeftBracket, c);
-                        }
-                        break;
-                    }
-                    case ']': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator_RightBracket, c); break;
-                    case '?': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator_Question, c); break;
-                    case '\\': {
-                        if (Advance() == '\n') {
-                            token = CreateToken(TokenType.DM_Preproc_LineSplice, c);
-                        } else {
-                            //An escaped identifier.
-                            //The next character turns into an identifier.
-                            token = CreateToken(TokenType.DM_Preproc_Identifier, GetCurrent());
-                        }
-
+                    return ignoreWhitespace
+                        ? NextToken()
+                        : CreateToken(TokenType.DM_Preproc_Whitespace, new string(c, whitespaceLength));
+                case '}': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, c);
+                case ';': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_Semicolon, c);
+                case '.': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_Period, c);
+                case ':':
+                    if (Advance() == '=') {
                         Advance();
-                        break;
+                        return CreateToken(TokenType.DM_Preproc_Punctuator, ":=");
                     }
-                    case '>': {
-                        switch (Advance()) {
-                            case '>': {
-                                if (Advance() == '=') {
-                                    Advance();
 
-                                    token = CreateToken(TokenType.DM_Preproc_Punctuator, ">>=");
-                                } else {
-                                    token = CreateToken(TokenType.DM_Preproc_Punctuator, ">>");
-                                }
-
-                                break;
-                            }
-                            case '=': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, ">="); break;
-                            default: token = CreateToken(TokenType.DM_Preproc_Punctuator, '>'); break;
+                    return CreateToken(TokenType.DM_Preproc_Punctuator_Colon, c);
+                case ',': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_Comma, c);
+                case '(': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_LeftParenthesis, c);
+                case ')': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_RightParenthesis, c);
+                case '[': {
+                    if (Advance() == ']') {
+                        if (Advance() == '=') {
+                            Advance();
+                            return CreateToken(TokenType.DM_Preproc_Punctuator, "[]=");
                         }
 
-                        break;
+                        return CreateToken(TokenType.DM_Preproc_Punctuator, "[]");
                     }
-                    case '<': {
-                        switch (Advance()) {
-                            case '<': {
-                                if (Advance() == '=') {
-                                    Advance();
 
-                                    token = CreateToken(TokenType.DM_Preproc_Punctuator, "<<=");
-                                } else {
-                                    token = CreateToken(TokenType.DM_Preproc_Punctuator, "<<");
-                                }
+                    return CreateToken(TokenType.DM_Preproc_Punctuator_LeftBracket, c);
+                }
+                case ']': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_RightBracket, c);
+                case '?': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator_Question, c);
+                case '\\': {
+                    c = Advance();
 
-                                break;
-                            }
-                            case '=': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "<="); break;
-                            case '>': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "<>"); break;
-                            default: token = CreateToken(TokenType.DM_Preproc_Punctuator, '<'); break;
-                        }
-
-                        break;
+                    if (HandleLineEnd()) {
+                        return CreateToken(TokenType.DM_Preproc_LineSplice, c);
                     }
-                    case '|': {
-                        switch (Advance()) {
-                            case '|': {
-                                switch (Advance()) {
-                                    case '=': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "||="); break;
-                                    default: token = CreateToken(TokenType.DM_Preproc_Punctuator, "||"); break;
-                                }
-                                break;
-                            }
-                            case '=': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "|="); break;
-                            default: token = CreateToken(TokenType.DM_Preproc_Punctuator, '|'); break;
-                        }
 
-                        break;
-                    }
-                    case '*': {
-                        switch (Advance()) {
-                            case '*': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "**"); break;
-                            case '=': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "*="); break;
-                            default: token = CreateToken(TokenType.DM_Preproc_Punctuator, '*'); break;
-                        }
-
-                        break;
-                    }
-                    case '+': {
-                        switch (Advance()) {
-                            case '+': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "++"); break;
-                            case '=': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "+="); break;
-                            default: token = CreateToken(TokenType.DM_Preproc_Punctuator, '+'); break;
-                        }
-
-                        break;
-                    }
-                    case '&': {
-                        switch (Advance()) {
-                            case '&': {
-                                switch (Advance()) {
-                                    case '=': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "&&="); break;
-                                    default: token = CreateToken(TokenType.DM_Preproc_Punctuator, "&&"); break;
-                                }
-                                break;
-                            }
-                            case '=': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "&="); break;
-                            default: token = CreateToken(TokenType.DM_Preproc_Punctuator, '&'); break;
-                        }
-
-                        break;
-                    }
-                    case '~': {
-                        switch (Advance()) {
-                            case '=': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "~="); break;
-                            case '!': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "~!"); break;
-                            default: token = CreateToken(TokenType.DM_Preproc_Punctuator, '~'); break;
-                        }
-
-                        break;
-                    }
-                    case '%': {
-                        switch (Advance()) {
-                            case '=': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "%="); break;
-                            case '%': {
-                                if (Advance() == '=') {
-                                    Advance();
-                                    token = CreateToken(TokenType.DM_Preproc_Punctuator, "%%=");
-                                    break;
-                                }
-                                token = CreateToken(TokenType.DM_Preproc_Punctuator, "%%");
-                                break;
-                            }
-                            default: token = CreateToken(TokenType.DM_Preproc_Punctuator, '%'); break;
-                        }
-
-                        break;
-                    }
-                    case '^': {
-                        switch (Advance()) {
-                            case '=': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "^="); break;
-                            default: token = CreateToken(TokenType.DM_Preproc_Punctuator, '^'); break;
-                        }
-
-                        break;
-                    }
-                    case '!': {
-                        switch (Advance()) {
-                            case '=': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "!="); break;
-                            default: token = CreateToken(TokenType.DM_Preproc_Punctuator, '!'); break;
-                        }
-
-                        break;
-                    }
-                    case '=': {
-                        switch (Advance()) {
-                            case '=': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "=="); break;
-                            default: token = CreateToken(TokenType.DM_Preproc_Punctuator, '='); break;
-                        }
-
-                        break;
-                    }
-                    case '-': {
-                        switch (Advance()) {
-                            case '-': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "--"); break;
-                            case '=': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "-="); break;
-                            default: token = CreateToken(TokenType.DM_Preproc_Punctuator, '-'); break;
-                        }
-
-                        break;
-                    }
-                    case '/': {
-                        switch (Advance()) {
-                            case '/': {
-                                do {
-                                    Advance();
-
-                                    if (GetCurrent() == '\\' && Advance() == '\n') { //Line splice within a comment
-                                        do {
-                                            Advance();
-                                        } while (GetCurrent() is ' ' or '\t' or '\n');
-                                    }
-                                } while (GetCurrent() != '\n');
-
-                                token = CreateToken(TokenType.Skip, "//");
-                                break;
-                            }
-                            case '*': {
-                                //Skip everything up to the "*/"
+                    //An escaped identifier.
+                    //The next character turns into an identifier.
+                    Advance();
+                    return CreateToken(TokenType.DM_Preproc_Identifier, c);
+                }
+                case '>': {
+                    switch (Advance()) {
+                        case '>': {
+                            if (Advance() == '=') {
                                 Advance();
-                                var comment_depth = 1;
-                                while (comment_depth > 0) {
-                                    if (GetCurrent() == '/') {
-                                        Advance();
-                                        if (GetCurrent() == '*') {
-                                            // We found another comment - up the nest count
-                                            comment_depth++;
-                                            Advance();
-                                        } else if (GetCurrent() == '/') {
-                                            // Encountered a line comment - skip to end of line
-                                            while (Advance() != '\n' && !AtEndOfSource) ;
-                                        }
-                                    } else if (GetCurrent() == '*') {
-                                        if (Advance() == '/') {
-                                            // End of comment - decrease nest count
-                                            comment_depth--;
-                                            Advance();
-                                        }
-                                    } else if (AtEndOfSource) {
-                                        return CreateToken(TokenType.Error, null, "Expected \"*/\" to end multiline comment");
-                                    } else {
-                                        Advance();
-                                    }
-                                }
 
-                                while (GetCurrent() == ' ' || GetCurrent() == '\t') {
-                                    Advance();
-                                }
-
-                                token = CreateToken(TokenType.Skip, "/* */");
-                                break;
-                            }
-                            case '=': Advance(); token = CreateToken(TokenType.DM_Preproc_Punctuator, "/="); break;
-                            default: token = CreateToken(TokenType.DM_Preproc_Punctuator, c); break;
-                        }
-
-                        break;
-                    }
-                    case '@': { //Raw string
-                        char delimiter = Advance();
-                        StringBuilder textBuilder = new StringBuilder();
-
-                        textBuilder.Append('@');
-                        textBuilder.Append(delimiter);
-
-                        bool isLong = false;
-                        c = Advance();
-                        if (delimiter == '{') {
-                            textBuilder.Append(c);
-
-                            if (c == '"') isLong = true;
-                        }
-
-                        if (isLong) {
-                            bool nextCharCanTerm = false;
-                            do {
-                                c = Advance();
-
-
-                                if(nextCharCanTerm && c == '}')
-                                    break;
-                                else {
-                                    textBuilder.Append(c);
-                                    nextCharCanTerm = false;
-                                }
-
-
-                                if (c == '"')
-                                    nextCharCanTerm = true;
-
-                            } while (!AtEndOfSource);
-                        } else {
-                            while (c != delimiter && c != '\n' && !AtEndOfSource) {
-                                textBuilder.Append(c);
-                                c = Advance();
-                            }
-                        }
-
-                        textBuilder.Append(c);
-                        Advance();
-
-                        string text = textBuilder.ToString();
-                        string value = isLong ? text.Substring(3, text.Length - 5) : text.Substring(2, text.Length - 3);
-                        token = CreateToken(TokenType.DM_Preproc_ConstantString, text, value);
-                        break;
-                    }
-                    case '\'':
-                    case '"': {
-                        token = LexString(false);
-
-                        break;
-                    }
-                    case '{': {
-                        if (Advance() == '"') {
-                            token = LexString(true);
-                        } else {
-                            token = CreateToken(TokenType.DM_Preproc_Punctuator, c);
-                        }
-
-                        break;
-                    }
-                    case '#': {
-                        bool isConcat = (Advance() == '#');
-                        if (isConcat) Advance();
-
-                        // Whitespace after '#' is ignored
-                        while (GetCurrent() is ' ' or '\t') {
-                            Advance();
-                        }
-
-                        StringBuilder textBuilder = new StringBuilder();
-                        while (char.IsAsciiLetter(GetCurrent()) || GetCurrent() == '_') {
-                            textBuilder.Append(GetCurrent());
-                            Advance();
-                        }
-
-                        string text = textBuilder.ToString();
-                        if (text == String.Empty) {
-                            token = CreateToken(TokenType.Skip, isConcat ? "##" : "#");
-                        } else if (isConcat) {
-                            token = CreateToken(TokenType.DM_Preproc_TokenConcat, $"##{text}", text);
-                        } else {
-                            if(!TryMacroKeyword(text,out token)) { // if not macro (sets it here otherwise)
-                                token = CreateToken(TokenType.DM_Preproc_ParameterStringify, $"#{text}", text);
-                                string macroAttempt = text.ToLower();
-                                if (TryMacroKeyword(macroAttempt, out _)) { // if they miscapitalized the keyword
-                                    DMCompiler.Emit(WarningCode.MiscapitalizedDirective, token.Location, $"#{text} is not a valid macro keyword. Did you mean '#{macroAttempt}'?");
-                                }
-                            }
-                        }
-
-                        break;
-                    }
-                    default: {
-                        if (char.IsAsciiLetter(c) || c == '_') {
-                            StringBuilder textBuilder = new StringBuilder(char.ToString(c));
-                            while ((char.IsAsciiLetterOrDigit(Advance()) || GetCurrent() == '_') && !AtEndOfSource) textBuilder.Append(GetCurrent());
-
-                            token = CreateToken(TokenType.DM_Preproc_Identifier, textBuilder.ToString());
-                        } else if (char.IsAsciiDigit(c)) {
-                            StringBuilder textBuilder = new StringBuilder(char.ToString(c));
-                            bool error = false;
-
-                            while (!AtEndOfSource) {
-                                char next = Advance();
-                                if ((c == 'e' || c == 'E') && (next == '-' || next == '+')) { //1e-10 or 1e+10
-                                    textBuilder.Append(next);
-                                    next = Advance();
-                                } else if (c == '#' && next == 'I') { //1.#INF and 1.#IND
-                                    if (Advance() != 'N' || Advance() != 'F' && GetCurrent() != 'D') {
-                                        error = true;
-
-                                        break;
-                                    }
-
-                                    textBuilder.Append("IN");
-                                    textBuilder.Append(GetCurrent());
-                                    next = Advance();
-                                }
-
-                                c = next;
-                                if (char.IsAsciiHexDigit(c) || c == '.' || c == 'x' || c == '#' || c == 'e' || c == 'E' || c == 'p' || c == 'P') {
-                                    textBuilder.Append(c);
-                                } else {
-                                    break;
-                                }
+                                return CreateToken(TokenType.DM_Preproc_Punctuator, ">>=");
                             }
 
-                            if (!error) token = CreateToken(TokenType.DM_Preproc_Number, textBuilder.ToString());
-                            else token = CreateToken(TokenType.Error, null, "Invalid number");
-                        } else {
-                            Advance();
-                            token = CreateToken(TokenType.Error, null, $"Unknown character: {c.ToString()}");
+                            return CreateToken(TokenType.DM_Preproc_Punctuator, ">>");
                         }
-
-                        break;
+                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, ">=");
+                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '>');
                     }
                 }
-            }
+                case '<': {
+                    switch (Advance()) {
+                        case '<': {
+                            if (Advance() == '=') {
+                                Advance();
 
-            return token;
+                                return CreateToken(TokenType.DM_Preproc_Punctuator, "<<=");
+                            }
+
+                            return CreateToken(TokenType.DM_Preproc_Punctuator, "<<");
+                        }
+                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "<=");
+                        case '>': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "<>");
+                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '<');
+                    }
+                }
+                case '|': {
+                    switch (Advance()) {
+                        case '|': {
+                            switch (Advance()) {
+                                case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "||=");
+                                default: return CreateToken(TokenType.DM_Preproc_Punctuator, "||");
+                            }
+                        }
+                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "|=");
+                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '|');
+                    }
+                }
+                case '*': {
+                    switch (Advance()) {
+                        case '*': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "**");
+                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "*=");
+                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '*');
+                    }
+                }
+                case '+': {
+                    switch (Advance()) {
+                        case '+': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "++");
+                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "+=");
+                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '+');
+                    }
+                }
+                case '&': {
+                    switch (Advance()) {
+                        case '&': {
+                            switch (Advance()) {
+                                case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "&&=");
+                                default: return CreateToken(TokenType.DM_Preproc_Punctuator, "&&");
+                            }
+                        }
+                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "&=");
+                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '&');
+                    }
+                }
+                case '~': {
+                    switch (Advance()) {
+                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "~=");
+                        case '!': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "~!");
+                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '~');
+                    }
+                }
+                case '%': {
+                    switch (Advance()) {
+                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "%=");
+                        case '%': {
+                            if (Advance() == '=') {
+                                Advance();
+                                return CreateToken(TokenType.DM_Preproc_Punctuator, "%%=");
+                            }
+
+                            return CreateToken(TokenType.DM_Preproc_Punctuator, "%%");
+                        }
+                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '%');
+                    }
+                }
+                case '^': {
+                    switch (Advance()) {
+                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "^=");
+                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '^');
+                    }
+                }
+                case '!': {
+                    switch (Advance()) {
+                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "!=");
+                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '!');
+                    }
+                }
+                case '=': {
+                    switch (Advance()) {
+                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "==");
+                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '=');
+                    }
+                }
+                case '-': {
+                    switch (Advance()) {
+                        case '-': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "--");
+                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "-=");
+                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, '-');
+                    }
+                }
+                case '/': {
+                    switch (Advance()) {
+                        case '/': {
+                            do {
+                                Advance();
+
+                                if (c == '\\') {
+                                    Advance();
+
+                                    if (AtLineEnd()) { //Line splice within a comment
+                                        do {
+                                            Advance();
+                                        } while (GetCurrent() is ' ' or '\t' || AtLineEnd());
+                                    }
+                                }
+                            } while (!AtLineEnd());
+
+                            return NextToken(ignoreWhitespace);
+                        }
+                        case '*': {
+                            //Skip everything up to the "*/"
+                            Advance();
+                            var commentDepth = 1;
+                            while (commentDepth > 0) {
+                                if (GetCurrent() == '/') {
+                                    if (Advance() == '*') {
+                                        // We found another comment - up the nest count
+                                        commentDepth++;
+                                        Advance();
+                                    } else if (GetCurrent() == '/') {
+                                        // Encountered a line comment - skip to end of line
+                                        do {
+                                            Advance();
+                                        } while (!AtLineEnd() && !AtEndOfSource());
+                                    }
+                                } else if (GetCurrent() == '*') {
+                                    if (Advance() == '/') {
+                                        // End of comment - decrease nest count
+                                        commentDepth--;
+                                        Advance();
+                                    }
+                                } else if (AtEndOfSource()) {
+                                    return CreateToken(TokenType.Error, string.Empty, "Expected \"*/\" to end multiline comment");
+                                } else {
+                                    Advance();
+                                }
+                            }
+
+                            while (GetCurrent() == ' ' || GetCurrent() == '\t') {
+                                Advance();
+                            }
+
+                            return NextToken(ignoreWhitespace);
+                        }
+                        case '=': Advance(); return CreateToken(TokenType.DM_Preproc_Punctuator, "/=");
+                        default: return CreateToken(TokenType.DM_Preproc_Punctuator, c);
+                    }
+                }
+                case '@': { //Raw string
+                    char delimiter = Advance();
+                    StringBuilder textBuilder = new StringBuilder();
+
+                    textBuilder.Append('@');
+                    textBuilder.Append(delimiter);
+
+                    bool isLong = false;
+                    c = Advance();
+                    if (delimiter == '{') {
+                        textBuilder.Append(c);
+
+                        if (c == '"') isLong = true;
+                    }
+
+                    if (isLong) {
+                        bool nextCharCanTerm = false;
+                        do {
+                            c = Advance();
+
+                            if(nextCharCanTerm && c == '}')
+                                break;
+                            else {
+                                textBuilder.Append(c);
+                                nextCharCanTerm = false;
+                            }
+
+                            if (c == '"')
+                                nextCharCanTerm = true;
+
+                        } while (!AtEndOfSource());
+                    } else {
+                        while (c != delimiter && !AtLineEnd() && !AtEndOfSource()) {
+                            textBuilder.Append(c);
+                            c = Advance();
+                        }
+                    }
+
+                    textBuilder.Append(c);
+                    Advance();
+
+                    string text = textBuilder.ToString();
+                    string value = isLong ? text.Substring(3, text.Length - 5) : text.Substring(2, text.Length - 3);
+                    return CreateToken(TokenType.DM_Preproc_ConstantString, text, value);
+                }
+                case '\'':
+                case '"':
+                    return LexString(false);
+                case '{':
+                    return Advance() == '"' ?
+                        LexString(true) :
+                        CreateToken(TokenType.DM_Preproc_Punctuator, c);
+                case '#': {
+                    bool isConcat = (Advance() == '#');
+                    if (isConcat) Advance();
+
+                    // Whitespace after '#' is ignored
+                    while (GetCurrent() is ' ' or '\t') {
+                        Advance();
+                    }
+
+                    StringBuilder textBuilder = new StringBuilder();
+                    while (char.IsAsciiLetter(GetCurrent()) || GetCurrent() == '_') {
+                        textBuilder.Append(GetCurrent());
+                        Advance();
+                    }
+
+                    string text = textBuilder.ToString();
+                    if (text == string.Empty) {
+                        return NextToken(ignoreWhitespace); // Skip this token
+                    } else if (isConcat) {
+                        return CreateToken(TokenType.DM_Preproc_TokenConcat, $"##{text}", text);
+                    }
+
+                    if (TryMacroKeyword(text, out var macroKeyword))
+                        return macroKeyword;
+
+                    string macroAttempt = text.ToLower();
+                    if (TryMacroKeyword(macroAttempt, out var attemptKeyword)) { // if they mis-capitalized the keyword
+                        DMCompiler.Emit(WarningCode.MiscapitalizedDirective, attemptKeyword.Location,
+                            $"#{text} is not a valid macro keyword. Did you mean '#{macroAttempt}'?");
+                    }
+
+                    return CreateToken(TokenType.DM_Preproc_ParameterStringify, $"#{text}", text);
+                }
+                default: {
+                    if (char.IsAsciiLetter(c) || c == '_') {
+                        StringBuilder textBuilder = new StringBuilder(char.ToString(c));
+                        while ((char.IsAsciiLetterOrDigit(Advance()) || GetCurrent() == '_') && !AtEndOfSource())
+                            textBuilder.Append(GetCurrent());
+
+                        return CreateToken(TokenType.DM_Preproc_Identifier, textBuilder.ToString());
+                    } else if (char.IsAsciiDigit(c)) {
+                        StringBuilder textBuilder = new StringBuilder(char.ToString(c));
+                        bool error = false;
+
+                        while (!AtEndOfSource()) {
+                            char next = Advance();
+                            if ((c == 'e' || c == 'E') && (next == '-' || next == '+')) { //1e-10 or 1e+10
+                                textBuilder.Append(next);
+                                next = Advance();
+                            } else if (c == '#' && next == 'I') { //1.#INF and 1.#IND
+                                if (Advance() != 'N' || Advance() != 'F' && GetCurrent() != 'D') {
+                                    error = true;
+
+                                    break;
+                                }
+
+                                textBuilder.Append("IN");
+                                textBuilder.Append(GetCurrent());
+                                next = Advance();
+                            }
+
+                            c = next;
+                            if (char.IsAsciiHexDigit(c) || c == '.' || c == 'x' || c == '#' || c == 'e' || c == 'E' || c == 'p' || c == 'P') {
+                                textBuilder.Append(c);
+                            } else {
+                                break;
+                            }
+                        }
+
+                        return error
+                            ? CreateToken(TokenType.Error, string.Empty, "Invalid number")
+                            : CreateToken(TokenType.DM_Preproc_Number, textBuilder.ToString());
+                    }
+
+                    Advance();
+                    return CreateToken(TokenType.Error, string.Empty, $"Unknown character: {c.ToString()}");
+                }
+            }
         }
 
         /// <returns>True if token was successfully set to a macro keyword token, false if not.</returns>
-        private bool TryMacroKeyword(string text, out Token token) {
+        private bool TryMacroKeyword(string text, [NotNullWhen(true)] out Token? token) {
             switch (text) {
                 case "warn":
                 case "warning": {
                     StringBuilder message = new StringBuilder();
 
-                    while (GetCurrent() is not '\0' and not '\n') {
+                    while (!AtEndOfSource() && !AtLineEnd()) {
                         message.Append(GetCurrent());
                         Advance();
                     }
 
-                    token = CreateToken(TokenType.DM_Preproc_Warning, "#warn" + message.ToString());
+                    token = CreateToken(TokenType.DM_Preproc_Warning, "#warn" + message);
                     break;
                 }
                 case "error": {
                     StringBuilder message = new StringBuilder();
 
-                    while (GetCurrent() is not '\0' and not '\n') {
+                    while (!AtEndOfSource() && !AtLineEnd()) {
                         message.Append(GetCurrent());
                         Advance();
                     }
 
-                    token = CreateToken(TokenType.DM_Preproc_Error, "#error" + message.ToString());
+                    token = CreateToken(TokenType.DM_Preproc_Error, "#error" + message);
                     break;
                 }
                 case "include": token = CreateToken(TokenType.DM_Preproc_Include, "#include"); break;
@@ -470,10 +436,10 @@ namespace DMCompiler.Compiler.DMPreprocessor {
 
 
         ///<summary>
-        /// Lexes a string <br/>
+        /// Lex a string <br/>
         ///</summary>
         ///<remarks>
-        /// If it contains string interpolations, it splits the string tokens into parts and lexes the expressions as normal <br/>
+        /// If it contains string interpolations, it splits the string tokens into parts and lex the expressions as normal <br/>
         /// For example, "There are [amount] of them" becomes: <br/>
         ///    DM_Preproc_String("There are "), DM_Preproc_Identifier(amount), DM_Preproc_String(" of them") <br/>
         /// If there is no string interpolation, it outputs a DM_Preproc_ConstantString token instead
@@ -484,7 +450,7 @@ namespace DMCompiler.Compiler.DMPreprocessor {
             Queue<Token> stringTokens = new();
 
             Advance();
-            while (!(!isLong && GetCurrent() == '\n') && !AtEndOfSource) {
+            while (!(!isLong && AtLineEnd()) && !AtEndOfSource()) {
                 char stringC = GetCurrent();
 
                 textBuilder.Append(stringC);
@@ -494,25 +460,28 @@ namespace DMCompiler.Compiler.DMPreprocessor {
 
                     Advance();
 
-                    Token exprToken = GetNextToken();
+                    Token exprToken = NextToken();
                     int bracketNesting = 0;
-                    while (!(bracketNesting == 0 && exprToken.Type == TokenType.DM_Preproc_Punctuator_RightBracket) && !AtEndOfSource) {
+                    while (!(bracketNesting == 0 && exprToken.Type == TokenType.DM_Preproc_Punctuator_RightBracket) && !AtEndOfSource()) {
                         stringTokens.Enqueue(exprToken);
 
                         if (exprToken.Type == TokenType.DM_Preproc_Punctuator_LeftBracket) bracketNesting++;
                         if (exprToken.Type == TokenType.DM_Preproc_Punctuator_RightBracket) bracketNesting--;
-                        exprToken = GetNextToken();
+                        exprToken = NextToken();
                     }
 
-                    if (exprToken.Type != TokenType.DM_Preproc_Punctuator_RightBracket) return CreateToken(TokenType.Error, null, "Expected ']' to end expression");
+                    if (exprToken.Type != TokenType.DM_Preproc_Punctuator_RightBracket)
+                        return CreateToken(TokenType.Error, string.Empty, "Expected ']' to end expression");
                     textBuilder.Append(']');
                 } else if (stringC == '\\') {
-                    if (Advance() == '\n') { //Line splice
+                    Advance();
+
+                    if (AtLineEnd()) { //Line splice
                         //Remove the '\' from textBuilder and ignore newlines & all incoming whitespace
                         textBuilder.Remove(textBuilder.Length - 1, 1);
                         do {
                             Advance();
-                        } while (GetCurrent() == '\n' || GetCurrent() == ' ' || GetCurrent() == '\t');
+                        } while (AtLineEnd() || GetCurrent() == ' ' || GetCurrent() == '\t');
                     } else {
                         textBuilder.Append(GetCurrent());
                         Advance();
@@ -534,11 +503,14 @@ namespace DMCompiler.Compiler.DMPreprocessor {
                 }
             }
 
-            Advance();
+            if (!AtEndOfSource())
+                Advance();
 
             string text = textBuilder.ToString();
-            if (!isLong && !(text.EndsWith(terminator) && text.Length != 1)) return CreateToken(TokenType.Error, null, "Expected '" + terminator + "' to end string");
-            else if (isLong && !text.EndsWith("}")) return CreateToken(TokenType.Error, null, "Expected '}' to end long string");
+            if (!isLong && !(text.EndsWith(terminator) && text.Length != 1))
+                return CreateToken(TokenType.Error, string.Empty, "Expected '" + terminator + "' to end string");
+            if (isLong && !text.EndsWith("}"))
+                return CreateToken(TokenType.Error, string.Empty, "Expected '}' to end long string");
 
             if (stringTokens.Count == 0) {
                 string stringValue = isLong ? text.Substring(2, text.Length - 4) : text.Substring(1, text.Length - 2);
@@ -551,8 +523,68 @@ namespace DMCompiler.Compiler.DMPreprocessor {
                     _pendingTokenQueue.Enqueue(stringToken);
                 }
 
-                return CreateToken(TokenType.Skip, null);
+                return _pendingTokenQueue.Dequeue();
             }
+        }
+
+        /// <summary>
+        /// Checks if the current position is at the end of a line (carriage return or newline)
+        /// </summary>
+        private bool AtLineEnd() {
+            return GetCurrent() is '\r' or '\n';
+        }
+
+        /// <summary>
+        /// Handles the end of a line by consuming all carriage returns before a newline or the absence of a newline
+        /// </summary>
+        /// <returns>True if this handled a line ending, otherwise false</returns>
+        private bool HandleLineEnd() {
+            char c = GetCurrent();
+
+            switch (c) {
+                case '\r':
+                    while (c == '\r')
+                        c = Advance();
+
+                    goto case '\n';
+                case '\n':
+                    _currentLine++;
+                    _currentColumn = 1;
+
+                    if (c == '\n') // This line could have ended with only \r
+                        Advance();
+
+                    return true;
+                default:
+                    return false; // No line ending
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private char GetCurrent() {
+            return AtEndOfSource() ? '\0' : _source[_currentIndex];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private char Advance() {
+            _currentColumn++;
+            _currentIndex++;
+            return GetCurrent();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool AtEndOfSource() {
+            return _currentIndex >= _source.Length;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private Token CreateToken(TokenType type, string text, object? value = null) {
+            return new Token(type, text, new Location(File, _currentLine, _currentColumn), value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private Token CreateToken(TokenType type, char text, object? value = null) {
+            return new Token(type, text.ToString(), new Location(File, _currentLine, _currentColumn), value);
         }
     }
 }

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorParser.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorParser.cs
@@ -1,293 +1,351 @@
 ﻿using DMCompiler.Compiler.DM;
-using DMCompiler.DM;
 using OpenDreamShared.Compiler;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-#nullable enable
-namespace DMCompiler.Compiler.DMPreprocessor {
-    /*
-     * NOTE: Some operations are (as in BYOND) not implemented for preproc expressions.
-     * This includes ternary, bitwise, and assignment.
-    Grammar: (As usual in extended BNF, {A} means 0 or more As, and [A] means an optional A. Brace characters are escaped with single-quotes.)
-    Expression ::= AndExp ['||' AndExp]
-    AndExp ::= CompExp ['&&' CompExp]
-    CompExp ::= LtGtExp [('==' | '!=') LtGtExp]
-    LtGtExp ::= AddSubExp [(‘<’ | ‘<=’ | ‘>’ | ‘>=’ | ‘==’ | ‘!=’) AddSubExp]
-    AddSubExp ::= MultExp [('+' | '-') MultExp]
-    MultExp ::= PowerExp [('*' | '/' | '%') PowerExp]
-    PowerExp ::= UnaryExp [** PowerExp]
-    UnaryExp ::= {!}SignExp
-    SignExp ::= [-]Primary
-    Primary ::= '(' Expression ')' | DefinedExp | Constant
-    DefinedExp ::= 'defined(' MacroIdentifier ')'
-    Constant ::= Integer | Float | Null
-    */
+namespace DMCompiler.Compiler.DMPreprocessor;
 
-    /// <summary>
-    /// An extremely simple parser that acts on a sliver of tokens that have been DM-lexed for evaluation in a preprocessor directive, <br/>
-    /// held separate from DMParser because of slightly different behaviour, far simpler implementation, and (<see langword="TODO"/>) possible statelessness.
-    /// </summary>
-    internal static class DMPreprocessorParser {
-        private static List<Token>? _tokens;
-        private static Dictionary<string, DMMacro>? _defines;
-        private static int _tokenIndex = 0;
-        private static readonly float DegenerateValue = 0.0f;
+/*
+ * NOTE: Some operations are (as in BYOND) not implemented for preproc expressions.
+ * This includes ternary, bitwise, and assignment.
+Grammar: (As usual in extended BNF, {A} means 0 or more As, and [A] means an optional A. Brace characters are escaped with single-quotes.)
+Expression ::= AndExp ['||' AndExp]
+AndExp ::= CompExp ['&&' CompExp]
+CompExp ::= LtGtExp [('==' | '!=') LtGtExp]
+LtGtExp ::= AddSubExp [(‘<’ | ‘<=’ | ‘>’ | ‘>=’ | ‘==’ | ‘!=’) AddSubExp]
+AddSubExp ::= MultExp [('+' | '-') MultExp]
+MultExp ::= PowerExp [('*' | '/' | '%') PowerExp]
+PowerExp ::= UnaryExp [** PowerExp]
+UnaryExp ::= {!}SignExp
+SignExp ::= [-]Primary
+Primary ::= '(' Expression ')' | DefinedExp | Constant
+DefinedExp ::= 'defined(' MacroIdentifier ')'
+Constant ::= Integer | Float | Null
+*/
 
-        /// <returns>A float, because that is the only possible thing a well-formed preproc expression can evaluate to.</returns>
-        public static float? ExpressionFromTokens(List<Token> input, Dictionary<string,DMMacro> defines) {
-            _tokens = input;
-            _defines = defines;
-            var ret = Expression();
-            _tokens = null;
-            _defines = null;
-            _tokenIndex = 0;
-            return ret;
+/// <summary>
+/// An extremely simple parser that acts on a sliver of tokens that have been DM-lexed for evaluation in a preprocessor directive, <br/>
+/// held separate from DMParser because of slightly different behaviour, far simpler implementation, and (<see langword="TODO"/>) possible statelessness.
+/// </summary>
+internal static class DMPreprocessorParser {
+    private static List<Token>? _tokens;
+    private static Dictionary<string, DMMacro>? _defines;
+    private static int _tokenIndex = 0;
+    private static readonly float DegenerateValue = 0.0f;
+
+    /// <returns>A float, because that is the only possible thing a well-formed preproc expression can evaluate to.</returns>
+    public static float? ExpressionFromTokens(List<Token> input, Dictionary<string, DMMacro> defines) {
+        _tokens = input;
+        _defines = defines;
+        var ret = Expression();
+        _tokens = null;
+        _defines = null;
+        _tokenIndex = 0;
+        return ret;
+    }
+
+    private static void Advance() {
+        ++_tokenIndex;
+    }
+
+    private static Token? Current() {
+        if (_tokenIndex >= _tokens!.Count())
+            return null;
+        return _tokens![_tokenIndex];
+    }
+
+    private static bool Check(TokenType type) {
+        if (Current()?.Type == type) {
+            Advance();
+            return true;
         }
 
-        private static void Advance() {
-            ++_tokenIndex;
-        }
-        private static Token? Current() {
-            if (_tokenIndex >= _tokens!.Count())
-                return null;
-            return _tokens![_tokenIndex];
-        }
-        private static bool Check(TokenType type) {
+        return false;
+    }
+
+    private static bool Check(TokenType[] types) {
+        foreach (TokenType type in types) {
             if (Current()?.Type == type) {
                 Advance();
                 return true;
             }
-            return false;
         }
-        private static bool Check(TokenType[] types) {
-            foreach (TokenType type in types) {
-                if (Current()?.Type == type) {
+
+        return false;
+    }
+
+    private static void Error(string msg) {
+        DMCompiler.Emit(WarningCode.BadDirective, Current()?.Location ?? Location.Unknown, msg);
+    }
+
+    private static float? Expression() {
+        return ExpressionOr();
+    }
+
+    private static float? ExpressionOr() {
+        float? a = ExpressionAnd()!.Value;
+        if (a is null) return a;
+
+        while (Check(TokenType.DM_BarBar)) {
+            float? b = ExpressionAnd();
+            if (b is null) {
+                Error("Expected a second value");
+                break;
+            }
+
+            if (a != 0f || b != 0f)
+                a = 1.0f;
+            else
+                a = 0.0f;
+        }
+
+        return a;
+    }
+
+    public static float? ExpressionAnd() {
+        float? a = ExpressionComparison()!.Value;
+        if (a is null) return a;
+
+        while (Check(TokenType.DM_AndAnd)) {
+            float? b = ExpressionComparison();
+            if (b is null) {
+                Error("Expected a second value");
+                break;
+            }
+
+            if (a != 0f && b != 0f)
+                a = 1.0f;
+            else
+                a = 0.0f;
+        }
+
+        return a;
+    }
+
+    public static float? ExpressionComparison() {
+        float? a = ExpressionComparisonLtGt();
+        if (a is null) return a;
+        for (Token? token = Current(); token != null && Check(DMParser.ComparisonTypes); token = Current()) {
+            float? b = ExpressionComparisonLtGt();
+            if (b is null) {
+                Error("Expected a second value");
+                break;
+            }
+
+            switch (token.Type) {
+                case TokenType.DM_EqualsEquals:
+                    a = (a == b ? 1.0f : 0.0f);
+                    break;
+                case TokenType.DM_ExclamationEquals:
+                    a = (a != b ? 1.0f : 0.0f);
+                    break;
+                case TokenType.DM_TildeEquals:
+                    Error("'~=' is not valid in preprocessor expressions");
+                    break;
+                case TokenType.DM_TildeExclamation:
+                    Error("'~!' is not valid in preprocessor expressions");
+                    break;
+            }
+        }
+
+        return a;
+    }
+
+    public static float? ExpressionComparisonLtGt() {
+        float? a = ExpressionAdditionSubtraction();
+        if (a is null) return a;
+        for (Token? token = Current(); token != null && Check(DMParser.LtGtComparisonTypes); token = Current()) {
+            float? b = ExpressionAdditionSubtraction();
+            if (b is null) {
+                Error("Expected a second value");
+                break;
+            }
+
+            switch (token.Type) {
+                case TokenType.DM_LessThan:
+                    a = (a < b ? 1.0f : 0.0f);
+                    break;
+                case TokenType.DM_LessThanEquals:
+                    a = (a <= b ? 1.0f : 0.0f);
+                    break;
+                case TokenType.DM_GreaterThan:
+                    a = (a > b ? 1.0f : 0.0f);
+                    break;
+                case TokenType.DM_GreaterThanEquals:
+                    a = (a >= b ? 1.0f : 0.0f);
+                    break;
+            }
+        }
+
+        return a;
+    }
+
+    public static float? ExpressionAdditionSubtraction() {
+        float? a = ExpressionMultiplicationDivisionModulus();
+        if (a is null) return a;
+        for (Token? token = Current(); token != null && Check(DMParser.PlusMinusTypes); token = Current()) {
+            float? b = ExpressionMultiplicationDivisionModulus();
+            if (b is null) {
+                Error("Expected a second value");
+                break;
+            }
+
+            switch (token.Type) {
+                case TokenType.DM_Plus:
+                    a += b;
+                    break;
+                case TokenType.DM_Minus:
+                    a -= b;
+                    break;
+            }
+        }
+
+        return a;
+    }
+
+    public static float? ExpressionMultiplicationDivisionModulus() {
+        float? a = ExpressionPower();
+        if (a is null) return a;
+        for (Token? token = Current(); token != null && Check(DMParser.MulDivModTypes); token = Current()) {
+            float? b = ExpressionPower();
+            if (b is null) {
+                Error("Expected a second value");
+                break;
+            }
+
+            switch (token.Type) {
+                case TokenType.DM_Star:
+                    a *= b;
+                    break;
+                case TokenType.DM_Slash:
+                    a /= b;
+                    break;
+                case TokenType.DM_Modulus:
+                    a %= b;
+                    break;
+            }
+        }
+
+        return a;
+    }
+
+    public static float? ExpressionPower() {
+        float? a = ExpressionUnary();
+        if (a is null) return a;
+        for (Token? token = Current(); token != null && Check(TokenType.DM_StarStar); token = Current()) {
+            float? b = ExpressionPower();
+            if (b is null) {
+                Error("Expected a second value");
+                break;
+            }
+
+            a = MathF.Pow(a.Value, b.Value);
+        }
+
+        return a;
+    }
+
+    public static float? ExpressionUnary() {
+        if (Check(TokenType.DM_Exclamation)) {
+            float? expression = ExpressionUnary();
+            if (expression == null) {
+                Error("Expected an expression");
+                return null;
+            }
+
+            return expression == 0.0f ? 1.0f : 0.0f;
+        }
+
+        return ExpressionSign();
+    }
+
+    public static float? ExpressionSign() {
+        Token? token = Current();
+
+        if (Check(DMParser.PlusMinusTypes)) {
+            float? expression = ExpressionSign();
+
+            if (expression is null) {
+                Error("Expected an expression");
+                return null;
+            }
+
+            if (token!.Type == TokenType.DM_Minus)
+                expression = -expression;
+            return expression;
+        }
+
+        return ExpressionPrimary();
+    }
+
+    public static float? ExpressionPrimary() {
+        Token? token = Current();
+        switch (token?.Type) {
+            case TokenType.DM_LeftParenthesis:
+                Advance();
+                float? inner = Expression();
+                if (!Check(TokenType.DM_RightParenthesis)) {
+                    Error("Expected ')' to close expression");
+                }
+
+                return inner;
+            case TokenType.DM_Identifier:
+                if (token.Text == "defined") {
                     Advance();
-                    return true;
-                }
-            }
-            return false;
-        }
-        private static void Error(string msg) {
-            DMCompiler.Emit(WarningCode.BadDirective, Current()?.Location ?? Location.Unknown, msg);
-        }
+                    if (!Check(TokenType.DM_LeftParenthesis)) {
+                        Error("Expected '(' to begin defined() expression");
+                        return DegenerateValue;
+                    }
 
-        private static float? Expression() {
-            return ExpressionOr();
-        }
-        private static float? ExpressionOr() {
-            float? a = ExpressionAnd()!.Value;
-            if (a is null) return a;
+                    Token? definedInner = Current();
+                    if (definedInner is null) {
+                        Error("Identifier expected for defined() expression");
+                        return DegenerateValue;
+                    }
 
-            while (Check(TokenType.DM_BarBar)) {
-                float? b = ExpressionAnd();
-                if (b is null) {
-                    Error("Expected a second value");
-                    break;
-                }
-                if (a != 0f || b != 0f)
-                    a = 1.0f;
-                else
-                    a = 0.0f;
-            }
-            return a;
-        }
-        public static float? ExpressionAnd() {
-            float? a = ExpressionComparison()!.Value;
-            if (a is null) return a;
+                    if (definedInner.Type != TokenType.DM_Identifier) {
+                        Error($"Unexpected token {definedInner.PrintableText} - identifier expected");
+                        return DegenerateValue;
+                    }
 
-            while (Check(TokenType.DM_AndAnd)) {
-                float? b = ExpressionComparison();
-                if (b is null) {
-                    Error("Expected a second value");
-                    break;
-                }
-                if (a != 0f && b != 0f)
-                    a = 1.0f;
-                else
-                    a = 0.0f;
-            }
-            return a;
-        }
-        public static float? ExpressionComparison() {
-            float? a = ExpressionComparisonLtGt();
-            if(a is null) return a;
-            for (Token? token = Current(); token != null && Check(DMParser.ComparisonTypes); token = Current()) {
-                float? b = ExpressionComparisonLtGt();
-                if (b is null) {
-                    Error("Expected a second value");
-                    break;
-                }
-                switch (token.Type) {
-                    case TokenType.DM_EqualsEquals: a = (a == b ? 1.0f : 0.0f); break;
-                    case TokenType.DM_ExclamationEquals: a = (a != b ? 1.0f : 0.0f); break;
-                    case TokenType.DM_TildeEquals: Error("'~=' is not valid in preprocessor expressions"); break;
-                    case TokenType.DM_TildeExclamation: Error("'~!' is not valid in preprocessor expressions"); break;
-                }
-            }
-
-            return a;
-        }
-        public static float? ExpressionComparisonLtGt() {
-            float? a = ExpressionAdditionSubtraction();
-            if (a is null) return a;
-            for (Token? token = Current(); token != null && Check(DMParser.LtGtComparisonTypes); token = Current()) {
-                float? b = ExpressionAdditionSubtraction();
-                if (b is null) {
-                    Error("Expected a second value");
-                    break;
-                }
-                switch (token.Type) {
-                    case TokenType.DM_LessThan: a = (a < b ? 1.0f : 0.0f); break;
-                    case TokenType.DM_LessThanEquals: a = (a <= b ? 1.0f : 0.0f); break;
-                    case TokenType.DM_GreaterThan: a = (a > b ? 1.0f : 0.0f); break;
-                    case TokenType.DM_GreaterThanEquals: a = (a >= b ? 1.0f : 0.0f); break;
-                }
-            }
-
-            return a;
-        }
-        public static float? ExpressionAdditionSubtraction() {
-            float? a = ExpressionMultiplicationDivisionModulus();
-            if (a is null) return a;
-            for (Token? token = Current(); token != null && Check(DMParser.PlusMinusTypes); token = Current()) {
-                float? b = ExpressionMultiplicationDivisionModulus();
-                if (b is null) {
-                    Error("Expected a second value");
-                    break;
-                }
-                switch (token.Type) {
-                    case TokenType.DM_Plus: a += b; break;
-                    case TokenType.DM_Minus: a -= b; break;
-                }
-            }
-
-            return a;
-        }
-        public static float? ExpressionMultiplicationDivisionModulus() {
-            float? a = ExpressionPower();
-            if (a is null) return a;
-            for (Token? token = Current(); token != null && Check(DMParser.MulDivModTypes); token = Current()) {
-                float? b = ExpressionPower();
-                if (b is null) {
-                    Error("Expected a second value");
-                    break;
-                }
-                switch (token.Type) {
-                    case TokenType.DM_Star: a *= b; break;
-                    case TokenType.DM_Slash: a /= b; break;
-                    case TokenType.DM_Modulus: a %= b; break;
-                }
-            }
-
-            return a;
-        }
-        public static float? ExpressionPower() {
-            float? a = ExpressionUnary();
-            if (a is null) return a;
-            for (Token? token = Current(); token != null && Check(TokenType.DM_StarStar); token = Current()) {
-                float? b = ExpressionPower();
-                if (b is null) {
-                    Error("Expected a second value");
-                    break;
-                }
-                a = MathF.Pow(a.Value, b.Value);
-            }
-
-            return a;
-        }
-        public static float? ExpressionUnary() {
-            if (Check(TokenType.DM_Exclamation)) {
-                float? expression = ExpressionUnary();
-                if (expression == null) {
-                    Error("Expected an expression");
-                    return null;
-                }
-
-                return expression == 0.0f ? 1.0f : 0.0f;
-            }
-            return ExpressionSign();
-        }
-        public static float? ExpressionSign() {
-            Token? token = Current();
-
-            if (Check(DMParser.PlusMinusTypes)) {
-                float? expression = ExpressionSign();
-
-                if (expression is null) {
-                    Error("Expected an expression");
-                    return null;
-                }
-                if (token!.Type == TokenType.DM_Minus)
-                    expression = -expression;
-                return expression;
-            }
-
-            return ExpressionPrimary();
-        }
-        public static float? ExpressionPrimary() {
-            Token? token = Current();
-            switch(token?.Type) {
-                case TokenType.DM_LeftParenthesis:
                     Advance();
-                    float? inner = Expression();
                     if (!Check(TokenType.DM_RightParenthesis)) {
-                        Error("Expected ')' to close expression");
+                        DMCompiler.Emit(WarningCode.DefinedMissingParen, token.Location,
+                            "Expected ')' to end defined() expression");
+                        //Electing to not return a degenerate value here since "defined(x" actually isn't an ambiguous grammar; we can figure out what they meant.
                     }
-                    return inner;
-                case TokenType.DM_Identifier:
-                    if(token.Text == "defined") {
-                        Advance();
-                        if(!Check(TokenType.DM_LeftParenthesis)) {
-                            Error("Expected '(' to begin defined() expression");
-                            return DegenerateValue;
-                        }
-                        Token? definedInner = Current();
-                        if(definedInner is null) {
-                            Error("Identifier expected for defined() expression");
-                            return DegenerateValue;
-                        }
-                        if(definedInner.Type != TokenType.DM_Identifier) {
-                            Error($"Unexpected token {definedInner.PrintableText} - identifier expected");
-                            return DegenerateValue;
-                        }
-                        Advance();
-                        if (!Check(TokenType.DM_RightParenthesis)) {
-                            DMCompiler.Emit(WarningCode.DefinedMissingParen, token.Location, "Expected ')' to end defined() expression");
-                            //Electing to not return a degenerate value here since "defined(x" actually isn't an ambiguous grammar; we can figure out what they meant.
-                        }
-                        return _defines!.ContainsKey(definedInner.Text) ? 1.0f : 0.0f;
-                    }
-                    Error($"Unexpected identifier {token.PrintableText} in preprocessor expression");
-                    return DegenerateValue;
-                default:
-                    return Constant();
-            }
-        }
-        public static float? Constant() {
-            Token? constantToken = Current();
 
-            switch (constantToken?.Type) {
-                case TokenType.DM_Integer: Advance();return (float)((int)constantToken.Value);
-                case TokenType.DM_Float: Advance(); return (float)constantToken.Value;
-                case TokenType.DM_String: {
-                    Advance();
-                    Error("Strings are not valid in preprocessor expressions. Did you mean to use a define() here?");
-                    return DegenerateValue;
+                    return _defines!.ContainsKey(definedInner.Text) ? 1.0f : 0.0f;
                 }
 
-                default: {
-                    Error($"Token not accepted in preprocessor expression: {constantToken?.PrintableText}");
-                    return DegenerateValue;
-                }
+                Error($"Unexpected identifier {token.PrintableText} in preprocessor expression");
+                return DegenerateValue;
+            default:
+                return Constant();
+        }
+    }
+
+    public static float? Constant() {
+        Token? constantToken = Current();
+
+        switch (constantToken?.Type) {
+            case TokenType.DM_Integer:
+                Advance();
+                return (float)((int)constantToken.Value);
+            case TokenType.DM_Float:
+                Advance();
+                return (float)constantToken.Value;
+            case TokenType.DM_String: {
+                Advance();
+                Error("Strings are not valid in preprocessor expressions. Did you mean to use a define() here?");
+                return DegenerateValue;
+            }
+
+            default: {
+                Error($"Token not accepted in preprocessor expression: {constantToken?.PrintableText}");
+                return DegenerateValue;
             }
         }
-
-
     }
 }
-#nullable restore

--- a/OpenDream.sln.DotSettings
+++ b/OpenDream.sln.DotSettings
@@ -25,6 +25,8 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fcopy/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=flist/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hwmode/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ifdef/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ifndef/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=isarea/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=isfile/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=isinf/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
Lines ending with just `\r` are treated as newlines.
Multiple consecutive `\r` characters are also handled now.

Also some general cleanup in the preprocessor, especially in the lexer which no longer inherits `TextLexer`

Fixes #1492