### PR TITLE
Make `world.Export()`'s returned CONTENT a resource value

### DIFF
--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
@@ -61,8 +61,9 @@ namespace OpenDreamRuntime.Procs.Native {
                 list.SetValue(new DreamValue(header.Key), new DreamValue(header.Value.First()));
             }
 
+            var content = state.ResourceManager.CreateResource(await response.Content.ReadAsByteArrayAsync());
             list.SetValue(new DreamValue("STATUS"), new DreamValue(((int) response.StatusCode).ToString()));
-            list.SetValue(new DreamValue("CONTENT"), new DreamValue(await response.Content.ReadAsStringAsync()));
+            list.SetValue(new DreamValue("CONTENT"), new DreamValue(content));
 
             return new DreamValue(list);
         }

--- a/OpenDreamRuntime/Resources/DreamResourceManager.cs
+++ b/OpenDreamRuntime/Resources/DreamResourceManager.cs
@@ -134,6 +134,18 @@ namespace OpenDreamRuntime.Resources {
         }
 
         /// <summary>
+        /// Dynamically create a new generic resource that clients can use
+        /// </summary>
+        /// <param name="data">The resource's data</param>
+        public DreamResource CreateResource(byte[] data) {
+            int resourceId = _resourceCache.Count;
+            DreamResource resource = new DreamResource(resourceId, data);
+
+            _resourceCache.Add(resource);
+            return resource;
+        }
+
+        /// <summary>
         /// Dynamically create a new icon resource that clients can use
         /// </summary>
         /// <param name="data">The resource's data</param>


### PR DESCRIPTION
Fixes #1497 