### PR TITLE
Fix incorrect usages of `RootPath`

### DIFF
--- a/OpenDreamRuntime/Procs/DllHelper.cs
+++ b/OpenDreamRuntime/Procs/DllHelper.cs
@@ -39,11 +39,9 @@ namespace OpenDreamRuntime.Procs
                 return true;
 
             // Simple load didn't pass, try next to dmb.
-            var root = resource.RootPath;
-            var fullPath = Path.Combine(root, dllName);
-            if(!File.Exists(fullPath))
-                throw new DllNotFoundException($"FFI: Unable to load {dllName}. File not found at {fullPath}");
-            return NativeLibrary.TryLoad(fullPath, out dll);
+            if(!File.Exists(dllName))
+                throw new DllNotFoundException($"FFI: Unable to load DLL {dllName}.");
+            return NativeLibrary.TryLoad(dllName, out dll);
         }
     }
 }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -721,7 +721,7 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("Path", Type = DreamValueTypeFlag.String)]
         public static DreamValue NativeProc_flist(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
             if (!bundle.GetArgument(0, "Path").TryGetValueAsString(out var path)) {
-                path = IoCManager.Resolve<DreamResourceManager>().RootPath + Path.DirectorySeparatorChar;
+                path = "./";
             }
 
             try {

--- a/OpenDreamRuntime/Resources/DreamResource.cs
+++ b/OpenDreamRuntime/Resources/DreamResource.cs
@@ -45,6 +45,9 @@ namespace OpenDreamRuntime.Resources {
         }
 
         public virtual void Output(DreamValue value) {
+            if (ResourcePath == null)
+                throw new Exception("Cannot write to resource without a path");
+
             string? text;
             if (value.IsNull) {
                 text = string.Empty;
@@ -52,10 +55,8 @@ namespace OpenDreamRuntime.Resources {
                 throw new Exception($"Invalid output operation '{ResourcePath}' << {value}");
             }
 
-            string filePath = Path.Combine(IoCManager.Resolve<DreamResourceManager>().RootPath, ResourcePath);
-
             CreateDirectory();
-            File.AppendAllText(filePath, text + "\r\n");
+            File.AppendAllText(ResourcePath, text + "\r\n");
             _resourceData = null;
         }
 

--- a/OpenDreamRuntime/Resources/DreamResourceManager.cs
+++ b/OpenDreamRuntime/Resources/DreamResourceManager.cs
@@ -49,7 +49,7 @@ namespace OpenDreamRuntime.Resources {
         }
 
         public bool DoesFileExist(string resourcePath) {
-            return File.Exists(Path.Combine(RootPath, resourcePath));
+            return File.Exists(resourcePath);
         }
 
         public DreamResource LoadResource(string resourcePath) {
@@ -58,14 +58,13 @@ namespace OpenDreamRuntime.Resources {
             if (_resourcePathToId.TryGetValue(resourcePath, out int resourceId)) {
                 resource = _resourceCache[resourceId];
             } else {
-                var filePath = Path.Combine(RootPath, resourcePath);
                 resourceId = _resourceCache.Count;
 
                 // Create a new type of resource based on its extension
                 switch (Path.GetExtension(resourcePath)) {
                     case ".dmi":
                     case ".png":
-                        resource = new IconResource(resourceId, filePath, resourcePath);
+                        resource = new IconResource(resourceId, resourcePath, resourcePath);
                         break;
                     case ".jpg":
                     case ".rsi": // RT-specific, not in BYOND
@@ -75,7 +74,7 @@ namespace OpenDreamRuntime.Resources {
                         goto default;
 
                     default:
-                        resource = new DreamResource(resourceId, filePath, resourcePath);
+                        resource = new DreamResource(resourceId, resourcePath, resourcePath);
                         break;
                 }
 
@@ -160,7 +159,7 @@ namespace OpenDreamRuntime.Resources {
 
         public bool DeleteFile(string filePath) {
             try {
-                File.Delete(Path.Combine(RootPath, filePath));
+                File.Delete(filePath);
             } catch (Exception) {
                 return false;
             }
@@ -170,7 +169,7 @@ namespace OpenDreamRuntime.Resources {
 
         public bool DeleteDirectory(string directoryPath) {
             try {
-                Directory.Delete(Path.Combine(RootPath, directoryPath), true);
+                Directory.Delete(directoryPath, true);
             } catch (Exception) {
                 return false;
             }
@@ -180,9 +179,8 @@ namespace OpenDreamRuntime.Resources {
 
         public bool SaveTextToFile(string filePath, string text) {
             try {
-                string absoluteFilePath = Path.Combine(RootPath, filePath);
-                Directory.GetParent(absoluteFilePath)?.Create();
-                File.WriteAllText(absoluteFilePath, text);
+                Directory.GetParent(filePath)?.Create();
+                File.WriteAllText(filePath, text);
             } catch (Exception) {
                 return false;
             }
@@ -192,15 +190,14 @@ namespace OpenDreamRuntime.Resources {
 
         public bool CopyFile(DreamResource sourceFile, string destinationFilePath) {
             try {
-                var dest = Path.Combine(RootPath, destinationFilePath);
-                var dir = Path.GetDirectoryName(dest);
+                var dir = Path.GetDirectoryName(destinationFilePath);
                 if (dir != null)
                     Directory.CreateDirectory(dir);
 
                 if (sourceFile.ResourceData == null)
-                    File.WriteAllText(string.Empty, dest);
+                    File.WriteAllText(string.Empty, destinationFilePath);
                 else
-                    File.WriteAllBytes(dest, sourceFile.ResourceData);
+                    File.WriteAllBytes(destinationFilePath, sourceFile.ResourceData);
             } catch (Exception) {
                 return false;
             }
@@ -209,7 +206,7 @@ namespace OpenDreamRuntime.Resources {
         }
 
         public string[] EnumerateListing(string path) {
-            string directory = Path.Combine(RootPath, Path.GetDirectoryName(path));
+            string directory = Path.GetDirectoryName(path);
             string searchPattern = Path.GetFileName(path);
 
             var entries = Directory.GetFileSystemEntries(directory, searchPattern);


### PR DESCRIPTION
Combining `RootPath` with every file operation was necessary before we set our CWD to the game's directory, but not anymore. This fixes problems that arise when you give OpenDreamServer a relative path to the json.