### PR TITLE
Set default port to 1212

### DIFF
--- a/OpenDreamClient/States/MainMenu/MainMenuControl.xaml
+++ b/OpenDreamClient/States/MainMenu/MainMenuControl.xaml
@@ -21,7 +21,7 @@
                                   SeparationOverride="4">
                         <Label Text="Address: " FontColorOverride="#FFFFFF"/>
                         <LineEdit Name="AddressBoxProtected"
-                                  PlaceHolder="127.0.0.1:25566"
+                                  PlaceHolder="127.0.0.1:1212"
                                   HorizontalExpand="True" />
                     </BoxContainer>
                     <Control MinSize="0 2" />

--- a/OpenDreamClient/States/MainMenu/MainMenuControl.xaml.cs
+++ b/OpenDreamClient/States/MainMenu/MainMenuControl.xaml.cs
@@ -34,7 +34,7 @@ public sealed partial class MainMenuControl : Control {
         var currentUserName = configMan.GetCVar(CVars.PlayerName);
         UserNameBox.Text = currentUserName;
 
-        AddressBoxProtected.Text = "127.0.0.1:25566";
+        AddressBoxProtected.Text = "127.0.0.1:1212";
 
 #if DEBUG
         DebugWarningLabel.Visible = true;

--- a/OpenDreamServer/Program.cs
+++ b/OpenDreamServer/Program.cs
@@ -2,10 +2,10 @@
 
 namespace OpenDreamServer;
 
-internal sealed class Program {
+internal static class Program {
     private static void Main(string[] args) {
         ContentStart.StartLibrary(args, new ServerOptions {
-            ContentModulePrefix = "OpenDream",
+            ContentModulePrefix = "OpenDream"
         });
     }
 }


### PR DESCRIPTION
The removal of `server_config.toml` in #1502 ended up changing the default server port from 25566 to 1212. I can't find another way to change the default port, and re-adding the file introduces issues with `dotnet publish` so I'm taking the path of least resistance and changing the default port on the client to 1212.