### PR TITLE
Create global.json to lock .NET version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "7.0.0",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
This fixes builds failing when .NET 8 is installed.