### PR TITLE
Fix an error on the client upon reconnect

### DIFF
--- a/OpenDreamClient/Input/MouseInputSystem.cs
+++ b/OpenDreamClient/Input/MouseInputSystem.cs
@@ -18,7 +18,7 @@ namespace OpenDreamClient.Input {
         [Dependency] private readonly IMapManager _mapManager = default!;
         [Dependency] private readonly IOverlayManager _overlayManager = default!;
         [Dependency] private readonly EntityLookupSystem _lookupSystem = default!;
-        [Dependency] private IEntityManager _entityManager = default!;
+        [Dependency] private readonly IEntityManager _entityManager = default!;
 
         private DreamViewOverlay? _dreamViewOverlay;
         private ContextMenuPopup _contextMenu = default!;

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -77,6 +77,8 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
     private ViewRange _view = new(5);
 
     public void LoadInterfaceFromSource(string source) {
+        Reset();
+
         DMFLexer dmfLexer = new DMFLexer("interface.dmf", source);
         DMFParser dmfParser = new DMFParser(dmfLexer, _serializationManager);
 
@@ -110,14 +112,6 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
     }
 
     public void Initialize() {
-        _userInterfaceManager.MainViewport.Visible = false;
-
-        AvailableVerbs = Array.Empty<(string, string, string)>();
-        Windows.Clear();
-        Menus.Clear();
-        MacroSets.Clear();
-        _popupWindows.Clear();
-
         // Set up the middle-mouse button keybind
         _inputManager.Contexts.GetContext("common").AddFunction(OpenDreamKeyFunctions.MouseMiddle);
         _inputManager.RegisterBinding(new KeyBindingRegistration() {
@@ -645,6 +639,16 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
         if(elementDescriptor is WindowDescriptor && Windows.TryGetValue(cloneId, out var window)){
             window.CreateChildControls();
         }
+    }
+
+    private void Reset() {
+        _userInterfaceManager.MainViewport.Visible = false;
+
+        AvailableVerbs = Array.Empty<(string, string, string)>();
+        Windows.Clear();
+        Menus.Clear();
+        MacroSets.Clear();
+        _popupWindows.Clear();
     }
 
     private void LoadInterface(InterfaceDescriptor descriptor) {


### PR DESCRIPTION
Properly resets the interface before attempting to load a new one. This fixes an error that would leave the client in a broken state when reconnecting without restarting the client.