### PR TITLE
Add support for tmp savefiles, fix multiple handles for savefiles, clean up

### DIFF
--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -98,7 +98,7 @@ namespace OpenDreamRuntime {
             _procScheduler.Process();
             UpdateStat();
             _dreamMapManager.UpdateTiles();
-
+            DreamObjectSavefile.FlushAllUpdates();
             WorldInstance.SetVariableValue("cpu", WorldInstance.GetVariable("tick_usage"));
         }
 

--- a/OpenDreamRuntime/EntryPoint.cs
+++ b/OpenDreamRuntime/EntryPoint.cs
@@ -72,7 +72,7 @@ namespace OpenDreamRuntime {
 
         protected override void Dispose(bool disposing) {
             // Write every savefile to disk
-            foreach (var savefile in DreamObjectSavefile.Savefiles) {
+            foreach (var savefile in DreamObjectSavefile.Savefiles.ToArray()) { //ToArray() to avoid modifying the collection while iterating over it
                 savefile.Close();
             }
 

--- a/OpenDreamRuntime/EntryPoint.cs
+++ b/OpenDreamRuntime/EntryPoint.cs
@@ -73,7 +73,7 @@ namespace OpenDreamRuntime {
         protected override void Dispose(bool disposing) {
             // Write every savefile to disk
             foreach (var savefile in DreamObjectSavefile.Savefiles) {
-                savefile.Flush();
+                savefile.Close();
             }
 
             _dreamManager.Shutdown();

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -12,7 +12,6 @@ using Robust.Server.Player;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Utility;
-using System.Runtime.Serialization;
 
 namespace OpenDreamRuntime.Objects {
     [Virtual]

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -12,6 +12,7 @@ using Robust.Server.Player;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Utility;
+using System.Runtime.Serialization;
 
 namespace OpenDreamRuntime.Objects {
     [Virtual]

--- a/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.IO;
+using System.Text.Json;
 using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
@@ -9,14 +10,31 @@ public sealed class DreamObjectSavefile : DreamObject {
     public sealed class SavefileDirectory : Dictionary<string, DreamValue> { }
 
     public static readonly List<DreamObjectSavefile> Savefiles = new();
+    //basically a global database of savefile contents, which each savefile datum points to - this preserves state between savefiles and reduces memory usage
+    private static readonly Dictionary<string, Dictionary<string, SavefileDirectory>> SavefileDirectories = new();
+    private static readonly HashSet<DreamObjectSavefile> _savefilesToFlush = new();
 
     public override bool ShouldCallNew => false;
 
     public DreamResource Resource;
-    public Dictionary<string, SavefileDirectory> Directories;
+    public Dictionary<string, SavefileDirectory> Directories => SavefileDirectories[Resource.ResourcePath ?? ""];
     public SavefileDirectory CurrentDir => Directories[_currentDirPath];
 
     private string _currentDirPath = "/";
+
+    //Temporary savefiles should be deleted when the DreamObjectSavefile is deleted. Temporary savefiles can be created by creating a new savefile datum with a null filename or an entry in the world's resource cache
+    private bool _isTemporary = false;
+
+
+    /// <summary>
+    /// Flushes all savefiles that have been marked as needing flushing. Basically just used to call Flush() between ticks instead of on every write.
+    /// </summary>
+    public static void FlushAllUpdates() {
+        foreach (DreamObjectSavefile savefile in _savefilesToFlush) {
+            savefile.Flush();
+        }
+        _savefilesToFlush.Clear();
+    }
 
     public DreamObjectSavefile(DreamObjectDefinition objectDefinition) : base(objectDefinition) {
 
@@ -25,32 +43,60 @@ public sealed class DreamObjectSavefile : DreamObject {
     public override void Initialize(DreamProcArguments args) {
         base.Initialize(args);
 
-        string filename = args.GetArgument(0).GetValueAsString();
+        args.GetArgument(0).TryGetValueAsString(out string? filename);
         DreamValue timeout = args.GetArgument(1); //TODO: timeout
+
+        if (string.IsNullOrEmpty(filename)) {
+            _isTemporary = true;
+            filename = Path.GetTempPath() + "tmp_opendream_savefile_" + System.DateTime.Now.Ticks.ToString();
+        }
 
         Resource = DreamResourceManager.LoadResource(filename);
 
-        string? data = Resource.ReadAsString();
-        if (!string.IsNullOrEmpty(data)) {
-            Directories = JsonSerializer.Deserialize<Dictionary<string, SavefileDirectory>>(data);
-        } else {
-            Directories = new() {
-                { "/", new SavefileDirectory() }
-            };
+        if(!SavefileDirectories.ContainsKey(filename))
+        {
+            //if the savefile hasn't already been loaded, load it or create it
+            string? data = Resource.ReadAsString();
+
+            if (!string.IsNullOrEmpty(data)) {
+                SavefileDirectories.Add(filename, JsonSerializer.Deserialize<Dictionary<string, SavefileDirectory>>(data));
+            } else {
+                 SavefileDirectories.Add(filename, new() {
+                    { "/", new SavefileDirectory() }
+                });
+                //create the file immediately
+                Flush();
+            }
         }
 
         Savefiles.Add(this);
     }
 
     protected override void HandleDeletion() {
-        Savefiles.Remove(this);
-
+        Close();
         base.HandleDeletion();
     }
 
     public void Flush() {
         Resource.Clear();
         Resource.Output(new DreamValue(JsonSerializer.Serialize(Directories)));
+    }
+
+    public void Close() {
+        Flush();
+        if (_isTemporary && Resource.ResourcePath != null) {
+            File.Delete(Resource.ResourcePath);
+        }
+        //check to see if the file is still in use by another savefile datum
+        if(Resource.ResourcePath != null) {
+            bool fineToDelete = true;
+            foreach (var savefile in Savefiles)
+                if (savefile != this && savefile.Resource.ResourcePath == Resource.ResourcePath)
+                    fineToDelete = false;
+            if (fineToDelete)
+                SavefileDirectories.Remove(Resource.ResourcePath);
+        }
+        Savefiles.Remove(this);
     }
 
     protected override bool TryGetVar(string varName, out DreamValue value) {
@@ -113,6 +159,7 @@ public sealed class DreamObjectSavefile : DreamObject {
             throw new Exception($"Invalid savefile index {index}");
 
         CurrentDir[entryName] = value;
+        _savefilesToFlush.Add(this); //mark this as needing flushing
     }
 
     private void ChangeDirectory(string path) {

--- a/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
@@ -30,8 +30,13 @@ public sealed class DreamObjectSavefile : DreamObject {
     /// Flushes all savefiles that have been marked as needing flushing. Basically just used to call Flush() between ticks instead of on every write.
     /// </summary>
     public static void FlushAllUpdates() {
+        var _sawmill = Logger.GetSawmill("opendream.res");
         foreach (DreamObjectSavefile savefile in _savefilesToFlush) {
-            savefile.Flush();
+            try {
+                savefile.Flush();
+            } catch (Exception e) {
+                _sawmill.Error($"Error flushing savefile {savefile.Resource.ResourcePath}: {e}");
+            }
         }
         _savefilesToFlush.Clear();
     }

--- a/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
@@ -25,12 +25,12 @@ public sealed class DreamObjectSavefile : DreamObject {
     //Temporary savefiles should be deleted when the DreamObjectSavefile is deleted. Temporary savefiles can be created by creating a new savefile datum with a null filename or an entry in the world's resource cache
     private bool _isTemporary = false;
 
-
+    private static ISawmill? _sawmill = null;
     /// <summary>
     /// Flushes all savefiles that have been marked as needing flushing. Basically just used to call Flush() between ticks instead of on every write.
     /// </summary>
     public static void FlushAllUpdates() {
-        var _sawmill = Logger.GetSawmill("opendream.res");
+        _sawmill ??= Logger.GetSawmill("opendream.res");
         foreach (DreamObjectSavefile savefile in _savefilesToFlush) {
             try {
                 savefile.Flush();
@@ -153,7 +153,7 @@ public sealed class DreamObjectSavefile : DreamObject {
             throw new Exception($"Invalid savefile index {index}");
 
         if (CurrentDir.TryGetValue(entryName, out DreamValue entry)) {
-            return entry;
+            return entry; //TODO: This should be something like value.DMProc("Read", new DreamProcArguments(this)) for DreamObjects and a copy for everything else
         } else {
             return DreamValue.Null;
         }
@@ -163,7 +163,7 @@ public sealed class DreamObjectSavefile : DreamObject {
         if (!index.TryGetValueAsString(out string? entryName))
             throw new Exception($"Invalid savefile index {index}");
 
-        CurrentDir[entryName] = value;
+        CurrentDir[entryName] = value; //TODO: This should be something like value.DMProc("Write", new DreamProcArguments(this)) for DreamObjects and a copy for everything else
         _savefilesToFlush.Add(this); //mark this as needing flushing
     }
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
@@ -58,8 +58,7 @@ public sealed class DreamObjectSavefile : DreamObject {
 
         Resource = DreamResourceManager.LoadResource(filename);
 
-        if(!SavefileDirectories.ContainsKey(filename))
-        {
+        if(!SavefileDirectories.ContainsKey(filename)) {
             //if the savefile hasn't already been loaded, load it or create it
             string? data = Resource.ReadAsString();
 
@@ -96,8 +95,10 @@ public sealed class DreamObjectSavefile : DreamObject {
         if(Resource.ResourcePath != null) {
             bool fineToDelete = true;
             foreach (var savefile in Savefiles)
-                if (savefile != this && savefile.Resource.ResourcePath == Resource.ResourcePath)
+                if (savefile != this && savefile.Resource.ResourcePath == Resource.ResourcePath) {
                     fineToDelete = false;
+                    break;
+                }
             if (fineToDelete)
                 SavefileDirectories.Remove(Resource.ResourcePath);
         }


### PR DESCRIPTION
Adds support for temporary savefiles (fixes #1449)
Allows multiple savefile datums pointing at the same file to remain synchronised
Reduces memory usage by reducing duplication of savefiles and closing resources when they're no longer in use
Moves savefile flushing to be between ticks, except when `flush()` is called manually.