### PR TITLE
Fix nullable warnings in DAP definitions

### DIFF
--- a/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
@@ -720,8 +720,7 @@ internal sealed class DreamDebugManager : IDreamDebugManager {
     }
 
     private Variable DescribeValue(string name, DreamValue value) {
-        var varDesc = new Variable { Name = name };
-        varDesc.Value = value.ToString();
+        var varDesc = new Variable { Name = name, Value = value.ToString() };
         if (value.TryGetValueAsDreamList(out var list)) {
             if (list.GetLength() > 0) {
                 varDesc.VariablesReference = AllocVariableRef(req => ExpandList(req, list));

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/Capabilities.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/Capabilities.cs
@@ -78,11 +78,13 @@ public sealed class Capabilities {
      */
     [JsonPropertyName("supportsModulesRequest")] public bool? SupportsModulesRequest { get; set; }
 
+    /*
     /**
      * The set of additional module information exposed by the debug adapter.
      */
     //[JsonPropertyName("additionalModuleColumns")] public ColumnDescriptor[]? AdditionalModuleColumns { get; set; }
 
+    /*
     /**
      * Checksum algorithms supported by the debug adapter.
      */

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/Checksum.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/Checksum.cs
@@ -1,8 +1,10 @@
 ﻿using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class Checksum {
-    [JsonPropertyName("algorithm")] public string Algorithm { get; set; }
-    [JsonPropertyName("checksum")] public string ChecksumValue { get; set; }
+    [JsonPropertyName("algorithm")] public required string Algorithm { get; set; }
+    [JsonPropertyName("checksum")] public required string ChecksumValue { get; set; }
 }

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/DisassembledInstruction.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/DisassembledInstruction.cs
@@ -7,7 +7,7 @@ public sealed class DisassembledInstruction {
      * The address of the instruction. Treated as a hex value if prefixed with
      * `0x`, or as a decimal value otherwise.
      */
-    [JsonPropertyName("address")] public string Address { get; set; }
+    [JsonPropertyName("address")] public required string Address { get; set; }
 
     /**
      * Raw bytes representing the instruction and its operands, in an
@@ -19,7 +19,7 @@ public sealed class DisassembledInstruction {
      * Text representing the instruction and its operands, in an
      * implementation-defined format.
      */
-    [JsonPropertyName("instruction")] public string Instruction { get; set; }
+    [JsonPropertyName("instruction")] public required string Instruction { get; set; }
 
     /**
      * Name of the symbol that corresponds with the location of this instruction,

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/ExceptionBreakMode.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/ExceptionBreakMode.cs
@@ -1,8 +1,0 @@
-namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
-
-public enum ExceptionBreakMode {
-    Never,
-    Always,
-    Unhandled,
-    UserUnhandled,
-}

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/ExceptionDetails.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/ExceptionDetails.cs
@@ -1,7 +1,9 @@
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class ExceptionDetails {
     /**
      * Message contained in the exception.

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/FunctionBreakpoint.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/FunctionBreakpoint.cs
@@ -1,9 +1,11 @@
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class FunctionBreakpoint {
-    [JsonPropertyName("name")] public string Name { get; set; }
+    [JsonPropertyName("name")] public required string Name { get; set; }
     [JsonPropertyName("condition")] public string? Condition { get; set; }
     [JsonPropertyName("hitCondition")] public string? HitCondition { get; set; }
 }

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/ProtocolMessage.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/ProtocolMessage.cs
@@ -5,9 +5,7 @@ namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 [Virtual]
 public class ProtocolMessage {
     [JsonPropertyName("seq")] public int Seq { get; set; }
-    [JsonPropertyName("type")] public string Type { get; set; }
-
-    public ProtocolMessage() { }
+    [JsonPropertyName("type")] public string Type { get; }
 
     protected ProtocolMessage(string type) {
         Type = type;

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/Request.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/Request.cs
@@ -5,9 +5,9 @@ namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
 [Virtual]
 public class Request : ProtocolMessage {
-    [JsonPropertyName("command")] public string Command { get; set; }
+    [JsonPropertyName("command")] public required string Command { get; set; }
 
-    public Request() : base("request") { }
+    protected Request() : base("request") { }
 
     public static Request? DeserializeRequest(JsonDocument json) {
         Request? request = json.Deserialize<Request>();

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestConfigurationDone.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestConfigurationDone.cs
@@ -1,5 +1,8 @@
+using JetBrains.Annotations;
+
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class RequestConfigurationDone : Request {
     public void Respond(DebugAdapterClient client) {
         client.SendMessage(Response.NewSuccess(this));

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestContinue.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestContinue.cs
@@ -1,10 +1,13 @@
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class RequestContinue : Request {
-    [JsonPropertyName("arguments")] public RequestContinueArguments Arguments { get; set; }
+    [JsonPropertyName("arguments")] public required RequestContinueArguments Arguments { get; set; }
 
+    [UsedImplicitly]
     public sealed class RequestContinueArguments {
         /**
          * Specifies the active thread. If the debug adapter supports single thread

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestDisassemble.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestDisassemble.cs
@@ -1,16 +1,19 @@
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class RequestDisassemble : Request {
-    [JsonPropertyName("arguments")] public RequestDisassembleArguments Arguments { get; set; }
+    [JsonPropertyName("arguments")] public required RequestDisassembleArguments Arguments { get; set; }
 
+    [UsedImplicitly]
     public sealed class RequestDisassembleArguments {
         /**
          * Memory reference to the base location containing the instructions to
          * disassemble.
          */
-        [JsonPropertyName("memoryReference")] public string MemoryReference { get; set; }
+        [JsonPropertyName("memoryReference")] public required string MemoryReference { get; set; }
 
         /**
          * Offset (in bytes) to be applied to the reference location before

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestDisconnect.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestDisconnect.cs
@@ -1,10 +1,13 @@
 ﻿using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class RequestDisconnect : Request {
-    [JsonPropertyName("arguments")] public RequestDisconnectArguments Arguments { get; set; }
+    [JsonPropertyName("arguments")] public required RequestDisconnectArguments Arguments { get; set; }
 
+    [UsedImplicitly]
     public sealed class RequestDisconnectArguments {
         [JsonPropertyName("restart")] public bool Restart { get; set; }
         [JsonPropertyName("terminateDebuggee")] public bool TerminateDebuggee { get; set; }

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestExceptionInfo.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestExceptionInfo.cs
@@ -1,10 +1,13 @@
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class RequestExceptionInfo : Request {
-    [JsonPropertyName("arguments")] public RequestExceptionInfoArguments Arguments { get; set; }
+    [JsonPropertyName("arguments")] public required RequestExceptionInfoArguments Arguments { get; set; }
 
+    [UsedImplicitly]
     public sealed class RequestExceptionInfoArguments {
         /**
          * Thread for which exception information should be retrieved.
@@ -16,7 +19,7 @@ public sealed class RequestExceptionInfo : Request {
         /**
          * ID of the exception that was thrown.
          */
-        [JsonPropertyName("exceptionId")] public string ExceptionId { get; set; }
+        [JsonPropertyName("exceptionId")] public required string ExceptionId { get; set; }
 
         /**
          * Descriptive text for the exception.
@@ -26,7 +29,7 @@ public sealed class RequestExceptionInfo : Request {
         /**
          * Mode that caused the exception notification to be raised.
          */
-        [JsonPropertyName("breakMode")] public string BreakMode { get; set; }
+        [JsonPropertyName("breakMode")] public required string BreakMode { get; set; }
         // enum ExceptionBreakMode, no custom values
         public const string BreakModeNever = "never";
         public const string BreakModeAlways = "always";

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestInitialize.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestInitialize.cs
@@ -1,14 +1,17 @@
 ﻿using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class RequestInitialize : Request {
-    [JsonPropertyName("arguments")] public RequestInitializeArguments Arguments { get; set; }
+    [JsonPropertyName("arguments")] public required RequestInitializeArguments Arguments { get; set; }
 
+    [UsedImplicitly]
     public sealed class RequestInitializeArguments {
         [JsonPropertyName("clientID")] public string? ClientId { get; set; }
         [JsonPropertyName("clientName")] public string? ClientName { get; set; }
-        [JsonPropertyName("adapterID")] public string AdapterId { get; set; }
+        [JsonPropertyName("adapterID")] public required string AdapterId { get; set; }
         [JsonPropertyName("locale")] public string? Locale { get; set; }
         [JsonPropertyName("linesStartAt1")] public bool LinesStartAt1 { get; set; } = true;
         [JsonPropertyName("columnsStartAt1")] public bool ColumnsStartAt1 { get; set; } = true;

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestLaunch.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestLaunch.cs
@@ -1,10 +1,13 @@
 ﻿using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class RequestLaunch : Request {
-    [JsonPropertyName("arguments")] public RequestLaunchArguments Arguments { get; set; }
+    [JsonPropertyName("arguments")] public required RequestLaunchArguments Arguments { get; set; }
 
+    [UsedImplicitly]
     public sealed class RequestLaunchArguments {
         [JsonPropertyName("noDebug")] public bool NoDebug { get; set; }
         [JsonPropertyName("__restart")] public object? RestartData { get; set; }

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestNext.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestNext.cs
@@ -1,10 +1,13 @@
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class RequestNext : Request {
-    [JsonPropertyName("arguments")] public RequestNextArguments Arguments { get; set; }
+    [JsonPropertyName("arguments")] public required RequestNextArguments Arguments { get; set; }
 
+    [UsedImplicitly]
     public sealed class RequestNextArguments {
         /**
          * Specifies the thread for which to resume execution for one step (of the

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestPause.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestPause.cs
@@ -1,10 +1,13 @@
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class RequestPause : Request {
-    [JsonPropertyName("arguments")] public RequestPauseArguments Arguments { get; set; }
+    [JsonPropertyName("arguments")] public required RequestPauseArguments Arguments { get; set; }
 
+    [UsedImplicitly]
     public sealed class RequestPauseArguments {
         /**
          * Pause execution for this thread.

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestScopes.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestScopes.cs
@@ -1,10 +1,13 @@
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class RequestScopes : Request {
-    [JsonPropertyName("arguments")] public RequestScopesArguments Arguments { get; set; }
+    [JsonPropertyName("arguments")] public required RequestScopesArguments Arguments { get; set; }
 
+    [UsedImplicitly]
     public sealed class RequestScopesArguments {
         /**
          * Retrieve the scopes for this stackframe.

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestSetBreakpoints.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestSetBreakpoints.cs
@@ -1,12 +1,15 @@
 ﻿using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class RequestSetBreakpoints : Request {
-    [JsonPropertyName("arguments")] public RequestSetBreakpointsArguments Arguments { get; set; }
+    [JsonPropertyName("arguments")] public required RequestSetBreakpointsArguments Arguments { get; set; }
 
+    [UsedImplicitly]
     public sealed class RequestSetBreakpointsArguments {
-        [JsonPropertyName("source")] public Source Source { get; set; }
+        [JsonPropertyName("source")] public required Source Source { get; set; }
         [JsonPropertyName("breakpoints")] public SourceBreakpoint[]? Breakpoints { get; set; }
         [JsonPropertyName("sourceModified")] public bool SourceModified { get; set; }
     }

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestSetExceptionBreakpoints.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestSetExceptionBreakpoints.cs
@@ -1,18 +1,22 @@
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class RequestSetExceptionBreakpoints : Request {
-    [JsonPropertyName("arguments")] public RequestSetExceptionBreakpointsArguments Arguments { get; set; }
+    [JsonPropertyName("arguments")] public required RequestSetExceptionBreakpointsArguments Arguments { get; set; }
 
+    [UsedImplicitly]
     public sealed class RequestSetExceptionBreakpointsArguments {
         /**
          * Set of exception filters specified by their ID. The set of all possible
          * exception filters is defined by the `exceptionBreakpointFilters`
          * capability. The `filter` and `filterOptions` sets are additive.
          */
-        [JsonPropertyName("filters")] public string[] Filters { get; set; }
+        [JsonPropertyName("filters")] public required string[] Filters { get; set; }
 
+        /*
         /**
          * Set of exception filters and their options. The set of all possible
          * exception filters is defined by the `exceptionBreakpointFilters`
@@ -22,6 +26,7 @@ public sealed class RequestSetExceptionBreakpoints : Request {
          */
         //[JsonPropertyName("filterOptions")] public ExceptionFilterOptions[]? FilterOptions { get; set; }
 
+        /*
         /**
          * Configuration options for selected exceptions.
          * The attribute is only honored by a debug adapter if the corresponding

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestSetFunctionBreakpoints.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestSetFunctionBreakpoints.cs
@@ -1,12 +1,15 @@
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class RequestSetFunctionBreakpoints : Request {
-    [JsonPropertyName("arguments")] public RequestSetBreakpointsArguments Arguments { get; set; }
+    [JsonPropertyName("arguments")] public required RequestSetBreakpointsArguments Arguments { get; set; }
 
+    [UsedImplicitly]
     public sealed class RequestSetBreakpointsArguments {
-        [JsonPropertyName("breakpoints")] public FunctionBreakpoint[] Breakpoints { get; set; }
+        [JsonPropertyName("breakpoints")] public required FunctionBreakpoint[] Breakpoints { get; set; }
     }
 
     public void Respond(DebugAdapterClient client, Breakpoint[] breakpoints) {

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestStackTrace.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestStackTrace.cs
@@ -1,10 +1,13 @@
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class RequestStackTrace : Request {
-    [JsonPropertyName("arguments")] public RequestSetBreakpointsArguments Arguments { get; set; }
+    [JsonPropertyName("arguments")] public required RequestSetBreakpointsArguments Arguments { get; set; }
 
+    [UsedImplicitly]
     public sealed class RequestSetBreakpointsArguments {
         /**
          * Retrieve the stacktrace for this thread.

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestStepIn.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestStepIn.cs
@@ -1,10 +1,13 @@
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class RequestStepIn : Request {
-    [JsonPropertyName("arguments")] public RequestStepInArguments Arguments { get; set; }
+    [JsonPropertyName("arguments")] public required RequestStepInArguments Arguments { get; set; }
 
+    [UsedImplicitly]
     public sealed class RequestStepInArguments {
         /**
          * Specifies the thread for which to resume execution for one step-into (of

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestStepOut.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestStepOut.cs
@@ -1,10 +1,13 @@
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class RequestStepOut : Request {
-    [JsonPropertyName("arguments")] public RequestStepOutArguments Arguments { get; set; }
+    [JsonPropertyName("arguments")] public required RequestStepOutArguments Arguments { get; set; }
 
+    [UsedImplicitly]
     public sealed class RequestStepOutArguments {
         /**
          * Specifies the thread for which to resume execution for one step (of the

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestThreads.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestThreads.cs
@@ -1,5 +1,8 @@
+using JetBrains.Annotations;
+
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class RequestThreads : Request {
     public void Respond(DebugAdapterClient client, IEnumerable<Thread> threads) {
         client.SendMessage(Response.NewSuccess(this, new { threads }));

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestVariables.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestVariables.cs
@@ -1,10 +1,13 @@
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class RequestVariables : Request {
-    [JsonPropertyName("arguments")] public RequestVariablesArguments Arguments { get; set; }
+    [JsonPropertyName("arguments")] public required RequestVariablesArguments Arguments { get; set; }
 
+    [UsedImplicitly]
     public sealed class RequestVariablesArguments {
         /**
          * The Variable reference.

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/Scope.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/Scope.cs
@@ -7,7 +7,7 @@ public sealed class Scope {
      * Name of the scope such as 'Arguments', 'Locals', or 'Registers'. This
      * string is shown in the UI as is and can be translated.
      */
-    [JsonPropertyName("name")] public string Name { get; set; }
+    [JsonPropertyName("name")] public required string Name { get; set; }
 
     /**
      * A hint for how to present this scope in the UI. If this attribute is

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/SourceBreakpoint.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/SourceBreakpoint.cs
@@ -1,7 +1,9 @@
 ﻿using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class SourceBreakpoint {
     [JsonPropertyName("line")] public int Line { get; set; }
     [JsonPropertyName("column")] public int? Column { get; set; }

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/StackFrame.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/StackFrame.cs
@@ -13,7 +13,7 @@ public sealed class StackFrame {
     /**
      * The name of the stack frame, typically a method name.
      */
-    [JsonPropertyName("name")] public string Name { get; set; }
+    [JsonPropertyName("name")] public required string Name { get; set; }
 
     /**
      * The source of the frame.

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/StackFrameFormat.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/StackFrameFormat.cs
@@ -1,7 +1,9 @@
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class StackFrameFormat : ValueFormat {
     /**
      * Displays parameters for the stack frame.

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/StoppedEvent.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/StoppedEvent.cs
@@ -12,7 +12,7 @@ public sealed class StoppedEvent : IEvent {
      * Values: 'step', 'breakpoint', 'exception', 'pause', 'entry', 'goto',
      * 'function breakpoint', 'data breakpoint', 'instruction breakpoint', etc.
      */
-    [JsonPropertyName("reason")] public string Reason { get; set; }
+    [JsonPropertyName("reason")] public required string Reason { get; set; }
     public const string ReasonStep = "step";
     public const string ReasonBreakpoint = "breakpoint";
     public const string ReasonException = "exception";

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/Variable.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/Variable.cs
@@ -6,7 +6,7 @@ public sealed class Variable {
     /**
      * The variable's name.
      */
-    [JsonPropertyName("name")] public string Name { get; set; }
+    [JsonPropertyName("name")] public required string Name { get; set; }
 
     /**
      * The variable's value.
@@ -17,7 +17,7 @@ public sealed class Variable {
      * its children are not yet visible.
      * An empty string can be used if no value should be shown in the UI.
      */
-    [JsonPropertyName("value")] public string Value { get; set; }
+    [JsonPropertyName("value")] public required string Value { get; set; }
 
     /**
      * The type of the variable's value. Typically shown in the UI when hovering

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/VariablePresentationHint.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/VariablePresentationHint.cs
@@ -1,7 +1,9 @@
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
+[UsedImplicitly]
 public sealed class VariablePresentationHint {
     /**
      * The kind of variable. Before introducing additional values, try to use the


### PR DESCRIPTION
Fix 35 warnings by marking non-nullable JSON properties as `required` in the debug adapter

Also fix several Rider messages, mostly using `[UsedImplicitly]`