### PR TITLE
Fix getting an appearance's `appearance` var

### DIFF
--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -232,6 +232,7 @@ public sealed class AtomManager {
             case "render_source":
             case "render_target":
             case "transform":
+            case "appearance":
                 return true;
 
             // Get/SetAppearanceVar doesn't handle these
@@ -336,6 +337,8 @@ public sealed class AtomManager {
 
                 appearance.Transform = transformArray;
                 break;
+            case "appearance":
+                throw new Exception("Cannot assign the appearance var on an appearance");
             // TODO: overlays, underlays, filters
             //       Those are handled separately by whatever is calling SetAppearanceVar currently
             default:
@@ -409,6 +412,9 @@ public sealed class AtomManager {
                     transform[1], transform[3], transform[5]);
 
                 return new(matrix);
+            case "appearance":
+                IconAppearance appearanceCopy = new IconAppearance(appearance); // Return a copy
+                return new(appearanceCopy);
             // TODO: overlays, underlays, filters
             //       Those are handled separately by whatever is calling GetAppearanceVar currently
             default:

--- a/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
@@ -102,6 +102,15 @@ public class DreamObjectAtom : DreamObject {
             case "desc":
                 value.TryGetValueAsString(out Desc);
                 break;
+            case "appearance":
+                if (!AtomManager.TryCreateAppearanceFrom(value, out var newAppearance))
+                    return; // Ignore attempts to set an invalid appearance
+
+                // The dir does not get changed
+                newAppearance.Direction = AtomManager.MustGetAppearance(this)!.Direction;
+
+                AtomManager.SetAtomAppearance(this, newAppearance);
+                break;
             case "overlays": {
                 Overlays.Cut();
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectImage.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectImage.cs
@@ -68,11 +68,6 @@ public sealed class DreamObjectImage : DreamObject {
     protected override bool TryGetVar(string varName, out DreamValue value) {
         // TODO: filters, transform
         switch(varName) {
-            case "appearance": {
-                IconAppearance appearanceCopy = new IconAppearance(Appearance!); // Return a copy
-                value = new(appearanceCopy);
-                return true;
-            }
             case "loc": {
                 value = new(_loc);
                 return true;
@@ -97,13 +92,12 @@ public sealed class DreamObjectImage : DreamObject {
 
     protected override void SetVar(string varName, DreamValue value) {
         switch (varName) {
-            case "appearance":
+            case "appearance": // Appearance var is mutable, don't use AtomManager.SetAppearanceVar()
                 if (!AtomManager.TryCreateAppearanceFrom(value, out var newAppearance))
                     return; // Ignore attempts to set an invalid appearance
 
                 // The dir does not get changed
-                var oldDir = Appearance!.Direction;
-                newAppearance.Direction = oldDir;
+                newAppearance.Direction = Appearance!.Direction;
 
                 Appearance = newAppearance;
                 break;


### PR DESCRIPTION
Gives a copy of the appearance. Also fixes #1090 by finishing the last 2 check boxes.

There were a ton of errors regarding this in tg init