### PR TITLE
Add compiler warning when enumerating the contents of an area

### DIFF
--- a/Content.Tests/DMProject/Tests/Loop/SuspiciousEnumerations.dm
+++ b/Content.Tests/DMProject/Tests/Loop/SuspiciousEnumerations.dm
@@ -1,6 +1,9 @@
 ﻿// COMPILE ERROR
 // Test that the pragma works
-#pragma SuspiciousAreaContentsEnumeration error
+#pragma SuspiciousAreaEnumeration error
+
+/area/test
+
 /proc/RunTest()
 	var/area/test/my_area
 	for(var/item in my_area)

--- a/Content.Tests/DMProject/Tests/Loop/SuspiciousEnumerations.dm
+++ b/Content.Tests/DMProject/Tests/Loop/SuspiciousEnumerations.dm
@@ -1,0 +1,7 @@
+﻿// COMPILE ERROR
+// Test that the pragma works
+#pragma SuspiciousAreaContentsEnumeration error
+/proc/RunTest()
+	var/area/test/my_area
+	for(var/item in my_area)
+		continue

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -466,7 +466,7 @@ namespace DMCompiler.DM.Visitors {
                             var outputVar = DMExpression.Create(_dmObject, _proc, outputExpr);
                             var list = DMExpression.Create(_dmObject, _proc, exprIn.List);
 
-                            if (list is LValue {Path: { } path} && path.IsDescendantOf(DreamPath.Area)) {
+                            if (list is {Path: { } path} && path.IsDescendantOf(DreamPath.Area)) {
                                 DMCompiler.Emit(WarningCode.SuspiciousAreaContentsEnumeration, list.Location,
                                     "Enumerating over the contents of an area implicitly performs a world enumeration in BYOND");
                             }

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -466,8 +466,10 @@ namespace DMCompiler.DM.Visitors {
                             var outputVar = DMExpression.Create(_dmObject, _proc, outputExpr);
                             var list = DMExpression.Create(_dmObject, _proc, exprIn.List);
 
-                            if (list is {Path: { } path} && path.IsDescendantOf(DreamPath.Area)) {
-                                DMCompiler.Emit(WarningCode.SuspiciousAreaContentsEnumeration, list.Location,
+                            if (list is {Path: { } path} &&
+                                DMObjectTree.GetDMObject(path, createIfNonexistent: false) is { } obj &&
+                                obj.IsSubtypeOf(DreamPath.Area)) {
+                                DMCompiler.Emit(WarningCode.SuspiciousAreaEnumeration, list.Location,
                                     "Enumerating over the contents of an area implicitly performs a world enumeration in BYOND");
                             }
 

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -466,6 +466,11 @@ namespace DMCompiler.DM.Visitors {
                             var outputVar = DMExpression.Create(_dmObject, _proc, outputExpr);
                             var list = DMExpression.Create(_dmObject, _proc, exprIn.List);
 
+                            if (list is LValue {Path: { } path} && path.IsDescendantOf(DreamPath.Area)) {
+                                DMCompiler.Emit(WarningCode.SuspiciousAreaContentsEnumeration, list.Location,
+                                    "Enumerating over the contents of an area implicitly performs a world enumeration in BYOND");
+                            }
+
                             ProcessStatementForList(list, outputVar, statementFor.DMTypes, statementFor.Body);
                             break;
                         }

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -20,7 +20,7 @@
 #pragma PointlessBuiltinCall warning
 #pragma SuspiciousMatrixCall warning
 #pragma FallbackBuiltinArgument warning
-#pragma SuspiciousAreaContentsEnumeration warning
+#pragma SuspiciousAreaEnumeration warning
 #pragma MalformedRange warning
 #pragma InvalidRange error
 #pragma InvalidSetStatement error

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -20,6 +20,7 @@
 #pragma PointlessBuiltinCall warning
 #pragma SuspiciousMatrixCall warning
 #pragma FallbackBuiltinArgument warning
+#pragma SuspiciousAreaContentsEnumeration warning
 #pragma MalformedRange warning
 #pragma InvalidRange error
 #pragma InvalidSetStatement error

--- a/OpenDreamShared/Compiler/CompilerError.cs
+++ b/OpenDreamShared/Compiler/CompilerError.cs
@@ -45,7 +45,6 @@ namespace OpenDreamShared.Compiler {
         PointlessBuiltinCall = 2206, // For pointless calls to issaved() or initial()
         SuspiciousMatrixCall = 2207, // Calling matrix() with seemingly the wrong arguments
         FallbackBuiltinArgument = 2208, // A builtin (sin(), cos(), etc) with an invalid/fallback argument
-        SuspiciousAreaContentsEnumeration = 2209, // See https://github.com/OpenDreamProject/OpenDream/issues/1003
         MalformedRange = 2300,
         InvalidRange = 2301,
         InvalidSetStatement = 2302,
@@ -57,7 +56,8 @@ namespace OpenDreamShared.Compiler {
         // 3000 - 3999 are reserved for stylistic configuration.
         EmptyBlock = 3100,
         EmptyProc = 3101,
-        UnsafeClientAccess = 3200
+        UnsafeClientAccess = 3200,
+        SuspiciousAreaEnumeration = 3201 // See https://github.com/OpenDreamProject/OpenDream/issues/1003
 
         // 4000 - 4999 are reserved for runtime configuration. (TODO: Runtime doesn't know about configs yet!)
     }

--- a/OpenDreamShared/Compiler/CompilerError.cs
+++ b/OpenDreamShared/Compiler/CompilerError.cs
@@ -45,6 +45,7 @@ namespace OpenDreamShared.Compiler {
         PointlessBuiltinCall = 2206, // For pointless calls to issaved() or initial()
         SuspiciousMatrixCall = 2207, // Calling matrix() with seemingly the wrong arguments
         FallbackBuiltinArgument = 2208, // A builtin (sin(), cos(), etc) with an invalid/fallback argument
+        SuspiciousAreaContentsEnumeration = 2209, // See https://github.com/OpenDreamProject/OpenDream/issues/1003
         MalformedRange = 2300,
         InvalidRange = 2301,
         InvalidSetStatement = 2302,


### PR DESCRIPTION
Fixes #1003

When enumerating over the contents of an area, BYOND  also enumerates over world contents apparently. That's not a thing here in OD land, but giving people a warning is nice I guess