### PR TITLE
Fix the debugger

### DIFF
--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/ProtocolMessage.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/ProtocolMessage.cs
@@ -1,11 +1,15 @@
 ﻿using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
 [Virtual]
 public class ProtocolMessage {
     [JsonPropertyName("seq")] public int Seq { get; set; }
-    [JsonPropertyName("type")] public string Type { get; }
+    [JsonPropertyName("type")] public string Type { get; set; } = null!;
+
+    [UsedImplicitly]
+    public ProtocolMessage() { }
 
     protected ProtocolMessage(string type) {
         Type = type;

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/Request.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/Request.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
+using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
@@ -7,7 +8,8 @@ namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 public class Request : ProtocolMessage {
     [JsonPropertyName("command")] public required string Command { get; set; }
 
-    protected Request() : base("request") { }
+    [UsedImplicitly]
+    public Request() : base("request") { }
 
     public static Request? DeserializeRequest(JsonDocument json) {
         Request? request = json.Deserialize<Request>();


### PR DESCRIPTION
#1541 removed an empty constructor that Rider marked as unused but turned out to be necessary for the JSON deserializer. Similar for a `public` -> `protected` constructor.