### PR TITLE
Update `Byond.TopicSender` to v8.0.1

### DIFF
--- a/OpenDreamPackageTool/ServerPackaging.cs
+++ b/OpenDreamPackageTool/ServerPackaging.cs
@@ -35,6 +35,7 @@ public static class ServerPackaging {
         "OpenDreamRuntime",
         "Byond.TopicSender",
         "Microsoft.Extensions.Logging.Abstractions", // dep of Byond.TopicSender
+        "Microsoft.Extensions.DependencyInjection.Abstractions", // dep of above
         "DMCompiler"
     };
 
@@ -45,6 +46,7 @@ public static class ServerPackaging {
         "OpenDreamRuntime",
         "Byond.TopicSender",
         "Microsoft.Extensions.Logging.Abstractions", // dep of Byond.TopicSender
+        "Microsoft.Extensions.DependencyInjection.Abstractions", // dep of above
         "DMCompiler"
     };
 

--- a/OpenDreamRuntime/OpenDreamRuntime.csproj
+++ b/OpenDreamRuntime/OpenDreamRuntime.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\RobustToolbox\Robust.Server\Robust.Server.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Byond.TopicSender" Version="7.0.1" />
+    <PackageReference Include="Byond.TopicSender" Version="8.0.1" />
   </ItemGroup>
 
   <Import Project="..\RobustToolbox\MSBuild\Robust.Properties.targets" />


### PR DESCRIPTION
Contains fixes for packet splintering, ValueTasks, records/structs and other goodness.