### PR TITLE
Fix `"` appearing in long strings

### DIFF
--- a/Content.Tests/DMProject/Tests/Text/LongString.dm
+++ b/Content.Tests/DMProject/Tests/Text/LongString.dm
@@ -1,0 +1,6 @@
+/proc/RunTest()
+	ASSERT({"A
+B
+C"} == "A\nB\nC")
+	
+	ASSERT({" " "} == " \" ")

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -532,6 +532,8 @@ internal sealed class DMPreprocessorLexer {
                         foundTerminator = true;
                         break;
                     }
+
+                    textBuilder.Append(stringC);
                 } else {
                     foundTerminator = true;
                     break;

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -539,7 +539,9 @@ internal sealed class DMPreprocessorLexer {
                     break;
                 }
             } else {
-                textBuilder.Append(stringC);
+                if (stringC != '\r') // \r\n becomes \n
+                    textBuilder.Append(stringC);
+
                 Advance();
             }
         }


### PR DESCRIPTION
#1555 broke instances of delimiters appearing in long strings, they were being excluded from the final string.