### PR TITLE
Add support for .NET pipe commands to server

### DIFF
--- a/OpenDreamRuntime/CommandPipeManager.cs
+++ b/OpenDreamRuntime/CommandPipeManager.cs
@@ -1,0 +1,90 @@
+﻿using System.IO;
+using System.IO.Pipes;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using OpenDreamShared;
+
+using Robust.Server;
+using Robust.Shared.Configuration;
+
+namespace OpenDreamRuntime {
+    /// <summary>
+    /// Handles commands from the <see cref="OpenDreamCVars.CommandPipe"/>.
+    /// </summary>
+    /// <remarks>Not reentrant.</remarks>
+    internal sealed class CommandPipeManager {
+        [Dependency] private readonly IConfigurationManager _configManager = default!;
+        [Dependency] private readonly IBaseServer _baseServer = default!;
+
+        private readonly ISawmill _sawmill;
+
+        private Task? activeTask;
+        private CancellationTokenSource? activeCts;
+
+        public CommandPipeManager() {
+            _sawmill = Logger.GetSawmill("opendream");
+        }
+
+        public void Start() {
+            if (activeTask != null)
+                throw new InvalidOperationException("Already running!");
+
+            activeCts = new CancellationTokenSource();
+            activeTask = RunAsync(activeCts.Token);
+        }
+
+        public async ValueTask Shutdown() {
+            if (activeTask == null)
+                return;
+
+            activeCts!.Cancel();
+            activeCts.Dispose();
+            activeCts = null;
+            await activeTask;
+            activeTask = null;
+        }
+
+        private async Task RunAsync(CancellationToken cancellationToken) {
+
+            var commandPipeName = _configManager.GetCVar(OpenDreamCVars.CommandPipe);
+            if (string.IsNullOrWhiteSpace(commandPipeName)) {
+                _sawmill.Debug("No command pipe present");
+                return;
+            }
+
+            _sawmill.Debug("Starting CommandPipeManager...");
+
+            // grab both pipes asap so we can close them on error
+            await using var commandPipeClient = new AnonymousPipeClientStream(
+                PipeDirection.In,
+                commandPipeName);
+
+            try {
+                using var streamReader = new StreamReader(commandPipeClient, Encoding.UTF8, leaveOpen: true);
+                while (!cancellationToken.IsCancellationRequested) {
+                    _sawmill.Debug("Waiting to read command...");
+                    var line = await streamReader.ReadLineAsync(cancellationToken);
+
+                    _sawmill.Info("Received pipe command: {0}", line);
+                    switch (line) {
+                        case "shutdown":
+                            _baseServer.Shutdown("Received shutdown pipe command");
+                            break;
+                        default:
+                            _sawmill.Warning("Unrecognized pipe command: {command}", line);
+                            break;
+                    }
+                }
+            } catch (OperationCanceledException) {
+                _sawmill.Debug("Command read task cancelled!");
+            } catch (Exception ex) {
+                _sawmill.Error("Command read task errored! Exception: {0}", ex);
+            }
+            finally {
+                _sawmill.Debug("Command read task exiting...");
+            }
+        }
+    }
+}

--- a/OpenDreamRuntime/EntryPoint.cs
+++ b/OpenDreamRuntime/EntryPoint.cs
@@ -18,6 +18,7 @@ namespace OpenDreamRuntime {
     public sealed class EntryPoint : GameServer {
         [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
         [Dependency] private readonly DreamManager _dreamManager = default!;
+        [Dependency] private readonly CommandPipeManager _commandPipeManager = default!;
         [Dependency] private readonly IConfigurationManager _configManager = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly IDreamDebugManager _debugManager = default!;
@@ -58,6 +59,7 @@ namespace OpenDreamRuntime {
         }
 
         public override void PostInit() {
+            _commandPipeManager.Start();
             _commandSystem = _entitySystemManager.GetEntitySystem<DreamCommandSystem>();
 
             int debugAdapterPort = _configManager.GetCVar(OpenDreamCVars.DebugAdapterLaunched);
@@ -71,6 +73,8 @@ namespace OpenDreamRuntime {
         }
 
         protected override void Dispose(bool disposing) {
+            _commandPipeManager.Shutdown().GetAwaiter().GetResult();
+
             // Write every savefile to disk
             foreach (var savefile in DreamObjectSavefile.Savefiles.ToArray()) { //ToArray() to avoid modifying the collection while iterating over it
                 savefile.Close();

--- a/OpenDreamRuntime/ServerContentIoC.cs
+++ b/OpenDreamRuntime/ServerContentIoC.cs
@@ -13,6 +13,7 @@ namespace OpenDreamRuntime {
             IoCManager.Register<DreamResourceManager>();
             IoCManager.Register<WalkManager, WalkManager>();
             IoCManager.Register<IDreamDebugManager, DreamDebugManager>();
+            IoCManager.Register<CommandPipeManager>();
 
             #if DEBUG
             IoCManager.Register<LocalHostConGroup>();

--- a/OpenDreamShared/OpenDreamCVars.cs
+++ b/OpenDreamShared/OpenDreamCVars.cs
@@ -24,5 +24,11 @@ namespace OpenDreamShared {
 
         public static readonly CVarDef<ushort> TopicPort =
             CVarDef.Create<ushort>("opendream.topic_port", 25567, CVar.SERVERONLY);
+
+        /// <summary>
+        /// Pipe for sending control commands from the parent process.
+        /// </summary>
+        public static readonly CVarDef<string> CommandPipe =
+            CVarDef.Create("opendream.command_pipe", String.Empty, CVar.SERVERONLY);
     }
 }


### PR DESCRIPTION
Allows TGS to send a cooperative `shutdown` command for graceful cleanup (mainly of sockets, which have been having lingering issues)