### PR TITLE
Move duplicate opcode check to a unit test

### DIFF
--- a/Content.Tests/RuntimeTests.cs
+++ b/Content.Tests/RuntimeTests.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using DMCompiler.Bytecode;
+using NUnit.Framework;
+
+namespace Content.Tests;
+
+[TestFixture]
+public sealed class RuntimeTests {
+    /// <summary>
+    /// Validates that the opcodes in DreamProcOpcode are all unique, such that none resolve to the same byte.
+    /// </summary>
+    [Test]
+    public void EnsureOpcodesUnique() {
+        Assert.That(Enum.GetValues<DreamProcOpcode>(), Is.Unique);
+    }
+}

--- a/DMCompiler/Bytecode/DreamProcOpcode.cs
+++ b/DMCompiler/Bytecode/DreamProcOpcode.cs
@@ -361,29 +361,9 @@ public struct DMReference {
     }
 }
 
+
 // Dummy class-as-namespace because C# just kinda be like this
 public static class OpcodeVerifier {
-    /// <summary>
-    /// Validates that the opcodes in DreamProcOpcode are all unique, such that none resolve to the same byte.
-    /// </summary>
-    /// <returns>True if there are duplicate opcodes, false if not</returns>
-    // FIXME: Can this be made into something done during compiletime? Like, *this code's* compiletime? >:/
-    public static bool AreOpcodesInvalid() {
-        // I'm not *too* satisfied with this boolean schtick, as opposed to throwing,
-        // but I want each executable to be able to do what they want with this information.
-
-        HashSet<DreamProcOpcode> bytePool = new();
-        foreach (DreamProcOpcode usedInt in Enum.GetValues(typeof(DreamProcOpcode))) {
-            if(bytePool.Contains(usedInt)) {
-                return true;
-            }
-
-            bytePool.Add(usedInt);
-        }
-
-        return false;
-    }
-
     /// <summary>
     /// Calculates a hash of all the <c>DreamProcOpcode</c>s for warning on incompatibilities.
     /// </summary>
@@ -402,6 +382,7 @@ public static class OpcodeVerifier {
         return BitConverter.ToString(hashBytes).Replace("-", "");
     }
 }
+
 
 /// <summary>
 /// Custom attribute for declaring <see cref="OpcodeMetadata"/> metadata for individual opcodes

--- a/DMCompiler/Bytecode/DreamProcOpcode.cs
+++ b/DMCompiler/Bytecode/DreamProcOpcode.cs
@@ -361,7 +361,6 @@ public struct DMReference {
     }
 }
 
-
 // Dummy class-as-namespace because C# just kinda be like this
 public static class OpcodeVerifier {
     /// <summary>
@@ -382,7 +381,6 @@ public static class OpcodeVerifier {
         return BitConverter.ToString(hashBytes).Replace("-", "");
     }
 }
-
 
 /// <summary>
 /// Custom attribute for declaring <see cref="OpcodeMetadata"/> metadata for individual opcodes

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -1,3 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DMCompiler.Bytecode;
 using DMCompiler.Compiler.DM;
 using DMCompiler.Compiler.DMM;
 using DMCompiler.Compiler.DMPreprocessor;
@@ -5,16 +15,6 @@ using DMCompiler.DM;
 using DMCompiler.DM.Visitors;
 using OpenDreamShared.Compiler;
 using OpenDreamShared.Json;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Reflection;
-using System.Linq;
-using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-using DMCompiler.Bytecode;
 using Robust.Shared.Utility;
 
 namespace DMCompiler;
@@ -49,10 +49,6 @@ public static class DMCompiler {
 
         if (settings.SuppressUnimplementedWarnings) {
             ForcedWarning("Unimplemented proc & var warnings are currently suppressed");
-        }
-
-        if(OpcodeVerifier.AreOpcodesInvalid()) {
-            ForcedError("Some opcodes have the same byte value! Output assembly may be corrupted.");
         }
 
         DMPreprocessor preprocessor = Preprocess(settings.Files, settings.MacroDefines);

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -1,12 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using DMCompiler.Bytecode;
 using DMCompiler.Compiler.DM;
 using DMCompiler.Compiler.DMM;
@@ -16,6 +7,15 @@ using DMCompiler.DM.Visitors;
 using OpenDreamShared.Compiler;
 using OpenDreamShared.Json;
 using Robust.Shared.Utility;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace DMCompiler;
 


### PR DESCRIPTION
We only need to make sure that all opcodes are unique when we prepare a deployment and not on a compiler run. This also tells us that the ODRT is valid too when deploying, as we don't have to rely on the compiler telling us that it is.