### PR TITLE
Fix Content.Client.zip name from packaging

### DIFF
--- a/OpenDreamPackageTool/ServerPackaging.cs
+++ b/OpenDreamPackageTool/ServerPackaging.cs
@@ -151,7 +151,7 @@ public static class ServerPackaging {
         CopyContentAssemblies(Path.Combine(releaseDir, "Resources", "Assemblies"));
         if (options.HybridAcz) {
             // Hybrid ACZ expects "Content.Client.zip" (as it's not OpenDream-specific)
-            ZipFile.CreateFromDirectory(Path.Combine(options.OutputDir, "OpenDreamClient"), Path.Combine(releaseDir, "Content.Client.Zip"));
+            ZipFile.CreateFromDirectory(Path.Combine(options.OutputDir, "OpenDreamClient"), Path.Combine(releaseDir, "Content.Client.zip"));
         }
     }
 


### PR DESCRIPTION
It was "Zip" (capitalized) instead of "zip" so the server couldn't find it on a case-sensitive file system.