### PR TITLE
Fix overlay blending multiplying for transparent alpha

### DIFF
--- a/OpenDreamRuntime/Objects/DreamIcon.cs
+++ b/OpenDreamRuntime/Objects/DreamIcon.cs
@@ -333,6 +333,14 @@ public class DreamIconOperationBlend : IDreamIconOperation {
             }
 
             case BlendType.Overlay: {
+                // When overlaying onto 0 alpha, don't multiply the RGB values by alpha.
+                if (dst.A == 0) {
+                    pixels[dstPixelPosition].R = src.R;
+                    pixels[dstPixelPosition].G = src.G;
+                    pixels[dstPixelPosition].B = src.B;
+                    pixels[dstPixelPosition].A = src.A;
+                    break;
+                }
                 pixels[dstPixelPosition].R = (byte) (dst.R + (src.R - dst.R) * src.A / 255);
                 pixels[dstPixelPosition].G = (byte) (dst.G + (src.G - dst.G) * src.A / 255);
                 pixels[dstPixelPosition].B = (byte) (dst.B + (src.B - dst.B) * src.A / 255);


### PR DESCRIPTION
BYOND seems to just copy the source RGB if the destination is 0 alpha, rather than doing multiplication by the source alpha.

```dm
/world
	fps = 25
	icon_size = 32
	view = 1

/mob/verb/Y()
	set name = "Y"
	var/atom/movable/Z = new (loc)
	var/icon/A = icon('transparent.dmi', "nothing")
	A.Blend(icon('transparent.dmi', "thing"), ICON_OVERLAY)
	Z.icon = A
```

BYOND result:
![image](https://github.com/OpenDreamProject/OpenDream/assets/10366817/438e1e2e-ba9a-499d-8cba-b3f6f43ba89d)

OpenDream result (old) - see how it's desaturated/darker?
![image](https://github.com/OpenDreamProject/OpenDream/assets/10366817/04fab35e-01c9-48d0-924a-087e9ed90fc7)

OpenDream result (new) - no longer desaturated.
![image](https://github.com/OpenDreamProject/OpenDream/assets/10366817/65c43e73-e6dd-4104-8d51-f5a8f005c094)

