### PR TITLE
Adds a warning when assigning a value in a conditional

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -1069,7 +1069,7 @@ namespace DMCompiler.Compiler.DM {
                     Error("Expected a condition");
                 }
                 if (condition is DMASTAssign) {
-                    DMCompiler.Emit(WarningCode.AssignmentInConditional, Current().Location, "Assignment in conditional");
+                    DMCompiler.Emit(WarningCode.AssignmentInConditional, condition.Location, "Assignment in conditional");
                 }
                 BracketWhitespace();
                 ConsumeRightParenthesis();
@@ -1381,9 +1381,6 @@ namespace DMCompiler.Compiler.DM {
                             DMCompiler.Emit(WarningCode.BadExpression, Current().Location, "Expected an expression");
 
                         break;
-                    }
-                    if (expression is DMASTAssign) {
-                        DMCompiler.Emit(WarningCode.AssignmentInConditional, Current().Location, "Assignment in conditional");
                     }
 
                     if (Check(TokenType.DM_To)) {

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -1065,7 +1065,12 @@ namespace DMCompiler.Compiler.DM {
                 Consume(TokenType.DM_LeftParenthesis, "Expected '('");
                 BracketWhitespace();
                 DMASTExpression? condition = Expression();
-                if (condition == null) Error("Expected a condition");
+                if (condition == null) {
+                    Error("Expected a condition");
+                }
+                if (condition is DMASTAssign) {
+                    DMCompiler.Emit(WarningCode.AssignmentInConditional, Current().Location, "Assignment in conditional");
+                }
                 BracketWhitespace();
                 ConsumeRightParenthesis();
                 Whitespace();
@@ -1376,6 +1381,9 @@ namespace DMCompiler.Compiler.DM {
                             DMCompiler.Emit(WarningCode.BadExpression, Current().Location, "Expected an expression");
 
                         break;
+                    }
+                    if (expression is DMASTAssign) {
+                        DMCompiler.Emit(WarningCode.AssignmentInConditional, Current().Location, "Assignment in conditional");
                     }
 
                     if (Check(TokenType.DM_To)) {

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -33,4 +33,4 @@
 #pragma EmptyBlock notice
 #pragma EmptyProc disabled // NOTE: If you enable this in OD's default pragma config file, it will emit for OD's DMStandard. Put it in your codebase's pragma config file.
 #pragma UnsafeClientAccess disabled // NOTE: Only checks for unsafe accesses like "client.foobar" and doesn't consider if the client was already null-checked earlier in the proc
-
+#pragma AssignmentInConditional warning 

--- a/OpenDreamShared/Compiler/CompilerError.cs
+++ b/OpenDreamShared/Compiler/CompilerError.cs
@@ -59,6 +59,7 @@ namespace OpenDreamShared.Compiler {
         EmptyProc = 3101,
         UnsafeClientAccess = 3200,
         SuspiciousSwitchCase = 3201, // "else if" cases are actually valid DM, they just spontaneously end the switch context and begin an if-else ladder within the else case of the switch
+        AssignmentInConditional = 3202,
 
         // 4000 - 4999 are reserved for runtime configuration. (TODO: Runtime doesn't know about configs yet!)
     }


### PR DESCRIPTION
When assigning a value in an `if()` or `switch()` statement, the compiler will emit an `AssignmentInConditional` warning.

Closes https://github.com/OpenDreamProject/OpenDream/issues/576