### PR TITLE
Don't release planes with a plane master

### DIFF
--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -608,7 +608,7 @@ internal sealed class DreamViewOverlay : Overlay {
             var plane = pair.Value;
 
             // We can remove the plane if there was nothing on it last frame
-            if (plane.IconDrawActions.Count == 0 && plane.MouseMapDrawActions.Count == 0) {
+            if (plane.IconDrawActions.Count == 0 && plane.MouseMapDrawActions.Count == 0 && plane.Master == null) {
                 _planes.Remove(pair.Key);
                 continue;
             }

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -609,6 +609,7 @@ internal sealed class DreamViewOverlay : Overlay {
 
             // We can remove the plane if there was nothing on it last frame
             if (plane.IconDrawActions.Count == 0 && plane.MouseMapDrawActions.Count == 0 && plane.Master == null) {
+                plane.Dispose();
                 _planes.Remove(pair.Key);
                 continue;
             }
@@ -625,6 +626,7 @@ internal sealed class DreamViewOverlay : Overlay {
 
         plane = new(renderTarget);
         _planes.Add(planeIndex, plane);
+        _sawmill.Info($"Created plane {planeIndex}");
         return plane;
     }
 


### PR DESCRIPTION
Planes with no atoms but a plane master were being thrown out and recreated every frame, render targets and all. This ~~fixes~~ heavily reduces the constant stuttering on the client.