### PR TITLE
Refactor dereference operations into tagged unions

### DIFF
--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -2693,34 +2693,42 @@ namespace DMCompiler.Compiler.DM {
 
 
     public sealed class DMASTDereference : DMASTExpression {
-        public enum OperationKind {
-            Invalid,
-
-            Field, // x.y
-            FieldSafe, // x?.y
-            FieldSearch, // x:y
-            FieldSafeSearch, // x?:y
-
-            Index, // x[y]
-            IndexSafe, // x?[y]
-
-            Call, // x.y()
-            CallSafe, // x?.y()
-            CallSearch, // x:y()
-            CallSafeSearch, // x?:y()
+        public abstract class Operation {
+            /// <summary>
+            /// The location of the operation.
+            /// </summary>
+            public required Location Location;
+            /// <summary>
+            /// Whether we should short circuit if the expression we are accessing is null.
+            /// </summary>
+            public required bool Safe; // x?.y, x?.y() etc
         }
 
-        public struct Operation {
-            public OperationKind Kind;
+        public abstract class NamedOperation : Operation {
+            /// <summary>
+            /// Name of the identifier.
+            /// </summary>
+            public required string Identifier;
+            /// <summary>
+            /// Whether we should check if the variable exists or not.
+            /// </summary>
+            public required bool NoSearch; // x:y, x:y()
+        }
 
-            // Field*, Call*
-            public DMASTIdentifier Identifier;
+        public sealed class FieldOperation : NamedOperation;
 
-            // Index*
-            public DMASTExpression Index;
+        public sealed class IndexOperation : Operation {
+            /// <summary>
+            /// The index expression that we use to index this expression (constant or otherwise).
+            /// </summary>
+            public required DMASTExpression Index; // x[y], x?[y]
+        }
 
-            // Call*
-            public DMASTCallParameter[] Parameters;
+        public sealed class CallOperation : NamedOperation {
+            /// <summary>
+            /// The parameters that we call this proc with.
+            /// </summary>
+            public required DMASTCallParameter[] Parameters; // x.y(),
         }
 
         public DMASTExpression Expression;

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -1,9 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using DMCompiler.Compiler.DMPreprocessor;
 using OpenDreamShared.Compiler;
 using OpenDreamShared.Dream;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using String = System.String;
 
 namespace DMCompiler.Compiler.DM {
@@ -2281,13 +2281,12 @@ namespace DMCompiler.Compiler.DM {
 
                             Whitespace();
                             var index = Expression();
+                            ConsumeRightBracket();
 
                             if (index == null) {
                                 DMCompiler.Emit(WarningCode.BadToken, token.Location, "Expression expected");
                                 return new DMASTConstantNull(token.Location);
                             }
-
-                            ConsumeRightBracket();
 
                             operation = new DMASTDereference.IndexOperation {
                                 Index = index,

--- a/DMCompiler/DM/DMExpression.cs
+++ b/DMCompiler/DM/DMExpression.cs
@@ -64,6 +64,12 @@ namespace DMCompiler.DM {
             throw new CompileAbortException(Location, "nameof: requires a var, proc reference, or type path");
         }
 
+        /// <summary>
+        /// Determines whether the expression returns an ambiguous path.
+        /// </summary>
+        /// <remarks>Dereferencing these expressions will always skip validation via the "expr:y" operation.</remarks>
+        public virtual bool PathIsFuzzy => false;
+
         public virtual DreamPath? Path => null;
 
         public virtual DreamPath? NestedPath => Path;

--- a/DMCompiler/DM/Expressions/Binary.cs
+++ b/DMCompiler/DM/Expressions/Binary.cs
@@ -214,6 +214,8 @@ namespace DMCompiler.DM.Expressions {
 
     // x & y
     sealed class BinaryAnd : BinaryOp {
+        public override bool PathIsFuzzy => true;
+
         public BinaryAnd(Location location, DMExpression lhs, DMExpression rhs)
             : base(location, lhs, rhs) { }
 

--- a/DMCompiler/DM/Expressions/Builtins.cs
+++ b/DMCompiler/DM/Expressions/Builtins.cs
@@ -48,6 +48,8 @@ namespace DMCompiler.DM.Expressions {
         private readonly DMExpression _expr;
         private readonly ArgumentList _arguments;
 
+        public override bool PathIsFuzzy => Path == null;
+
         public New(Location location, DMExpression expr, ArgumentList arguments) : base(location) {
             _expr = expr;
             _arguments = arguments;
@@ -345,6 +347,8 @@ namespace DMCompiler.DM.Expressions {
     internal sealed class IsNull : DMExpression {
         private readonly DMExpression _value;
 
+        public override bool PathIsFuzzy => true;
+
         public IsNull(Location location, DMExpression value) : base(location) {
             _value = value;
         }
@@ -358,6 +362,8 @@ namespace DMCompiler.DM.Expressions {
     // length(x)
     internal sealed class Length : DMExpression {
         private readonly DMExpression _value;
+
+        public override bool PathIsFuzzy => true;
 
         public Length(Location location, DMExpression value) : base(location) {
             _value = value;
@@ -373,6 +379,8 @@ namespace DMCompiler.DM.Expressions {
     internal sealed class GetStep : DMExpression {
         private readonly DMExpression _ref;
         private readonly DMExpression _dir;
+
+        public override bool PathIsFuzzy => true;
 
         public GetStep(Location location, DMExpression refValue, DMExpression dir) : base(location) {
             _ref = refValue;
@@ -391,6 +399,8 @@ namespace DMCompiler.DM.Expressions {
         private readonly DMExpression _loc1;
         private readonly DMExpression _loc2;
 
+        public override bool PathIsFuzzy => true;
+
         public GetDir(Location location, DMExpression loc1, DMExpression loc2) : base(location) {
             _loc1 = loc1;
             _loc2 = loc2;
@@ -407,6 +417,8 @@ namespace DMCompiler.DM.Expressions {
     sealed class List : DMExpression {
         private readonly (DMExpression? Key, DMExpression Value)[] _values;
         private readonly bool _isAssociative;
+
+        public override bool PathIsFuzzy => true;
 
         public List(Location location, (DMExpression? Key, DMExpression Value)[] values) : base(location) {
             _values = values;

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -227,7 +227,7 @@ namespace DMCompiler.DM.Expressions {
             switch (operation) {
                 case FieldOperation fieldOperation:
                     if (prevPath is not null) {
-                        var obj = DMObjectTree.GetDMObject(prevPath.GetValueOrDefault());
+                        var obj = DMObjectTree.GetDMObject(prevPath.Value);
                         var variable = obj!.GetVariable(fieldOperation.Identifier);
                         if (variable != null) {
                             if (variable.IsConst)

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -89,7 +89,7 @@ namespace DMCompiler.DM.Expressions {
                     break;
 
                 default:
-                    throw new NotImplementedException();
+                    throw new InvalidOperationException("Unimplemented dereference operation");
             }
         }
 
@@ -134,10 +134,12 @@ namespace DMCompiler.DM.Expressions {
                     return DMReference.ListIndex;
 
                 case CallOperation:
-                    throw new CompileErrorException(Location, "Expected field or index as reference, got proc call result");
+                    DMCompiler.Emit(WarningCode.BadExpression, Location,
+                        "Expected field or index as reference, got proc call result");
+                    return default;
 
                 default:
-                    throw new NotImplementedException();
+                    throw new InvalidOperationException("Unimplemented dereference operation");
             }
         }
 
@@ -171,10 +173,12 @@ namespace DMCompiler.DM.Expressions {
                     break;
 
                 case CallOperation:
-                    throw new CompileErrorException(Location, "Expected field or index for initial(), got proc call");
+                    DMCompiler.Emit(WarningCode.BadExpression, Location,
+                        "Expected field or index for initial(), got proc call result");
+                    break;
 
                 default:
-                    throw new NotImplementedException();
+                    throw new InvalidOperationException("Unimplemented dereference operation");
             }
 
             proc.AddLabel(endLabel);
@@ -210,10 +214,12 @@ namespace DMCompiler.DM.Expressions {
                     break;
 
                 case CallOperation:
-                    throw new CompileErrorException(Location, "Expected field or index for issaved(), got proc call");
+                    DMCompiler.Emit(WarningCode.BadExpression, Location,
+                        "Expected field or index for issaved(), got proc call result");
+                    break;
 
                 default:
-                    throw new NotImplementedException();
+                    throw new InvalidOperationException("Unimplemented dereference operation");
             }
 
             proc.AddLabel(endLabel);

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -13,7 +13,7 @@ namespace DMCompiler.DM.Expressions {
     internal class Dereference : LValue {
         public abstract class Operation {
             public required bool Safe { get; init; }
-            public DreamPath? Path { get; set; }
+            public DreamPath? Path { get; init; }
         }
 
         public abstract class NamedOperation : Operation {

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -35,6 +35,7 @@ namespace DMCompiler.DM.Expressions {
 
         public override DreamPath? Path { get; }
         public override DreamPath? NestedPath { get; }
+        public override bool PathIsFuzzy => Path == null;
 
         public Dereference(Location location, DreamPath? path, DMExpression expression, Operation[] operations)
             : base(location, null) {

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -1,31 +1,33 @@
+using DMCompiler.Bytecode;
 using OpenDreamShared.Compiler;
-using DMCompiler.Compiler.DM;
 using OpenDreamShared.Dream;
 using System;
-using DMCompiler.Bytecode;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace DMCompiler.DM.Expressions {
     // x.y.z
     // x[y][z]
     // x.f().y.g()[2]
     // etc.
-    class Dereference : LValue {
-        public struct Operation {
-            public DMASTDereference.OperationKind Kind;
+    internal class Dereference : LValue {
+        public abstract class Operation {
+            public required bool Safe { get; init; }
+            public DreamPath? Path { get; set; }
+        }
 
-            // Field*, Call*
-            public string Identifier;
+        public abstract class NamedOperation : Operation {
+            public required string Identifier { get; init; }
+        }
 
-            // Field*
-            public int? GlobalId;
+        public sealed class FieldOperation : NamedOperation;
 
-            // Index*
-            public DMExpression Index;
+        public sealed class IndexOperation : Operation {
+            public required DMExpression Index { get; init; }
+        }
 
-            // Call*
-            public ArgumentList Parameters;
-
-            public DreamPath? Path;
+        public sealed class CallOperation : NamedOperation {
+            public required ArgumentList Parameters { get; init; }
         }
 
         private readonly DMExpression _expression;
@@ -60,49 +62,34 @@ namespace DMCompiler.DM.Expressions {
             }
         }
 
-        private void EmitOperation(DMObject dmObject, DMProc proc, ref Operation operation, string endLabel, ShortCircuitMode shortCircuitMode) {
-            switch (operation.Kind) {
-                case DMASTDereference.OperationKind.Field:
-                case DMASTDereference.OperationKind.FieldSearch:
-                    proc.DereferenceField(operation.Identifier);
+        private void EmitOperation(DMObject dmObject, DMProc proc, Operation operation, string endLabel, ShortCircuitMode shortCircuitMode) {
+            switch (operation) {
+                case FieldOperation fieldOperation:
+                    if (fieldOperation.Safe) {
+                        ShortCircuitHandler(proc, endLabel, shortCircuitMode);
+                    }
+                    proc.DereferenceField(fieldOperation.Identifier);
                     break;
 
-                case DMASTDereference.OperationKind.FieldSafe:
-                case DMASTDereference.OperationKind.FieldSafeSearch:
-                    ShortCircuitHandler(proc, endLabel, shortCircuitMode);
-                    proc.DereferenceField(operation.Identifier);
-                    break;
-
-                case DMASTDereference.OperationKind.Index:
-                    operation.Index.EmitPushValue(dmObject, proc);
+                case IndexOperation indexOperation:
+                    if (indexOperation.Safe) {
+                        ShortCircuitHandler(proc, endLabel, shortCircuitMode);
+                    }
+                    indexOperation.Index.EmitPushValue(dmObject, proc);
                     proc.DereferenceIndex();
                     break;
 
-                case DMASTDereference.OperationKind.IndexSafe:
-                    ShortCircuitHandler(proc, endLabel, shortCircuitMode);
-                    operation.Index.EmitPushValue(dmObject, proc);
-                    proc.DereferenceIndex();
+                case CallOperation callOperation:
+                    if (callOperation.Safe) {
+                        ShortCircuitHandler(proc, endLabel, shortCircuitMode);
+                    }
+                    var (argumentsType, argumentStackSize) = callOperation.Parameters.EmitArguments(dmObject, proc);
+                    proc.DereferenceCall(callOperation.Identifier, argumentsType, argumentStackSize);
                     break;
 
-                case DMASTDereference.OperationKind.Call:
-                case DMASTDereference.OperationKind.CallSearch: {
-                    var (argumentsType, argumentStackSize) = operation.Parameters.EmitArguments(dmObject, proc);
-                    proc.DereferenceCall(operation.Identifier, argumentsType, argumentStackSize);
-                    break;
-                }
-
-                case DMASTDereference.OperationKind.CallSafe:
-                case DMASTDereference.OperationKind.CallSafeSearch: {
-                    ShortCircuitHandler(proc, endLabel, shortCircuitMode);
-                    var (argumentsType, argumentStackSize) = operation.Parameters.EmitArguments(dmObject, proc);
-                    proc.DereferenceCall(operation.Identifier, argumentsType, argumentStackSize);
-                    break;
-                }
-
-                case DMASTDereference.OperationKind.Invalid:
                 default:
                     throw new NotImplementedException();
-            };
+            }
         }
 
         public override void EmitPushValue(DMObject dmObject, DMProc proc) {
@@ -110,78 +97,47 @@ namespace DMCompiler.DM.Expressions {
 
             _expression.EmitPushValue(dmObject, proc);
 
-            foreach (ref var operation in _operations.AsSpan()) {
-                EmitOperation(dmObject, proc, ref operation, endLabel, ShortCircuitMode.KeepNull);
+            foreach (var operation in _operations) {
+                EmitOperation(dmObject, proc, operation, endLabel, ShortCircuitMode.KeepNull);
             }
 
             proc.AddLabel(endLabel);
         }
 
         public override bool CanReferenceShortCircuit() {
-            foreach (var operation in _operations) {
-                switch (operation.Kind) {
-                    case DMASTDereference.OperationKind.FieldSafe:
-                    case DMASTDereference.OperationKind.FieldSafeSearch:
-                    case DMASTDereference.OperationKind.IndexSafe:
-                    case DMASTDereference.OperationKind.CallSafe:
-                    case DMASTDereference.OperationKind.CallSafeSearch:
-                        return true;
-
-                    case DMASTDereference.OperationKind.Field:
-                    case DMASTDereference.OperationKind.FieldSearch:
-                    case DMASTDereference.OperationKind.Index:
-                    case DMASTDereference.OperationKind.Call:
-                    case DMASTDereference.OperationKind.CallSearch:
-                        break;
-
-                    case DMASTDereference.OperationKind.Invalid:
-                    default:
-                        throw new NotImplementedException();
-                }
-            }
-
-            return base.CanReferenceShortCircuit();
+            return _operations.Any(operation => operation.Safe);
         }
 
-        public override DMReference EmitReference(DMObject dmObject, DMProc proc, string endLabel, ShortCircuitMode shortCircuitMode) {
+        public override DMReference EmitReference(DMObject dmObject, DMProc proc, string endLabel, ShortCircuitMode shortCircuitMode = ShortCircuitMode.KeepNull) {
             _expression.EmitPushValue(dmObject, proc);
 
             // Perform all except for our last operation
             for (int i = 0; i < _operations.Length - 1; i++) {
-                EmitOperation(dmObject, proc, ref _operations[i], endLabel, shortCircuitMode);
+                EmitOperation(dmObject, proc, _operations[i], endLabel, shortCircuitMode);
             }
 
-            ref var operation = ref _operations[^1];
+            var operation = _operations[^1];
 
-            switch (operation.Kind) {
-                case DMASTDereference.OperationKind.Field:
-                case DMASTDereference.OperationKind.FieldSearch:
-                    return DMReference.CreateField(operation.Identifier);
+            switch (operation) {
+                case FieldOperation fieldOperation:
+                    if (fieldOperation.Safe) {
+                        ShortCircuitHandler(proc, endLabel, shortCircuitMode);
+                    }
+                    return DMReference.CreateField(fieldOperation.Identifier);
 
-                case DMASTDereference.OperationKind.FieldSafe:
-                case DMASTDereference.OperationKind.FieldSafeSearch:
-                    ShortCircuitHandler(proc, endLabel, shortCircuitMode);
-                    return DMReference.CreateField(operation.Identifier);
-
-                case DMASTDereference.OperationKind.Index:
-                    operation.Index.EmitPushValue(dmObject, proc);
+                case IndexOperation indexOperation:
+                    if (indexOperation.Safe) {
+                        ShortCircuitHandler(proc, endLabel, shortCircuitMode);
+                    }
+                    indexOperation.Index.EmitPushValue(dmObject, proc);
                     return DMReference.ListIndex;
 
-                case DMASTDereference.OperationKind.IndexSafe:
-                    ShortCircuitHandler(proc, endLabel, shortCircuitMode);
-                    operation.Index.EmitPushValue(dmObject, proc);
-                    return DMReference.ListIndex;
+                case CallOperation:
+                    throw new CompileErrorException(Location, "Expected field or index as reference, got proc call result");
 
-                case DMASTDereference.OperationKind.Call:
-                case DMASTDereference.OperationKind.CallSearch:
-                case DMASTDereference.OperationKind.CallSafe:
-                case DMASTDereference.OperationKind.CallSafeSearch:
-                    throw new CompileErrorException(Location, $"attempt to reference proc call result");
-
-                case DMASTDereference.OperationKind.Invalid:
                 default:
                     throw new NotImplementedException();
-            };
+            }
         }
 
         public override void EmitPushInitial(DMObject dmObject, DMProc proc) {
@@ -191,46 +147,34 @@ namespace DMCompiler.DM.Expressions {
 
             // Perform all except for our last operation
             for (int i = 0; i < _operations.Length - 1; i++) {
-                EmitOperation(dmObject, proc, ref _operations[i], endLabel, ShortCircuitMode.KeepNull);
+                EmitOperation(dmObject, proc, _operations[i], endLabel, ShortCircuitMode.KeepNull);
             }
 
-            ref var operation = ref _operations[^1];
+            var operation = _operations[^1];
 
-            switch (operation.Kind) {
-                case DMASTDereference.OperationKind.Field:
-                case DMASTDereference.OperationKind.FieldSearch:
-                    proc.PushString(operation.Identifier);
+            switch (operation) {
+                case FieldOperation fieldOperation:
+                    if (fieldOperation.Safe) {
+                        proc.JumpIfNullNoPop(endLabel);
+                    }
+                    proc.PushString(fieldOperation.Identifier);
                     proc.Initial();
                     break;
 
-                case DMASTDereference.OperationKind.FieldSafe:
-                case DMASTDereference.OperationKind.FieldSafeSearch:
-                    proc.JumpIfNullNoPop(endLabel);
-                    proc.PushString(operation.Identifier);
+                case IndexOperation indexOperation:
+                    if (indexOperation.Safe) {
+                        proc.JumpIfNullNoPop(endLabel);
+                    }
+                    indexOperation.Index.EmitPushValue(dmObject, proc);
                     proc.Initial();
                     break;
 
-                case DMASTDereference.OperationKind.Index:
-                    operation.Index.EmitPushValue(dmObject, proc);
-                    proc.Initial();
-                    break;
+                case CallOperation:
+                    throw new CompileErrorException(Location, "Expected field or index for initial(), got proc call");
 
-                case DMASTDereference.OperationKind.IndexSafe:
-                    proc.JumpIfNullNoPop(endLabel);
-                    operation.Index.EmitPushValue(dmObject, proc);
-                    proc.Initial();
-                    break;
-
-                case DMASTDereference.OperationKind.Call:
-                case DMASTDereference.OperationKind.CallSearch:
-                case DMASTDereference.OperationKind.CallSafe:
-                case DMASTDereference.OperationKind.CallSafeSearch:
-                    throw new CompileErrorException(Location, $"attempt to get `initial` of a proc call");
-
-                case DMASTDereference.OperationKind.Invalid:
                 default:
                     throw new NotImplementedException();
-            };
+            }
 
             proc.AddLabel(endLabel);
         }
@@ -242,74 +186,53 @@ namespace DMCompiler.DM.Expressions {
 
             // Perform all except for our last operation
             for (int i = 0; i < _operations.Length - 1; i++) {
-                EmitOperation(dmObject, proc, ref _operations[i], endLabel, ShortCircuitMode.KeepNull);
+                EmitOperation(dmObject, proc, _operations[i], endLabel, ShortCircuitMode.KeepNull);
             }
 
-            ref var operation = ref _operations[^1];
+            var operation = _operations[^1];
 
-            switch (operation.Kind) {
-                case DMASTDereference.OperationKind.Field:
-                case DMASTDereference.OperationKind.FieldSearch:
-                    proc.PushString(operation.Identifier);
+            switch (operation) {
+                case FieldOperation fieldOperation:
+                    if (fieldOperation.Safe) {
+                        proc.JumpIfNullNoPop(endLabel);
+                    }
+                    proc.PushString(fieldOperation.Identifier);
                     proc.IsSaved();
                     break;
 
-                case DMASTDereference.OperationKind.FieldSafe:
-                case DMASTDereference.OperationKind.FieldSafeSearch:
-                    proc.JumpIfNullNoPop(endLabel);
-                    proc.PushString(operation.Identifier);
+                case IndexOperation indexOperation:
+                    if (indexOperation.Safe) {
+                        proc.JumpIfNullNoPop(endLabel);
+                    }
+                    indexOperation.Index.EmitPushValue(dmObject, proc);
                     proc.IsSaved();
                     break;
 
-                case DMASTDereference.OperationKind.Index:
-                    operation.Index.EmitPushValue(dmObject, proc);
-                    proc.IsSaved();
-                    break;
+                case CallOperation:
+                    throw new CompileErrorException(Location, "Expected field or index for issaved(), got proc call");
 
-                case DMASTDereference.OperationKind.IndexSafe:
-                    proc.JumpIfNullNoPop(endLabel);
-                    operation.Index.EmitPushValue(dmObject, proc);
-                    proc.IsSaved();
-                    break;
-
-                case DMASTDereference.OperationKind.Call:
-                case DMASTDereference.OperationKind.CallSearch:
-                case DMASTDereference.OperationKind.CallSafe:
-                case DMASTDereference.OperationKind.CallSafeSearch:
-                    throw new CompileErrorException(Location, $"attempt to get `issaved` of a proc call");
-
-                case DMASTDereference.OperationKind.Invalid:
                 default:
                     throw new NotImplementedException();
-            };
+            }
 
             proc.AddLabel(endLabel);
         }
 
-        public override bool TryAsConstant(out Constant constant) {
-            DreamPath? prevPath = null;
+        public override bool TryAsConstant([NotNullWhen(true)] out Constant? constant) {
+            var prevPath = _operations.Length == 1 ? _expression.Path : _operations[^2].Path;
 
-            if (_operations.Length == 1) {
-                prevPath = _expression.Path;
-            } else {
-                prevPath = _operations[^2].Path;
-            }
+            var operation = _operations[^1];
 
-            ref var operation = ref _operations[^1];
-
-            switch (operation.Kind) {
-                case DMASTDereference.OperationKind.Field:
-                case DMASTDereference.OperationKind.FieldSearch:
-                case DMASTDereference.OperationKind.FieldSafe:
-                case DMASTDereference.OperationKind.FieldSafeSearch:
+            switch (operation) {
+                case FieldOperation fieldOperation:
                     if (prevPath is not null) {
                         var obj = DMObjectTree.GetDMObject(prevPath.GetValueOrDefault());
-                        var variable = obj.GetVariable(operation.Identifier);
+                        var variable = obj!.GetVariable(fieldOperation.Identifier);
                         if (variable != null) {
                             if (variable.IsConst)
                                 return variable.Value.TryAsConstant(out constant);
-                            if ((variable.ValType & DMValueType.CompiletimeReadonly) == DMValueType.CompiletimeReadonly) {
-                                variable.Value.TryAsConstant(out constant);
+                            if (variable.ValType.HasFlag(DMValueType.CompiletimeReadonly)) {
+                                variable.Value.TryAsConstant(out constant!);
                                 return true; // MUST be true.
                             }
                         }

--- a/DMCompiler/DM/Expressions/Procs.cs
+++ b/DMCompiler/DM/Expressions/Procs.cs
@@ -102,6 +102,8 @@ namespace DMCompiler.DM.Expressions {
         private readonly DMExpression _target;
         private readonly ArgumentList _arguments;
 
+        public override bool PathIsFuzzy => Path == null;
+
         public ProcCall(Location location, DMExpression target, ArgumentList arguments) : base(location) {
             _target = target;
             _arguments = arguments;

--- a/DMCompiler/DM/Expressions/Ternary.cs
+++ b/DMCompiler/DM/Expressions/Ternary.cs
@@ -6,6 +6,8 @@ namespace DMCompiler.DM.Expressions {
     sealed class Ternary : DMExpression {
         private readonly DMExpression _a, _b, _c;
 
+        public override bool PathIsFuzzy => true;
+
         public Ternary(Location location, DMExpression a, DMExpression b, DMExpression c) : base(location) {
             _a = a;
             _b = b;

--- a/DMCompiler/DM/Visitors/DMASTSimplifier.cs
+++ b/DMCompiler/DM/Visitors/DMASTSimplifier.cs
@@ -1,4 +1,5 @@
 using DMCompiler.Compiler.DM;
+using DMCompiler.DM.Expressions;
 using System;
 
 namespace DMCompiler.DM.Visitors {
@@ -556,19 +557,19 @@ namespace DMCompiler.DM.Visitors {
                 }
             }
 
-            DMASTDereference deref = expression as DMASTDereference;
-            if (deref != null) {
+            if (expression is DMASTDereference deref) {
                 SimplifyExpression(ref deref.Expression);
 
-                foreach (ref var operation in deref.Operations.AsSpan()) {
-                    if (operation.Index != null) {
-                        SimplifyExpression(ref deref.Expression);
-                    }
-
-                    if (operation.Parameters != null) {
-                        foreach (DMASTCallParameter parameter in operation.Parameters) {
-                            SimplifyExpression(ref parameter.Value);
-                        }
+                foreach (var operation in deref.Operations) {
+                    switch (operation) {
+                        case DMASTDereference.IndexOperation indexOperation:
+                            SimplifyExpression(ref indexOperation.Index);
+                            break;
+                        case DMASTDereference.CallOperation callOperation:
+                            foreach (var param in callOperation.Parameters) {
+                                SimplifyExpression(ref param.Value);
+                            }
+                            break;
                     }
                 }
             }

--- a/DMCompiler/DM/Visitors/DMExpressionBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMExpressionBuilder.cs
@@ -1,9 +1,9 @@
-using System;
+using DMCompiler.Compiler.DM;
 using DMCompiler.DM.Expressions;
 using OpenDreamShared.Compiler;
-using DMCompiler.Compiler.DM;
 using OpenDreamShared.Dream;
 using Robust.Shared.Utility;
+using System;
 
 namespace DMCompiler.DM.Visitors;
 
@@ -612,8 +612,8 @@ internal static class DMExpressionBuilder {
                 }
 
                 case DMASTDereference.IndexOperation indexOperation:
-                    // Passing the path here is cursed, but one of the tests seems to suggest we want that?
                     operation = new Dereference.IndexOperation {
+                        // Passing the path here is cursed, but one of the tests seems to suggest we want that?
                         Index = DMExpression.Create(dmObject, proc, indexOperation.Index, prevPath),
                         Safe = indexOperation.Safe,
                         Path = prevPath

--- a/DMCompiler/DM/Visitors/DMExpressionBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMExpressionBuilder.cs
@@ -583,7 +583,8 @@ internal static class DMExpressionBuilder {
                             }
 
                             if ((property.ValType & DMValueType.Unimplemented) == DMValueType.Unimplemented) {
-                                DMCompiler.UnimplementedWarning(deref.Location, $"{prevPath}.{field} is not implemented and will have unexpected behavior");
+                                DMCompiler.UnimplementedWarning(deref.Location,
+                                    $"{prevPath}.{field} is not implemented and will have unexpected behavior");
                             }
 
                             operations = new Dereference.Operation[newOperationCount];
@@ -592,6 +593,10 @@ internal static class DMExpressionBuilder {
                             prevPath = property.Type;
                             pathIsFuzzy = prevPath == null;
                             continue;
+                        }
+
+                        if (property == null) {
+                            throw new UnknownIdentifierException(deref.Location, field);
                         }
                     }
 
@@ -628,11 +633,15 @@ internal static class DMExpressionBuilder {
 
                         DMObject? fromObject = DMObjectTree.GetDMObject(prevPath.Value, false);
                         if (fromObject == null) {
-                            throw new CompileErrorException(deref.Location, $"Type {prevPath.Value} does not exist");
+                            DMCompiler.Emit(WarningCode.ItemDoesntExist, callOperation.Location,
+                                $"Type {prevPath.Value} does not exist");
+                            return new Null(deref.Location);
                         }
 
                         if (!fromObject.HasProc(field)) {
-                            throw new CompileErrorException(deref.Location, $"Type {prevPath.Value} does not have a proc named \"{field}\"");
+                            DMCompiler.Emit(WarningCode.ItemDoesntExist, callOperation.Location,
+                                $"Type {prevPath.Value} does not have a proc named \"{field}\"");
+                            return new Null(deref.Location);
                         }
                     }
 

--- a/DMCompiler/DM/Visitors/DMExpressionBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMExpressionBuilder.cs
@@ -522,7 +522,7 @@ internal static class DMExpressionBuilder {
                         pathIsFuzzy = false;
                         break;
                     default:
-                        throw new NotImplementedException($"Missing implementation for {namedOperation}");
+                        throw new ArgumentOutOfRangeException($"Missing implementation for {namedOperation}");
                 }
 
                 var newOperationCount = operations.Length - 1;


### PR DESCRIPTION
It's just like rust enums no wayyyy

This PR tackles mainly nullability by refactoring the existing Dereference operation to be safer with the help of the type system. 

The previous implementation used a struct called `Operation`, which held an enum value for what kind of operation the struct described as well as metadata about the operation. This resulted in a struct where pretty much every additional metadata was optional and had to be asserted at the time of checking `Kind`, which wasn't very elegant.

I refactored dereference operations by binding the metadata into types with one shared superclass called `Operation`. 
The subclasses are there to describe all kinds of different metadata that they need. To get the metadata, you can use type patterns to extract the data. This completely eliminates the need to assert no nullability with `!`, making the code much clearer and more elegant. 

Since `Operation` had to inherit from other things now, I had to turn it into a class. This has zero impact on performance since all operations were located on the heap anyways.

Additionally I cleaned up some of the code involving dereferences. One less area with warnings.
