### PR TITLE
Tiny fix to enumerators

### DIFF
--- a/OpenDreamRuntime/Procs/DreamEnumerators.cs
+++ b/OpenDreamRuntime/Procs/DreamEnumerators.cs
@@ -55,7 +55,7 @@ internal sealed class DreamObjectEnumerator : IDreamValueEnumerator {
 
         // Assign regardless of success
         if (reference != null)
-            state.AssignReference(reference.Value, new DreamValue(_dreamObjectEnumerator.Current));
+            state.AssignReference(reference.Value, success ? new DreamValue(_dreamObjectEnumerator.Current) : DreamValue.Null);
         return success;
     }
 }


### PR DESCRIPTION
Was throwing on `for(var/client/C)` when no clients were connected because accessing `.Current` when the enumerator is finished throws.