### PR TITLE
Optimize `DMISpriteComponent.IsVisible()`

### DIFF
--- a/OpenDreamClient/Rendering/DMISpriteComponent.cs
+++ b/OpenDreamClient/Rendering/DMISpriteComponent.cs
@@ -8,17 +8,19 @@ internal sealed partial class DMISpriteComponent : SharedDMISpriteComponent {
     [ViewVariables] public DreamIcon Icon { get; set; }
     [ViewVariables] public ScreenLocation? ScreenLocation { get; set; }
 
-    [Dependency] private readonly IEntityManager _entityManager = default!;
+    /// <summary>
+    /// Checks if this sprite should be visible to the player<br/>
+    /// Checks the appearance's invisibility, and if a transform is given, whether it's parented to another entity
+    /// </summary>
+    /// <param name="transform">The entity's transform, the parent check is skipped if this is null</param>
+    /// <param name="seeInvisibility">The eye's see_invisibility var</param>
+    /// <returns></returns>
+    public bool IsVisible(TransformComponent? transform, int seeInvisibility) {
+        if (Icon.Appearance?.Invisibility > seeInvisibility) return false;
 
-    public bool IsVisible(bool checkWorld = true, int seeInvis = 0) {
-        if (Icon.Appearance?.Invisibility > seeInvis) return false;
-
-        if (checkWorld) {
+        if (transform != null) {
             //Only render movables not inside another movable's contents (parented to the grid)
             //TODO: Use RobustToolbox's container system/components?
-            if (!_entityManager.TryGetComponent<TransformComponent>(Owner, out var transform))
-                return false;
-
             if (transform.ParentUid != transform.GridUid)
                 return false;
         }

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -752,12 +752,14 @@ internal sealed class DreamViewOverlay : Overlay {
             // TODO use a sprite tree.
             if (!_spriteQuery.TryGetComponent(entity, out var sprite))
                 continue;
-            if (!sprite.IsVisible(seeInvis: seeVis))
+
+            var transform = _xformQuery.GetComponent(entity);
+            if (!sprite.IsVisible(transform, seeVis))
                 continue;
             if (sprite.Icon.Appearance == null) //appearance hasn't loaded yet
                 continue;
 
-            var worldPos = _transformSystem.GetWorldPosition(entity, _xformQuery);
+            var worldPos = _transformSystem.GetWorldPosition(transform);
             var tilePos = grid.WorldToTile(worldPos) - eyeTile.GridIndices + viewRange.Center;
             if (tilePos.X < 0 || tilePos.Y < 0 || tilePos.X >= _tileInfo.GetLength(0) || tilePos.Y >= _tileInfo.GetLength(1))
                 continue;
@@ -801,10 +803,12 @@ internal sealed class DreamViewOverlay : Overlay {
                 // TODO use a sprite tree.
                 if (!_spriteQuery.TryGetComponent(entity, out var sprite))
                     continue;
-                if (!sprite.IsVisible(seeInvis: seeVis))
+
+                var transform = _xformQuery.GetComponent(entity);
+                if (!sprite.IsVisible(transform, seeVis))
                     continue;
 
-                var worldPos = _transformSystem.GetWorldPosition(entity, _xformQuery);
+                var worldPos = _transformSystem.GetWorldPosition(transform);
 
                 // Check for visibility if the eye doesn't have SEE_OBJS or SEE_MOBS
                 // TODO: Differentiate between objs and mobs
@@ -830,7 +834,7 @@ internal sealed class DreamViewOverlay : Overlay {
             foreach (EntityUid uid in _screenOverlaySystem.ScreenObjects) {
                 if (!_entityManager.TryGetComponent(uid, out DMISpriteComponent? sprite) || sprite.ScreenLocation == null)
                     continue;
-                if (!sprite.IsVisible(checkWorld: false, seeInvis: seeVis))
+                if (!sprite.IsVisible(null, seeVis))
                     continue;
                 if (sprite.ScreenLocation.MapControl != null) // Don't render screen objects meant for other map controls
                     continue;


### PR DESCRIPTION
This had an `IEntityManager.TryGetComponent<TransformComponent>()` call, which is slow for how often this gets called. Now the `TransformComponent` is an argument, and the calling code uses an EntityQuery which speeds it up.