### PR TITLE
Handle `glide_size` being updated mid-glide

### DIFF
--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -328,7 +328,7 @@ public sealed class AtomManager {
                 break;
             case "glide_size":
                 value.TryGetValueAsFloat(out float glideSize);
-                appearance.GlideSize = (byte) glideSize;
+                appearance.GlideSize = glideSize;
                 break;
             case "render_source":
                 value.TryGetValueAsString(out appearance.RenderSource);

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1697,14 +1697,13 @@ namespace OpenDreamRuntime.Procs {
         public static ProcStatus Spawn(DMProcState state) {
             int jumpTo = state.ReadInt();
             state.Pop().TryGetValueAsFloat(out var delay);
-            int delayMilliseconds = (int)(delay * 100);
 
             // TODO: It'd be nicer if we could use something such as DreamThread.Spawn here
             // and have state.Spawn return a ProcState instead
             DreamThread newContext = state.Spawn();
 
             //Negative delays mean the spawned code runs immediately
-            if (delayMilliseconds < 0) {
+            if (delay < 0) {
                 newContext.Resume();
                 // TODO: Does the rest of the proc get scheduled?
                 // Does the value of the delay mean anything?

--- a/OpenDreamShared/Dream/IconAppearance.cs
+++ b/OpenDreamShared/Dream/IconAppearance.cs
@@ -17,7 +17,7 @@ namespace OpenDreamShared.Dream {
         [ViewVariables] public Vector2i PixelOffset;
         [ViewVariables] public Color Color = Color.White;
         [ViewVariables] public byte Alpha = 255;
-        [ViewVariables] public byte GlideSize;
+        [ViewVariables] public float GlideSize;
         /// <summary>
         /// An appearance can gain a color matrix filter by two possible forces: <br/>
         /// 1. the /atom.color var is modified. <br/>


### PR DESCRIPTION
If `glide_size` is changed mid-movement the client will now use that updated speed. I also changed the GlideSize field on appearances from a byte to a float, so non-integer sizes work.

In Paradise, this fixes gliding for anything with a movespeed other than 1. This includes slower mobs, walking, and crawling.