### PR TITLE
Tweak `Nameof` slightly, add `GetNameof()` support to more expressions

### DIFF
--- a/Content.Tests/DMProject/Tests/Special Procs/nameof/nameof.dm
+++ b/Content.Tests/DMProject/Tests/Special Procs/nameof/nameof.dm
@@ -2,7 +2,14 @@
 var/global/foobar
 /proc/meep()
 
+/datum/test/two
+	var/name = "some name"
+
+/datum/test
+	var/datum/test/two/two
+
 /datum/test/proc/testarg(atom/movable/A, B)
+	ASSERT(two == "two")
 	ASSERT(nameof(A) == "A")
 	ASSERT(nameof(B) == "B")
 
@@ -13,4 +20,5 @@ var/global/foobar
 	ASSERT(nameof(/datum/test) == "test")
 	ASSERT(nameof(global.foobar) == "foobar")
 	var/datum/test/T = new
+	ASSERT(nameof(T.two.name) == "name")
 	T.testarg(new /datum) // Just for fun we won't pass the arg's declared type

--- a/Content.Tests/DMProject/Tests/Special Procs/nameof/nameof.dm
+++ b/Content.Tests/DMProject/Tests/Special Procs/nameof/nameof.dm
@@ -9,7 +9,7 @@ var/global/foobar
 	var/datum/test/two/two
 
 /datum/test/proc/testarg(atom/movable/A, B)
-	ASSERT(two == "two")
+	ASSERT(nameof(two) == "two")
 	ASSERT(nameof(A) == "A")
 	ASSERT(nameof(B) == "B")
 

--- a/DMCompiler/DM/DMExpression.cs
+++ b/DMCompiler/DM/DMExpression.cs
@@ -1,9 +1,9 @@
-using System;
+using DMCompiler.Bytecode;
+using DMCompiler.Compiler.DM;
 using DMCompiler.DM.Visitors;
 using OpenDreamShared.Compiler;
-using DMCompiler.Compiler.DM;
+using System;
 using System.Diagnostics.CodeAnalysis;
-using DMCompiler.Bytecode;
 
 namespace DMCompiler.DM {
     internal abstract class DMExpression {
@@ -64,7 +64,7 @@ namespace DMCompiler.DM {
         /// Gets the canonical name of the expression if it exists.
         /// </summary>
         /// <returns>The name of the expression, or <c>null</c> if it does not have one.</returns>
-        public virtual string? GetNameof() => null;
+        public virtual string? GetNameof(DMObject dmObject, DMProc proc) => null;
 
         /// <summary>
         /// Determines whether the expression returns an ambiguous path.

--- a/DMCompiler/DM/DMExpression.cs
+++ b/DMCompiler/DM/DMExpression.cs
@@ -60,9 +60,7 @@ namespace DMCompiler.DM {
             throw new CompileErrorException(Location, $"attempt to reference r-value");
         }
 
-        public virtual string GetNameof(DMObject dmObject, DMProc proc) {
-            throw new CompileAbortException(Location, "nameof: requires a var, proc reference, or type path");
-        }
+        public virtual string? GetNameof() => null;
 
         /// <summary>
         /// Determines whether the expression returns an ambiguous path.

--- a/DMCompiler/DM/DMExpression.cs
+++ b/DMCompiler/DM/DMExpression.cs
@@ -60,6 +60,10 @@ namespace DMCompiler.DM {
             throw new CompileErrorException(Location, $"attempt to reference r-value");
         }
 
+        /// <summary>
+        /// Gets the canonical name of the expression if it exists.
+        /// </summary>
+        /// <returns>The name of the expression, or <c>null</c> if it does not have one.</returns>
         public virtual string? GetNameof() => null;
 
         /// <summary>

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -13,11 +13,13 @@ using OpenDreamShared.Compiler;
 namespace DMCompiler.DM {
     internal sealed class DMProc {
         public class LocalVariable {
+            public readonly string Name;
             public readonly int Id;
             public readonly bool IsParameter;
             public DreamPath? Type;
 
-            public LocalVariable(int id, bool isParameter, DreamPath? type) {
+            public LocalVariable(string name, int id, bool isParameter, DreamPath? type) {
+                Name = name;
                 Id = id;
                 IsParameter = isParameter;
                 Type = type;
@@ -27,7 +29,8 @@ namespace DMCompiler.DM {
         public sealed class LocalConstVariable : LocalVariable {
             public readonly Expressions.Constant Value;
 
-            public LocalConstVariable(int id, DreamPath? type, Expressions.Constant value) : base(id, false, type) {
+            public LocalConstVariable(string name, int id, DreamPath? type, Expressions.Constant value)
+                : base(name, id, false, type) {
                 Value = value;
             }
         }
@@ -227,7 +230,7 @@ namespace DMCompiler.DM {
             if (_parameters.ContainsKey(name)) {
                 DMCompiler.Emit(WarningCode.DuplicateVariable, _astDefinition.Location, $"Duplicate argument \"{name}\"");
             } else {
-                _parameters.Add(name, new LocalVariable(_parameters.Count, true, type));
+                _parameters.Add(name, new LocalVariable(name, _parameters.Count, true, type));
             }
         }
 
@@ -320,7 +323,7 @@ namespace DMCompiler.DM {
                 return false;
 
             int localVarId = AllocLocalVariable(name);
-            return _scopes.Peek().LocalVariables.TryAdd(name, new LocalVariable(localVarId, false, type));
+            return _scopes.Peek().LocalVariables.TryAdd(name, new LocalVariable(name, localVarId, false, type));
         }
 
         public bool TryAddLocalConstVariable(string name, DreamPath? type, Expressions.Constant value) {
@@ -328,7 +331,7 @@ namespace DMCompiler.DM {
                 return false;
 
             int localVarId = AllocLocalVariable(name);
-            return _scopes.Peek().LocalVariables.TryAdd(name, new LocalConstVariable(localVarId, type, value));
+            return _scopes.Peek().LocalVariables.TryAdd(name, new LocalConstVariable(name, localVarId, type, value));
         }
 
         public LocalVariable? GetLocalVariable(string name) {

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -1,5 +1,7 @@
-using DMCompiler.DM.Visitors;
+using DMCompiler.Bytecode;
 using DMCompiler.Compiler.DM;
+using DMCompiler.DM.Visitors;
+using OpenDreamShared.Compiler;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Dream.Procs;
 using OpenDreamShared.Json;
@@ -7,8 +9,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using DMCompiler.Bytecode;
-using OpenDreamShared.Compiler;
 
 namespace DMCompiler.DM {
     internal sealed class DMProc {
@@ -193,10 +193,6 @@ namespace DMCompiler.DM {
             }
 
             return procDefinition;
-        }
-
-        public string GetLocalVarName(int index) {
-            return _localVariableNames[index].Add;
         }
 
         public void WaitFor(bool waitFor) {

--- a/DMCompiler/DM/Expressions/Builtins.cs
+++ b/DMCompiler/DM/Expressions/Builtins.cs
@@ -603,8 +603,7 @@ namespace DMCompiler.DM.Expressions {
             if (_expr.GetNameof() is { } nameof) {
                 proc.PushString(nameof);
             } else {
-                DMCompiler.Emit(WarningCode.BadArgument, Location,
-                    "nameof() requires a var, proc reference, or type path");
+                DMCompiler.Emit(WarningCode.BadArgument, Location, "nameof() requires a var, proc reference, or type path");
                 proc.PushString("");
             }
         }
@@ -614,8 +613,7 @@ namespace DMCompiler.DM.Expressions {
                 constant = new String(Location, nameof);
                 return true;
             }
-            DMCompiler.Emit(WarningCode.BadArgument, Location,
-                "nameof() requires a var, proc reference, or type path");
+            DMCompiler.Emit(WarningCode.BadArgument, Location, "nameof() requires a var, proc reference, or type path");
             constant = null;
             return false;
         }

--- a/DMCompiler/DM/Expressions/Builtins.cs
+++ b/DMCompiler/DM/Expressions/Builtins.cs
@@ -600,7 +600,24 @@ namespace DMCompiler.DM.Expressions {
         }
 
         public override void EmitPushValue(DMObject dmObject, DMProc proc) {
-            proc.PushString(_expr.GetNameof(dmObject, proc));
+            if (_expr.GetNameof() is { } nameof) {
+                proc.PushString(nameof);
+            } else {
+                DMCompiler.Emit(WarningCode.BadArgument, Location,
+                    "nameof() requires a var, proc reference, or type path");
+                proc.PushString("");
+            }
+        }
+
+        public override bool TryAsConstant([NotNullWhen(true)] out Constant? constant) {
+            if (_expr.GetNameof() is { } nameof) {
+                constant = new String(Location, nameof);
+                return true;
+            }
+            DMCompiler.Emit(WarningCode.BadArgument, Location,
+                "nameof() requires a var, proc reference, or type path");
+            constant = null;
+            return false;
         }
     }
 
@@ -644,6 +661,11 @@ namespace DMCompiler.DM.Expressions {
                 proc.PushType(dmObject.Id);
             }
         }
+
+        public override string GetNameof() {
+            DMCompiler.UnimplementedWarning(Location, "nameof(__TYPE__) is unimplemented");
+            return "";
+        }
     }
 
     // __PROC__
@@ -654,6 +676,12 @@ namespace DMCompiler.DM.Expressions {
 
         public override void EmitPushValue(DMObject dmObject, DMProc proc) {
             proc.PushProc(proc.Id);
+        }
+
+        public override string GetNameof() {
+            // TODO: refactor proc references
+            DMCompiler.UnimplementedWarning(Location, "nameof(__PROC__) is unimplemented");
+            return "";
         }
     }
 

--- a/DMCompiler/DM/Expressions/Constant.cs
+++ b/DMCompiler/DM/Expressions/Constant.cs
@@ -523,9 +523,7 @@ namespace DMCompiler.DM.Expressions {
             }
         }
 
-        public override string? GetNameof() {
-            return Value.LastElement;
-        }
+        public override string? GetNameof(DMObject dmObject, DMProc proc) => Value.LastElement;
 
         public override bool IsTruthy() => true;
 

--- a/DMCompiler/DM/Expressions/Constant.cs
+++ b/DMCompiler/DM/Expressions/Constant.cs
@@ -523,7 +523,7 @@ namespace DMCompiler.DM.Expressions {
             }
         }
 
-        public override string GetNameof(DMObject dmObject, DMProc proc) {
+        public override string? GetNameof() {
             return Value.LastElement;
         }
 

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -2,6 +2,7 @@ using DMCompiler.Bytecode;
 using OpenDreamShared.Compiler;
 using OpenDreamShared.Dream;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace DMCompiler.DM.Expressions {
@@ -241,11 +242,13 @@ namespace DMCompiler.DM.Expressions {
         }
 
         // BYOND says the nameof is invalid if the chain is not purely field operations
-        public override string? GetNameof() => _operations.All(op => op is FieldOperation)
-            ? ((FieldOperation)_operations[^1]).Identifier
-            : null;
+        public override string? GetNameof(DMObject dmObject, DMProc proc) {
+            return _operations.All(op => op is FieldOperation)
+                ? ((FieldOperation)_operations[^1]).Identifier
+                : null;
+        }
 
-        public override bool TryAsConstant(out Constant constant) {
+        public override bool TryAsConstant([NotNullWhen(true)] out Constant? constant) {
             var prevPath = _operations.Length == 1 ? _expression.Path : _operations[^2].Path;
 
             var operation = _operations[^1];

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -2,7 +2,6 @@ using DMCompiler.Bytecode;
 using OpenDreamShared.Compiler;
 using OpenDreamShared.Dream;
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace DMCompiler.DM.Expressions {
@@ -241,7 +240,12 @@ namespace DMCompiler.DM.Expressions {
             proc.AddLabel(endLabel);
         }
 
-        public override bool TryAsConstant([NotNullWhen(true)] out Constant? constant) {
+        // BYOND says the nameof is invalid if the chain is not purely field operations
+        public override string? GetNameof() => _operations.All(op => op is FieldOperation)
+            ? ((FieldOperation)_operations[^1]).Identifier
+            : null;
+
+        public override bool TryAsConstant(out Constant constant) {
             var prevPath = _operations.Length == 1 ? _expression.Path : _operations[^2].Path;
 
             var operation = _operations[^1];

--- a/DMCompiler/DM/Expressions/LValue.cs
+++ b/DMCompiler/DM/Expressions/LValue.cs
@@ -1,6 +1,6 @@
-using System.Diagnostics.CodeAnalysis;
 using DMCompiler.Bytecode;
 using OpenDreamShared.Compiler;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DMCompiler.DM.Expressions {
     abstract class LValue : DMExpression {
@@ -43,7 +43,7 @@ namespace DMCompiler.DM.Expressions {
             return DMReference.Src;
         }
 
-        public override string GetNameof() => "src";
+        public override string GetNameof(DMObject dmObject, DMProc proc) => "src";
     }
 
     // usr
@@ -56,7 +56,7 @@ namespace DMCompiler.DM.Expressions {
             return DMReference.Usr;
         }
 
-        public override string GetNameof() => "usr";
+        public override string GetNameof(DMObject dmObject, DMProc proc) => "usr";
     }
 
     // args
@@ -69,7 +69,7 @@ namespace DMCompiler.DM.Expressions {
             return DMReference.Args;
         }
 
-        public override string GetNameof() => "args";
+        public override string GetNameof(DMObject dmObject, DMProc proc) => "args";
     }
 
     // Identifier of local variable
@@ -105,7 +105,7 @@ namespace DMCompiler.DM.Expressions {
             EmitPushValue(dmObject, proc);
         }
 
-        public override string GetNameof() => LocalVar.Name;
+        public override string GetNameof(DMObject dmObject, DMProc proc) => LocalVar.Name;
     }
 
     // Identifier of field
@@ -133,7 +133,7 @@ namespace DMCompiler.DM.Expressions {
             return DMReference.CreateSrcField(Variable.Name);
         }
 
-        public override string GetNameof() => Variable.Name;
+        public override string GetNameof(DMObject dmObject, DMProc proc) => Variable.Name;
 
         public override bool TryAsConstant([NotNullWhen(true)] out Constant? constant) {
             if (Variable.IsConst && Variable.Value != null) {
@@ -168,7 +168,7 @@ namespace DMCompiler.DM.Expressions {
             EmitPushValue(dmObject, proc);
         }
 
-        public override string GetNameof() {
+        public override string GetNameof(DMObject dmObject, DMProc proc) {
             DMVariable global = DMObjectTree.Globals[Id];
             return global.Name;
         }
@@ -193,6 +193,6 @@ namespace DMCompiler.DM.Expressions {
             proc.PushGlobalVars();
         }
 
-        public override string GetNameof() => "vars";
+        public override string GetNameof(DMObject dmObject, DMProc proc) => "vars";
     }
 }

--- a/DMCompiler/DM/Expressions/LValue.cs
+++ b/DMCompiler/DM/Expressions/LValue.cs
@@ -26,8 +26,7 @@ namespace DMCompiler.DM.Expressions {
 
     // global
     class Global : LValue {
-        public Global(Location location)
-            : base(location, null) { }
+        public Global(Location location) : base(location, null) { }
 
         public override DMReference EmitReference(DMObject dmObject, DMProc proc, string endLabel, ShortCircuitMode shortCircuitMode) {
             throw new CompileErrorException(Location, $"attempt to use `global` as a reference");
@@ -44,9 +43,7 @@ namespace DMCompiler.DM.Expressions {
             return DMReference.Src;
         }
 
-        public override string GetNameof(DMObject dmObject, DMProc proc) {
-            return "src";
-        }
+        public override string GetNameof() => "src";
     }
 
     // usr
@@ -58,6 +55,8 @@ namespace DMCompiler.DM.Expressions {
         public override DMReference EmitReference(DMObject dmObject, DMProc proc, string endLabel, ShortCircuitMode shortCircuitMode) {
             return DMReference.Usr;
         }
+
+        public override string GetNameof() => "usr";
     }
 
     // args
@@ -69,6 +68,8 @@ namespace DMCompiler.DM.Expressions {
         public override DMReference EmitReference(DMObject dmObject, DMProc proc, string endLabel, ShortCircuitMode shortCircuitMode) {
             return DMReference.Args;
         }
+
+        public override string GetNameof() => "args";
     }
 
     // Identifier of local variable
@@ -104,9 +105,7 @@ namespace DMCompiler.DM.Expressions {
             EmitPushValue(dmObject, proc);
         }
 
-        public override string GetNameof(DMObject dmObject, DMProc proc) {
-            return LocalVar.IsParameter ? proc.Parameters[LocalVar.Id] : proc.GetLocalVarName(LocalVar.Id);
-        }
+        public override string GetNameof() => LocalVar.Name;
     }
 
     // Identifier of field
@@ -133,6 +132,8 @@ namespace DMCompiler.DM.Expressions {
         public override DMReference EmitReference(DMObject dmObject, DMProc proc, string endLabel, ShortCircuitMode shortCircuitMode) {
             return DMReference.CreateSrcField(Variable.Name);
         }
+
+        public override string GetNameof() => Variable.Name;
 
         public override bool TryAsConstant([NotNullWhen(true)] out Constant? constant) {
             if (Variable.IsConst && Variable.Value != null) {
@@ -167,7 +168,7 @@ namespace DMCompiler.DM.Expressions {
             EmitPushValue(dmObject, proc);
         }
 
-        public override string GetNameof(DMObject dmObject, DMProc proc) {
+        public override string GetNameof() {
             DMVariable global = DMObjectTree.Globals[Id];
             return global.Name;
         }
@@ -191,5 +192,7 @@ namespace DMCompiler.DM.Expressions {
         public override void EmitPushValue(DMObject dmObject, DMProc proc) {
             proc.PushGlobalVars();
         }
+
+        public override string GetNameof() => "vars";
     }
 }

--- a/DMCompiler/DM/Visitors/DMExpressionBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMExpressionBuilder.cs
@@ -248,7 +248,7 @@ internal static class DMExpressionBuilder {
             case DMASTInitial initial:
                 return new Initial(initial.Location, BuildExpression(initial.Expression, dmObject, proc, inferredPath));
             case DMASTNameof nameof:
-                return new Nameof(nameof.Location, BuildExpression(nameof.Expression, dmObject, proc, inferredPath));
+                return BuildNameof(nameof, dmObject, proc, inferredPath);
             case DMASTExpressionIn expressionIn:
                 return new In(expressionIn.Location,
                     BuildExpression(expressionIn.Value, dmObject, proc, inferredPath),
@@ -718,6 +718,17 @@ internal static class DMExpressionBuilder {
         }
 
         return new DimensionalList(list.Location, sizes);
+    }
+
+    // nameof(x)
+    private static DMExpression BuildNameof(DMASTNameof nameof, DMObject dmObject, DMProc proc, DreamPath? inferredPath) {
+        var expr = BuildExpression(nameof.Expression, dmObject, proc, inferredPath);
+        if (expr.GetNameof(dmObject, proc) is { } name) {
+            return new Expressions.String(nameof.Location, name);
+        }
+
+        DMCompiler.Emit(WarningCode.BadArgument, nameof.Location, "nameof() requires a var, proc reference, or type path");
+        return new Null(nameof.Location);
     }
 
     private static DMExpression BuildNewList(DMASTNewList newList, DMObject dmObject, DMProc proc, DreamPath? inferredPath) {


### PR DESCRIPTION
Throwing is bad. Unwinding isn't healthy for tracking code errors. I refactored `GetNameof()` to return an optional string, which gets checked in the actual `Nameof` expression. There we can emit the error. 

The arguments for `GetNameof` felt unnecessary since `dmObject` was unused, `proc` was used only once in `Local`, so I cut the arguments from the method. Let me know if I should keep it.

`nameof()` is also usable in constant contexts (eg. switch cases), so I added an override for `TryAsConstant()`.

Also a few l-values didn't have any nameof support, so I added it in this PR.