### PR TITLE
Halve the renderer's allocation rate

### DIFF
--- a/OpenDreamClient/DreamClientSystem.cs
+++ b/OpenDreamClient/DreamClientSystem.cs
@@ -10,6 +10,7 @@ internal sealed class DreamClientSystem : EntitySystem {
     [Dependency] private readonly IDreamInterfaceManager _interfaceManager = default!;
     [Dependency] private readonly IOverlayManager _overlayManager = default!;
     [Dependency] private readonly TransformSystem _transformSystem = default!;
+    [Dependency] private readonly MapSystem _mapSystem = default!;
     [Dependency] private readonly EntityLookupSystem _lookupSystem = default!;
     [Dependency] private readonly ClientAppearanceSystem _appearanceSystem = default!;
     [Dependency] private readonly ClientScreenOverlaySystem _screenOverlaySystem = default!;
@@ -18,7 +19,7 @@ internal sealed class DreamClientSystem : EntitySystem {
     public override void Initialize() {
         SubscribeLocalEvent<LocalPlayerAttachedEvent>(OnPlayerAttached);
 
-        var mapOverlay = new DreamViewOverlay(_transformSystem, _lookupSystem, _appearanceSystem, _screenOverlaySystem, _clientImagesSystem);
+        var mapOverlay = new DreamViewOverlay(_transformSystem, _mapSystem, _lookupSystem, _appearanceSystem, _screenOverlaySystem, _clientImagesSystem);
         _overlayManager.AddOverlay(mapOverlay);
     }
 

--- a/OpenDreamClient/Rendering/DreamPlane.cs
+++ b/OpenDreamClient/Rendering/DreamPlane.cs
@@ -62,8 +62,6 @@ internal sealed class DreamPlane(IRenderTexture mainRenderTarget) : IDisposable 
                 handle.UseShader(overlay.GetBlendAndColorShader(Master, useOverlayMode: true));
                 handle.SetTransform(DreamViewOverlay.CreateRenderTargetFlipMatrix(_temporaryRenderTarget.Size, Vector2.Zero));
                 handle.DrawTextureRect(mainRenderTarget.Texture, new Box2(Vector2.Zero, mainRenderTarget.Size));
-                handle.SetTransform(Matrix3.Identity);
-                handle.UseShader(null);
             }, new Color());
         }
     }

--- a/OpenDreamClient/Rendering/DreamPlane.cs
+++ b/OpenDreamClient/Rendering/DreamPlane.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Client.Graphics;
+﻿using OpenDreamShared.Dream;
+using Robust.Client.Graphics;
 using Robust.Shared.Utility;
 
 namespace OpenDreamClient.Rendering;
@@ -7,15 +8,13 @@ internal sealed class DreamPlane(IRenderTexture mainRenderTarget) : IDisposable 
     public IRenderTexture RenderTarget => _temporaryRenderTarget ?? mainRenderTarget;
     public RendererMetaData? Master;
 
-    public readonly List<Action<Vector2i>> IconDrawActions = new();
-    public readonly List<Action<Vector2i>> MouseMapDrawActions = new();
+    public readonly List<RendererMetaData> Sprites = new();
 
     private IRenderTexture? _temporaryRenderTarget;
 
     public void Clear() {
         Master = null;
-        IconDrawActions.Clear();
-        MouseMapDrawActions.Clear();
+        Sprites.Clear();
         _temporaryRenderTarget = null;
     }
 
@@ -44,18 +43,24 @@ internal sealed class DreamPlane(IRenderTexture mainRenderTarget) : IDisposable 
     /// <summary>
     /// Clears this plane's render target, then draws all the plane's icons onto it
     /// </summary>
-    public void Draw(DreamViewOverlay overlay, DrawingHandleWorld handle) {
+    public void Draw(DreamViewOverlay overlay, DrawingHandleWorld handle, Box2 worldAABB) {
         // Draw all icons
         handle.RenderInRenderTarget(mainRenderTarget, () => {
-            foreach (Action<Vector2i> iconAction in IconDrawActions)
-                iconAction(mainRenderTarget.Size);
+            foreach (var sprite in Sprites) {
+                if (sprite.HasRenderSource && overlay.RenderSourceLookup.TryGetValue(sprite.RenderSource!, out var renderSourceTexture)) {
+                    sprite.TextureOverride = renderSourceTexture.Texture;
+                    overlay.DrawIcon(handle, mainRenderTarget.Size, sprite, (-worldAABB.BottomLeft)-(worldAABB.Size/2)+new Vector2(0.5f,0.5f));
+                } else {
+                    overlay.DrawIcon(handle, mainRenderTarget.Size, sprite, -worldAABB.BottomLeft);
+                }
+            }
         }, new Color());
 
         if (_temporaryRenderTarget != null) {
             // Draw again, but with the color applied
             handle.RenderInRenderTarget(_temporaryRenderTarget, () => {
                 handle.UseShader(overlay.GetBlendAndColorShader(Master, useOverlayMode: true));
-                handle.SetTransform(overlay.CreateRenderTargetFlipMatrix(_temporaryRenderTarget.Size, Vector2.Zero));
+                handle.SetTransform(DreamViewOverlay.CreateRenderTargetFlipMatrix(_temporaryRenderTarget.Size, Vector2.Zero));
                 handle.DrawTextureRect(mainRenderTarget.Texture, new Box2(Vector2.Zero, mainRenderTarget.Size));
                 handle.SetTransform(Matrix3.Identity);
                 handle.UseShader(null);
@@ -66,8 +71,29 @@ internal sealed class DreamPlane(IRenderTexture mainRenderTarget) : IDisposable 
     /// <summary>
     /// Draws this plane's mouse map onto the current render target
     /// </summary>
-    public void DrawMouseMap(Vector2i renderTargetSize) {
-        foreach (Action<Vector2i> mouseMapAction in MouseMapDrawActions)
-            mouseMapAction(renderTargetSize);
+    public void DrawMouseMap(DrawingHandleWorld handle, DreamViewOverlay overlay, Vector2i renderTargetSize, Box2 worldAABB) {
+        handle.UseShader(overlay.BlockColorInstance);
+        foreach (var sprite in Sprites) {
+            if (sprite.MouseOpacity == MouseOpacity.Transparent || sprite.ShouldPassMouse)
+                continue;
+
+            var texture = sprite.Texture;
+            if (texture == null)
+                continue;
+
+            var pos = (sprite.Position - worldAABB.BottomLeft) * EyeManager.PixelsPerMeter;
+            if (sprite.TextureOverride != null)
+                pos -= sprite.TextureOverride.Size / 2 - new Vector2(EyeManager.PixelsPerMeter, EyeManager.PixelsPerMeter) / 2;
+
+            int hash = sprite.GetHashCode();
+            var colorR = (byte)(hash & 0xFF);
+            var colorG = (byte)((hash >> 8) & 0xFF);
+            var colorB = (byte)((hash >> 16) & 0xFF);
+            Color targetColor = new Color(colorR, colorG, colorB); //TODO - this could result in mis-clicks due to hash-collision since we ditch a whole byte.
+            overlay.MouseMapLookup[targetColor] = sprite;
+
+            handle.SetTransform(DreamViewOverlay.CreateRenderTargetFlipMatrix(renderTargetSize, pos));
+            handle.DrawTextureRect(texture, new Box2(Vector2.Zero, texture.Size), targetColor);
+        }
     }
 }

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Runtime.CompilerServices;
 using OpenDreamClient.Interface;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
@@ -24,22 +25,25 @@ internal sealed class DreamViewOverlay : Overlay {
     public bool ScreenOverlayEnabled = true;
     public bool MouseMapRenderEnabled;
 
+    public ShaderInstance BlockColorInstance;
     public Texture? MouseMap => _mouseMapRenderTarget?.Texture;
     public readonly Dictionary<Color, RendererMetaData> MouseMapLookup = new();
+    public readonly Dictionary<string, IRenderTexture> RenderSourceLookup = new();
 
     private const LookupFlags MapLookupFlags = LookupFlags.Approximate | LookupFlags.Uncontained;
 
-    [Dependency] private readonly IDreamInterfaceManager _interfaceManager = default!;
-    [Dependency] private readonly IPlayerManager _playerManager = default!;
-    [Dependency] private readonly IEntityManager _entityManager = default!;
-    [Dependency] private readonly IMapManager _mapManager = default!;
-    [Dependency] private readonly IClyde _clyde = default!;
-    [Dependency] private readonly IPrototypeManager _protoManager = default!;
-    [Dependency] private readonly ProfManager _prof = default!;
+    [Robust.Shared.IoC.Dependency] private readonly IDreamInterfaceManager _interfaceManager = default!;
+    [Robust.Shared.IoC.Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Robust.Shared.IoC.Dependency] private readonly IEntityManager _entityManager = default!;
+    [Robust.Shared.IoC.Dependency] private readonly IMapManager _mapManager = default!;
+    [Robust.Shared.IoC.Dependency] private readonly IClyde _clyde = default!;
+    [Robust.Shared.IoC.Dependency] private readonly IPrototypeManager _protoManager = default!;
+    [Robust.Shared.IoC.Dependency] private readonly ProfManager _prof = default!;
 
     private readonly ISawmill _sawmill = Logger.GetSawmill("opendream.view");
 
     private readonly TransformSystem _transformSystem;
+    private readonly MapSystem _mapSystem;
     private readonly EntityLookupSystem _lookupSystem;
     private readonly ClientAppearanceSystem _appearanceSystem;
     private readonly ClientScreenOverlaySystem _screenOverlaySystem;
@@ -52,28 +56,30 @@ internal sealed class DreamViewOverlay : Overlay {
     private readonly Dictionary<int, DreamPlane> _planes = new();
     private readonly List<RendererMetaData> _spriteContainer = new();
 
-    private readonly ShaderInstance _blockColorInstance;
-    private readonly ShaderInstance _colorInstance;
     private readonly Dictionary<BlendMode, ShaderInstance> _blendModeInstances;
+    private static ShaderInstance _colorInstance = default!;
 
     private readonly Dictionary<Vector2i, List<IRenderTexture>> _renderTargetCache = new();
 
     private IRenderTexture? _mouseMapRenderTarget;
     private IRenderTexture? _baseRenderTarget;
-    private readonly Dictionary<string, IRenderTexture> _renderSourceLookup = new();
     private readonly Stack<IRenderTexture> _renderTargetsToReturn = new();
     private readonly Stack<RendererMetaData> _rendererMetaDataRental = new();
     private readonly Stack<RendererMetaData> _rendererMetaDataToReturn = new();
-    private readonly Matrix3 _flipMatrix;
+
+    private static readonly Matrix3 FlipMatrix = Matrix3.Identity with {
+        R1C1 = -1
+    };
 
     // Defined here so it isn't recreated every frame
     private ViewAlgorithm.Tile?[,]? _tileInfo;
     private readonly HashSet<EntityUid> _entities = new();
 
-    public DreamViewOverlay(TransformSystem transformSystem, EntityLookupSystem lookupSystem,
+    public DreamViewOverlay(TransformSystem transformSystem, MapSystem mapSystem, EntityLookupSystem lookupSystem,
         ClientAppearanceSystem appearanceSystem, ClientScreenOverlaySystem screenOverlaySystem, ClientImagesSystem clientImagesSystem) {
         IoCManager.InjectDependencies(this);
         _transformSystem = transformSystem;
+        _mapSystem = mapSystem;
         _lookupSystem = lookupSystem;
         _appearanceSystem = appearanceSystem;
         _screenOverlaySystem = screenOverlaySystem;
@@ -84,7 +90,7 @@ internal sealed class DreamViewOverlay : Overlay {
         _mobSightQuery = _entityManager.GetEntityQuery<DreamMobSightComponent>();
 
         _sawmill.Debug("Loading shaders...");
-        _blockColorInstance = _protoManager.Index<ShaderPrototype>("blockcolor").InstanceUnique();
+        BlockColorInstance = _protoManager.Index<ShaderPrototype>("blockcolor").InstanceUnique();
         _colorInstance = _protoManager.Index<ShaderPrototype>("color").InstanceUnique();
         _blendModeInstances = new(6) {
             {BlendMode.Default, _protoManager.Index<ShaderPrototype>("blend_overlay").InstanceUnique()}, //BLEND_DEFAULT (Same as BLEND_OVERLAY when there's no parent)
@@ -94,15 +100,12 @@ internal sealed class DreamViewOverlay : Overlay {
             {BlendMode.Multiply, _protoManager.Index<ShaderPrototype>("blend_multiply").InstanceUnique()}, //BLEND_MULTIPLY
             {BlendMode.InsertOverlay, _protoManager.Index<ShaderPrototype>("blend_inset_overlay").InstanceUnique()} //BLEND_INSET_OVERLAY //TODO
         };
-
-        _flipMatrix = Matrix3.Identity;
-        _flipMatrix.R1C1 = -1;
     }
 
     protected override void Draw(in OverlayDrawArgs args) {
         using var _ = _prof.Group("Dream View Overlay");
 
-        EntityUid? eye = _playerManager.LocalPlayer?.Session.AttachedEntity;
+        EntityUid? eye = _playerManager.LocalSession?.AttachedEntity;
         if (eye == null)
             return;
 
@@ -118,7 +121,7 @@ internal sealed class DreamViewOverlay : Overlay {
         _appearanceSystem.CleanUpUnusedFilters();
         _appearanceSystem.ResetFilterUsageFlags();
 
-        _renderSourceLookup.Clear();
+        RenderSourceLookup.Clear();
 
         //some render targets need to be kept until the end of the render cycle, so return them here.
         while(_renderTargetsToReturn.Count > 0)
@@ -132,7 +135,9 @@ internal sealed class DreamViewOverlay : Overlay {
     private void DrawAll(OverlayDrawArgs args, EntityUid eye, Vector2i viewportSize) {
         if (!_xformQuery.TryGetComponent(eye, out var eyeTransform))
             return;
-        if (!_mapManager.TryFindGridAt(eyeTransform.MapPosition, out _, out var grid))
+
+        var eyeCoords = _transformSystem.GetMapCoordinates(eye, eyeTransform);
+        if (!_mapManager.TryFindGridAt(eyeCoords, out var gridUid, out var grid))
             return;
 
         _mobSightQuery.TryGetComponent(eye, out var mobSight);
@@ -147,17 +152,17 @@ internal sealed class DreamViewOverlay : Overlay {
             _lookupSystem.GetEntitiesIntersecting(args.MapId, args.WorldAABB.Scale(1.2f), _entities, MapLookupFlags);
         }
 
-        var eyeTile = grid.GetTileRef(eyeTransform.MapPosition);
-        var tiles = CalculateTileVisibility(grid, _entities, eyeTile, seeVis);
+        var eyeTile = _mapSystem.GetTileRef(gridUid, grid, eyeCoords);
+        var tiles = CalculateTileVisibility(gridUid, grid, _entities, eyeTile, seeVis);
 
         RefreshRenderTargets(args.WorldHandle, viewportSize);
 
-        CollectVisibleSprites(tiles, grid, eyeTile, _entities, seeVis, sight, args.WorldAABB);
+        CollectVisibleSprites(tiles, gridUid, grid, eyeTile, _entities, seeVis, sight, args.WorldAABB);
         ClearPlanes();
         ProcessSprites(worldHandle, viewportSize, args.WorldAABB);
 
         //Final draw
-        DrawPlanes(worldHandle);
+        DrawPlanes(worldHandle, args.WorldAABB);
 
         //At this point all the sprites have been rendered to the base target, now we just draw it to the viewport!
         worldHandle.DrawTexture(
@@ -215,10 +220,7 @@ internal sealed class DreamViewOverlay : Overlay {
             else
                 current.Plane = icon.Appearance.Plane;
 
-            if (icon.Appearance.Layer < 0) //FLOAT_LAYER
-                current.Layer = parentIcon.Layer;
-            else
-                current.Layer = icon.Appearance.Layer;
+            current.Layer = (icon.Appearance.Layer < 0) ? parentIcon.Layer : icon.Appearance.Layer; //FLOAT_LAYER
 
             if (current.BlendMode == BlendMode.Default)
                 current.BlendMode = parentIcon.BlendMode;
@@ -305,8 +307,8 @@ internal sealed class DreamViewOverlay : Overlay {
         //notably they cannot be applied to overlays, so don't check for them if this is an under/overlay
         //note also that we use turfCoords and not current.Position because we want world-coordinates, not screen coordinates. This is only used for turfs.
         if(parentIcon == null && _clientImagesSystem.TryGetClientImages(current.Uid, turfCoords, out List<NetEntity>? attachedClientImages)){
-            foreach(NetEntity CINetEntity in attachedClientImages){
-                EntityUid imageEntity = _entityManager.GetEntity(CINetEntity);
+            foreach(NetEntity ciNetEntity in attachedClientImages) {
+                EntityUid imageEntity = _entityManager.GetEntity(ciNetEntity);
                 if (!_spriteQuery.TryGetComponent(imageEntity, out var sprite))
                     continue;
                 if(sprite.Icon.Appearance == null)
@@ -314,7 +316,7 @@ internal sealed class DreamViewOverlay : Overlay {
                 if(sprite.Icon.Appearance.Override)
                     current.MainIcon = sprite.Icon;
                 else
-                    ProcessIconComponents(sprite.Icon, current.Position, uid, isScreen, ref tieBreaker, result, current, false);
+                    ProcessIconComponents(sprite.Icon, current.Position, uid, isScreen, ref tieBreaker, result, current);
             }
         }
 
@@ -334,7 +336,7 @@ internal sealed class DreamViewOverlay : Overlay {
         //TODO particles - colour and transform don't apply?
 
         //flatten KeepTogetherGroup. Done here so we get implicit recursive iteration down the tree.
-        if (current.KeepTogetherGroup != null && current.KeepTogetherGroup.Count > 0) {
+        if (current.KeepTogetherGroup?.Count > 0) {
             List<RendererMetaData> flatKeepTogetherGroup = new List<RendererMetaData>(current.KeepTogetherGroup.Count);
 
             foreach (RendererMetaData ktItem in current.KeepTogetherGroup) {
@@ -369,8 +371,10 @@ internal sealed class DreamViewOverlay : Overlay {
     }
 
     private void ReturnRenderTarget(IRenderTexture rental) {
-        if (!_renderTargetCache.TryGetValue(rental.Size, out var storeList))
+        if (!_renderTargetCache.TryGetValue(rental.Size, out var storeList)) {
             storeList = new List<IRenderTexture>(4);
+            _renderTargetCache.Add(rental.Size, storeList);
+        }
 
         storeList.Add(rental);
     }
@@ -395,97 +399,36 @@ internal sealed class DreamViewOverlay : Overlay {
             colorMatrix.Equals(ColorMatrix.Identity))
             return null;
 
-        if (!_blendModeInstances.TryGetValue(blendMode, out var blendAndColor))
-            blendAndColor = _blendModeInstances[BlendMode.Default];
-
-        blendAndColor = blendAndColor.Duplicate();
+        var blendAndColor = _blendModeInstances[blendMode].Duplicate();
         blendAndColor.SetParameter("colorMatrix", colorMatrix.GetMatrix4());
         blendAndColor.SetParameter("offsetVector", colorMatrix.GetOffsetVector());
         blendAndColor.SetParameter("isPlaneMaster", iconMetaData.IsPlaneMaster);
         return blendAndColor;
     }
 
-    private (Action<Vector2i>?, Action<Vector2i>?) DrawIconAction(DrawingHandleWorld handle, RendererMetaData iconMetaData, Vector2 positionOffset, Texture? textureOverride = null) {
+    public void DrawIcon(DrawingHandleWorld handle, Vector2i renderTargetSize, RendererMetaData iconMetaData, Vector2 positionOffset) {
         DreamIcon? icon = iconMetaData.MainIcon;
         if (icon == null)
-            return (null, null);
-
-        Vector2 position = iconMetaData.Position + positionOffset;
-        Vector2 pixelPosition = position*EyeManager.PixelsPerMeter;
-
-        Texture? frame;
-        if (textureOverride != null) {
-            frame = textureOverride;
-        } else {
-            frame = icon.CurrentFrame;
-        }
+            return;
 
         //KEEP_TOGETHER groups
-        if (iconMetaData.KeepTogetherGroup != null && iconMetaData.KeepTogetherGroup.Count > 0) {
-            //store the parent's transform, color, blend, and alpha - then clear them for drawing to the render target
-            Matrix3 ktParentTransform = iconMetaData.TransformToApply;
-            Color ktParentColor = iconMetaData.ColorToApply;
-            float ktParentAlpha = iconMetaData.AlphaToApply;
-            BlendMode ktParentBlendMode = iconMetaData.BlendMode;
-
-            iconMetaData.TransformToApply = Matrix3.Identity;
-            iconMetaData.ColorToApply = Color.White;
-            iconMetaData.AlphaToApply = 1f;
-            iconMetaData.BlendMode = BlendMode.Default;
-
-            List<RendererMetaData> ktItems = new List<RendererMetaData>(iconMetaData.KeepTogetherGroup.Count+1);
-            ktItems.Add(iconMetaData);
-            ktItems.AddRange(iconMetaData.KeepTogetherGroup);
-            iconMetaData.KeepTogetherGroup.Clear();
-
-            ktItems.Sort();
-            //draw it onto an additional render target that we can return immediately for correction of transform
+        if (iconMetaData.KeepTogetherGroup?.Count > 0) {
             // TODO: Use something better than a hardcoded 64x64 fallback
-            IRenderTexture tempTexture = RentRenderTarget(frame?.Size ?? (64,64));
-            ClearRenderTarget(tempTexture, handle, Color.Transparent);
-
-            foreach (RendererMetaData ktItem in ktItems) {
-                DrawIconNow(handle, tempTexture.Size, tempTexture, ktItem, -ktItem.Position);
-            }
-
-            //but keep the handle to the final KT group's render target so we don't override it later in the render cycle
-            IRenderTexture ktTexture = RentRenderTarget(tempTexture.Size);
-            handle.RenderInRenderTarget(ktTexture, () => {
-                handle.SetTransform(CreateRenderTargetFlipMatrix(tempTexture.Size, Vector2.Zero));
-                handle.DrawTextureRect(tempTexture.Texture, new Box2(Vector2.Zero, tempTexture.Size));
-                handle.SetTransform(Matrix3.Identity);
-            }, Color.Transparent);
-
-            frame = ktTexture.Texture;
-            _renderTargetsToReturn.Push(tempTexture);
-
-            //now restore the original color, alpha, blend, and transform so they can be applied to the render target as a whole
-            iconMetaData.TransformToApply = ktParentTransform;
-            iconMetaData.ColorToApply = ktParentColor;
-            iconMetaData.AlphaToApply = ktParentAlpha;
-            iconMetaData.BlendMode = ktParentBlendMode;
-
-            _renderTargetsToReturn.Push(ktTexture);
+            iconMetaData.TextureOverride = ProcessKeepTogether(handle, iconMetaData, iconMetaData.Texture?.Size ?? (64,64));
         }
 
-        //if frame is still null, this doesn't require a draw, so return NOP
+        var pixelPosition = (iconMetaData.Position + positionOffset) * EyeManager.PixelsPerMeter;
+        var frame = iconMetaData.Texture;
+
+        //if frame is null, this doesn't require a draw, so return NOP
         if (frame == null)
-            return (null, null);
-
-        Action<Vector2i> iconDrawAction;
-        Action<Vector2i>? mouseMapDrawAction;
-
-        //setup the MouseMapLookup shader for use in DrawIcon()
-        int hash = iconMetaData.GetHashCode();
-        var colorR = (byte)(hash & 0xFF);
-        var colorG = (byte)((hash >> 8) & 0xFF);
-        var colorB = (byte)((hash >> 16) & 0xFF);
-        Color targetColor = new Color(colorR, colorG, colorB); //TODO - this could result in mis-clicks due to hash-collision since we ditch a whole byte.
-        MouseMapLookup[targetColor] = iconMetaData;
+            return;
 
         //go fast when the only filter is color, and we don't have more color things to consider
         bool goFastOverride = false;
-        if (icon.Appearance != null && iconMetaData.ColorMatrixToApply.Equals(ColorMatrix.Identity) && iconMetaData.ColorToApply == Color.White && iconMetaData.AlphaToApply == 1.0f && icon.Appearance.Filters.Count == 1 && icon.Appearance.Filters[0].FilterType == "color") {
+        if (icon.Appearance != null && iconMetaData.ColorMatrixToApply.Equals(ColorMatrix.Identity) &&
+            iconMetaData.ColorToApply == Color.White && iconMetaData.AlphaToApply.Equals(1.0f) &&
+            icon.Appearance.Filters is [{ FilterType: "color" }]) {
             DreamFilterColor colorFilter = (DreamFilterColor)icon.Appearance.Filters[0];
             iconMetaData.ColorMatrixToApply = colorFilter.Color;
             goFastOverride = true;
@@ -493,93 +436,10 @@ internal sealed class DreamViewOverlay : Overlay {
 
         if (goFastOverride || icon.Appearance == null || icon.Appearance.Filters.Count == 0) {
             //faster path for rendering unfiltered sprites
-            iconDrawAction = renderTargetSize => {
-                handle.UseShader(GetBlendAndColorShader(iconMetaData));
-                handle.SetTransform(CreateRenderTargetFlipMatrix(renderTargetSize, pixelPosition));
-                handle.DrawTextureRect(frame, Box2.FromDimensions(Vector2.Zero, frame.Size));
-                handle.UseShader(null);
-                handle.SetTransform(Matrix3.Identity);
-            };
-
-            if (iconMetaData.MouseOpacity != MouseOpacity.Transparent && !iconMetaData.ShouldPassMouse) {
-                mouseMapDrawAction = renderTargetSize => {
-                    handle.UseShader(_blockColorInstance);
-                    handle.SetTransform(CreateRenderTargetFlipMatrix(renderTargetSize, pixelPosition));
-                    handle.DrawTextureRect(frame, new Box2(Vector2.Zero, frame.Size), targetColor);
-                    handle.SetTransform(Matrix3.Identity);
-                    handle.UseShader(null);
-                };
-            } else {
-                mouseMapDrawAction = null;
-            }
-
-            return (iconDrawAction, mouseMapDrawAction);
-        } else { //Slower path for filtered icons
-            //first we do ping pong rendering for the multiple filters
-            // TODO: This should determine the size from the filters and their settings, not just double the original
-            IRenderTexture ping = RentRenderTarget(frame.Size * 2);
-            IRenderTexture pong = RentRenderTarget(frame.Size * 2);
-
-            handle.RenderInRenderTarget(pong, () => {
-                //we can use the color matrix shader here, since we don't need to blend
-                //also because blend mode is none, we don't need to clear
-                ColorMatrix colorMatrix;
-                if (iconMetaData.ColorMatrixToApply.Equals(ColorMatrix.Identity))
-                    colorMatrix = new ColorMatrix(iconMetaData.ColorToApply.WithAlpha(iconMetaData.AlphaToApply));
-                else
-                    colorMatrix = iconMetaData.ColorMatrixToApply;
-
-                ShaderInstance colorShader = _colorInstance.Duplicate();
-                colorShader.SetParameter("colorMatrix", colorMatrix.GetMatrix4());
-                colorShader.SetParameter("offsetVector", colorMatrix.GetOffsetVector());
-                colorShader.SetParameter("isPlaneMaster",iconMetaData.IsPlaneMaster);
-                handle.UseShader(colorShader);
-
-                handle.SetTransform(CreateRenderTargetFlipMatrix(pong.Size, frame.Size / 2));
-                handle.DrawTextureRect(frame, new Box2(Vector2.Zero, frame.Size));
-                handle.SetTransform(Matrix3.Identity);
-                handle.UseShader(null);
-            }, Color.Black.WithAlpha(0));
-
-            foreach (DreamFilter filterId in icon.Appearance.Filters) {
-                ShaderInstance s = _appearanceSystem.GetFilterShader(filterId, _renderSourceLookup);
-
-                handle.RenderInRenderTarget(ping, () => {
-                    handle.UseShader(s);
-                    handle.SetTransform(CreateRenderTargetFlipMatrix(ping.Size, Vector2.Zero));
-                    handle.DrawTextureRect(pong.Texture, new Box2(Vector2.Zero, pong.Size));
-                    handle.SetTransform(Matrix3.Identity);
-                    handle.UseShader(null);
-                }, Color.Black.WithAlpha(0));
-
-                (ping, pong) = (pong, ping);
-            }
-
-            //then we return the Action that draws the actual icon with filters applied
-            iconDrawAction = renderTargetSize => {
-                //note we apply the color *before* the filters, so we use override here
-                handle.UseShader(GetBlendAndColorShader(iconMetaData, ignoreColor: true));
-                handle.SetTransform(CreateRenderTargetFlipMatrix(renderTargetSize, pixelPosition - frame.Size / 2));
-                handle.DrawTextureRect(pong.Texture, new Box2(Vector2.Zero, pong.Size));
-                handle.UseShader(null);
-                handle.SetTransform(Matrix3.Identity);
-            };
-
-            if (iconMetaData.MouseOpacity != MouseOpacity.Transparent && !iconMetaData.ShouldPassMouse) {
-                mouseMapDrawAction = renderTargetSize => {
-                    handle.UseShader(_blockColorInstance);
-                    handle.SetTransform(CreateRenderTargetFlipMatrix(renderTargetSize, pixelPosition - (frame.Size / 2)));
-                    handle.DrawTextureRect(pong.Texture, new Box2(Vector2.Zero, pong.Size), targetColor);
-                    handle.UseShader(null);
-                    handle.SetTransform(Matrix3.Identity);
-                };
-            } else {
-                mouseMapDrawAction = null;
-            }
-
-            ReturnRenderTarget(ping);
-            _renderTargetsToReturn.Push(pong);
-            return (iconDrawAction, mouseMapDrawAction);
+            DrawIconFast(handle, renderTargetSize, frame, pixelPosition, GetBlendAndColorShader(iconMetaData));
+        } else {
+            //Slower path for filtered icons
+            DrawIconSlow(handle, frame, iconMetaData, renderTargetSize, pixelPosition);
         }
     }
 
@@ -611,7 +471,7 @@ internal sealed class DreamViewOverlay : Overlay {
             var plane = pair.Value;
 
             // We can remove the plane if there was nothing on it last frame
-            if (plane.IconDrawActions.Count == 0 && plane.MouseMapDrawActions.Count == 0 && plane.Master == null) {
+            if (plane.Sprites.Count == 0 && plane.Master == null) {
                 plane.Dispose();
                 _planes.Remove(pair.Key);
                 continue;
@@ -642,10 +502,10 @@ internal sealed class DreamViewOverlay : Overlay {
 
             if (!string.IsNullOrEmpty(sprite.RenderTarget)) {
                 //if this sprite has a render target, draw it to a slate instead. If it needs to be drawn on the map, a second sprite instance will already have been created for that purpose
-                if (!_renderSourceLookup.TryGetValue(sprite.RenderTarget, out var tmpRenderTarget)) {
+                if (!RenderSourceLookup.TryGetValue(sprite.RenderTarget, out var tmpRenderTarget)) {
                     tmpRenderTarget = RentRenderTarget(viewportSize);
                     ClearRenderTarget(tmpRenderTarget, handle, new Color());
-                    _renderSourceLookup.Add(sprite.RenderTarget, tmpRenderTarget);
+                    RenderSourceLookup.Add(sprite.RenderTarget, tmpRenderTarget);
                     _renderTargetsToReturn.Push(tmpRenderTarget);
                 }
 
@@ -655,7 +515,10 @@ internal sealed class DreamViewOverlay : Overlay {
                     plane.SetTemporaryRenderTarget(tmpRenderTarget);
                 } else { //if not a plane master, draw the sprite to the render target
                     //note we don't draw this to the mouse-map because that's handled when the RenderTarget is used as a source later
-                    DrawIconNow(handle, tmpRenderTarget.Size, tmpRenderTarget, sprite, ((worldAABB.Size/2)-sprite.Position)-new Vector2(0.5f,0.5f), null, true); //draw the sprite centered on the RenderTarget
+                    handle.RenderInRenderTarget(tmpRenderTarget, () => {
+                        //draw the sprite centered on the RenderTarget
+                        DrawIcon(handle, tmpRenderTarget.Size, sprite, ((worldAABB.Size/2)-sprite.Position)-new Vector2(0.5f,0.5f));
+                    }, null);
                 }
             } else { //We are no longer dealing with RenderTargets, just regular old planes, so we collect the draw actions for batching
                 //if this is a plane master then we don't render it, we just set it as the plane's master
@@ -667,35 +530,26 @@ internal sealed class DreamViewOverlay : Overlay {
                 }
 
                 //add this sprite for rendering
-                (Action<Vector2i>?, Action<Vector2i>?) drawActions;
-                if (sprite.HasRenderSource && _renderSourceLookup.TryGetValue(sprite.RenderSource, out var renderSourceTexture)) {
-                    drawActions = DrawIconAction(handle, sprite, (-worldAABB.BottomLeft)-(worldAABB.Size/2)+new Vector2(0.5f,0.5f), renderSourceTexture.Texture);
-                } else {
-                    drawActions = DrawIconAction(handle, sprite, -worldAABB.BottomLeft);
-                }
-
-                if (drawActions.Item1 != null)
-                    plane.IconDrawActions.Add(drawActions.Item1);
-                if (drawActions.Item2 != null)
-                    plane.MouseMapDrawActions.Add(drawActions.Item2);
+                plane.Sprites.Add(sprite);
             }
         }
     }
 
-    private void DrawPlanes(DrawingHandleWorld handle) {
+    private void DrawPlanes(DrawingHandleWorld handle, Box2 worldAABB) {
         using (var _ = _prof.Group("draw planes map")) {
             handle.RenderInRenderTarget(_baseRenderTarget!, () => {
                 foreach (int planeIndex in _planes.Keys.Order()) {
                     var plane = _planes[planeIndex];
 
-                    plane.Draw(this, handle);
+                    plane.Draw(this, handle, worldAABB);
 
                     if (plane.Master != null) {
                         // Don't draw this to the base render target if this itself is a render target
                         if (!string.IsNullOrEmpty(plane.Master.RenderTarget))
                             continue;
 
-                        DrawIconNow(handle, _baseRenderTarget!.Size, null, plane.Master, Vector2.Zero, plane.RenderTarget.Texture, noMouseMap: true);
+                        plane.Master.TextureOverride = plane.RenderTarget.Texture;
+                        DrawIcon(handle, _baseRenderTarget!.Size, plane.Master, Vector2.Zero);
                     } else {
                         handle.SetTransform(CreateRenderTargetFlipMatrix(_baseRenderTarget!.Size, Vector2.Zero));
                         handle.DrawTextureRect(plane.RenderTarget.Texture, Box2.FromTwoPoints(Vector2.Zero, _baseRenderTarget.Size));
@@ -704,15 +558,16 @@ internal sealed class DreamViewOverlay : Overlay {
             }, null);
         }
 
+        // TODO: Can this only be done once the user clicks?
         using (_prof.Group("draw planes mouse map")) {
             handle.RenderInRenderTarget(_mouseMapRenderTarget!, () => {
                 foreach (int planeIndex in _planes.Keys.Order())
-                    _planes[planeIndex].DrawMouseMap(_mouseMapRenderTarget!.Size);
+                    _planes[planeIndex].DrawMouseMap(handle, this, _mouseMapRenderTarget!.Size, worldAABB);
             }, null);
         }
     }
 
-    private ViewAlgorithm.Tile?[,] CalculateTileVisibility(MapGridComponent grid, HashSet<EntityUid> entities, TileRef eyeTile, int seeVis) {
+    private ViewAlgorithm.Tile?[,] CalculateTileVisibility(EntityUid gridUid, MapGridComponent grid, HashSet<EntityUid> entities, TileRef eyeTile, int seeVis) {
         using var _ = _prof.Group("visible turfs");
 
         var viewRange = _interfaceManager.View;
@@ -722,11 +577,12 @@ internal sealed class DreamViewOverlay : Overlay {
             _tileInfo = new ViewAlgorithm.Tile[viewRange.Width + 2, viewRange.Height + 2];
         }
 
-        var eyeWorldPos = grid.GridTileToWorld(eyeTile.GridIndices);
-        var tileRefs = grid.GetTilesIntersecting(Box2.CenteredAround(eyeWorldPos.Position, new Vector2(_tileInfo.GetLength(0), _tileInfo.GetLength(1))));
+        var eyeWorldPos = _mapSystem.GridTileToWorld(gridUid, grid, eyeTile.GridIndices);
+        var tileRefs = _mapSystem.GetTilesEnumerator(gridUid, grid,
+            Box2.CenteredAround(eyeWorldPos.Position, new Vector2(_tileInfo.GetLength(0), _tileInfo.GetLength(1))));
 
         // Gather up all the data the view algorithm needs
-        foreach (TileRef tileRef in tileRefs) {
+        while (tileRefs.MoveNext(out var tileRef)) {
             var delta = tileRef.GridIndices - eyeTile.GridIndices;
             var appearance = _appearanceSystem.GetTurfIcon(tileRef.Tile.TypeId).Appearance;
             if (appearance == null)
@@ -760,7 +616,7 @@ internal sealed class DreamViewOverlay : Overlay {
                 continue;
 
             var worldPos = _transformSystem.GetWorldPosition(transform);
-            var tilePos = grid.WorldToTile(worldPos) - eyeTile.GridIndices + viewRange.Center;
+            var tilePos = _mapSystem.WorldToTile(gridUid, grid, worldPos) - eyeTile.GridIndices + viewRange.Center;
             if (tilePos.X < 0 || tilePos.Y < 0 || tilePos.X >= _tileInfo.GetLength(0) || tilePos.Y >= _tileInfo.GetLength(1))
                 continue;
 
@@ -773,7 +629,7 @@ internal sealed class DreamViewOverlay : Overlay {
         return _tileInfo;
     }
 
-    private void CollectVisibleSprites(ViewAlgorithm.Tile?[,] tiles, MapGridComponent grid, TileRef eyeTile, HashSet<EntityUid> entities, int seeVis, SightFlags sight, Box2 worldAABB) {
+    private void CollectVisibleSprites(ViewAlgorithm.Tile?[,] tiles, EntityUid gridUid, MapGridComponent grid, TileRef eyeTile, HashSet<EntityUid> entities, int seeVis, SightFlags sight, Box2 worldAABB) {
         _spriteContainer.Clear();
 
         // This exists purely because the tiebreaker var needs to exist somewhere
@@ -788,8 +644,8 @@ internal sealed class DreamViewOverlay : Overlay {
                 continue;
 
             Vector2i tilePos = eyeTile.GridIndices + (tile.DeltaX, tile.DeltaY);
-            TileRef tileRef = grid.GetTileRef(tilePos);
-            MapCoordinates worldPos = grid.GridTileToWorld(tilePos);
+            TileRef tileRef = _mapSystem.GetTileRef(gridUid, grid, tilePos);
+            MapCoordinates worldPos = _mapSystem.GridTileToWorld(gridUid, grid, tilePos);
 
             tValue = 0;
             //pass the turf coords for client.images lookup
@@ -813,7 +669,7 @@ internal sealed class DreamViewOverlay : Overlay {
                 // Check for visibility if the eye doesn't have SEE_OBJS or SEE_MOBS
                 // TODO: Differentiate between objs and mobs
                 if ((sight & (SightFlags.SeeObjs|SightFlags.SeeMobs)) == 0 && _tileInfo != null) {
-                    var tilePos = grid.WorldToTile(worldPos) - eyeTile.GridIndices + _interfaceManager.View.Center;
+                    var tilePos = _mapSystem.WorldToTile(gridUid, grid, worldPos) - eyeTile.GridIndices + _interfaceManager.View.Center;
                     if (tilePos.X < 0 || tilePos.Y < 0 || tilePos.X >= _tileInfo.GetLength(0) || tilePos.Y >= _tileInfo.GetLength(1))
                         continue;
 
@@ -855,23 +711,6 @@ internal sealed class DreamViewOverlay : Overlay {
         }
     }
 
-    private void DrawIconNow(DrawingHandleWorld handle, Vector2i renderTargetSize, IRenderTarget? renderTarget, RendererMetaData iconMetaData, Vector2 positionOffset, Texture? textureOverride = null, bool noMouseMap = false) {
-        (Action<Vector2i>? iconDrawAction, Action<Vector2i>? mouseMapDrawAction) = DrawIconAction(handle, iconMetaData, positionOffset, textureOverride);
-
-        if (iconDrawAction == null)
-            return;
-
-        if (renderTarget != null) {
-            handle.RenderInRenderTarget(renderTarget, () => iconDrawAction(renderTargetSize), null);
-        } else {
-            iconDrawAction(renderTargetSize);
-        }
-
-        if (mouseMapDrawAction != null && !noMouseMap) {
-            handle.RenderInRenderTarget(_mouseMapRenderTarget!, () => mouseMapDrawAction(renderTargetSize), null);
-        }
-    }
-
     private RendererMetaData RentRendererMetaData() {
         RendererMetaData result;
         if (_rendererMetaDataRental.Count == 0)
@@ -886,6 +725,117 @@ internal sealed class DreamViewOverlay : Overlay {
     }
 
     /// <summary>
+    /// Collect all of an icon's keep-together group and render them into one texture.
+    /// </summary>
+    private Texture ProcessKeepTogether(DrawingHandleWorld handle, RendererMetaData iconMetaData, Vector2i size) {
+        //store the parent's transform, color, blend, and alpha - then clear them for drawing to the render target
+        Matrix3 ktParentTransform = iconMetaData.TransformToApply;
+        Color ktParentColor = iconMetaData.ColorToApply;
+        float ktParentAlpha = iconMetaData.AlphaToApply;
+        BlendMode ktParentBlendMode = iconMetaData.BlendMode;
+
+        iconMetaData.TransformToApply = Matrix3.Identity;
+        iconMetaData.ColorToApply = Color.White;
+        iconMetaData.AlphaToApply = 1f;
+        iconMetaData.BlendMode = BlendMode.Default;
+
+        List<RendererMetaData> ktItems = new List<RendererMetaData>(iconMetaData.KeepTogetherGroup!.Count+1);
+        ktItems.Add(iconMetaData);
+        ktItems.AddRange(iconMetaData.KeepTogetherGroup);
+        iconMetaData.KeepTogetherGroup.Clear();
+
+        ktItems.Sort();
+        //draw it onto an additional render target that we can return immediately for correction of transform
+        IRenderTexture tempTexture = RentRenderTarget(size);
+        ClearRenderTarget(tempTexture, handle, Color.Transparent);
+
+        handle.RenderInRenderTarget(tempTexture, () => {
+            foreach (RendererMetaData ktItem in ktItems) {
+                DrawIcon(handle, tempTexture.Size, ktItem, -ktItem.Position);
+            }
+        }, null);
+
+        //but keep the handle to the final KT group's render target so we don't override it later in the render cycle
+        IRenderTexture ktTexture = RentRenderTarget(tempTexture.Size);
+        handle.RenderInRenderTarget(ktTexture, () => {
+            handle.SetTransform(CreateRenderTargetFlipMatrix(tempTexture.Size, Vector2.Zero));
+            handle.DrawTextureRect(tempTexture.Texture, new Box2(Vector2.Zero, tempTexture.Size));
+        }, Color.Transparent);
+
+        _renderTargetsToReturn.Push(tempTexture);
+
+        //now restore the original color, alpha, blend, and transform so they can be applied to the render target as a whole
+        iconMetaData.TransformToApply = ktParentTransform;
+        iconMetaData.ColorToApply = ktParentColor;
+        iconMetaData.AlphaToApply = ktParentAlpha;
+        iconMetaData.BlendMode = ktParentBlendMode;
+
+        _renderTargetsToReturn.Push(ktTexture);
+        return ktTexture.Texture;
+    }
+
+    /// <summary>
+    /// Render a texture without applying any filters, making this faster and cheaper.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void DrawIconFast(DrawingHandleWorld handle, Vector2i renderTargetSize, Texture texture, Vector2 pos, ShaderInstance? shader) {
+        handle.UseShader(shader);
+        handle.SetTransform(CreateRenderTargetFlipMatrix(renderTargetSize, pos));
+        handle.DrawTextureRect(texture, Box2.FromDimensions(Vector2.Zero, texture.Size));
+    }
+
+    /// <summary>
+    /// A slower method of drawing an icon. This one renders an atom's filters.
+    /// Use <see cref="DrawIconFast"/> instead if the icon has no special rendering needs.
+    /// </summary>
+    private void DrawIconSlow(DrawingHandleWorld handle, Texture frame, RendererMetaData iconMetaData, Vector2i renderTargetSize, Vector2 pos) {
+        //first we do ping pong rendering for the multiple filters
+        // TODO: This should determine the size from the filters and their settings, not just double the original
+        IRenderTexture ping = RentRenderTarget(frame.Size * 2);
+        IRenderTexture pong = RentRenderTarget(ping.Size);
+
+        //we can use the color matrix shader here, since we don't need to blend
+        //also because blend mode is none, we don't need to clear
+        var colorMatrix = iconMetaData.ColorMatrixToApply.Equals(ColorMatrix.Identity)
+            ? new ColorMatrix(iconMetaData.ColorToApply.WithAlpha(iconMetaData.AlphaToApply))
+            : iconMetaData.ColorMatrixToApply;
+
+        ShaderInstance colorShader = _colorInstance.Duplicate();
+        colorShader.SetParameter("colorMatrix", colorMatrix.GetMatrix4());
+        colorShader.SetParameter("offsetVector", colorMatrix.GetOffsetVector());
+        colorShader.SetParameter("isPlaneMaster",iconMetaData.IsPlaneMaster);
+        handle.UseShader(colorShader);
+        handle.RenderInRenderTarget(pong, () => {
+            handle.SetTransform(CreateRenderTargetFlipMatrix(pong.Size, frame.Size / 2));
+            handle.DrawTextureRect(frame, new Box2(Vector2.Zero, frame.Size));
+        }, Color.Black.WithAlpha(0));
+
+        foreach (DreamFilter filterId in iconMetaData.MainIcon!.Appearance!.Filters) {
+            ShaderInstance s = _appearanceSystem.GetFilterShader(filterId, RenderSourceLookup);
+
+            handle.UseShader(s); // Set the shader out here to avoid a closure alloc
+            handle.RenderInRenderTarget(ping, () => {
+                // Technically this should be ping.Size, but they are the same size so avoid the extra closure alloc
+                var transform = CreateRenderTargetFlipMatrix(pong.Size, Vector2.Zero);
+
+                handle.SetTransform(transform);
+                handle.DrawTextureRect(pong.Texture, new Box2(Vector2.Zero, pong.Size));
+            }, Color.Black.WithAlpha(0));
+
+            (ping, pong) = (pong, ping);
+        }
+
+        //then we draw the actual icon with filters applied
+        DrawIconFast(handle, renderTargetSize, pong.Texture, pos - frame.Size / 2,
+            //note we apply the color *before* the filters, so we ignore color here
+            GetBlendAndColorShader(iconMetaData, ignoreColor: true)
+        );
+
+        ReturnRenderTarget(ping);
+        _renderTargetsToReturn.Push(pong);
+    }
+
+    /// <summary>
     /// Creates a transformation matrix that counteracts RT's
     /// <see cref="DrawingHandleBase.RenderInRenderTarget(IRenderTarget,Action,System.Nullable{Robust.Shared.Maths.Color})"/> quirks
     /// <br/>
@@ -894,10 +844,10 @@ internal sealed class DreamViewOverlay : Overlay {
     /// <param name="renderTargetSize">Size of the render target</param>
     /// <param name="renderPosition">The translation to draw the icon at</param>
     /// <remarks>Due to RT applying transformations out of order, render the icon at Vector2.Zero</remarks>
-    public Matrix3 CreateRenderTargetFlipMatrix(Vector2i renderTargetSize, Vector2 renderPosition) {
+    public static Matrix3 CreateRenderTargetFlipMatrix(Vector2i renderTargetSize, Vector2 renderPosition) {
         // RT flips the texture when doing a RenderInRenderTarget(), so we use _flipMatrix to reverse it
         // We must also handle translations here, since RT applies its own transform in an unexpected order
-        return _flipMatrix * Matrix3.CreateTranslation(renderPosition.X, renderTargetSize.Y - renderPosition.Y);
+        return FlipMatrix * Matrix3.CreateTranslation(renderPosition.X, renderTargetSize.Y - renderPosition.Y);
     }
 }
 
@@ -920,7 +870,9 @@ internal sealed class RendererMetaData : IComparable<RendererMetaData> {
     public AppearanceFlags AppearanceFlags;
     public BlendMode BlendMode;
     public MouseOpacity MouseOpacity;
+    public Texture? TextureOverride;
 
+    public Texture? Texture => TextureOverride ?? MainIcon?.CurrentFrame;
     public bool IsPlaneMaster => (AppearanceFlags & AppearanceFlags.PlaneMaster) != 0;
     public bool HasRenderSource => !string.IsNullOrEmpty(RenderSource);
     public bool ShouldPassMouse => HasRenderSource && (AppearanceFlags & AppearanceFlags.PassMouse) != 0;
@@ -948,6 +900,7 @@ internal sealed class RendererMetaData : IComparable<RendererMetaData> {
         AppearanceFlags = AppearanceFlags.None;
         BlendMode = BlendMode.Default;
         MouseOpacity = MouseOpacity.Transparent;
+        TextureOverride = null;
     }
 
     public int CompareTo(RendererMetaData? other) {
@@ -1026,6 +979,7 @@ internal sealed class RendererMetaData : IComparable<RendererMetaData> {
 
 #region Render Toggle Commands
 public sealed class ToggleScreenOverlayCommand : IConsoleCommand {
+    // ReSharper disable once StringLiteralTypo
     public string Command => "togglescreenoverlay";
     public string Description => "Toggle rendering of screen objects";
     public string Help => "";
@@ -1045,6 +999,7 @@ public sealed class ToggleScreenOverlayCommand : IConsoleCommand {
 }
 
 public sealed class ToggleMouseOverlayCommand : IConsoleCommand {
+    // ReSharper disable once StringLiteralTypo
     public string Command => "togglemouseoverlay";
     public string Description => "Toggle rendering of mouse click area for screen objects";
     public string Help => "";

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -802,18 +802,19 @@ internal sealed class DreamViewOverlay : Overlay {
         IRenderTexture ping = RentRenderTarget(frame.Size * 2);
         IRenderTexture pong = RentRenderTarget(ping.Size);
 
-        //we can use the color matrix shader here, since we don't need to blend
-        //also because blend mode is none, we don't need to clear
-        var colorMatrix = iconMetaData.ColorMatrixToApply.Equals(ColorMatrix.Identity)
-            ? new ColorMatrix(iconMetaData.ColorToApply.WithAlpha(iconMetaData.AlphaToApply))
-            : iconMetaData.ColorMatrixToApply;
-
-        ShaderInstance colorShader = _colorInstance.Duplicate();
-        colorShader.SetParameter("colorMatrix", colorMatrix.GetMatrix4());
-        colorShader.SetParameter("offsetVector", colorMatrix.GetOffsetVector());
-        colorShader.SetParameter("isPlaneMaster",iconMetaData.IsPlaneMaster);
-        handle.UseShader(colorShader);
         handle.RenderInRenderTarget(pong, () => {
+            //we can use the color matrix shader here, since we don't need to blend
+            //also because blend mode is none, we don't need to clear
+            var colorMatrix = iconMetaData.ColorMatrixToApply.Equals(ColorMatrix.Identity)
+                ? new ColorMatrix(iconMetaData.ColorToApply.WithAlpha(iconMetaData.AlphaToApply))
+                : iconMetaData.ColorMatrixToApply;
+
+            ShaderInstance colorShader = _colorInstance.Duplicate();
+            colorShader.SetParameter("colorMatrix", colorMatrix.GetMatrix4());
+            colorShader.SetParameter("offsetVector", colorMatrix.GetOffsetVector());
+            colorShader.SetParameter("isPlaneMaster",iconMetaData.IsPlaneMaster);
+            handle.UseShader(colorShader);
+
             handle.SetTransform(CreateRenderTargetFlipMatrix(pong.Size, frame.Size / 2));
             handle.DrawTextureRect(frame, new Box2(Vector2.Zero, frame.Size));
         }, Color.Black.WithAlpha(0));
@@ -821,8 +822,9 @@ internal sealed class DreamViewOverlay : Overlay {
         foreach (DreamFilter filterId in iconMetaData.MainIcon!.Appearance!.Filters) {
             ShaderInstance s = _appearanceSystem.GetFilterShader(filterId, RenderSourceLookup);
 
-            handle.UseShader(s); // Set the shader out here to avoid a closure alloc
             handle.RenderInRenderTarget(ping, () => {
+                handle.UseShader(s);
+
                 // Technically this should be ping.Size, but they are the same size so avoid the extra closure alloc
                 var transform = CreateRenderTargetFlipMatrix(pong.Size, Vector2.Zero);
 

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -266,7 +266,7 @@ internal sealed class DreamViewOverlay : Overlay {
                 renderTargetPlaceholder.BlendMode = current.BlendMode;
             }
             renderTargetPlaceholder.AppearanceFlags = current.AppearanceFlags;
-            current.AppearanceFlags = current.AppearanceFlags & ~AppearanceFlags.PlaneMaster; //only the placeholder should be marked as master
+            current.AppearanceFlags &= ~AppearanceFlags.PlaneMaster; //only the placeholder should be marked as master
             result.Add(renderTargetPlaceholder);
         }
 
@@ -515,10 +515,7 @@ internal sealed class DreamViewOverlay : Overlay {
                     plane.SetTemporaryRenderTarget(tmpRenderTarget);
                 } else { //if not a plane master, draw the sprite to the render target
                     //note we don't draw this to the mouse-map because that's handled when the RenderTarget is used as a source later
-                    handle.RenderInRenderTarget(tmpRenderTarget, () => {
-                        //draw the sprite centered on the RenderTarget
-                        DrawIcon(handle, tmpRenderTarget.Size, sprite, ((worldAABB.Size/2)-sprite.Position)-new Vector2(0.5f,0.5f));
-                    }, null);
+                    DrawOnRenderTarget(handle, tmpRenderTarget, sprite, worldAABB);
                 }
             } else { //We are no longer dealing with RenderTargets, just regular old planes, so we collect the draw actions for batching
                 //if this is a plane master then we don't render it, we just set it as the plane's master
@@ -533,6 +530,17 @@ internal sealed class DreamViewOverlay : Overlay {
                 plane.Sprites.Add(sprite);
             }
         }
+    }
+
+    /// <summary>
+    /// Used by <see cref="ProcessSprites"/> to render an icon onto its render_target.
+    /// In a separate method to prevent unused closure allocations.
+    /// </summary>
+    private void DrawOnRenderTarget(DrawingHandleWorld handle, IRenderTarget renderTarget, RendererMetaData sprite, Box2 worldAABB) {
+        handle.RenderInRenderTarget(renderTarget, () => {
+            //draw the sprite centered on the RenderTarget
+            DrawIcon(handle, renderTarget.Size, sprite, ((worldAABB.Size/2)-sprite.Position)-new Vector2(0.5f,0.5f));
+        }, null);
     }
 
     private void DrawPlanes(DrawingHandleWorld handle, Box2 worldAABB) {

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -13,6 +13,7 @@ using Robust.Client.GameObjects;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Profiling;
 using Vector3 = Robust.Shared.Maths.Vector3;
+using Dependency = Robust.Shared.IoC.DependencyAttribute;
 
 namespace OpenDreamClient.Rendering;
 
@@ -32,13 +33,13 @@ internal sealed class DreamViewOverlay : Overlay {
 
     private const LookupFlags MapLookupFlags = LookupFlags.Approximate | LookupFlags.Uncontained;
 
-    [Robust.Shared.IoC.Dependency] private readonly IDreamInterfaceManager _interfaceManager = default!;
-    [Robust.Shared.IoC.Dependency] private readonly IPlayerManager _playerManager = default!;
-    [Robust.Shared.IoC.Dependency] private readonly IEntityManager _entityManager = default!;
-    [Robust.Shared.IoC.Dependency] private readonly IMapManager _mapManager = default!;
-    [Robust.Shared.IoC.Dependency] private readonly IClyde _clyde = default!;
-    [Robust.Shared.IoC.Dependency] private readonly IPrototypeManager _protoManager = default!;
-    [Robust.Shared.IoC.Dependency] private readonly ProfManager _prof = default!;
+    [Dependency] private readonly IDreamInterfaceManager _interfaceManager = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IMapManager _mapManager = default!;
+    [Dependency] private readonly IClyde _clyde = default!;
+    [Dependency] private readonly IPrototypeManager _protoManager = default!;
+    [Dependency] private readonly ProfManager _prof = default!;
 
     private readonly ISawmill _sawmill = Logger.GetSawmill("opendream.view");
 


### PR DESCRIPTION
Some renderer optimizations with a focus on memory allocation rate.

1. Split `DrawIconAction()` (now `DrawIcon()`) into several methods (`ProcessKeepTogether()`, `DrawIconFast()`, and `DrawIconSlow()`) so it no longer holds any lambdas. The C# compiler was allocating the lambdas' closures even though the closures weren't used in a majority of cases. Now they're only allocated when necessary.
2. `DrawIcon()` now draws the icon directly instead of returning two actions for drawing the icon and its mouse map. This allows for less lambda usage.
3. Deprecated RT component methods were replaced with their system equivalent.

Before:
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/aa8f5eaa-b82e-457b-8bc7-44fc4a8e9916)

After:
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/513701b3-5f9e-4cc1-b7c4-c557fb472e1e)

Large majority of allocations now are in shader setup, `GetBlendAndColorShader()`