### PR TITLE
Fix edge-case positional/named argument handling in `image()`

### DIFF
--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -41,13 +41,14 @@ namespace OpenDreamRuntime {
 
         // Global state that may not really (really really) belong here
         public DreamValue[] Globals { get; set; } = Array.Empty<DreamValue>();
-        public List<string> GlobalNames { get; private set; } = new List<string>();
+        public List<string> GlobalNames { get; private set; } = new();
         public Dictionary<DreamObject, int> ReferenceIDs { get; } = new();
         public Dictionary<int, DreamObject> ReferenceIDsToDreamObject { get; } = new();
         public HashSet<DreamObject> Clients { get; set; } = new();
         public HashSet<DreamObject> Datums { get; set; } = new();
         public Random Random { get; set; } = new();
         public Dictionary<string, List<DreamObject>> Tags { get; set; } = new();
+        public DreamProc ImageConstructor, ImageFactoryProc;
         private int _dreamObjectRefIdCounter;
 
         private DreamCompiledJson _compiledJson;
@@ -123,8 +124,9 @@ namespace OpenDreamRuntime {
                 throw new FileNotFoundException("Interface DMF not found at "+Path.Join(rootPath,_compiledJson.Interface));
 
             _objectTree.LoadJson(json);
-
             DreamProcNative.SetupNativeProcs(_objectTree);
+            ImageConstructor = _objectTree.Image.ObjectDefinition.GetProc("New");
+            _objectTree.TryGetGlobalProc("image", out ImageFactoryProc!);
 
             _dreamMapManager.Initialize();
             WorldInstance = new DreamObjectWorld(_objectTree.World.ObjectDefinition);

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -977,6 +977,9 @@ namespace OpenDreamRuntime.Procs {
 
                     var argumentCount = argumentStackSize / 2;
                     var arguments = new DreamValue[Math.Max(argumentCount, proc.ArgumentNames.Count)];
+                    var skippingArg = false;
+                    var isImageConstructor = proc == Proc.DreamManager.ImageConstructor ||
+                                             proc == Proc.DreamManager.ImageFactoryProc;
 
                     Array.Fill(arguments, DreamValue.Null);
                     for (int i = 0; i < argumentCount; i++) {
@@ -984,7 +987,15 @@ namespace OpenDreamRuntime.Procs {
                         var value = values[i*2+1];
 
                         if (key.IsNull) {
-                            arguments[i] = value;
+                            // image() or new /image() will skip the loc arg if the second arg is a string
+                            // Really don't like this but it's BYOND behavior
+                            // Note that the way we're doing it leads to different argument placement when there are no named args
+                            // Hopefully nothing depends on that though
+                            // TODO: We aim to do sanity improvements in the future, yea? Big one here
+                            if (isImageConstructor && i == 1 && value.Type == DreamValue.DreamValueType.String)
+                                skippingArg = true;
+
+                            arguments[skippingArg ? i + 1 : i] = value;
                         } else {
                             string argumentName = key.MustGetValueAsString();
                             int argumentIndex = proc.ArgumentNames.IndexOf(argumentName);
@@ -1005,6 +1016,9 @@ namespace OpenDreamRuntime.Procs {
 
                     var listValues = argList.GetValues();
                     var arguments = new DreamValue[Math.Max(listValues.Count, proc.ArgumentNames.Count)];
+                    var skippingArg = false;
+                    var isImageConstructor = proc == Proc.DreamManager.ImageConstructor ||
+                                             proc == Proc.DreamManager.ImageFactoryProc;
 
                     Array.Fill(arguments, DreamValue.Null);
                     for (int i = 0; i < listValues.Count; i++) {
@@ -1020,8 +1034,15 @@ namespace OpenDreamRuntime.Procs {
 
                             arguments[argumentIndex] = argList.GetValue(value);
                         } else { //Ordered argument
+                            // image() or new /image() will skip the loc arg if the second arg is a string
+                            // Really don't like this but it's BYOND behavior
+                            // Note that the way we're doing it leads to different argument placement when there are no named args
+                            // Hopefully nothing depends on that though
+                            if (isImageConstructor && i == 1 && value.Type == DreamValue.DreamValueType.String)
+                                skippingArg = true;
+
                             // TODO: Verify ordered args precede all named args
-                            arguments[i] = value;
+                            arguments[skippingArg ? i + 1 : i] = value;
                         }
                     }
 


### PR DESCRIPTION
Fixes #1261

When using named arguments in `image()` or `new /image()`, using a string in the second positional argument will now place an implicit `null` in between the first and second arg. This is what BYOND does:

![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/68d39d4f-b40a-43d8-bc47-78d30d44cc68)

BYOND does this even when there are no named arguments being used. For the sake of performance I'm just ignoring that here in the hopes no one depends on such niche behavior. This does mean keeping the argument-skipping behavior in DreamObjectImage's initializer.