### PR TITLE
Fix `roll(sides)`

### DIFF
--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2072,21 +2072,24 @@ namespace OpenDreamRuntime.Procs.Native {
             int sides;
             int modifier = 0;
             if (bundle.Arguments.Length == 1) {
-                if(!bundle.GetArgument(0, "ndice").TryGetValueAsString(out var diceInput)) {
-                    return new DreamValue(1);
-                }
+                var arg = bundle.GetArgument(0, "ndice");
+                if(arg.TryGetValueAsString(out var diceInput)) {
+                    string[] diceList = diceInput.Split('d');
+                    if (diceList.Length < 2) {
+                        if (!Int32.TryParse(diceList[0], out sides)) { throw new Exception($"Invalid dice value: {diceInput}"); }
+                    } else {
+                        if (!Int32.TryParse(diceList[0], out dice)) { throw new Exception($"Invalid dice value: {diceInput}"); }
+                        if (!Int32.TryParse(diceList[1], out sides)) {
+                            string[] sideList = diceList[1].Split('+');
 
-                string[] diceList = diceInput.Split('d');
-                if (diceList.Length < 2) {
-                    if (!Int32.TryParse(diceList[0], out sides)) { throw new Exception($"Invalid dice value: {diceInput}"); }
-                } else {
-                    if (!Int32.TryParse(diceList[0], out dice)) { throw new Exception($"Invalid dice value: {diceInput}"); }
-                    if (!Int32.TryParse(diceList[1], out sides)) {
-                        string[] sideList = diceList[1].Split('+');
-
-                        if (!Int32.TryParse(sideList[0], out sides) || !Int32.TryParse(sideList[1], out modifier))
-                            throw new Exception($"Invalid dice value: {diceInput}");
+                            if (!Int32.TryParse(sideList[0], out sides) || !Int32.TryParse(sideList[1], out modifier))
+                                throw new Exception($"Invalid dice value: {diceInput}");
+                        }
                     }
+                } else if (arg.IsNull) {
+                    return new DreamValue(1);
+                } else if (!arg.TryGetValueAsInteger(out sides)) {
+                    throw new Exception($"Invalid dice value: {arg}");
                 }
             } else if (!bundle.GetArgument(0, "ndice").TryGetValueAsInteger(out dice) || !bundle.GetArgument(1, "sides").TryGetValueAsInteger(out sides)) {
                 return new DreamValue(0);


### PR DESCRIPTION
Fixes #1604 

Also handles `roll(null)`

![image](https://github.com/OpenDreamProject/OpenDream/assets/5714543/e95003cc-c293-4188-b300-73e4c294e8de)
