### PR TITLE
Fix min icon size in GenerateDMI()

### DIFF
--- a/OpenDreamRuntime/Objects/DreamIcon.cs
+++ b/OpenDreamRuntime/Objects/DreamIcon.cs
@@ -83,6 +83,9 @@ public sealed class DreamIcon {
         if (_cachedDMI != null)
             return _cachedDMI;
 
+        if(Width == 0 && Height == 0)
+           Width = Height = 32; //TODO should be world.icon_size
+
         int frameCount = FrameCount;
 
         int frameWidth = Width, frameHeight = Height;


### PR DESCRIPTION
Default value of 0,0 when the icon passed to `new /image()` is null throws an error.