### PR TITLE
Fix PR labeler

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -17,7 +17,7 @@ jobs:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           commentOnDirty: "This pull request has conflicts, please resolve those before we can evaluate the pull request."
       - name: Apply Size Label
-        if: ${{ github.ref != 'refs/heads/master' }}
+        if: (github.event_name == 'pull_request_target' && github.head_ref != 'refs/heads/master')
         uses: pascalgn/size-label-action@v0.5.0
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"          


### PR DESCRIPTION
if it's the on push master event, the ref is always master. We don't want to check size label on push to master, so we force it to only happen on pull request events (ie, creation and commits), where the branch name is set properly