### PR TITLE
Fix automatic `Compiler` label

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -7,5 +7,5 @@ labelPRBasedOnFilePath:
     - OpenDreamServer/**/*
     - OpenDreamShared/**/*
   Compiler:
-    - OpenDreamCompiler/**/*
-    - DMDissasembler/**/*
+    - DMCompiler/**/*
+    - DMDisassembler/**/*


### PR DESCRIPTION
The compiler tag used incorrect paths