### PR TITLE
Add "null statements" to the compiler

### DIFF
--- a/Content.Tests/DMProject/Tests/Statements/EmptyBlock.dm
+++ b/Content.Tests/DMProject/Tests/Statements/EmptyBlock.dm
@@ -1,0 +1,5 @@
+﻿// COMPILE ERROR
+#pragma EmptyBlock error
+
+/proc/RunTest()
+	if (TRUE)

--- a/Content.Tests/DMProject/Tests/Statements/EmptyBlockSuppressed.dm
+++ b/Content.Tests/DMProject/Tests/Statements/EmptyBlockSuppressed.dm
@@ -1,0 +1,5 @@
+﻿#pragma EmptyBlock error
+
+/proc/RunTest()
+	if (TRUE)
+		;

--- a/DMCompiler/Compiler/DM/DMAST.cs
+++ b/DMCompiler/Compiler/DM/DMAST.cs
@@ -37,6 +37,10 @@ namespace DMCompiler.Compiler.DM {
             throw new NotImplementedException();
         }
 
+        public void VisitNullProcStatement(DMASTNullProcStatement nullProcStatement) {
+            throw new NotImplementedException();
+        }
+
         public void VisitProcStatementExpression(DMASTProcStatementExpression statementExpression) {
             throw new NotImplementedException();
         }
@@ -769,6 +773,14 @@ namespace DMCompiler.Compiler.DM {
 
         public override void Visit(DMASTVisitor visitor) {
             visitor.VisitObjectVarOverride(this);
+        }
+    }
+
+    /// Lone semicolon, analogous to null statements in C.
+    /// Main purpose is to suppress EmptyBlock emissions.
+    public sealed class DMASTNullProcStatement(Location location) : DMASTProcStatement(location) {
+        public override void Visit(DMASTVisitor visitor) {
+            visitor.VisitNullProcStatement(this);
         }
     }
 

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -194,6 +194,7 @@ namespace DMCompiler.Compiler.DM {
 
         public DMASTStatement? Statement(bool requireDelimiter = true) {
             var loc = Current().Location;
+
             DMASTPath? path = Path();
             if (path is null)
                 return null;
@@ -618,6 +619,12 @@ namespace DMCompiler.Compiler.DM {
 
         public DMASTProcStatement? ProcStatement() {
             var loc = Current().Location;
+
+            if (Current().Type == TokenType.DM_Semicolon) { // A lone semicolon creates a "null statement" (like C)
+                // Note that we do not consume the semicolon here
+                return new DMASTNullProcStatement(loc);
+            }
+
             var leadingColon = Check(TokenType.DM_Colon);
 
             DMASTExpression? expression = null;

--- a/DMCompiler/DM/Visitors/DMASTSimplifier.cs
+++ b/DMCompiler/DM/Visitors/DMASTSimplifier.cs
@@ -53,6 +53,8 @@ namespace DMCompiler.DM.Visitors {
             }
         }
 
+        public void VisitNullProcStatement(DMASTNullProcStatement nullProcStatement) { }
+
         public void VisitProcStatementExpression(DMASTProcStatementExpression statementExpression) {
             SimplifyExpression(ref statementExpression.Expression);
         }

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -112,6 +112,7 @@ namespace DMCompiler.DM.Visitors {
 
         public void ProcessStatement(DMASTProcStatement statement) {
             switch (statement) {
+                case DMASTNullProcStatement: break;
                 case DMASTProcStatementExpression statementExpression: ProcessStatementExpression(statementExpression); break;
                 case DMASTProcStatementContinue statementContinue: ProcessStatementContinue(statementContinue); break;
                 case DMASTProcStatementGoto statementGoto: ProcessStatementGoto(statementGoto); break;


### PR DESCRIPTION
Just a lone semicolon that represents a statement with nothing in it. Allows for suppressing EmptyBlock emissions.

```dm
/proc/main()
    if (TRUE) // Has no body, considered an empty block.
```
```dm
/proc/main()
    if (TRUE)
        ; // A null statement. Not considered an empty block.
```