### PR TITLE
Set the default secondary icon in Discord Rich Presence

### DIFF
--- a/OpenDreamRuntime/EntryPoint.cs
+++ b/OpenDreamRuntime/EntryPoint.cs
@@ -43,6 +43,7 @@ namespace OpenDreamRuntime {
 
             _configManager.OverrideDefault(CVars.NetLogLateMsg, false); // Disable since disabling prediction causes timing errors otherwise.
             _configManager.OverrideDefault(CVars.GameAutoPauseEmpty, false); // TODO: world.sleep_offline can control this
+            _configManager.OverrideDefault(CVars.DiscordRichPresenceSecondIconId, "opendream");
             _configManager.SetCVar(CVars.GridSplitting, false); // Grid splitting should never be used
             if(String.IsNullOrEmpty(_configManager.GetCVar<string>(OpenDreamCVars.JsonPath))) //if you haven't set the jsonpath cvar, set it to the first valid file path passed as an arg
                 foreach (string arg in Environment.GetCommandLineArgs().Skip(1)) //skip the first element, because it's just the server's exe path


### PR DESCRIPTION
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/42ebd00d-0b53-4e36-b88e-68eeb7a48da1)

Unfortunately we can't use arbitrary images, so the main icon will have to be left to server owners to set after they get it uploaded to Discord through [here](https://github.com/space-wizards/asset-dump/tree/master/discord-app-assets).