### PR TITLE
Remove obsolete `Error()` in DMParser

### DIFF
--- a/DMCompiler/Compiler/CompilerError.cs
+++ b/DMCompiler/Compiler/CompilerError.cs
@@ -12,6 +12,7 @@ public enum WarningCode {
     BadDirective = 10,
     BadExpression = 11,
     MissingExpression = 12,
+    InvalidArgumentCount = 13,
     BadLabel = 19,
     InvalidReference = 50,
     BadArgument = 100,
@@ -41,7 +42,6 @@ public enum WarningCode {
     SoftReservedKeyword = 2000, // For keywords that SHOULD be reserved, but don't have to be. 'null' and 'defined', for instance
     DuplicateVariable = 2100,
     DuplicateProcDefinition = 2101,
-    TooManyArguments = 2200,
     PointlessParentCall = 2205,
     PointlessBuiltinCall = 2206, // For pointless calls to issaved() or initial()
     SuspiciousMatrixCall = 2207, // Calling matrix() with seemingly the wrong arguments

--- a/DMCompiler/Compiler/CompilerError.cs
+++ b/DMCompiler/Compiler/CompilerError.cs
@@ -13,6 +13,8 @@ public enum WarningCode {
     BadExpression = 11,
     MissingExpression = 12,
     InvalidArgumentCount = 13,
+    InvalidVarDefinition = 14,
+    MissingBody = 15,
     BadLabel = 19,
     InvalidReference = 50,
     BadArgument = 100,

--- a/DMCompiler/Compiler/DM/AST/DMAST.Expression.cs
+++ b/DMCompiler/Compiler/DM/AST/DMAST.Expression.cs
@@ -141,9 +141,9 @@ public sealed class DMASTNewExpr(Location location, DMASTExpression expression, 
     public readonly DMASTCallParameter[]? Parameters = parameters;
 }
 
-public sealed class DMASTNewInferred(Location location, DMASTCallParameter[] parameters)
+public sealed class DMASTNewInferred(Location location, DMASTCallParameter[]? parameters)
     : DMASTExpression(location) {
-    public readonly DMASTCallParameter[] Parameters = parameters;
+    public readonly DMASTCallParameter[]? Parameters = parameters;
 }
 
 public sealed class DMASTTernary(Location location, DMASTExpression a, DMASTExpression b, DMASTExpression c)

--- a/DMCompiler/Compiler/DM/AST/DMAST.Expression.cs
+++ b/DMCompiler/Compiler/DM/AST/DMAST.Expression.cs
@@ -21,6 +21,7 @@ public abstract class DMASTExpression(Location location) : DMASTNode(location) {
 /// <summary>
 /// Used when there was an error parsing an expression
 /// </summary>
+/// <remarks>Emit an error code before creating!</remarks>
 public sealed class DMASTInvalidExpression(Location location) : DMASTExpression(location);
 
 public sealed class DMASTVoid(Location location) : DMASTExpression(location);

--- a/DMCompiler/Compiler/DM/AST/DMAST.Expression.cs
+++ b/DMCompiler/Compiler/DM/AST/DMAST.Expression.cs
@@ -18,6 +18,11 @@ public abstract class DMASTExpression(Location location) : DMASTNode(location) {
     }
 }
 
+/// <summary>
+/// Used when there was an error parsing an expression
+/// </summary>
+public sealed class DMASTInvalidExpression(Location location) : DMASTExpression(location);
+
 public sealed class DMASTVoid(Location location) : DMASTExpression(location);
 
 public sealed class DMASTIdentifier(Location location, string identifier) : DMASTExpression(location) {

--- a/DMCompiler/Compiler/DM/AST/DMAST.ProcStatements.cs
+++ b/DMCompiler/Compiler/DM/AST/DMAST.ProcStatements.cs
@@ -14,7 +14,15 @@ public abstract class DMASTProcStatement(Location location) : DMASTNode(location
     }
 }
 
+/// Lone semicolon, analogous to null statements in C.
+/// Main purpose is to suppress EmptyBlock emissions.
 public sealed class DMASTNullProcStatement(Location location) : DMASTProcStatement(location);
+
+/// <summary>
+/// Used when there was an error parsing a statement
+/// </summary>
+/// <remarks>Emit an error code before creating!</remarks>
+public sealed class DMASTInvalidProcStatement(Location location) : DMASTProcStatement(location);
 
 public sealed class DMASTProcStatementExpression(Location location, DMASTExpression expression)
     : DMASTProcStatement(location) {

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -7,7 +7,7 @@ using DMCompiler.DM;
 
 namespace DMCompiler.Compiler.DM {
     public partial class DMParser(DMLexer lexer) : Parser<Token>(lexer) {
-        private Location CurrentLoc => Current().Location;
+        protected Location CurrentLoc => Current().Location;
 
         private DreamPath _currentPath = DreamPath.Root;
         private bool _allowVarDeclExpression;

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -1813,7 +1813,7 @@ namespace DMCompiler.Compiler.DM {
 
                 if (b is DMASTVoid) b = new DMASTConstantNull(b.Location);
 
-                Consume(TokenType.DM_Colon, WarningCode.BadToken, "Expected ':'");
+                Consume(TokenType.DM_Colon, "Expected ':'");
                 Whitespace();
 
                 DMASTExpression? c = ExpressionTernary(isTernaryB);

--- a/DMCompiler/Compiler/DM/DMParserHelper.cs
+++ b/DMCompiler/Compiler/DM/DMParserHelper.cs
@@ -9,12 +9,6 @@ using DMCompiler.Compiler.DM.AST;
 namespace DMCompiler.Compiler.DM;
 
 public partial class DMParser {
-    /// <inheritdoc cref="Parser{SourceType}.Error(string, bool)"/>
-    [Obsolete("This is not a desirable way for DMParser to emit an error, as errors should emit an error code and not cause unnecessary throws. Use DMParser's overrides of this method, instead.")]
-    protected new void Error(string message, bool throwException = true) {
-        base.Error(message, throwException);
-    }
-
     /// <summary>
     /// If the expression is null, emit an error and set it to a new <see cref="DMASTInvalidExpression" />
     /// </summary>

--- a/DMCompiler/Compiler/DM/DMParserHelper.cs
+++ b/DMCompiler/Compiler/DM/DMParserHelper.cs
@@ -9,24 +9,10 @@ using DMCompiler.Compiler.DM.AST;
 namespace DMCompiler.Compiler.DM;
 
 public partial class DMParser {
-    /// <returns> True if this will raise an error, false if not. You can use this return value to help improve error emission around this (depending on how permissive we're being)</returns>
-    protected bool Emit(WarningCode code, Location location, string message) {
-        return DMCompiler.Emit(code, location, message);
-    }
-
-    protected bool Emit(WarningCode code, string message) {
-        return Emit(code, CurrentLoc, message);
-    }
-
     /// <inheritdoc cref="Parser{SourceType}.Error(string, bool)"/>
     [Obsolete("This is not a desirable way for DMParser to emit an error, as errors should emit an error code and not cause unnecessary throws. Use DMParser's overrides of this method, instead.")]
     protected new void Error(string message, bool throwException = true) {
         base.Error(message, throwException);
-    }
-
-    protected void Consume(TokenType type, WarningCode code, string message) {
-        if (!Check(type))
-            Emit(code, CurrentLoc, message);
     }
 
     /// <summary>

--- a/DMCompiler/Compiler/DM/DMParserHelper.cs
+++ b/DMCompiler/Compiler/DM/DMParserHelper.cs
@@ -8,18 +8,13 @@ using DMCompiler.Compiler.DM.AST;
 namespace DMCompiler.Compiler.DM;
 
 public partial class DMParser {
-    /// <summary>
-    /// A special override of Error() since, for DMParser, we know we are in a compilation context and can make use of error codes.
-    /// </summary>
-    /// <remarks>
-    /// Should only be called AFTER <see cref="DMCompiler"/> has built up its list of pragma configurations.
-    /// </remarks>
     /// <returns> True if this will raise an error, false if not. You can use this return value to help improve error emission around this (depending on how permissive we're being)</returns>
-    protected bool Error(WarningCode code, string message) {
-        ErrorLevel level = DMCompiler.CodeToLevel(code);
-        if (Emissions.Count < MAX_EMISSIONS_RECORDED)
-            Emissions.Add(new CompilerEmission(level, code, Current().Location, message));
-        return level == ErrorLevel.Error;
+    protected bool Emit(WarningCode code, Location location, string message) {
+        return DMCompiler.Emit(code, location, message);
+    }
+
+    protected bool Emit(WarningCode code, string message) {
+        return Emit(code, Current().Location, message);
     }
 
     /// <inheritdoc cref="Parser{SourceType}.Error(string, bool)"/>

--- a/DMCompiler/Compiler/Parser.cs
+++ b/DMCompiler/Compiler/Parser.cs
@@ -3,15 +3,9 @@ using System.Collections.Generic;
 namespace DMCompiler.Compiler;
 
 public class Parser<SourceType> {
-    /// <summary> Includes errors and warnings accumulated by this parser. </summary>
-    /// <remarks> These initial capacities are arbitrary. We just assume there's a decent chance you'll get a handful of errors/warnings. </remarks>
-    public List<CompilerEmission> Emissions = new(8);
-
     protected Lexer<SourceType> _lexer;
     private Token _currentToken;
     private readonly Stack<Token> _tokenStack = new(1);
-    /// <summary>The maximum number of errors or warnings we'd ever place into <see cref="Emissions"/>.</summary>
-    protected const int MAX_EMISSIONS_RECORDED = 50_000_000;
 
     protected Parser(Lexer<SourceType> lexer) {
         _lexer = lexer;
@@ -95,12 +89,10 @@ public class Parser<SourceType> {
     /// since there are some parsers that aren't always in the compilation context, like the ones for DMF and DMM. <br/>
     /// </remarks>
     protected void Error(string message, bool throwException = true) {
-        CompilerEmission error = new CompilerEmission(ErrorLevel.Error, _currentToken.Location, message);
+        DMCompiler.ForcedError(_currentToken.Location, message);
 
-        if(Emissions.Count < MAX_EMISSIONS_RECORDED)
-            Emissions.Add(error);
         if (throwException)
-            throw new CompileErrorException(error);
+            throw new CompileErrorException(message);
     }
 
     /// <summary>
@@ -111,6 +103,6 @@ public class Parser<SourceType> {
     /// </remarks>
     protected void Warning(string message, Token? token = null) {
         token ??= _currentToken;
-        Emissions.Add(new CompilerEmission(ErrorLevel.Warning, token?.Location, message));
+        DMCompiler.ForcedWarning(token.Value.Location, message);
     }
 }

--- a/DMCompiler/Compiler/Parser.cs
+++ b/DMCompiler/Compiler/Parser.cs
@@ -28,7 +28,7 @@ public class Parser<SourceType> {
             _currentToken = _lexer.GetNextToken();
 
             if (_currentToken.Type == TokenType.Error) {
-                Error((string)_currentToken.Value!, throwException: false);
+                Emit(WarningCode.BadToken, (string)_currentToken.Value!);
                 Advance();
             } else if (_currentToken.Type == TokenType.Warning) {
                 Warning((string)_currentToken.Value!);
@@ -87,19 +87,6 @@ public class Parser<SourceType> {
 
         Emit(WarningCode.BadToken, errorMessage);
         return TokenType.Unknown;
-    }
-
-    /// <summary>
-    /// Emits an error discovered during parsing, optionally causing a throw.
-    /// </summary>
-    /// <remarks> This implementation on <see cref="Parser{SourceType}"/> does not make use of <see cref="WarningCode"/> <br/>
-    /// since there are some parsers that aren't always in the compilation context, like the ones for DMF and DMM. <br/>
-    /// </remarks>
-    protected void Error(string message, bool throwException = true) {
-        DMCompiler.ForcedError(_currentToken.Location, message);
-
-        if (throwException)
-            throw new CompileErrorException(message);
     }
 
     /// <summary>

--- a/DMCompiler/Compiler/Parser.cs
+++ b/DMCompiler/Compiler/Parser.cs
@@ -73,21 +73,19 @@ public class Parser<SourceType> {
         return false;
     }
 
-    [Obsolete("This throws, which is not a desirable way for the compiler to emit an error.")]
     protected void Consume(TokenType type, string errorMessage) {
         if (!Check(type)) {
-            Error(errorMessage);
+            Emit(WarningCode.BadToken, errorMessage);
         }
     }
 
     /// <returns>The <see cref="TokenType"/> that was found.</returns>
-    [Obsolete("This throws, which is not a desirable way for the compiler to emit an error.")]
     protected TokenType Consume(TokenType[] types, string errorMessage) {
         foreach (TokenType type in types) {
             if (Check(type)) return type;
         }
 
-        Error(errorMessage);
+        Emit(WarningCode.BadToken, errorMessage);
         return TokenType.Unknown;
     }
 
@@ -113,5 +111,14 @@ public class Parser<SourceType> {
     protected void Warning(string message, Token? token = null) {
         token ??= _currentToken;
         DMCompiler.ForcedWarning(token.Value.Location, message);
+    }
+
+    /// <returns> True if this will raise an error, false if not. You can use this return value to help improve error emission around this (depending on how permissive we're being)</returns>
+    protected bool Emit(WarningCode code, Location location, string message) {
+        return DMCompiler.Emit(code, location, message);
+    }
+
+    protected bool Emit(WarningCode code, string message) {
+        return Emit(code, Current().Location, message);
     }
 }

--- a/DMCompiler/Compiler/Parser.cs
+++ b/DMCompiler/Compiler/Parser.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace DMCompiler.Compiler;
@@ -53,19 +54,26 @@ public class Parser<SourceType> {
         return false;
     }
 
-    protected bool Check(TokenType[] types) {
+    protected bool Check(Span<TokenType> types) {
+        return Check(types, out _);
+    }
+
+    protected bool Check(Span<TokenType> types, out Token matchedToken) {
         TokenType currentType = Current().Type;
         foreach (TokenType type in types) {
             if (currentType == type) {
+                matchedToken = Current();
                 Advance();
 
                 return true;
             }
         }
 
+        matchedToken = default;
         return false;
     }
 
+    [Obsolete("This throws, which is not a desirable way for the compiler to emit an error.")]
     protected void Consume(TokenType type, string errorMessage) {
         if (!Check(type)) {
             Error(errorMessage);
@@ -73,6 +81,7 @@ public class Parser<SourceType> {
     }
 
     /// <returns>The <see cref="TokenType"/> that was found.</returns>
+    [Obsolete("This throws, which is not a desirable way for the compiler to emit an error.")]
     protected TokenType Consume(TokenType[] types, string errorMessage) {
         foreach (TokenType type in types) {
             if (Check(type)) return type;

--- a/DMCompiler/DM/Builders/DMExpressionBuilder.cs
+++ b/DMCompiler/DM/Builders/DMExpressionBuilder.cs
@@ -21,6 +21,9 @@ internal static class DMExpressionBuilder {
 
     public static DMExpression BuildExpression(DMASTExpression expression, DMObject dmObject, DMProc proc, DreamPath? inferredPath = null) {
         switch (expression) {
+            case DMASTInvalidExpression:
+                return new Null(expression.Location);
+
             case DMASTExpressionConstant constant: return BuildConstant(constant, dmObject, proc);
             case DMASTStringFormat stringFormat: return BuildStringFormat(stringFormat, dmObject, proc, inferredPath);
             case DMASTIdentifier identifier: return BuildIdentifier(identifier, dmObject, proc);
@@ -398,7 +401,7 @@ internal static class DMExpressionBuilder {
                     break;
                 default:
                     DMCompiler.Emit(
-                        WarningCode.TooManyArguments,
+                        WarningCode.InvalidArgumentCount,
                         procCall.Location,
                         $"arglist() given {procCall.Parameters.Length} arguments, expecting 1");
                     break;
@@ -738,7 +741,7 @@ internal static class DMExpressionBuilder {
         for (int i = 0; i < expArr.Length; i++) {
             DMASTCallParameter parameter = addText.Parameters[i];
             if(parameter.Key != null)
-                DMCompiler.Emit(WarningCode.TooManyArguments, parameter.Location, "addtext() does not take named arguments");
+                DMCompiler.Emit(WarningCode.InvalidArgumentKey, parameter.Location, "addtext() does not take named arguments");
 
             expArr[i] = DMExpression.Create(dmObject,proc, parameter.Value, inferredPath);
         }
@@ -812,7 +815,7 @@ internal static class DMExpressionBuilder {
 
         switch (call.CallParameters.Length) {
             default:
-                DMCompiler.Emit(WarningCode.TooManyArguments, call.Location, "Too many arguments for call()");
+                DMCompiler.Emit(WarningCode.InvalidArgumentCount, call.Location, "Too many arguments for call()");
                 goto case 2; // Fallthrough!
             case 2: {
                 var a = DMExpression.Create(dmObject, proc, call.CallParameters[0].Value, inferredPath);
@@ -824,7 +827,7 @@ internal static class DMExpressionBuilder {
                 return new CallStatement(call.Location, a, procArgs);
             }
             case 0:
-                DMCompiler.Emit(WarningCode.BadArgument, call.Location, "Not enough arguments for call()");
+                DMCompiler.Emit(WarningCode.InvalidArgumentCount, call.Location, "Not enough arguments for call()");
                 return new CallStatement(call.Location, new Null(Location.Internal), procArgs);
         }
     }

--- a/DMCompiler/DM/Builders/DMProcBuilder.cs
+++ b/DMCompiler/DM/Builders/DMProcBuilder.cs
@@ -8,10 +8,7 @@ using DMCompiler.Compiler.DM.AST;
 using DMCompiler.DM.Expressions;
 
 namespace DMCompiler.DM.Builders {
-    internal sealed class DMProcBuilder {
-        private readonly DMObject _dmObject;
-        private readonly DMProc _proc;
-
+    internal sealed class DMProcBuilder(DMObject dmObject, DMProc proc) {
         /// <summary>
         /// BYOND currently has a ridiculous behaviour, where, <br/>
         /// sometimes when a set statement has a right-hand side that is non-constant, <br/>
@@ -19,13 +16,8 @@ namespace DMCompiler.DM.Builders {
         /// This behaviour is nonsense but for harsh parity we sometimes may need to carry it out to hold up a codebase; <br/>
         /// Yogstation (at time of writing) actually errors on OD if we don't implement this.
         /// </summary>
+        // Starts null; marks that we've never seen one before and should just error like normal people.
         private Constant? _previousSetStatementValue;
-
-        public DMProcBuilder(DMObject dmObject, DMProc proc) {
-            _dmObject = dmObject;
-            _proc = proc;
-            _previousSetStatementValue = null; // Intentional; marks that we've never seen one before and should just error like normal people.
-        }
 
         public void ProcessProcDefinition(DMASTProcDefinition procDefinition) {
             if (procDefinition.Body == null) return;
@@ -34,33 +26,33 @@ namespace DMCompiler.DM.Builders {
                 string parameterName = parameter.Name;
 
                 if (parameter.Value != null) { //Parameter has a default value
-                    string afterDefaultValueCheck = _proc.NewLabelName();
-                    DMReference parameterRef = _proc.GetLocalVariableReference(parameterName);
+                    string afterDefaultValueCheck = proc.NewLabelName();
+                    DMReference parameterRef = proc.GetLocalVariableReference(parameterName);
 
                     //Don't set parameter to default if not null
-                    _proc.PushReferenceValue(parameterRef);
-                    _proc.IsNull();
-                    _proc.JumpIfFalse(afterDefaultValueCheck);
+                    proc.PushReferenceValue(parameterRef);
+                    proc.IsNull();
+                    proc.JumpIfFalse(afterDefaultValueCheck);
 
                     //Set default
                     try {
-                        DMExpression.Emit(_dmObject, _proc, parameter.Value, parameter.ObjectType);
+                        DMExpression.Emit(dmObject, proc, parameter.Value, parameter.ObjectType);
                     } catch (CompileErrorException e) {
                         DMCompiler.Emit(e.Error);
                     }
-                    _proc.Assign(parameterRef);
-                    _proc.Pop();
+                    proc.Assign(parameterRef);
+                    proc.Pop();
 
-                    _proc.AddLabel(afterDefaultValueCheck);
+                    proc.AddLabel(afterDefaultValueCheck);
                 }
             }
 
             if (procDefinition.Body.Statements.Length == 0) {
-                DMCompiler.Emit(WarningCode.EmptyProc, _proc.Location,"Empty proc detected - add an explicit \"return\" statement");
+                DMCompiler.Emit(WarningCode.EmptyProc, proc.Location,"Empty proc detected - add an explicit \"return\" statement");
             }
 
             ProcessBlockInner(procDefinition.Body, silenceEmptyBlockWarning : true);
-            _proc.ResolveLabels();
+            proc.ResolveLabels();
         }
 
         /// <param name="silenceEmptyBlockWarning">Used to avoid emitting noisy warnings about procs with nothing in them. <br/>
@@ -95,7 +87,7 @@ namespace DMCompiler.DM.Builders {
             }
 
             foreach (DMASTProcStatement statement in block.Statements) {
-                _proc.DebugSource(statement.Location);
+                proc.DebugSource(statement.Location);
 
                 try {
                     ProcessStatement(statement);
@@ -153,36 +145,36 @@ namespace DMCompiler.DM.Builders {
         }
 
         public void ProcessStatementExpression(DMASTProcStatementExpression statement) {
-            DMExpression.Emit(_dmObject, _proc, statement.Expression);
-            _proc.Pop();
+            DMExpression.Emit(dmObject, proc, statement.Expression);
+            proc.Pop();
         }
 
         public void ProcessStatementContinue(DMASTProcStatementContinue statementContinue) {
-            _proc.Continue(statementContinue.Label);
+            proc.Continue(statementContinue.Label);
         }
 
         public void ProcessStatementGoto(DMASTProcStatementGoto statementGoto) {
-            _proc.Goto(statementGoto.Label);
+            proc.Goto(statementGoto.Label);
         }
 
         public void ProcessStatementLabel(DMASTProcStatementLabel statementLabel) {
-            var codeLabel = _proc.TryAddCodeLabel(statementLabel.Name);
+            var codeLabel = proc.TryAddCodeLabel(statementLabel.Name);
             var labelName = codeLabel?.LabelName ?? statementLabel.Name;
 
-            _proc.AddLabel(labelName);
+            proc.AddLabel(labelName);
 
             if (statementLabel.Body is not null) {
-                _proc.StartScope();
+                proc.StartScope();
                 {
                     ProcessBlockInner(statementLabel.Body);
                 }
-                _proc.EndScope();
-                _proc.AddLabel(labelName + "_end");
+                proc.EndScope();
+                proc.AddLabel(labelName + "_end");
             }
         }
 
         public void ProcessStatementBreak(DMASTProcStatementBreak statementBreak) {
-            _proc.Break(statementBreak.Label);
+            proc.Break(statementBreak.Label);
         }
 
         public void ProcessStatementSet(DMASTProcStatementSet statementSet) {
@@ -192,7 +184,7 @@ namespace DMCompiler.DM.Builders {
                 // TODO: Would be much better if the parser was just more strict with the expression
                 switch (statementSet.Value) {
                     case DMASTIdentifier {Identifier: "usr"}:
-                        _proc.VerbSrc = statementSet.WasInKeyword ? VerbSrc.InUsr : VerbSrc.Usr;
+                        proc.VerbSrc = statementSet.WasInKeyword ? VerbSrc.InUsr : VerbSrc.Usr;
                         if (statementSet.WasInKeyword)
                             DMCompiler.UnimplementedWarning(statementSet.Location,
                                 "'set src = usr.contents' is unimplemented");
@@ -202,15 +194,15 @@ namespace DMCompiler.DM.Builders {
                             goto default;
 
                         if (deref == "contents") {
-                            _proc.VerbSrc = VerbSrc.InUsr;
+                            proc.VerbSrc = VerbSrc.InUsr;
                             DMCompiler.UnimplementedWarning(statementSet.Location,
                                 "'set src = usr.contents' is unimplemented");
                         }  else if (deref == "loc") {
-                            _proc.VerbSrc = VerbSrc.UsrLoc;
+                            proc.VerbSrc = VerbSrc.UsrLoc;
                             DMCompiler.UnimplementedWarning(statementSet.Location,
                                 "'set src = usr.loc' is unimplemented");
                         } else if (deref == "group") {
-                            _proc.VerbSrc = VerbSrc.UsrGroup;
+                            proc.VerbSrc = VerbSrc.UsrGroup;
                             DMCompiler.UnimplementedWarning(statementSet.Location,
                                 "'set src = usr.group' is unimplemented");
                         } else {
@@ -219,7 +211,7 @@ namespace DMCompiler.DM.Builders {
 
                         break;
                     case DMASTIdentifier {Identifier: "world"}:
-                        _proc.VerbSrc = statementSet.WasInKeyword ? VerbSrc.InWorld : VerbSrc.World;
+                        proc.VerbSrc = statementSet.WasInKeyword ? VerbSrc.InWorld : VerbSrc.World;
                         if (statementSet.WasInKeyword)
                             DMCompiler.UnimplementedWarning(statementSet.Location,
                                 "'set src = world.contents' is unimplemented");
@@ -231,24 +223,24 @@ namespace DMCompiler.DM.Builders {
                         if (operations is not [DMASTDereference.FieldOperation {Identifier: "contents"}])
                             goto default;
 
-                        _proc.VerbSrc = VerbSrc.InWorld;
+                        proc.VerbSrc = VerbSrc.InWorld;
                         DMCompiler.UnimplementedWarning(statementSet.Location,
                             "'set src = world.contents' is unimplemented");
                         break;
                     case DMASTProcCall {Callable: DMASTCallableProcIdentifier {Identifier: { } viewType and ("view" or "oview")}}:
                         // TODO: Ranges
                         if (statementSet.WasInKeyword)
-                            _proc.VerbSrc = viewType == "view" ? VerbSrc.InView : VerbSrc.InOView;
+                            proc.VerbSrc = viewType == "view" ? VerbSrc.InView : VerbSrc.InOView;
                         else
-                            _proc.VerbSrc = viewType == "view" ? VerbSrc.View : VerbSrc.OView;
+                            proc.VerbSrc = viewType == "view" ? VerbSrc.View : VerbSrc.OView;
                         break;
                     // range() and orange() are undocumented, but they work
                     case DMASTProcCall {Callable: DMASTCallableProcIdentifier {Identifier: { } viewType and ("range" or "orange")}}:
                         // TODO: Ranges
                         if (statementSet.WasInKeyword)
-                            _proc.VerbSrc = viewType == "range" ? VerbSrc.InRange : VerbSrc.InORange;
+                            proc.VerbSrc = viewType == "range" ? VerbSrc.InRange : VerbSrc.InORange;
                         else
-                            _proc.VerbSrc = viewType == "range" ? VerbSrc.Range : VerbSrc.ORange;
+                            proc.VerbSrc = viewType == "range" ? VerbSrc.Range : VerbSrc.ORange;
                         break;
                     default:
                         DMCompiler.Emit(WarningCode.BadExpression, statementSet.Value.Location, "Invalid verb src");
@@ -258,7 +250,7 @@ namespace DMCompiler.DM.Builders {
                 return;
             }
 
-            if (!DMExpression.TryConstant(_dmObject, _proc, statementSet.Value, out var constant)) { // If this set statement's rhs is not constant
+            if (!DMExpression.TryConstant(dmObject, proc, statementSet.Value, out var constant)) { // If this set statement's rhs is not constant
                 bool didError = DMCompiler.Emit(WarningCode.InvalidSetStatement, statementSet.Location, $"'{attribute}' attribute should be a constant");
                 if (didError) // if this is an error
                     return; // don't do the cursed thing
@@ -281,53 +273,53 @@ namespace DMCompiler.DM.Builders {
 
             switch (statementSet.Attribute.ToLower()) {
                 case "waitfor": {
-                    _proc.WaitFor(constant.IsTruthy());
+                    proc.WaitFor(constant.IsTruthy());
                     break;
                 }
                 case "opendream_unimplemented": {
                     if (constant.IsTruthy())
-                        _proc.Attributes |= ProcAttributes.Unimplemented;
+                        proc.Attributes |= ProcAttributes.Unimplemented;
                     else
-                        _proc.Attributes &= ~ProcAttributes.Unimplemented;
+                        proc.Attributes &= ~ProcAttributes.Unimplemented;
                     break;
                 }
                 case "hidden":
                     if (constant.IsTruthy())
-                        _proc.Attributes |= ProcAttributes.Hidden;
+                        proc.Attributes |= ProcAttributes.Hidden;
                     else
-                        _proc.Attributes &= ~ProcAttributes.Hidden;
+                        proc.Attributes &= ~ProcAttributes.Hidden;
                     break;
                 case "popup_menu":
                     if (constant.IsTruthy()) // The default is to show it so we flag it if it's hidden
-                        _proc.Attributes &= ~ProcAttributes.HidePopupMenu;
+                        proc.Attributes &= ~ProcAttributes.HidePopupMenu;
                     else
-                        _proc.Attributes |= ProcAttributes.HidePopupMenu;
+                        proc.Attributes |= ProcAttributes.HidePopupMenu;
 
                     DMCompiler.UnimplementedWarning(statementSet.Location, "set popup_menu is not implemented");
                     break;
                 case "instant":
                     if (constant.IsTruthy())
-                        _proc.Attributes |= ProcAttributes.Instant;
+                        proc.Attributes |= ProcAttributes.Instant;
                     else
-                        _proc.Attributes &= ~ProcAttributes.Instant;
+                        proc.Attributes &= ~ProcAttributes.Instant;
 
                     DMCompiler.UnimplementedWarning(statementSet.Location, "set instant is not implemented");
                     break;
                 case "background":
                     if (constant.IsTruthy())
-                        _proc.Attributes |= ProcAttributes.Background;
+                        proc.Attributes |= ProcAttributes.Background;
                     else
-                        _proc.Attributes &= ~ProcAttributes.Background;
+                        proc.Attributes &= ~ProcAttributes.Background;
                     break;
                 case "name":
                     if (constant is not Expressions.String nameStr) {
                         throw new CompileErrorException(statementSet.Location, "name attribute must be a string");
                     }
 
-                    _proc.VerbName = nameStr.Value;
+                    proc.VerbName = nameStr.Value;
                     break;
                 case "category":
-                    _proc.VerbCategory = constant switch {
+                    proc.VerbCategory = constant switch {
                         Expressions.String str => str.Value,
                         Expressions.Null => null,
                         _ => throw new CompileErrorException(statementSet.Location, "category attribute must be a string or null")
@@ -340,7 +332,7 @@ namespace DMCompiler.DM.Builders {
                         throw new CompileErrorException(statementSet.Location, "desc attribute must be a string");
                     }
 
-                    _proc.VerbDesc = descStr.Value;
+                    proc.VerbDesc = descStr.Value;
                     break;
                 case "invisibility":
                     // The ref says 0-101 for atoms and 0-100 for verbs
@@ -349,7 +341,7 @@ namespace DMCompiler.DM.Builders {
                         throw new CompileErrorException(statementSet.Location, "invisibility attribute must be an int");
                     }
 
-                    _proc.Invisibility = Convert.ToSByte(Math.Clamp(MathF.Floor(invisNum.Value), 0f, 100f));
+                    proc.Invisibility = Convert.ToSByte(Math.Clamp(MathF.Floor(invisNum.Value), 0f, 100f));
                     break;
                 case "src":
                     DMCompiler.UnimplementedWarning(statementSet.Location, "set src is not implemented");
@@ -358,27 +350,27 @@ namespace DMCompiler.DM.Builders {
         }
 
         public void ProcessStatementDel(DMASTProcStatementDel statementDel) {
-            DMExpression.Emit(_dmObject, _proc, statementDel.Value);
-            _proc.DeleteObject();
+            DMExpression.Emit(dmObject, proc, statementDel.Value);
+            proc.DeleteObject();
         }
 
         public void ProcessStatementSpawn(DMASTProcStatementSpawn statementSpawn) {
-            DMExpression.Emit(_dmObject, _proc, statementSpawn.Delay);
+            DMExpression.Emit(dmObject, proc, statementSpawn.Delay);
 
-            string afterSpawnLabel = _proc.NewLabelName();
-            _proc.Spawn(afterSpawnLabel);
+            string afterSpawnLabel = proc.NewLabelName();
+            proc.Spawn(afterSpawnLabel);
 
-            _proc.StartScope();
+            proc.StartScope();
             {
                 ProcessBlockInner(statementSpawn.Body);
 
                 //Prevent the new thread from executing outside its own code
-                _proc.PushNull();
-                _proc.Return();
+                proc.PushNull();
+                proc.Return();
             }
-            _proc.EndScope();
+            proc.EndScope();
 
-            _proc.AddLabel(afterSpawnLabel);
+            proc.AddLabel(afterSpawnLabel);
         }
 
         public void ProcessStatementVarDeclaration(DMASTProcStatementVarDeclaration varDeclaration) {
@@ -387,7 +379,7 @@ namespace DMCompiler.DM.Builders {
             DMExpression value;
             if (varDeclaration.Value != null) {
                 try {
-                    value = DMExpression.Create(_dmObject, _proc, varDeclaration.Value, varDeclaration.Type);
+                    value = DMExpression.Create(dmObject, proc, varDeclaration.Value, varDeclaration.Type);
                 } catch (CompileErrorException e) {
                     DMCompiler.Emit(e.Error);
                     value = new Expressions.Null(varDeclaration.Location);
@@ -403,9 +395,9 @@ namespace DMCompiler.DM.Builders {
                     return;
                 }
 
-                successful = _proc.TryAddLocalConstVariable(varDeclaration.Name, varDeclaration.Type, constValue);
+                successful = proc.TryAddLocalConstVariable(varDeclaration.Name, varDeclaration.Type, constValue);
             } else {
-                successful = _proc.TryAddLocalVariable(varDeclaration.Name, varDeclaration.Type);
+                successful = proc.TryAddLocalVariable(varDeclaration.Name, varDeclaration.Type);
             }
 
             if (!successful) {
@@ -413,75 +405,75 @@ namespace DMCompiler.DM.Builders {
                 return;
             }
 
-            value.EmitPushValue(_dmObject, _proc);
-            _proc.Assign(_proc.GetLocalVariableReference(varDeclaration.Name));
-            _proc.Pop();
+            value.EmitPushValue(dmObject, proc);
+            proc.Assign(proc.GetLocalVariableReference(varDeclaration.Name));
+            proc.Pop();
         }
 
         public void ProcessStatementReturn(DMASTProcStatementReturn statement) {
             if (statement.Value != null) {
-                DMExpression.Emit(_dmObject, _proc, statement.Value);
+                DMExpression.Emit(dmObject, proc, statement.Value);
             } else {
-                _proc.PushReferenceValue(DMReference.Self); //Default return value
+                proc.PushReferenceValue(DMReference.Self); //Default return value
             }
 
-            _proc.Return();
+            proc.Return();
         }
 
         public void ProcessStatementIf(DMASTProcStatementIf statement) {
-            DMExpression.Emit(_dmObject, _proc, statement.Condition);
+            DMExpression.Emit(dmObject, proc, statement.Condition);
 
             if (statement.ElseBody == null) {
-                string endLabel = _proc.NewLabelName();
+                string endLabel = proc.NewLabelName();
 
-                _proc.JumpIfFalse(endLabel);
-                _proc.StartScope();
+                proc.JumpIfFalse(endLabel);
+                proc.StartScope();
                 ProcessBlockInner(statement.Body);
-                _proc.EndScope();
-                _proc.AddLabel(endLabel);
+                proc.EndScope();
+                proc.AddLabel(endLabel);
             } else {
-                string elseLabel = _proc.NewLabelName();
-                string endLabel = _proc.NewLabelName();
+                string elseLabel = proc.NewLabelName();
+                string endLabel = proc.NewLabelName();
 
-                _proc.JumpIfFalse(elseLabel);
+                proc.JumpIfFalse(elseLabel);
 
-                _proc.StartScope();
+                proc.StartScope();
                 ProcessBlockInner(statement.Body);
-                _proc.EndScope();
-                _proc.Jump(endLabel);
+                proc.EndScope();
+                proc.Jump(endLabel);
 
-                _proc.AddLabel(elseLabel);
-                _proc.StartScope();
+                proc.AddLabel(elseLabel);
+                proc.StartScope();
                 ProcessBlockInner(statement.ElseBody);
-                _proc.EndScope();
-                _proc.AddLabel(endLabel);
+                proc.EndScope();
+                proc.AddLabel(endLabel);
             }
         }
 
         public void ProcessStatementFor(DMASTProcStatementFor statementFor) {
-            _proc.StartScope();
+            proc.StartScope();
             {
                 foreach (var decl in FindVarDecls(statementFor.Expression1)) {
                     ProcessStatementVarDeclaration(new DMASTProcStatementVarDeclaration(statementFor.Location, decl.DeclPath, null));
                 }
 
-                var initializer = statementFor.Expression1 != null ? DMExpression.Create(_dmObject, _proc, statementFor.Expression1) : null;
+                var initializer = statementFor.Expression1 != null ? DMExpression.Create(dmObject, proc, statementFor.Expression1) : null;
 
                 if (statementFor.Expression2 != null || statementFor.Expression3 != null) {
-                    var comparator = statementFor.Expression2 != null ? DMExpression.Create(_dmObject, _proc, statementFor.Expression2) : null;
-                    var incrementor = statementFor.Expression3 != null ? DMExpression.Create(_dmObject, _proc, statementFor.Expression3) : null;
+                    var comparator = statementFor.Expression2 != null ? DMExpression.Create(dmObject, proc, statementFor.Expression2) : null;
+                    var incrementor = statementFor.Expression3 != null ? DMExpression.Create(dmObject, proc, statementFor.Expression3) : null;
 
                     ProcessStatementForStandard(initializer, comparator, incrementor, statementFor.Body);
                 } else {
                     switch (statementFor.Expression1) {
                         case DMASTAssign {LHS: DMASTVarDeclExpression decl, RHS: DMASTExpressionInRange range}: {
                             var identifier = new DMASTIdentifier(decl.Location, decl.DeclPath.Path.LastElement);
-                            var outputVar = DMExpression.Create(_dmObject, _proc, identifier);
+                            var outputVar = DMExpression.Create(dmObject, proc, identifier);
 
-                            var start = DMExpression.Create(_dmObject, _proc, range.StartRange);
-                            var end = DMExpression.Create(_dmObject, _proc, range.EndRange);
+                            var start = DMExpression.Create(dmObject, proc, range.StartRange);
+                            var end = DMExpression.Create(dmObject, proc, range.EndRange);
                             var step = range.Step != null
-                                ? DMExpression.Create(_dmObject, _proc, range.Step)
+                                ? DMExpression.Create(dmObject, proc, range.Step)
                                 : new Number(range.Location, 1);
 
                             ProcessStatementForRange(initializer, outputVar, start, end, step, statementFor.Body);
@@ -500,12 +492,12 @@ namespace DMCompiler.DM.Builders {
                                 outputExpr = exprRange.Value;
                             }
 
-                            var outputVar = DMExpression.Create(_dmObject, _proc, outputExpr);
+                            var outputVar = DMExpression.Create(dmObject, proc, outputExpr);
 
-                            var start = DMExpression.Create(_dmObject, _proc, exprRange.StartRange);
-                            var end = DMExpression.Create(_dmObject, _proc, exprRange.EndRange);
+                            var start = DMExpression.Create(dmObject, proc, exprRange.StartRange);
+                            var end = DMExpression.Create(dmObject, proc, exprRange.EndRange);
                             var step = exprRange.Step != null
-                                ? DMExpression.Create(_dmObject, _proc, exprRange.Step)
+                                ? DMExpression.Create(dmObject, proc, exprRange.Step)
                                 : new Number(exprRange.Location, 1);
 
                             ProcessStatementForRange(null, outputVar, start, end, step, statementFor.Body);
@@ -514,7 +506,7 @@ namespace DMCompiler.DM.Builders {
                         case DMASTVarDeclExpression vd: {
                             var declInfo = new ProcVarDeclInfo(vd.DeclPath.Path);
                             var identifier = new DMASTIdentifier(vd.Location, declInfo.VarName);
-                            var outputVar = DMExpression.Create(_dmObject, _proc, identifier);
+                            var outputVar = DMExpression.Create(dmObject, proc, identifier);
 
                             ProcessStatementForType(initializer, outputVar, declInfo.TypePath, statementFor.Body);
                             break;
@@ -527,8 +519,8 @@ namespace DMCompiler.DM.Builders {
                                 outputExpr = exprIn.LHS;
                             }
 
-                            var outputVar = DMExpression.Create(_dmObject, _proc, outputExpr);
-                            var list = DMExpression.Create(_dmObject, _proc, exprIn.RHS);
+                            var outputVar = DMExpression.Create(dmObject, proc, outputExpr);
+                            var list = DMExpression.Create(dmObject, proc, exprIn.RHS);
 
                             ProcessStatementForList(list, outputVar, statementFor.DMTypes, statementFor.Body);
                             break;
@@ -539,7 +531,7 @@ namespace DMCompiler.DM.Builders {
                     }
                 }
             }
-            _proc.EndScope();
+            proc.EndScope();
 
             IEnumerable<DMASTVarDeclExpression> FindVarDecls(DMASTExpression expr) {
                 if (expr is DMASTVarDeclExpression p) {
@@ -554,50 +546,50 @@ namespace DMCompiler.DM.Builders {
         }
 
         public void ProcessStatementForStandard(DMExpression? initializer, DMExpression? comparator, DMExpression? incrementor, DMASTProcBlockInner body) {
-            _proc.StartScope();
+            proc.StartScope();
             {
                 if (initializer != null) {
-                    initializer.EmitPushValue(_dmObject, _proc);
-                    _proc.Pop();
+                    initializer.EmitPushValue(dmObject, proc);
+                    proc.Pop();
                 }
 
-                string loopLabel = _proc.NewLabelName();
-                _proc.LoopStart(loopLabel);
+                string loopLabel = proc.NewLabelName();
+                proc.LoopStart(loopLabel);
                 {
                     if (comparator != null) {
-                        comparator.EmitPushValue(_dmObject, _proc);
-                        _proc.BreakIfFalse();
+                        comparator.EmitPushValue(dmObject, proc);
+                        proc.BreakIfFalse();
                     }
 
                     ProcessBlockInner(body);
 
-                    _proc.MarkLoopContinue(loopLabel);
+                    proc.MarkLoopContinue(loopLabel);
                     if (incrementor != null) {
-                        incrementor.EmitPushValue(_dmObject, _proc);
-                        _proc.Pop();
+                        incrementor.EmitPushValue(dmObject, proc);
+                        proc.Pop();
                     }
-                    _proc.LoopJumpToStart(loopLabel);
+                    proc.LoopJumpToStart(loopLabel);
                 }
-                _proc.LoopEnd();
+                proc.LoopEnd();
             }
-            _proc.EndScope();
+            proc.EndScope();
         }
 
         public void ProcessLoopAssignment(LValue lValue) {
             if (lValue.CanReferenceShortCircuit()) {
-                string endLabel = _proc.NewLabelName();
-                string endLabel2 = _proc.NewLabelName();
+                string endLabel = proc.NewLabelName();
+                string endLabel2 = proc.NewLabelName();
 
-                DMReference outputRef = lValue.EmitReference(_dmObject, _proc, endLabel, DMExpression.ShortCircuitMode.PopNull);
-                _proc.Enumerate(outputRef);
-                _proc.Jump(endLabel2);
+                DMReference outputRef = lValue.EmitReference(dmObject, proc, endLabel, DMExpression.ShortCircuitMode.PopNull);
+                proc.Enumerate(outputRef);
+                proc.Jump(endLabel2);
 
-                _proc.AddLabel(endLabel);
-                _proc.EnumerateNoAssign();
-                _proc.AddLabel(endLabel2);
+                proc.AddLabel(endLabel);
+                proc.EnumerateNoAssign();
+                proc.AddLabel(endLabel2);
             } else {
-                DMReference outputRef = lValue.EmitReference(_dmObject, _proc, null);
-                _proc.Enumerate(outputRef);
+                DMReference outputRef = lValue.EmitReference(dmObject, proc, null);
+                proc.Enumerate(outputRef);
             }
         }
 
@@ -618,38 +610,38 @@ namespace DMCompiler.DM.Builders {
                     $"As type \"{dmTypes}\" in for loops is unimplemented. No type check will be performed.");
             }
 
-            list.EmitPushValue(_dmObject, _proc);
+            list.EmitPushValue(dmObject, proc);
             if (implicitTypeCheck != null) {
                 if (DMObjectTree.TryGetTypeId(implicitTypeCheck.Value, out var filterTypeId)) {
                     // Create an enumerator that will do the implicit istype() for us
-                    _proc.CreateFilteredListEnumerator(filterTypeId);
+                    proc.CreateFilteredListEnumerator(filterTypeId);
                 } else {
                     DMCompiler.Emit(WarningCode.ItemDoesntExist, outputVar.Location,
                         $"Cannot filter enumeration by type {implicitTypeCheck.Value}, it does not exist");
-                    _proc.CreateListEnumerator();
+                    proc.CreateListEnumerator();
                 }
             } else {
-                _proc.CreateListEnumerator();
+                proc.CreateListEnumerator();
             }
 
-            _proc.StartScope();
+            proc.StartScope();
             {
-                string loopLabel = _proc.NewLabelName();
-                _proc.LoopStart(loopLabel);
+                string loopLabel = proc.NewLabelName();
+                proc.LoopStart(loopLabel);
                 {
-                    _proc.MarkLoopContinue(loopLabel);
+                    proc.MarkLoopContinue(loopLabel);
 
                     if (lValue != null) {
                         ProcessLoopAssignment(lValue);
                     }
 
                     ProcessBlockInner(body);
-                    _proc.LoopJumpToStart(loopLabel);
+                    proc.LoopJumpToStart(loopLabel);
                 }
-                _proc.LoopEnd();
+                proc.LoopEnd();
             }
-            _proc.EndScope();
-            _proc.DestroyEnumerator();
+            proc.EndScope();
+            proc.DestroyEnumerator();
         }
 
         public void ProcessStatementForType(DMExpression? initializer, DMExpression outputVar, DreamPath? type, DMASTProcBlockInner body) {
@@ -661,23 +653,23 @@ namespace DMCompiler.DM.Builders {
             }
 
             if (DMObjectTree.TryGetTypeId(type.Value, out var typeId)) {
-                _proc.PushType(typeId);
-                _proc.CreateTypeEnumerator();
+                proc.PushType(typeId);
+                proc.CreateTypeEnumerator();
             } else {
                 DMCompiler.Emit(WarningCode.ItemDoesntExist, initializer.Location, $"Type {type.Value} does not exist");
             }
 
-            _proc.StartScope();
+            proc.StartScope();
             {
                 if (initializer != null) {
-                    initializer.EmitPushValue(_dmObject, _proc);
-                    _proc.Pop();
+                    initializer.EmitPushValue(dmObject, proc);
+                    proc.Pop();
                 }
 
-                string loopLabel = _proc.NewLabelName();
-                _proc.LoopStart(loopLabel);
+                string loopLabel = proc.NewLabelName();
+                proc.LoopStart(loopLabel);
                 {
-                    _proc.MarkLoopContinue(loopLabel);
+                    proc.MarkLoopContinue(loopLabel);
 
                     if (outputVar is Expressions.LValue lValue) {
                         ProcessLoopAssignment(lValue);
@@ -686,35 +678,35 @@ namespace DMCompiler.DM.Builders {
                     }
 
                     ProcessBlockInner(body);
-                    _proc.LoopJumpToStart(loopLabel);
+                    proc.LoopJumpToStart(loopLabel);
                 }
-                _proc.LoopEnd();
+                proc.LoopEnd();
             }
-            _proc.EndScope();
-            _proc.DestroyEnumerator();
+            proc.EndScope();
+            proc.DestroyEnumerator();
         }
 
         public void ProcessStatementForRange(DMExpression? initializer, DMExpression outputVar, DMExpression start, DMExpression end, DMExpression? step, DMASTProcBlockInner body) {
-            start.EmitPushValue(_dmObject, _proc);
-            end.EmitPushValue(_dmObject, _proc);
+            start.EmitPushValue(dmObject, proc);
+            end.EmitPushValue(dmObject, proc);
             if (step != null) {
-                step.EmitPushValue(_dmObject, _proc);
+                step.EmitPushValue(dmObject, proc);
             } else {
-                _proc.PushFloat(1.0f);
+                proc.PushFloat(1.0f);
             }
 
-            _proc.CreateRangeEnumerator();
-            _proc.StartScope();
+            proc.CreateRangeEnumerator();
+            proc.StartScope();
             {
                 if (initializer != null) {
-                    initializer.EmitPushValue(_dmObject, _proc);
-                    _proc.Pop();
+                    initializer.EmitPushValue(dmObject, proc);
+                    proc.Pop();
                 }
 
-                string loopLabel = _proc.NewLabelName();
-                _proc.LoopStart(loopLabel);
+                string loopLabel = proc.NewLabelName();
+                proc.LoopStart(loopLabel);
                 {
-                    _proc.MarkLoopContinue(loopLabel);
+                    proc.MarkLoopContinue(loopLabel);
 
                     if (outputVar is Expressions.LValue lValue) {
                         ProcessLoopAssignment(lValue);
@@ -723,84 +715,84 @@ namespace DMCompiler.DM.Builders {
                     }
 
                     ProcessBlockInner(body);
-                    _proc.LoopJumpToStart(loopLabel);
+                    proc.LoopJumpToStart(loopLabel);
                 }
-                _proc.LoopEnd();
+                proc.LoopEnd();
             }
-            _proc.EndScope();
-            _proc.DestroyEnumerator();
+            proc.EndScope();
+            proc.DestroyEnumerator();
         }
 
         //Generic infinite loop, while loops with static expression as their conditional with positive truthfullness get turned into this as well as empty for() calls
         public void ProcessStatementInfLoop(DMASTProcStatementInfLoop statementInfLoop){
-            _proc.StartScope();
+            proc.StartScope();
             {
-                string loopLabel = _proc.NewLabelName();
-                _proc.LoopStart(loopLabel);
+                string loopLabel = proc.NewLabelName();
+                proc.LoopStart(loopLabel);
                 {
-                    _proc.MarkLoopContinue(loopLabel);
+                    proc.MarkLoopContinue(loopLabel);
                     ProcessBlockInner(statementInfLoop.Body);
-                    _proc.LoopJumpToStart(loopLabel);
+                    proc.LoopJumpToStart(loopLabel);
                 }
-                _proc.LoopEnd();
+                proc.LoopEnd();
             }
-            _proc.EndScope();
+            proc.EndScope();
         }
 
         public void ProcessStatementWhile(DMASTProcStatementWhile statementWhile) {
-            string loopLabel = _proc.NewLabelName();
+            string loopLabel = proc.NewLabelName();
 
-            _proc.LoopStart(loopLabel);
+            proc.LoopStart(loopLabel);
             {
-                _proc.MarkLoopContinue(loopLabel);
-                DMExpression.Emit(_dmObject, _proc, statementWhile.Conditional);
-                _proc.BreakIfFalse();
+                proc.MarkLoopContinue(loopLabel);
+                DMExpression.Emit(dmObject, proc, statementWhile.Conditional);
+                proc.BreakIfFalse();
 
-                _proc.StartScope();
+                proc.StartScope();
                 {
                     ProcessBlockInner(statementWhile.Body);
-                    _proc.LoopJumpToStart(loopLabel);
+                    proc.LoopJumpToStart(loopLabel);
                 }
-                _proc.EndScope();
+                proc.EndScope();
             }
-            _proc.LoopEnd();
+            proc.LoopEnd();
         }
 
         public void ProcessStatementDoWhile(DMASTProcStatementDoWhile statementDoWhile) {
-            string loopLabel = _proc.NewLabelName();
-            string loopEndLabel = _proc.NewLabelName();
+            string loopLabel = proc.NewLabelName();
+            string loopEndLabel = proc.NewLabelName();
 
-            _proc.LoopStart(loopLabel);
+            proc.LoopStart(loopLabel);
             {
                 ProcessBlockInner(statementDoWhile.Body);
 
-                _proc.MarkLoopContinue(loopLabel);
-                DMExpression.Emit(_dmObject, _proc, statementDoWhile.Conditional);
-                _proc.JumpIfFalse(loopEndLabel);
-                _proc.LoopJumpToStart(loopLabel);
+                proc.MarkLoopContinue(loopLabel);
+                DMExpression.Emit(dmObject, proc, statementDoWhile.Conditional);
+                proc.JumpIfFalse(loopEndLabel);
+                proc.LoopJumpToStart(loopLabel);
 
-                _proc.AddLabel(loopEndLabel);
-                _proc.Break();
+                proc.AddLabel(loopEndLabel);
+                proc.Break();
             }
-            _proc.LoopEnd();
+            proc.LoopEnd();
         }
 
         public void ProcessStatementSwitch(DMASTProcStatementSwitch statementSwitch) {
-            string endLabel = _proc.NewLabelName();
+            string endLabel = proc.NewLabelName();
             List<(string CaseLabel, DMASTProcBlockInner CaseBody)> valueCases = new();
             DMASTProcBlockInner? defaultCaseBody = null;
 
-            DMExpression.Emit(_dmObject, _proc, statementSwitch.Value);
+            DMExpression.Emit(dmObject, proc, statementSwitch.Value);
             foreach (DMASTProcStatementSwitch.SwitchCase switchCase in statementSwitch.Cases) {
                 if (switchCase is DMASTProcStatementSwitch.SwitchCaseValues switchCaseValues) {
-                    string caseLabel = _proc.NewLabelName();
+                    string caseLabel = proc.NewLabelName();
 
                     foreach (DMASTExpression value in switchCaseValues.Values) {
                         Constant GetCaseValue(DMASTExpression expression) {
                             Constant? constant = null;
 
                             try {
-                                if (!DMExpression.TryConstant(_dmObject, _proc, expression, out constant))
+                                if (!DMExpression.TryConstant(dmObject, proc, expression, out constant))
                                     DMCompiler.Emit(WarningCode.HardConstContext, expression.Location, "Expected a constant");
                             } catch (CompileErrorException e) {
                                 DMCompiler.Emit(e.Error);
@@ -835,14 +827,14 @@ namespace DMCompiler.DM.Builders {
                             lower = CoerceBound(lower);
                             upper = CoerceBound(upper);
 
-                            lower.EmitPushValue(_dmObject, _proc);
-                            upper.EmitPushValue(_dmObject, _proc);
-                            _proc.SwitchCaseRange(caseLabel);
+                            lower.EmitPushValue(dmObject, proc);
+                            upper.EmitPushValue(dmObject, proc);
+                            proc.SwitchCaseRange(caseLabel);
                         } else {
                             Constant constant = GetCaseValue(value);
 
-                            constant.EmitPushValue(_dmObject, _proc);
-                            _proc.SwitchCase(caseLabel);
+                            constant.EmitPushValue(dmObject, proc);
+                            proc.SwitchCase(caseLabel);
                         }
                     }
 
@@ -851,81 +843,81 @@ namespace DMCompiler.DM.Builders {
                     defaultCaseBody = ((DMASTProcStatementSwitch.SwitchCaseDefault)switchCase).Body;
                 }
             }
-            _proc.Pop();
+            proc.Pop();
 
             if (defaultCaseBody != null) {
-                _proc.StartScope();
+                proc.StartScope();
                 {
                     ProcessBlockInner(defaultCaseBody);
                 }
-                _proc.EndScope();
+                proc.EndScope();
             }
-            _proc.Jump(endLabel);
+            proc.Jump(endLabel);
 
             foreach ((string CaseLabel, DMASTProcBlockInner CaseBody) valueCase in valueCases) {
-                _proc.AddLabel(valueCase.CaseLabel);
-                _proc.StartScope();
+                proc.AddLabel(valueCase.CaseLabel);
+                proc.StartScope();
                 {
                     ProcessBlockInner(valueCase.CaseBody);
                 }
-                _proc.EndScope();
-                _proc.Jump(endLabel);
+                proc.EndScope();
+                proc.Jump(endLabel);
             }
 
-            _proc.AddLabel(endLabel);
+            proc.AddLabel(endLabel);
         }
 
         public void ProcessStatementBrowse(DMASTProcStatementBrowse statementBrowse) {
-            DMExpression.Emit(_dmObject, _proc, statementBrowse.Receiver);
-            DMExpression.Emit(_dmObject, _proc, statementBrowse.Body);
-            DMExpression.Emit(_dmObject, _proc, statementBrowse.Options);
-            _proc.Browse();
+            DMExpression.Emit(dmObject, proc, statementBrowse.Receiver);
+            DMExpression.Emit(dmObject, proc, statementBrowse.Body);
+            DMExpression.Emit(dmObject, proc, statementBrowse.Options);
+            proc.Browse();
         }
 
         public void ProcessStatementBrowseResource(DMASTProcStatementBrowseResource statementBrowseResource) {
-            DMExpression.Emit(_dmObject, _proc, statementBrowseResource.Receiver);
-            DMExpression.Emit(_dmObject, _proc, statementBrowseResource.File);
-            DMExpression.Emit(_dmObject, _proc, statementBrowseResource.Filename);
-            _proc.BrowseResource();
+            DMExpression.Emit(dmObject, proc, statementBrowseResource.Receiver);
+            DMExpression.Emit(dmObject, proc, statementBrowseResource.File);
+            DMExpression.Emit(dmObject, proc, statementBrowseResource.Filename);
+            proc.BrowseResource();
         }
 
         public void ProcessStatementOutputControl(DMASTProcStatementOutputControl statementOutputControl) {
-            DMExpression.Emit(_dmObject, _proc, statementOutputControl.Receiver);
-            DMExpression.Emit(_dmObject, _proc, statementOutputControl.Message);
-            DMExpression.Emit(_dmObject, _proc, statementOutputControl.Control);
-            _proc.OutputControl();
+            DMExpression.Emit(dmObject, proc, statementOutputControl.Receiver);
+            DMExpression.Emit(dmObject, proc, statementOutputControl.Message);
+            DMExpression.Emit(dmObject, proc, statementOutputControl.Control);
+            proc.OutputControl();
         }
 
         public void ProcessStatementFtp(DMASTProcStatementFtp statementFtp) {
-            DMExpression.Emit(_dmObject, _proc, statementFtp.Receiver);
-            DMExpression.Emit(_dmObject, _proc, statementFtp.File);
-            DMExpression.Emit(_dmObject, _proc, statementFtp.Name);
-            _proc.Ftp();
+            DMExpression.Emit(dmObject, proc, statementFtp.Receiver);
+            DMExpression.Emit(dmObject, proc, statementFtp.File);
+            DMExpression.Emit(dmObject, proc, statementFtp.Name);
+            proc.Ftp();
         }
 
         public void ProcessStatementOutput(DMASTProcStatementOutput statementOutput) {
-            DMExpression left = DMExpression.Create(_dmObject, _proc, statementOutput.A);
-            DMExpression right = DMExpression.Create(_dmObject, _proc, statementOutput.B);
+            DMExpression left = DMExpression.Create(dmObject, proc, statementOutput.A);
+            DMExpression right = DMExpression.Create(dmObject, proc, statementOutput.B);
 
             if (left is LValue) {
                 // An LValue on the left needs a special opcode so that its reference can be used
                 // This allows for special operations like "savefile[...] << ..."
 
-                string endLabel = _proc.NewLabelName();
-                DMReference leftRef = left.EmitReference(_dmObject, _proc, endLabel, DMExpression.ShortCircuitMode.PopNull);
-                right.EmitPushValue(_dmObject, _proc);
-                _proc.OutputReference(leftRef);
-                _proc.AddLabel(endLabel);
+                string endLabel = proc.NewLabelName();
+                DMReference leftRef = left.EmitReference(dmObject, proc, endLabel, DMExpression.ShortCircuitMode.PopNull);
+                right.EmitPushValue(dmObject, proc);
+                proc.OutputReference(leftRef);
+                proc.AddLabel(endLabel);
             } else {
-                left.EmitPushValue(_dmObject, _proc);
-                right.EmitPushValue(_dmObject, _proc);
-                _proc.Output();
+                left.EmitPushValue(dmObject, proc);
+                right.EmitPushValue(dmObject, proc);
+                proc.Output();
             }
         }
 
         public void ProcessStatementInput(DMASTProcStatementInput statementInput) {
-            DMExpression left = DMExpression.Create(_dmObject, _proc, statementInput.A);
-            DMExpression right = DMExpression.Create(_dmObject, _proc, statementInput.B);
+            DMExpression left = DMExpression.Create(dmObject, proc, statementInput.A);
+            DMExpression right = DMExpression.Create(dmObject, proc, statementInput.B);
 
             // The left-side value of an input operation must be an LValue
             // (I think? I haven't found an exception but there could be one)
@@ -940,53 +932,53 @@ namespace DMCompiler.DM.Builders {
                 return;
             }
 
-            string rightEndLabel = _proc.NewLabelName();
-            string leftEndLabel = _proc.NewLabelName();
-            DMReference rightRef = right.EmitReference(_dmObject, _proc, rightEndLabel, DMExpression.ShortCircuitMode.PopNull);
-            DMReference leftRef = left.EmitReference(_dmObject, _proc, leftEndLabel, DMExpression.ShortCircuitMode.PopNull);
+            string rightEndLabel = proc.NewLabelName();
+            string leftEndLabel = proc.NewLabelName();
+            DMReference rightRef = right.EmitReference(dmObject, proc, rightEndLabel, DMExpression.ShortCircuitMode.PopNull);
+            DMReference leftRef = left.EmitReference(dmObject, proc, leftEndLabel, DMExpression.ShortCircuitMode.PopNull);
 
-            _proc.Input(leftRef, rightRef);
+            proc.Input(leftRef, rightRef);
 
-            _proc.AddLabel(leftEndLabel);
-            _proc.PopReference(rightRef);
-            _proc.AddLabel(rightEndLabel);
+            proc.AddLabel(leftEndLabel);
+            proc.PopReference(rightRef);
+            proc.AddLabel(rightEndLabel);
         }
 
         public void ProcessStatementTryCatch(DMASTProcStatementTryCatch tryCatch) {
-            string catchLabel = _proc.NewLabelName();
-            string endLabel = _proc.NewLabelName();
+            string catchLabel = proc.NewLabelName();
+            string endLabel = proc.NewLabelName();
 
             if (tryCatch.CatchParameter != null) {
                 var param = tryCatch.CatchParameter as DMASTProcStatementVarDeclaration;
 
-                if (!_proc.TryAddLocalVariable(param.Name, param.Type)) {
+                if (!proc.TryAddLocalVariable(param.Name, param.Type)) {
                     DMCompiler.Emit(WarningCode.DuplicateVariable, param.Location, $"Duplicate var {param.Name}");
                 }
 
-                _proc.StartTry(catchLabel, _proc.GetLocalVariableReference(param.Name));
+                proc.StartTry(catchLabel, proc.GetLocalVariableReference(param.Name));
             } else {
-                _proc.StartTryNoValue(catchLabel);
+                proc.StartTryNoValue(catchLabel);
             }
 
-            _proc.StartScope();
+            proc.StartScope();
             ProcessBlockInner(tryCatch.TryBody);
-            _proc.EndScope();
-            _proc.EndTry();
-            _proc.Jump(endLabel);
+            proc.EndScope();
+            proc.EndTry();
+            proc.Jump(endLabel);
 
-            _proc.AddLabel(catchLabel);
+            proc.AddLabel(catchLabel);
             if (tryCatch.CatchBody != null) {
-                _proc.StartScope();
+                proc.StartScope();
                 ProcessBlockInner(tryCatch.CatchBody);
-                _proc.EndScope();
+                proc.EndScope();
             }
-            _proc.AddLabel(endLabel);
+            proc.AddLabel(endLabel);
 
         }
 
         public void ProcessStatementThrow(DMASTProcStatementThrow statement) {
-            DMExpression.Emit(_dmObject, _proc, statement.Value);
-            _proc.Throw();
+            DMExpression.Emit(dmObject, proc, statement.Value);
+            proc.Throw();
         }
     }
 }

--- a/DMCompiler/DM/Builders/DMProcBuilder.cs
+++ b/DMCompiler/DM/Builders/DMProcBuilder.cs
@@ -105,6 +105,7 @@ namespace DMCompiler.DM.Builders {
 
         public void ProcessStatement(DMASTProcStatement statement) {
             switch (statement) {
+                case DMASTInvalidProcStatement: break;
                 case DMASTNullProcStatement: break;
                 case DMASTProcStatementExpression statementExpression: ProcessStatementExpression(statementExpression); break;
                 case DMASTProcStatementContinue statementContinue: ProcessStatementContinue(statementContinue); break;

--- a/DMCompiler/DM/Expressions/Procs.cs
+++ b/DMCompiler/DM/Expressions/Procs.cs
@@ -175,7 +175,7 @@ namespace DMCompiler.DM.Expressions {
                                 $"Calling matrix() with 5 arguments will always error when called at runtime");
                             break;
                         default: // BYOND always compiletimes here
-                            DMCompiler.Emit(WarningCode.TooManyArguments, _arguments.Location,
+                            DMCompiler.Emit(WarningCode.InvalidArgumentCount, _arguments.Location,
                                 $"Too many arguments to matrix() - got {_arguments.Length} arguments, expecting 6 or less");
                             break;
 

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -245,15 +245,10 @@ public static class DMCompiler {
 
             DMLexer lexer = new DMLexer(mapPath, preprocessor);
             DMMParser parser = new DMMParser(lexer, zOffset);
+            DreamMapJson map = parser.ParseMap();
 
-            try {
-                DreamMapJson map = parser.ParseMap();
-
-                zOffset = Math.Max(zOffset + 1, map.MaxZ);
-                maps.Add(map);
-            } catch (CompileErrorException e) {
-                Emit(e.Error);
-            }
+            zOffset = Math.Max(zOffset + 1, map.MaxZ);
+            maps.Add(map);
         }
 
         return maps;

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -154,10 +154,6 @@ public static class DMCompiler {
         VerbosePrint("Parsing");
         DMASTFile astFile = dmParser.File();
 
-        foreach (CompilerEmission warning in dmParser.Emissions) {
-            Emit(warning);
-        }
-
         DMASTFolder astSimplifier = new DMASTFolder();
         VerbosePrint("Constant folding");
         astSimplifier.FoldAst(astFile);
@@ -249,21 +245,15 @@ public static class DMCompiler {
 
             DMLexer lexer = new DMLexer(mapPath, preprocessor);
             DMMParser parser = new DMMParser(lexer, zOffset);
-            DreamMapJson map = parser.ParseMap();
 
-            bool hadErrors = false;
-            if (parser.Emissions.Count > 0) {
-                foreach (CompilerEmission error in parser.Emissions) {
-                    if (error.Level == ErrorLevel.Error)
-                        hadErrors = true;
+            try {
+                DreamMapJson map = parser.ParseMap();
 
-                    Emit(error);
-                }
-            }
-
-            zOffset = Math.Max(zOffset + 1, map.MaxZ);
-            if (!hadErrors)
+                zOffset = Math.Max(zOffset + 1, map.MaxZ);
                 maps.Add(map);
+            } catch (CompileErrorException e) {
+                Emit(e.Error);
+            }
         }
 
         return maps;

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -15,7 +15,6 @@
 #pragma SoftReservedKeyword error
 #pragma DuplicateVariable error
 #pragma DuplicateProcDefinition error
-#pragma TooManyArguments error
 #pragma PointlessParentCall warning
 #pragma PointlessBuiltinCall warning
 #pragma SuspiciousMatrixCall warning

--- a/OpenDream.sln.DotSettings
+++ b/OpenDream.sln.DotSettings
@@ -19,6 +19,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=centerable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ckey/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cmptext/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=compiletimereadonly/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=copytext/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Debuggee/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=deciseconds/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
This removes all the uses of the obsolete `Error(string message, bool throwException = true)` in the compiler. Parsing errors no longer throw/catch a `CompileErrorException` and error handling should be generally more flexible. This also brings the total warnings when building DMCompiler from 338 to 174 (down 164).

Will need more testing to make sure error handling is in a good place.