### PR TITLE
Fix /image objects sharing appearances

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamObjectImage.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectImage.cs
@@ -41,7 +41,7 @@ public sealed class DreamObjectImage : DreamObject {
         DreamValue icon = args.GetArgument(0);
         if (icon.IsNull || !AtomManager.TryCreateAppearanceFrom(icon, out Appearance)) {
             // Use a default appearance, but log a warning about it if icon wasn't null
-            Appearance = AtomManager.GetAppearanceFromDefinition(ObjectDefinition);
+            Appearance = new(AtomManager.GetAppearanceFromDefinition(ObjectDefinition));
             if (!icon.IsNull)
                 Logger.GetSawmill("opendream.image")
                     .Warning($"Attempted to create an /image from {icon}. This is invalid and a default image was created instead.");


### PR DESCRIPTION
The /image initializer wasn't copying its default appearance. This meant modifications to one /image would affect every other /image too.