### PR TITLE
Prevent runtimes after deleting the world

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamObjectWorld.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectWorld.cs
@@ -86,7 +86,8 @@ public sealed class DreamObjectWorld : DreamObject {
     }
 
     protected override void HandleDeletion() {
-        base.HandleDeletion();
+        // we're special snowflakes
+        // base.HandleDeletion();
 
         _server.Shutdown("world was deleted");
     }


### PR DESCRIPTION
Don't perform normal deletion behavior as the `world` object is special