### PR TITLE
Fix clientside ouptut parsing of list2params

### DIFF
--- a/OpenDreamClient/Interface/Controls/ControlBrowser.cs
+++ b/OpenDreamClient/Interface/Controls/ControlBrowser.cs
@@ -66,11 +66,14 @@ internal sealed class ControlBrowser : InterfaceControl {
         if (jsFunction == null) return;
 
         // Prepare the argument to be used in JS
-        value = HttpUtility.UrlDecode(value);
-        value = HttpUtility.JavaScriptStringEncode(value);
-
+        //output is formatted by list2params sometimes, which means raw strings are url encoded, but the message contains & chars which are not encoded that are the params
+        //so we split on &, url decode the parts, and then join them back together with , as the separator for the JS params
+        var parts = value.Split('&');
+        for (var i = 0; i < parts.Length; i++) {
+            parts[i] = "\""+HttpUtility.JavaScriptStringEncode(HttpUtility.UrlDecode(parts[i]))+"\""; //wrap in quotes and encode for JS
+        }
         // Insert the values directly into JS and execute it (what could go wrong??)
-        _webView.ExecuteJavaScript($"{jsFunction}(\"{value}\")");
+        _webView.ExecuteJavaScript($"{jsFunction}({string.Join(",", parts)})");
     }
 
     public void SetFileSource(ResPath filepath, bool userData) {


### PR DESCRIPTION
Fixes the `&&0&0` thing in goon.
Basically, you can call `output(list2params(list_of_things), "clientbrowserelement:javafunction")` which will call `javafunction(list, of, things)` on the clientside. We weren't handling that, and only handling the case where there was single param.

![image](https://github.com/OpenDreamProject/OpenDream/assets/3855802/83cf7e0f-8321-468d-9272-533323e2add3)
