### PR TITLE
Fix incorrect line counter when lexing line-spliced strings

### DIFF
--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -519,11 +519,11 @@ internal sealed class DMPreprocessorLexer {
             } else if (stringC == '\\') {
                 Advance();
 
-                if (AtLineEnd()) { //Line splice
+                if (HandleLineEnd()) { //Line splice
                     // Ignore newlines & all incoming whitespace
                     do {
                         Advance();
-                    } while (AtLineEnd() || GetCurrent() == ' ' || GetCurrent() == '\t');
+                    } while (HandleLineEnd() || GetCurrent() == ' ' || GetCurrent() == '\t');
                 } else {
                     textBuilder.Append(stringC);
                     textBuilder.Append(GetCurrent());


### PR DESCRIPTION
This would have given an error on line 2 rather than 4:
```dm
var/a = "A\
B\
C"
#error Error here
```

That's fixed now.