### PR TITLE
Fix a character skip after string line splices

### DIFF
--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -521,9 +521,10 @@ internal sealed class DMPreprocessorLexer {
 
                 if (HandleLineEnd()) { //Line splice
                     // Ignore newlines & all incoming whitespace
-                    do {
-                        Advance();
-                    } while (HandleLineEnd() || GetCurrent() == ' ' || GetCurrent() == '\t');
+                    while (AtLineEnd() || GetCurrent() == ' ' || GetCurrent() == '\t') {
+                        if (!HandleLineEnd())
+                            Advance(); // Was a space or tab so advance it
+                    }
                 } else {
                     textBuilder.Append(stringC);
                     textBuilder.Append(GetCurrent());

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -521,7 +521,7 @@ internal sealed class DMPreprocessorLexer {
 
                 if (HandleLineEnd()) { //Line splice
                     // Ignore newlines & all incoming whitespace
-                    while (AtLineEnd() || GetCurrent() == ' ' || GetCurrent() == '\t') {
+                    while (AtLineEnd() || GetCurrent() is ' ' or '\t') {
                         if (!HandleLineEnd())
                             Advance(); // Was a space or tab so advance it
                     }


### PR DESCRIPTION
An extra character was being skipped after line splices inside strings