### PR TITLE
Define `/sound.pitch`

### DIFF
--- a/DMCompiler/DMStandard/Types/Sound.dm
+++ b/DMCompiler/DMStandard/Types/Sound.dm
@@ -7,6 +7,7 @@
 	var/channel = 0
 	var/volume = 100
 	var/frequency = 0
+	var/pitch = 0 as opendream_unimplemented
 	var/pan = 0 as opendream_unimplemented
 	var/falloff = 1 as opendream_unimplemented
 	var/x as opendream_unimplemented


### PR DESCRIPTION
A new sound property added in v515. Not implemented, but won't error if used.