### PR TITLE
Add a debug assert in `DMProcState.PopDrop()`

### DIFF
--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -10,6 +10,7 @@ using OpenDreamRuntime.Objects.Types;
 using OpenDreamRuntime.Procs.DebugAdapter;
 using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
+using Robust.Shared.Utility;
 
 namespace OpenDreamRuntime.Procs {
     public sealed class DMProc : DreamProc {
@@ -554,6 +555,7 @@ namespace OpenDreamRuntime.Procs {
         }
 
         public void PopDrop() {
+            DebugTools.Assert(_stackIndex > 0, "Attempted to PopDrop with a stack index of (or below?) 0");
             _stackIndex -= 1;
         }
 


### PR DESCRIPTION
I saw that #1554 fixed a bug with the PopReference opcode being used where it shouldn't have been (the reference had already been popped from the stack). An assert in `PopDrop()` would have made this easier to catch.