### PR TITLE
Implement MAP's `icon-size` property

### DIFF
--- a/OpenDreamClient/Interface/Controls/ControlMap.cs
+++ b/OpenDreamClient/Interface/Controls/ControlMap.cs
@@ -37,8 +37,11 @@ public sealed class ControlMap(ControlDescriptor controlDescriptor, ControlWindo
 
         Viewport.ViewportSize = new Vector2i(viewWidth, viewHeight) * EyeManager.PixelsPerMeter;
         if (MapDescriptor.IconSize != 0) {
-            Viewport.SetWidth = MapDescriptor.IconSize * viewWidth;
-            Viewport.SetHeight = MapDescriptor.IconSize * viewHeight;
+            // BYOND supports a negative number here (flips the view), but we're gonna enforce a positive number instead
+            var iconSize = Math.Min(MapDescriptor.IconSize, 1);
+
+            Viewport.SetWidth = iconSize * viewWidth;
+            Viewport.SetHeight = iconSize * viewHeight;
         } else {
             // icon-size of 0 means stretch to fit the available space
             Viewport.SetWidth = float.NaN;

--- a/OpenDreamClient/Interface/Descriptors/ControlDescriptors.cs
+++ b/OpenDreamClient/Interface/Descriptors/ControlDescriptors.cs
@@ -151,6 +151,8 @@ public sealed partial class ControlDescriptorMap : ControlDescriptor {
     public string? OnHideCommand;
     [DataField("zoom-mode")]
     public string ZoomMode = "normal";
+    [DataField("icon-size")]
+    public int IconSize;
 }
 
 public sealed partial class ControlDescriptorBrowser : ControlDescriptor {


### PR DESCRIPTION
Setting a MAP control's `icon-size` property now sets the size given to each tile. This makes these settings work:
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/208b8105-9b20-466d-a886-32ebe4b58bdf)

32x32:
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/c909beb7-67af-4dba-876b-5869d33a6361)

128x128:
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/c8dcd56f-ea83-49e1-a764-95704f7c5470)
