### PR TITLE
Update the compiler test workflow's repositories

### DIFF
--- a/.github/workflows/compiler-test.yml
+++ b/.github/workflows/compiler-test.yml
@@ -40,7 +40,7 @@ jobs:
         repository: tgstation/tgstation
         ref: 88bdabe53bb85f2a7f54e479f6c4a243650043d5
         path: tg
-    - name: Compile /tg/station 0792800
+    - name: Compile /tg/station 88bdabe
       run: main\bin\DMCompiler\DMCompiler.exe tg\tgstation.dme
     - name: Checkout Goonstation 8c8b527
       uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
         repository: goonstation/goonstation
         ref: 8c8b5276f231ae42b3b2390d837cab68af138fa6
         path: goon
-    - name: Compile Goonstation c478a52
+    - name: Compile Goonstation 8c8b527
       run: |
         New-Item goon\+secret\__secret.dme -type file
         main\bin\DMCompiler\DMCompiler.exe goon\goonstation.dme --version=514.1584

--- a/.github/workflows/compiler-test.yml
+++ b/.github/workflows/compiler-test.yml
@@ -34,7 +34,7 @@ jobs:
       run: dotnet build main/DMCompiler/DMCompiler.csproj --configuration Release --no-restore /m
     - name: Compile TestGame
       run: main\bin\DMCompiler\DMCompiler.exe main\TestGame\environment.dme
-    - name: Checkout /tg/station 0792800
+    - name: Checkout /tg/station 88bdabe
       uses: actions/checkout@v2
       with:
         repository: tgstation/tgstation
@@ -42,7 +42,7 @@ jobs:
         path: tg
     - name: Compile /tg/station 0792800
       run: main\bin\DMCompiler\DMCompiler.exe tg\tgstation.dme
-    - name: Checkout Goonstation c478a52
+    - name: Checkout Goonstation 8c8b527
       uses: actions/checkout@v2
       with:
         repository: goonstation/goonstation

--- a/.github/workflows/compiler-test.yml
+++ b/.github/workflows/compiler-test.yml
@@ -49,7 +49,9 @@ jobs:
         ref: 8c8b5276f231ae42b3b2390d837cab68af138fa6
         path: goon
     - name: Compile Goonstation c478a52
-      run: main\bin\DMCompiler\DMCompiler.exe goon\goonstation.dme
+      run: |
+        copy NUL goon\+secret\__secret.dme
+        main\bin\DMCompiler\DMCompiler.exe goon\goonstation.dme --version=514.1584
     - name: Checkout 64-bit Paradise
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/compiler-test.yml
+++ b/.github/workflows/compiler-test.yml
@@ -50,7 +50,7 @@ jobs:
         path: goon
     - name: Compile Goonstation c478a52
       run: |
-        echo. > goon\+secret\__secret.dme
+        New-Item goon\+secret\__secret.dme -type file
         main\bin\DMCompiler\DMCompiler.exe goon\goonstation.dme --version=514.1584
     - name: Checkout 64-bit Paradise
       uses: actions/checkout@v2

--- a/.github/workflows/compiler-test.yml
+++ b/.github/workflows/compiler-test.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: tgstation/tgstation
-        ref: 07928006665e320b5546de04c6368c3a9d01ec12
+        ref: 88bdabe53bb85f2a7f54e479f6c4a243650043d5
         path: tg
     - name: Compile /tg/station 0792800
       run: main\bin\DMCompiler\DMCompiler.exe tg\tgstation.dme
@@ -46,7 +46,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: goonstation/goonstation
-        ref: c478a521a6c75668e2ae04b4baa791c061c4987c
+        ref: 8c8b5276f231ae42b3b2390d837cab68af138fa6
         path: goon
     - name: Compile Goonstation c478a52
       run: main\bin\DMCompiler\DMCompiler.exe goon\goonstation.dme

--- a/.github/workflows/compiler-test.yml
+++ b/.github/workflows/compiler-test.yml
@@ -50,7 +50,7 @@ jobs:
         path: goon
     - name: Compile Goonstation c478a52
       run: |
-        copy NUL goon\+secret\__secret.dme
+        echo. > goon\+secret\__secret.dme
         main\bin\DMCompiler\DMCompiler.exe goon\goonstation.dme --version=514.1584
     - name: Checkout 64-bit Paradise
       uses: actions/checkout@v2

--- a/.github/workflows/compiler-test.yml
+++ b/.github/workflows/compiler-test.yml
@@ -34,13 +34,22 @@ jobs:
       run: dotnet build main/DMCompiler/DMCompiler.csproj --configuration Release --no-restore /m
     - name: Compile TestGame
       run: main\bin\DMCompiler\DMCompiler.exe main\TestGame\environment.dme
-    - name: Checkout Modified /tg/station
+    - name: Checkout /tg/station 0792800
       uses: actions/checkout@v2
       with:
-        repository: wixoaGit/tgstation
+        repository: tgstation/tgstation
+        ref: 07928006665e320b5546de04c6368c3a9d01ec12
         path: tg
-    - name: Compile Modified /tg/station
-      run: main\bin\DMCompiler\DMCompiler.exe tg\tgstation.dme 
+    - name: Compile /tg/station 0792800
+      run: main\bin\DMCompiler\DMCompiler.exe tg\tgstation.dme
+    - name: Checkout Goonstation c478a52
+      uses: actions/checkout@v2
+      with:
+        repository: goonstation/goonstation
+        ref: c478a521a6c75668e2ae04b4baa791c061c4987c
+        path: goon
+    - name: Compile Goonstation c478a52
+      run: main\bin\DMCompiler\DMCompiler.exe goon\goonstation.dme
     - name: Checkout 64-bit Paradise
       uses: actions/checkout@v2
       with:

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -370,8 +370,8 @@ public struct DMCompilerSettings {
     public string? PragmaFileOverride = null;
 
     // These are the default DM_VERSION and DM_BUILD values. They're strings because that's what the preprocessor expects (seriously)
-    public string DMVersion = "514";
-    public string DMBuild = "1584";
+    public string DMVersion = "515";
+    public string DMBuild = "1633";
 
     public DMCompilerSettings() {
     }


### PR DESCRIPTION
I removed modified /tg/station (which hasn't been relevant for a while now) and replaced it with a fixed commit of /tg/station and Goonstation. This should help ensure we don't break anything in those codebases that currently works.