### PR TITLE
winset ternaries and embedded wingets

### DIFF
--- a/OpenDreamClient/Interface/Controls/ControlInput.cs
+++ b/OpenDreamClient/Interface/Controls/ControlInput.cs
@@ -19,4 +19,20 @@ internal sealed class ControlInput : InterfaceControl {
         _interfaceManager.RunCommand(_textBox.Text);
         _textBox.Clear();
     }
+
+    protected override void UpdateElementDescriptor() {
+        base.UpdateElementDescriptor();
+        ControlDescriptorInput inputDescriptor = (ControlDescriptorInput)ElementDescriptor;
+        _textBox.Text = inputDescriptor.Text ?? "";
+    }
+
+    public override bool TryGetProperty(string property, out string value) {
+        switch (property) {
+            case "text":
+                value = _textBox.Text;
+                return true;
+            default:
+                return base.TryGetProperty(property, out value);
+        }
+    }
 }

--- a/OpenDreamClient/Interface/Controls/ControlWindow.cs
+++ b/OpenDreamClient/Interface/Controls/ControlWindow.cs
@@ -301,7 +301,7 @@ public sealed class ControlWindow : InterfaceControl {
                     value = "false";
                     return true;
                 }
-            case "is-maximized": //TODO this is current "not isMinimised" because RT doesn't expose a maximised check
+            case "is-maximized": //TODO this is currently "not isMinimised" because RT doesn't expose a maximised check
                 if(_myWindow.osWindow?.ClydeWindow != null){
                     value = !_myWindow.osWindow.ClydeWindow.IsMinimized ? "true" : "false";
                     return true;

--- a/OpenDreamClient/Interface/DMF/DMFLexer.cs
+++ b/OpenDreamClient/Interface/DMF/DMFLexer.cs
@@ -104,14 +104,14 @@ public sealed class DMFLexer(string source) {
                 if(GetCurrent() != '[') //must be [[
                     throw new Exception("Expected '['");
 
-                StringBuilder textBuilder = new StringBuilder(c.ToString());
+                StringBuilder textBuilder = new StringBuilder("[[");
 
                 while (Advance() != ']' && !AtEndOfSource) {
                     textBuilder.Append(GetCurrent());
                 }
                 if (GetCurrent() != ']') throw new Exception("Expected ']'");
                 Advance();
-
+                textBuilder.Append("]]");
                 return new(TokenType.Lookup, textBuilder.ToString());
             }
             default: {

--- a/OpenDreamClient/Interface/DMF/DMFParser.cs
+++ b/OpenDreamClient/Interface/DMF/DMFParser.cs
@@ -228,7 +228,6 @@ public sealed class DMFParser(DMFLexer lexer, ISerializationManager serializatio
                 else
                     Error($"Invalid attribute value ({valueText})");
             else if (Check(TokenType.Ternary)) {
-                condition = new DMFWinSet(element, attributeToken.Text, valueText);
                 List<DMFWinSet> ifValues = new();
                 List<DMFWinSet> elseValues = new();
                 while(TryGetAttribute(out var ifValue)){

--- a/OpenDreamClient/Interface/DMF/DMFParser.cs
+++ b/OpenDreamClient/Interface/DMF/DMFParser.cs
@@ -225,17 +225,17 @@ public sealed class DMFParser(DMFLexer lexer, ISerializationManager serializatio
                 else
                     Error($"Invalid attribute value ({valueText})");
             else if (Check(TokenType.Ternary)) {
-                List<DMFWinSet> ifValues = new();
-                List<DMFWinSet> elseValues = new();
-                while(TryGetAttribute(out var ifValue)){
-                    ifValues.Add(ifValue);
+                List<DMFWinSet> trueStatements = new();
+                List<DMFWinSet> falseStatements = new();
+                while(TryGetAttribute(out var statement)){
+                    trueStatements.Add(statement);
                 }
                 if(Check(TokenType.Colon)){ //not all ternarys have an else
-                    while(TryGetAttribute(out var elseValue)) {
-                        elseValues.Add(elseValue);
+                    while(TryGetAttribute(out var statement)){
+                        falseStatements.Add(statement);
                     }
                 }
-                winSet = new DMFWinSet(element, attributeToken.Text, valueText, ifValues, elseValues);
+                winSet = new DMFWinSet(element, attributeToken.Text, valueText, trueStatements, falseStatements);
                 return true;
             }
 

--- a/OpenDreamClient/Interface/DMF/DMFParser.cs
+++ b/OpenDreamClient/Interface/DMF/DMFParser.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using OpenDreamClient.Interface.Descriptors;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Markdown.Mapping;
+using YamlDotNet.Core.Tokens;
 using Token = OpenDreamClient.Interface.DMF.DMFLexer.Token;
 using TokenType = OpenDreamClient.Interface.DMF.DMFLexer.TokenType;
 
@@ -228,12 +229,17 @@ public sealed class DMFParser(DMFLexer lexer, ISerializationManager serializatio
                     Error($"Invalid attribute value ({valueText})");
             else if (Check(TokenType.Ternary)) {
                 condition = new DMFWinSet(element, attributeToken.Text, valueText);
-                if (!(TryGetAttribute(out winSet) && Check(TokenType.Colon)) || !TryGetAttribute(out elseValue)) {
-                    Error("Badly formatted ternary!");
-                    return false;
+                List<DMFWinSet> ifValues = new();
+                List<DMFWinSet> elseValues = new();
+                while(TryGetAttribute(out var ifValue)){
+                    ifValues.Add(ifValue);
                 }
-                winSet.Condition = condition;
-                winSet.ElseValue = elseValue;
+                if(Check(TokenType.Colon)){ //not all ternarys have an else
+                    while(TryGetAttribute(out elseValue)) {
+                        elseValues.Add(elseValue);
+                    }
+                }
+                winSet = new DMFWinSet(element, attributeToken.Text, valueText, ifValues, elseValues);
                 return true;
             }
 

--- a/OpenDreamClient/Interface/DMF/DMFParser.cs
+++ b/OpenDreamClient/Interface/DMF/DMFParser.cs
@@ -188,8 +188,6 @@ public sealed class DMFParser(DMFLexer lexer, ISerializationManager serializatio
     private bool TryGetAttribute([NotNullWhen(true)] out DMFWinSet? winSet) {
         string? element = null;
         winSet = null;
-        DMFWinSet? condition;
-        DMFWinSet? elseValue;
         Token attributeToken = Current();
 
         if (Check(_attributeTokenTypes)) {
@@ -233,7 +231,7 @@ public sealed class DMFParser(DMFLexer lexer, ISerializationManager serializatio
                     ifValues.Add(ifValue);
                 }
                 if(Check(TokenType.Colon)){ //not all ternarys have an else
-                    while(TryGetAttribute(out elseValue)) {
+                    while(TryGetAttribute(out var elseValue)) {
                         elseValues.Add(elseValue);
                     }
                 }

--- a/OpenDreamClient/Interface/DMF/DMFParser.cs
+++ b/OpenDreamClient/Interface/DMF/DMFParser.cs
@@ -223,7 +223,7 @@ public sealed class DMFParser(DMFLexer lexer, ISerializationManager serializatio
                 if (!Check(TokenType.Value) && !Check(TokenType.Attribute))
                     Error($"Invalid attribute value ({valueText})");
             } else if (!Check(TokenType.Value))
-                if(Check(TokenType.Semicolon)) //thing.attribute=; means thing.attribute=empty string
+                if(Check(TokenType.Semicolon) || Check(TokenType.EndOfFile)) //thing.attribute=; means thing.attribute=empty string
                     valueText = "";
                 else
                     Error($"Invalid attribute value ({valueText})");

--- a/OpenDreamClient/Interface/DMF/DMFParser.cs
+++ b/OpenDreamClient/Interface/DMF/DMFParser.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using OpenDreamClient.Interface.Descriptors;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Markdown.Mapping;
-using YamlDotNet.Core.Tokens;
 using Token = OpenDreamClient.Interface.DMF.DMFLexer.Token;
 using TokenType = OpenDreamClient.Interface.DMF.DMFLexer.TokenType;
 

--- a/OpenDreamClient/Interface/DMF/DMFParser.cs
+++ b/OpenDreamClient/Interface/DMF/DMFParser.cs
@@ -187,11 +187,9 @@ public sealed class DMFParser(DMFLexer lexer, ISerializationManager serializatio
 
     private bool TryGetAttribute([NotNullWhen(true)] out DMFWinSet? winSet) {
         string? element = null;
-        string? key = null;
-        string? token = null;
         winSet = null;
-        DMFWinSet? condition = null;
-        DMFWinSet? elseValue = null;
+        DMFWinSet? condition;
+        DMFWinSet? elseValue;
         Token attributeToken = Current();
 
         if (Check(_attributeTokenTypes)) {

--- a/OpenDreamClient/Interface/DMF/DMFWinSet.cs
+++ b/OpenDreamClient/Interface/DMF/DMFWinSet.cs
@@ -4,14 +4,16 @@ public sealed class DMFWinSet {
     public readonly string? Element;
     public readonly string Attribute;
     public readonly string Value;
-    public List<DMFWinSet>? IfValues;
-    public List<DMFWinSet>? ElseValues;
+    /// Winsets that are evaluated if Element.Attribute == Value
+    public List<DMFWinSet>? TrueStatements;
+    /// Winsets that are evaluated if Element.Attribute != Value
+    public List<DMFWinSet>? FalseStatements;
 
-    public DMFWinSet(string? element, string attribute, string value, List<DMFWinSet>? ifValue = null, List<DMFWinSet>? elseValue = null) {
+    public DMFWinSet(string? element, string attribute, string value, List<DMFWinSet>? trueStatements = null, List<DMFWinSet>? falseStatements = null) {
         Element = element;
         Attribute = attribute;
         Value = value;
-        IfValues = ifValue;
-        ElseValues = elseValue;
+        TrueStatements = trueStatements;
+        FalseStatements = falseStatements;
     }
 }

--- a/OpenDreamClient/Interface/DMF/DMFWinSet.cs
+++ b/OpenDreamClient/Interface/DMF/DMFWinSet.cs
@@ -1,13 +1,17 @@
 ﻿namespace OpenDreamClient.Interface.DMF;
 
-public struct DMFWinSet {
+public sealed class DMFWinSet {
     public readonly string? Element;
     public readonly string Attribute;
     public readonly string Value;
+    public DMFWinSet? Condition;
+    public DMFWinSet? ElseValue;
 
-    public DMFWinSet(string? element, string attribute, string value) {
+    public DMFWinSet(string? element, string attribute, string value, DMFWinSet? condition = null, DMFWinSet? elseValue = null) {
         Element = element;
         Attribute = attribute;
         Value = value;
+        Condition = condition;
+        ElseValue = elseValue;
     }
 }

--- a/OpenDreamClient/Interface/DMF/DMFWinSet.cs
+++ b/OpenDreamClient/Interface/DMF/DMFWinSet.cs
@@ -4,14 +4,14 @@ public sealed class DMFWinSet {
     public readonly string? Element;
     public readonly string Attribute;
     public readonly string Value;
-    public DMFWinSet? Condition;
-    public DMFWinSet? ElseValue;
+    public List<DMFWinSet>? IfValues;
+    public List<DMFWinSet>? ElseValues;
 
-    public DMFWinSet(string? element, string attribute, string value, DMFWinSet? condition = null, DMFWinSet? elseValue = null) {
+    public DMFWinSet(string? element, string attribute, string value, List<DMFWinSet>? ifValue = null, List<DMFWinSet>? elseValue = null) {
         Element = element;
         Attribute = attribute;
         Value = value;
-        Condition = condition;
-        ElseValue = elseValue;
+        IfValues = ifValue;
+        ElseValues = elseValue;
     }
 }

--- a/OpenDreamClient/Interface/Descriptors/ControlDescriptors.cs
+++ b/OpenDreamClient/Interface/Descriptors/ControlDescriptors.cs
@@ -26,6 +26,8 @@ public partial class ControlDescriptor : ElementDescriptor {
     public bool IsDefault;
     [DataField("is-disabled")]
     public bool IsDisabled;
+    [DataField("saved-params")]
+    public string? SavedParams;
 }
 
 public sealed partial class WindowDescriptor : ControlDescriptor {
@@ -123,6 +125,8 @@ public sealed partial class ControlDescriptorChild : ControlDescriptor {
 }
 
 public sealed partial class ControlDescriptorInput : ControlDescriptor {
+    [DataField("text")]
+    public string? Text;
 }
 
 public sealed partial class ControlDescriptorButton : ControlDescriptor {

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -513,8 +513,9 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
 
             // id=abc overrides the elements of other winsets without an element
             string? elementOverride = null;
-            if(winSets.Count > 0 && winSets[0].Attribute == "id" && winSets[0].Element == null)
-                elementOverride = winSets[0].Value;
+            foreach(var winSet in winSets)
+                if(winSet.Attribute == "id" && winSet.Element == null)
+                    elementOverride = winSet.Value;
 
             foreach (DMFWinSet winSet in winSets) {
                 string? elementId = winSet.Element ?? elementOverride;

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -553,29 +553,29 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
                             _sawmill.Error($"Invalid element on ternary condition \"{elementId}\"");
                         else
                             if(conditionalElement.TryGetProperty(winSet.Attribute, out var conditionalCheckValue) && conditionalCheckValue.Equals(winSet.Value, StringComparison.InvariantCultureIgnoreCase)) {
-                                foreach(DMFWinSet IfValue in winSet.IfValues) {
-                                    string? IfElementId = IfValue.Element ?? elementId;
-                                    InterfaceElement? IfElement = FindElementWithId(IfElementId);
-                                    if(IfElement is not null) {
+                                foreach(DMFWinSet ifValue in winSet.IfValues) {
+                                    string? ifElementId = ifValue.Element ?? elementId;
+                                    InterfaceElement? ifElement = FindElementWithId(ifElementId);
+                                    if(ifElement is not null) {
                                         MappingDataNode node = new() {
-                                            {IfValue.Attribute, HandleEmbeddedWinget(IfElementId, IfValue.Value)}
+                                            {ifValue.Attribute, HandleEmbeddedWinget(ifElementId, ifValue.Value)}
                                         };
-                                        IfElement.PopulateElementDescriptor(node, _serializationManager);
+                                        ifElement.PopulateElementDescriptor(node, _serializationManager);
                                     } else {
-                                        _sawmill.Error($"Invalid element on ternary \"{IfElementId}\"");
+                                        _sawmill.Error($"Invalid element on ternary \"{ifElementId}\"");
                                     }
                                 }
                             } else if (winSet.ElseValues is not null){
-                                foreach(DMFWinSet ElseValue in winSet.ElseValues) {
-                                    string? ElseElementId = ElseValue.Element ?? elementId;
-                                    InterfaceElement? ElseElement = FindElementWithId(ElseElementId);
-                                    if(ElseElement is not null) {
+                                foreach(DMFWinSet elseValue in winSet.ElseValues) {
+                                    string? elseElementId = elseValue.Element ?? elementId;
+                                    InterfaceElement? elseElement = FindElementWithId(elseElementId);
+                                    if(elseElement is not null) {
                                         MappingDataNode node = new() {
-                                            {ElseValue.Attribute, HandleEmbeddedWinget(ElseElementId, ElseValue.Value)}
+                                            {elseValue.Attribute, HandleEmbeddedWinget(elseElementId, elseValue.Value)}
                                         };
-                                        ElseElement.PopulateElementDescriptor(node, _serializationManager);
+                                        elseElement.PopulateElementDescriptor(node, _serializationManager);
                                     } else {
-                                        _sawmill.Error($"Invalid element on ternary \"{ElseElementId}\"");
+                                        _sawmill.Error($"Invalid element on ternary \"{elseElementId}\"");
                                     }
                                 }
                             }

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -547,35 +547,35 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
                         _sawmill.Error($"Invalid global winset \"{winsetParams}\"");
                     }
                 } else {
-                    if(winSet.IfValues is not null) {
+                    if(winSet.TrueStatements is not null) {
                         InterfaceElement? conditionalElement = FindElementWithId(elementId);
                         if(conditionalElement is null)
                             _sawmill.Error($"Invalid element on ternary condition \"{elementId}\"");
                         else
                             if(conditionalElement.TryGetProperty(winSet.Attribute, out var conditionalCheckValue) && conditionalCheckValue.Equals(winSet.Value, StringComparison.InvariantCultureIgnoreCase)) {
-                                foreach(DMFWinSet ifValue in winSet.IfValues) {
-                                    string? ifElementId = ifValue.Element ?? elementId;
-                                    InterfaceElement? ifElement = FindElementWithId(ifElementId);
-                                    if(ifElement is not null) {
+                                foreach(DMFWinSet statement in winSet.TrueStatements) {
+                                    string? statementElementId = statement.Element ?? elementId;
+                                    InterfaceElement? statementElement = FindElementWithId(statementElementId);
+                                    if(statementElement is not null) {
                                         MappingDataNode node = new() {
-                                            {ifValue.Attribute, HandleEmbeddedWinget(ifElementId, ifValue.Value)}
+                                            {statement.Attribute, HandleEmbeddedWinget(statementElementId, statement.Value)}
                                         };
-                                        ifElement.PopulateElementDescriptor(node, _serializationManager);
+                                        statementElement.PopulateElementDescriptor(node, _serializationManager);
                                     } else {
-                                        _sawmill.Error($"Invalid element on ternary \"{ifElementId}\"");
+                                        _sawmill.Error($"Invalid element on ternary \"{statementElementId}\"");
                                     }
                                 }
-                            } else if (winSet.ElseValues is not null){
-                                foreach(DMFWinSet elseValue in winSet.ElseValues) {
-                                    string? elseElementId = elseValue.Element ?? elementId;
-                                    InterfaceElement? elseElement = FindElementWithId(elseElementId);
-                                    if(elseElement is not null) {
+                            } else if (winSet.FalseStatements is not null){
+                                foreach(DMFWinSet statement in winSet.FalseStatements) {
+                                    string? statementElementId = statement.Element ?? elementId;
+                                    InterfaceElement? statementElement = FindElementWithId(statementElementId);
+                                    if(statementElement is not null) {
                                         MappingDataNode node = new() {
-                                            {elseValue.Attribute, HandleEmbeddedWinget(elseElementId, elseValue.Value)}
+                                            {statement.Attribute, HandleEmbeddedWinget(statementElementId, statement.Value)}
                                         };
-                                        elseElement.PopulateElementDescriptor(node, _serializationManager);
+                                        statementElement.PopulateElementDescriptor(node, _serializationManager);
                                     } else {
-                                        _sawmill.Error($"Invalid element on ternary \"{elseElementId}\"");
+                                        _sawmill.Error($"Invalid element on ternary \"{statementElementId}\"");
                                     }
                                 }
                             }

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -23,7 +23,6 @@ using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using SixLabors.ImageSharp;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace OpenDreamClient.Interface;
 

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -532,10 +532,7 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
                 return;
 
             // id=abc overrides the elements of other winsets without an element
-            string? elementOverride = null;
-            foreach(var winSet in winSets)
-                if(winSet.Attribute == "id" && winSet.Element == null)
-                    elementOverride = HandleEmbeddedWinget(controlId, winSet.Value);
+            string? elementOverride = winSets.FirstOrDefault(winSet => winSet.Element == null && winSet.Attribute == "id")?.Value;
 
             foreach (DMFWinSet winSet in winSets) {
                 string? elementId = winSet.Element ?? elementOverride;

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -527,36 +527,40 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
                         _sawmill.Error($"Invalid global winset \"{winsetParams}\"");
                     }
                 } else {
-                    InterfaceElement? element = FindElementWithId(elementId);
-                    if(winSet.Condition is not null) {
-                        string conditionalElementId = winSet.Condition.Element ?? elementId;
-                        InterfaceElement? conditionalElement = FindElementWithId(conditionalElementId);
+                    if(winSet.IfValues is not null) {
+                        InterfaceElement? conditionalElement = FindElementWithId(elementId);
                         if(conditionalElement is null)
-                            _sawmill.Error($"Invalid element on ternary condition \"{conditionalElementId}\"");
+                            _sawmill.Error($"Invalid element on ternary condition \"{elementId}\"");
                         else
-                            if(conditionalElement.TryGetProperty(winSet.Condition.Attribute, out var conditionalCheckValue) && conditionalCheckValue.Equals(winSet.Condition.Value, StringComparison.InvariantCultureIgnoreCase)) {
-                                MappingDataNode node = new() {
-                                    {winSet.Attribute, winSet.Value}
-                                };
-
-                                if (element != null) {
-                                    element.PopulateElementDescriptor(node, _serializationManager);
-                                } else {
-                                    _sawmill.Error($"Invalid element on ternary \"{elementId}\"");
+                            if(conditionalElement.TryGetProperty(winSet.Attribute, out var conditionalCheckValue) && conditionalCheckValue.Equals(winSet.Value, StringComparison.InvariantCultureIgnoreCase)) {
+                                foreach(DMFWinSet IfValue in winSet.IfValues) {
+                                    string? IfElementId = IfValue.Element ?? elementId;
+                                    InterfaceElement? IfElement = FindElementWithId(IfElementId);
+                                    if(IfElement is not null) {
+                                        MappingDataNode node = new() {
+                                            {IfValue.Attribute, IfValue.Value}
+                                        };
+                                        IfElement.PopulateElementDescriptor(node, _serializationManager);
+                                    } else {
+                                        _sawmill.Error($"Invalid element on ternary \"{IfElementId}\"");
+                                    }
                                 }
-                            } else if (winSet.ElseValue is not null){
-                                string elseElementId = winSet.ElseValue.Element ?? elementId;
-                                InterfaceElement? elseElement = FindElementWithId(elseElementId);
-                                if(elseElement is not null) {
-                                    MappingDataNode node = new() {
-                                        {winSet.ElseValue.Attribute, winSet.ElseValue.Value}
-                                    };
-                                    elseElement.PopulateElementDescriptor(node, _serializationManager);
-                                } else {
-                                    _sawmill.Error($"Invalid element on ternary else \"{elseElementId}\"");
+                            } else if (winSet.ElseValues is not null){
+                                foreach(DMFWinSet ElseValue in winSet.ElseValues) {
+                                    string? ElseElementId = ElseValue.Element ?? elementId;
+                                    InterfaceElement? ElseElement = FindElementWithId(ElseElementId);
+                                    if(ElseElement is not null) {
+                                        MappingDataNode node = new() {
+                                            {ElseValue.Attribute, ElseValue.Value}
+                                        };
+                                        ElseElement.PopulateElementDescriptor(node, _serializationManager);
+                                    } else {
+                                        _sawmill.Error($"Invalid element on ternary \"{ElseElementId}\"");
+                                    }
                                 }
                             }
                     } else {
+                        InterfaceElement? element = FindElementWithId(elementId);
                         MappingDataNode node = new() {
                             {winSet.Attribute, winSet.Value}
                         };

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -484,10 +484,9 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
     }
 
     public void WinSet(string? controlId, string winsetParams) {
-        DMFLexer lexer;
         DMFParser parser;
         try{
-            lexer = new DMFLexer(winsetParams);
+            var lexer = new DMFLexer(winsetParams);
             parser = new DMFParser(lexer, _serializationManager);
         } catch (Exception e) {
             _sawmill.Error($"Error parsing winset: {e}");
@@ -507,9 +506,9 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
 
         string HandleEmbeddedWinget(string? controlId, string value) {
             string result = value;
-            int startPos = result.IndexOf("[[");
+            int startPos = result.IndexOf("[[", StringComparison.Ordinal);
             while(startPos > -1){
-                int endPos = result.IndexOf("]]", startPos);
+                int endPos = result.IndexOf("]]", startPos, StringComparison.Ordinal);
                 if(endPos == -1)
                     break;
                 string inner = result.Substring(startPos+2, endPos-startPos-2);
@@ -521,7 +520,7 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
                 }
                 string innerResult = WinGet(innerControlId, inner);
                 result = result.Substring(0, startPos) + innerResult + result.Substring(endPos+2);
-                startPos = result.IndexOf("[[");
+                startPos = result.IndexOf("[[", StringComparison.Ordinal);
             }
             return result;
         }

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -507,11 +507,15 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
         }
 
         string HandleEmbeddedWinget(string? controlId, string value) {
-            string pattern = @"\[\[.*\]\]";
             string result = value;
-            foreach (Match match in Regex.Matches(value, pattern)) {
-                string innerResult = WinGet(controlId ?? "", match.Value[2..^2]);
-                result = result.Replace(match.Value, innerResult);
+            int startPos = result.IndexOf("[[");
+            while(startPos > -1){
+                int endPos = result.IndexOf("]]", startPos);
+                if(endPos == -1)
+                    break;
+                string innerResult = WinGet(controlId ?? "", result.Substring(startPos+2, endPos-startPos-2));
+                result = result.Substring(0, startPos) + innerResult + result.Substring(endPos+2);
+                startPos = result.IndexOf("[[");
             }
             return result;
         }

--- a/OpenDreamClient/Interface/InterfaceElement.cs
+++ b/OpenDreamClient/Interface/InterfaceElement.cs
@@ -11,6 +11,7 @@ public class InterfaceElement {
 
     public ElementDescriptor ElementDescriptor;
     [Dependency] protected readonly IDreamInterfaceManager _interfaceManager = default!;
+    [Dependency] private readonly ISerializationManager _serializationManager = default!;
     protected InterfaceElement(ElementDescriptor elementDescriptor) {
         ElementDescriptor = elementDescriptor;
         IoCManager.InjectDependencies(this);
@@ -36,8 +37,15 @@ public class InterfaceElement {
     /// Attempt to get a DMF property
     /// </summary>
     public virtual bool TryGetProperty(string property, out string value) {
-        value = string.Empty;
-        return false;
+        MappingDataNode original = (MappingDataNode)_serializationManager.WriteValue(ElementDescriptor.GetType(), ElementDescriptor);
+        original.TryGet(property, out var valueNode);
+        if (valueNode != null) {
+            value = valueNode.ToString();
+            return true;
+        }else {
+            value = string.Empty;
+            return false;
+        }
     }
 
     protected virtual void UpdateElementDescriptor() {

--- a/Resources/OpenDream/DefaultInterface.dmf
+++ b/Resources/OpenDream/DefaultInterface.dmf
@@ -46,7 +46,11 @@ menu "menu"
 	elem
 		name = "Hide Popup"
 		command = ".winset \"testwindow.is-visible=false\""
-		category = "Menu"		
+		category = "Menu"
+	elem
+		name = "Toggle Popup"
+		command = ".winset \"testwindow.is-visible=false?testwindow.is-visible=true:testwindow.is-visible=false\""	
+		category = "Menu"
 
 window "mapwindow"
 	elem "mapwindow"


### PR DESCRIPTION
Implements the `thing.attribute=value?thing.attribute=newvalue:thing.attribute=othervalue` syntax. 
Implements `thing.attribute=[[whatever.attribute as escaped]]`

oh also I made it so you don't need to explicitly implement `TryGetProperty` for every property, they are now backed by the data field annotations.