### PR TITLE
Implements `ImportText()`

### DIFF
--- a/Content.Tests/DMProject/Tests/Savefile/ImportText.dm
+++ b/Content.Tests/DMProject/Tests/Savefile/ImportText.dm
@@ -1,0 +1,31 @@
+/proc/RunTest()
+	var/savefile/S = new()
+	// Uncomment once issue 1707 is resolved
+	/*S.ImportText("/", "basefoldercheck")
+	ASSERT("basefoldercheck" in S)
+
+	S.ImportText("/", "subdirectory/insert")
+	ASSERT(!("insert" in S))
+	ASSERT("subdirectory" in S)
+
+	S.ImportText("/subdirectory", "insert2")
+	ASSERT(!("insert2" in S))*/
+
+	var/savefile/S2 = new()
+	S2.ImportText("/", "importexport")
+	ASSERT(S2.ExportText("/") == "\nimportexport\n")
+
+	S.ImportText("/", "key = value")
+	ASSERT(S["key"] == "value")
+
+	// See previous comment
+	/*S.ImportText("/", "concurrent_entry1;concurrent_entry2")
+	ASSERT("concurrent_entry1" in S)
+	ASSERT("concurrent_entry2" in S)*/
+
+	S.ImportText("/", "concurrent_keyvalue1 = 5;concurrent_keyvalue2 = 10")
+	ASSERT(S["concurrent_keyvalue1"] == 5)
+	ASSERT(S["concurrent_keyvalue2"] == 10)
+
+	S.ImportText("/", file("ImportTextFile.txt"))
+	ASSERT(S["textfile_import_test"] == 2)

--- a/Content.Tests/DMProject/Tests/Savefile/ImportText.dm
+++ b/Content.Tests/DMProject/Tests/Savefile/ImportText.dm
@@ -1,31 +1,48 @@
+/obj/savetest
+
 /proc/RunTest()
-	var/savefile/S = new()
-	// Uncomment once issue 1707 is resolved
-	/*S.ImportText("/", "basefoldercheck")
-	ASSERT("basefoldercheck" in S)
+	var/obj/savetest/O = new() //create a test object
+	O.name = "test"
 
-	S.ImportText("/", "subdirectory/insert")
-	ASSERT(!("insert" in S))
-	ASSERT("subdirectory" in S)
+	var/savefile/F = new() //create a temporary savefile
 
-	S.ImportText("/subdirectory", "insert2")
-	ASSERT(!("insert2" in S))*/
+	F["dir"] = O
+	F["dir2"] = "object(\".0\")"
+	F["dir3"] = 1080
+	F["dir4"] = "the afternoon of the 3rd"
+	F["dir6/subdir6"] = 321
+	F["dir7"] = null
+	F["dir8"] = "double entry 1 = 5; double entry 2 = 10"
+	F["list"] << list("1",2,"three"=3,4, new /datum(), new /datum(), list(1,2,3, new /datum()))
 
-	var/savefile/S2 = new()
-	S2.ImportText("/", "importexport")
-	ASSERT(S2.ExportText("/") == "\nimportexport\n")
+	var/total_export = F.ExportText()
 
-	S.ImportText("/", "key = value")
-	ASSERT(S["key"] == "value")
-
-	// See previous comment
-	/*S.ImportText("/", "concurrent_entry1;concurrent_entry2")
-	ASSERT("concurrent_entry1" in S)
-	ASSERT("concurrent_entry2" in S)*/
-
-	S.ImportText("/", "concurrent_keyvalue1 = 5;concurrent_keyvalue2 = 10")
-	ASSERT(S["concurrent_keyvalue1"] == 5)
-	ASSERT(S["concurrent_keyvalue2"] == 10)
-
-	S.ImportText("/", file("ImportTextFile.txt"))
-	ASSERT(S["textfile_import_test"] == 2)
+	var/savefile/F2 = new()
+	F2.ImportText("/",total_export)
+	//object test
+	ASSERT(F2["dir"].name == "test")
+	//string test
+	ASSERT(F2["dir2"] == F["dir2"])
+	ASSERT(F2["dir4"] == F["dir4"])
+	//int test
+	ASSERT(F2["dir3"] == F["dir3"])
+	//null test
+	ASSERT(F2["dir7"] == null)
+	//subdir test
+	ASSERT(F2["dir6"] == null)
+	ASSERT(F2["dir6/subdir6"] == 321)
+	//list test
+	ASSERT(F2["list"][1] == "1")
+	ASSERT(F2["list"][2] == 2)
+	ASSERT(F2["list"]["three"] == 3)
+	ASSERT(F2["list"][4] == 4)
+	ASSERT(istype(F2["list"][5], /datum))
+	ASSERT(istype(F2["list"][6], /datum))
+	//nested list
+	ASSERT(F2["list"][7][1] == 1)
+	ASSERT(F2["list"][7][2] == 2)
+	ASSERT(F2["list"][7][3] == 3)
+	ASSERT(istype(F2["list"][7][4], /datum))
+	//multiple entry test
+	ASSERT(F2["dir8"]["double entry 1"] == 5)
+	ASSERT(F2["dir8"]["double entry 2"] == 10)

--- a/Content.Tests/DMProject/Tests/Savefile/ImportTextFile.txt
+++ b/Content.Tests/DMProject/Tests/Savefile/ImportTextFile.txt
@@ -1,0 +1,1 @@
+textfile_import_test = 2

--- a/DMCompiler/DMStandard/Types/Savefile.dm
+++ b/DMCompiler/DMStandard/Types/Savefile.dm
@@ -9,7 +9,6 @@
 	proc/ExportText(path = cd, file)
 
 	proc/ImportText(path = cd, source)
-		set opendream_unimplemented = TRUE
 
 	proc/Lock(timeout)
 		set opendream_unimplemented = TRUE

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -142,6 +142,7 @@ namespace OpenDreamRuntime.Procs.Native {
             objectTree.SetNativeProc(objectTree.Icon, DreamProcNativeIcon.NativeProc_Turn);
 
             objectTree.SetNativeProc(objectTree.Savefile, DreamProcNativeSavefile.NativeProc_ExportText);
+            objectTree.SetNativeProc(objectTree.Savefile, DreamProcNativeSavefile.NativeProc_ImportText);
             objectTree.SetNativeProc(objectTree.Savefile, DreamProcNativeSavefile.NativeProc_Flush);
 
             objectTree.SetNativeProc(objectTree.World, DreamProcNativeWorld.NativeProc_Export);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeSavefile.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeSavefile.cs
@@ -218,8 +218,8 @@ internal static class DreamProcNativeSavefile {
             }
 
             if(!foundEquals && (foundValue == "")) {
-                //todo: sort out the difference between "key = null" and "key"
-                savefile.SetSavefileValue(foundIndex, DreamValue.Null);
+                // GetSavefileValue creates the index in the savefile if it doesn't exist while not needing a value
+                savefile.GetSavefileValue(foundIndex);
             }
 
             if((foundValue != "") && (foundIndex != "")) {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeSavefile.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeSavefile.cs
@@ -188,10 +188,14 @@ internal static class DreamProcNativeSavefile {
             // We cannot split by " = " or similar because we cannot guarantee there will be only one = or that there is consistent spacing
             string[] spaceSplit = savefileEntry.Split(" ");
             bool foundEquals = false;
+            bool firstEntryIsEquals = false;
             string foundValue = "";
             string foundIndex = "";
             for(int i = 0; i < spaceSplit.Length; i++) {
                 if(i == 0) {
+                    if(spaceSplit[i] == "=") {
+                        firstEntryIsEquals = true;
+                    }
                     foundIndex = spaceSplit[i];
                     continue;
                 }
@@ -227,10 +231,10 @@ internal static class DreamProcNativeSavefile {
                 // DM implicitly converts values to numbers if possible
                 if (canConvert) {
                     DreamValue value = new(possibleNumber);
-                    savefile.SetSavefileValue(foundIndex, value);
+                    savefile.SetSavefileValue(!firstEntryIsEquals ? foundIndex : null, value);
                 } else {
                     DreamValue value = new(foundValue);
-                    savefile.SetSavefileValue(foundIndex, value);
+                    savefile.SetSavefileValue(!firstEntryIsEquals ? foundIndex : null, value);
                 }
             }
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeSavefile.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeSavefile.cs
@@ -131,6 +131,113 @@ internal static class DreamProcNativeSavefile {
 
     }
 
+    [DreamProc("ImportText")]
+    [DreamProcParameter("path", Type = DreamValueTypeFlag.String)]
+    [DreamProcParameter("source", Type = DreamValueTypeFlag.String | DreamValueTypeFlag.DreamResource)]
+    public static DreamValue NativeProc_ImportText(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
+        var savefile = (DreamObjectSavefile)src!;
+        DreamValue path = bundle.GetArgument(0, "path");
+        DreamValue source = bundle.GetArgument(1, "source");
+
+        string oldPath = savefile.CurrentPath;
+        if(!path.IsNull && path.TryGetValueAsString(out var pathStr)) { //invalid path values are just ignored in BYOND
+            savefile.CurrentPath = pathStr;
+        }
+
+        int result = ImportTextInternal(savefile, source, bundle);
+
+        savefile.CurrentPath = oldPath; //restore current directory after a query
+        return new DreamValue(result);
+    }
+
+    private static int ImportTextInternal(DreamObjectSavefile savefile, DreamValue source, NativeProc.Bundle bundle) {
+        if(source.IsNull) {
+            return 0;
+        }
+
+        if(source.TryGetValueAsString(out var sourceStr)) {
+            return ImportTextParseLine(sourceStr, savefile, bundle);
+        } else if(source.TryGetValueAsDreamResource(out var fileResource)) {
+            if(fileResource.ResourceData == null) {
+                return 0;
+            }
+
+            string fileString = fileResource.ReadAsString()!;
+            string[] fileStrings = fileString.Split("\n");
+            bool returnedFalse = false;
+            foreach(string fileLine in fileStrings) {
+                int returnValue = ImportTextParseLine(fileLine, savefile, bundle);
+                if(returnValue == 0) {
+                    returnedFalse = true;
+                }
+            }
+            if(returnedFalse) {
+                return 0;
+            } else {
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+
+    private static int ImportTextParseLine(string lineToParse, DreamObjectSavefile savefile, NativeProc.Bundle bundle) {
+        // ; is used to split individual savefile entries in ImportText()
+        string[] savefileImports = lineToParse.Split(";");
+        foreach(string savefileEntry in savefileImports) {
+            // We cannot split by " = " or similar because we cannot guarantee there will be only one = or that there is consistent spacing
+            string[] spaceSplit = savefileEntry.Split(" ");
+            bool foundEquals = false;
+            string foundValue = "";
+            string foundIndex = "";
+            for(int i = 0; i < spaceSplit.Length; i++) {
+                if(i == 0) {
+                    foundIndex = spaceSplit[i];
+                    continue;
+                }
+                string individualWord = spaceSplit[i];
+                if(individualWord == "=") {
+                    // "entry = ="
+                    if(foundEquals) {
+                        bundle.DreamManager.WriteWorldLog($"failed to parse savefile text at line 0 (reading 'end of file'): expecting ;");
+                    }
+                    foundEquals = true;
+                    continue;
+                }
+                // "entry = a b"
+                if(spaceSplit[i - 1] != "=") {
+                    bundle.DreamManager.WriteWorldLog($"failed to parse savefile text at line 0 (reading 'end of file'): expecting ;");
+                } else {
+                    foundValue = individualWord;
+                }
+            }
+
+            // "entry ="
+            if(foundEquals && (foundValue == "")) {
+                bundle.DreamManager.WriteWorldLog($"failed to parse savefile text at line 0 (reading 'end of file'): expecting ;");
+            }
+
+            if(!foundEquals && (foundValue == "")) {
+                //todo: sort out the difference between "key = null" and "key"
+                savefile.SetSavefileValue(foundIndex, DreamValue.Null);
+            }
+
+            if((foundValue != "") && (foundIndex != "")) {
+                bool canConvert = float.TryParse(foundValue, out float possibleNumber);
+                // DM implicitly converts values to numbers if possible
+                if (canConvert) {
+                    DreamValue value = new(possibleNumber);
+                    savefile.SetSavefileValue(foundIndex, value);
+                } else {
+                    DreamValue value = new(foundValue);
+                    savefile.SetSavefileValue(foundIndex, value);
+                }
+            }
+
+        }
+        return 1;
+    }
+
     [DreamProc("Flush")]
     public static DreamValue NativeProc_Flush(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
         var savefile = (DreamObjectSavefile)src!;


### PR DESCRIPTION
Implements the `ImportText()` proc.
Closes #1639

## (Unchanged) Functionality

- Can take multiple savefile insertions by adding `;` to the 2nd argument
- Can take a key-value pair by adding `=` in-between a string and a number/string in the 2nd argument
- Can insert valueless entries
- If you insert a key-value pair with an empty key (`= 6`), `.` will become equal to the value.

## Parity Breaks

- Changes the strange BYOND pseudo-errors into simple worldLogs
- Requires there to be a space on both sides of an `=`. I have made this change because the overall functionality of the `=` was incredibly inconsistent, as shown below:
   - "foo = bar" is valid and fine
   - "foo= 1" causes an error (due to how ImportText() works, it will still insert `foo\=` into the savefile)
   - "foo =1" is valid and fine
   - "foo =bar" causes an error like bullet point 2
 
## TODO

- [x] Write unit tests
- [x] Differentiate between having no value and having a null value 

Shoutout to goon for being the only codebase I could find that uses this proc