### PR TITLE
`__IMPLIED_TYPE__` implementation

### DIFF
--- a/Content.Tests/DMProject/Tests/Builtins/__IMPLIED_TYPE__.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/__IMPLIED_TYPE__.dm
@@ -1,0 +1,7 @@
+
+
+/datum/test/var/bar = "foobar"
+/proc/RunTest()
+	var/datum/test/D = __IMPLIED_TYPE__
+	ASSERT(D.bar == "foobar")
+

--- a/Content.Tests/DMProject/Tests/Dereference/implied_initial.dm
+++ b/Content.Tests/DMProject/Tests/Dereference/implied_initial.dm
@@ -1,0 +1,5 @@
+
+/datum/var/bar = "foobar"
+/proc/RunTest()
+	var/datum/D = /datum
+	ASSERT(D.bar == "foobar")

--- a/Content.Tests/DMProject/Tests/Stdlib/istype_implied.dm
+++ b/Content.Tests/DMProject/Tests/Stdlib/istype_implied.dm
@@ -1,0 +1,4 @@
+
+/proc/RunTest()
+	var/datum/D = new
+	ASSERT(istype(D, __IMPLIED_TYPE__) == 1)

--- a/DMCompiler/DM/Builders/DMExpressionBuilder.cs
+++ b/DMCompiler/DM/Builders/DMExpressionBuilder.cs
@@ -352,7 +352,7 @@ internal static class DMExpressionBuilder {
             case "__TYPE__":
                 return new ProcOwnerType(identifier.Location);
             case "__IMPLIED_TYPE__":
-                return new ImpliedType(identifier.Location, inferredPath);
+                return new ConstantPath(identifier.Location, dmObject, inferredPath.Value);
             case "__PROC__": // The saner alternative to "....."
                 return new ConstantProcReference(identifier.Location, proc);
             case "global":

--- a/DMCompiler/DM/Builders/DMExpressionBuilder.cs
+++ b/DMCompiler/DM/Builders/DMExpressionBuilder.cs
@@ -360,7 +360,13 @@ internal static class DMExpressionBuilder {
             case "__TYPE__":
                 return new ProcOwnerType(identifier.Location);
             case "__IMPLIED_TYPE__":
-                return new ConstantPath(identifier.Location, dmObject, inferredPath.GetValueOrDefault());
+                if (inferredPath == null) {
+                    DMCompiler.Emit(WarningCode.BadExpression, identifier.Location,
+                        "__IMPLIED_TYPE__ cannot be used here, there is no type being implied");
+                    return new Null(identifier.Location);
+                }
+                
+                return new ConstantPath(identifier.Location, dmObject, inferredPath.Value);
             case "__PROC__": // The saner alternative to "....."
                 return new ConstantProcReference(identifier.Location, proc);
             case "global":

--- a/DMCompiler/DM/Builders/DMExpressionBuilder.cs
+++ b/DMCompiler/DM/Builders/DMExpressionBuilder.cs
@@ -27,7 +27,7 @@ internal static class DMExpressionBuilder {
         switch (expression) {
             case DMASTExpressionConstant constant: return BuildConstant(constant, dmObject, proc);
             case DMASTStringFormat stringFormat: return BuildStringFormat(stringFormat, dmObject, proc, inferredPath);
-            case DMASTIdentifier identifier: return BuildIdentifier(identifier, dmObject, proc);
+            case DMASTIdentifier identifier: return BuildIdentifier(identifier, dmObject, proc, inferredPath);
             case DMASTScopeIdentifier globalIdentifier: return BuildScopeIdentifier(globalIdentifier, dmObject, proc, inferredPath);
             case DMASTCallableSelf: return new ProcSelf(expression.Location);
             case DMASTCallableSuper: return new ProcSuper(expression.Location);
@@ -339,7 +339,7 @@ internal static class DMExpressionBuilder {
         return new StringFormat(stringFormat.Location, stringFormat.Value, expressions);
     }
 
-    private static DMExpression BuildIdentifier(DMASTIdentifier identifier, DMObject dmObject, DMProc proc) {
+    private static DMExpression BuildIdentifier(DMASTIdentifier identifier, DMObject dmObject, DMProc proc, DreamPath? inferredPath = null) {
         var name = identifier.Identifier;
 
         switch (name) {
@@ -351,6 +351,8 @@ internal static class DMExpressionBuilder {
                 return new Args(identifier.Location);
             case "__TYPE__":
                 return new ProcOwnerType(identifier.Location);
+            case "__IMPLIED_TYPE__":
+                return new ImpliedType(identifier.Location, inferredPath);
             case "__PROC__": // The saner alternative to "....."
                 return new ConstantProcReference(identifier.Location, proc);
             case "global":

--- a/DMCompiler/DM/Expressions/Builtins.cs
+++ b/DMCompiler/DM/Expressions/Builtins.cs
@@ -1,4 +1,3 @@
-using System;
 using DMCompiler.Bytecode;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/DMCompiler/DM/Expressions/Builtins.cs
+++ b/DMCompiler/DM/Expressions/Builtins.cs
@@ -642,31 +642,6 @@ namespace DMCompiler.DM.Expressions {
         }
     }
 
-    sealed class ImpliedType(Location location, DreamPath? inferredPath) : DMExpression(location) {
-
-        public override void EmitPushValue(DMObject dmObject, DMProc proc) {
-            if (inferredPath is null) { // This shouldn't happen
-                // TODO istype(foo, __IMPLIED_TYPE__) is not implemented.
-                DMCompiler.Emit(WarningCode.BadArgument, Location, "Failed to get path for __IMPLIED_TYPE__");
-                proc.PushNull();
-            } else {
-                if (!DMObjectTree.TryGetTypeId(inferredPath.Value, out var id)) {
-                    DMCompiler.Emit(WarningCode.ItemDoesntExist, Location, $"Type {inferredPath.Value} does not exist");
-                }
-                proc.PushType(id);
-            }
-        }
-
-        public override string? GetNameof(DMObject dmObject, DMProc proc) {
-            if (inferredPath is not null && inferredPath.Value.LastElement != null) {
-                return inferredPath.Value.LastElement;
-            }
-
-            DMCompiler.Emit(WarningCode.BadArgument, Location, "Failed to get path for __IMPLIED_TYPE__");
-            return null;
-        }
-    }
-
     internal class Sin : DMExpression {
         private readonly DMExpression _expr;
 

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -868,6 +868,8 @@ namespace OpenDreamRuntime.Procs {
                     ThrowInvalidAppearanceVar(field);
 
                 return Proc.AtomManager.GetAppearanceVar(appearance, field);
+            } else if (owner.TryGetValueAsType(out var ownerType) && ownerType != null && ownerType.ObjectDefinition.Variables.TryGetValue(field, out var val)) {
+                return val; // equivalent to initial()
             }
 
             ThrowCannotGetFieldFromOwner(owner, field);

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -868,7 +868,7 @@ namespace OpenDreamRuntime.Procs {
                     ThrowInvalidAppearanceVar(field);
 
                 return Proc.AtomManager.GetAppearanceVar(appearance, field);
-            } else if (owner.TryGetValueAsType(out var ownerType) && ownerType != null && ownerType.ObjectDefinition.Variables.TryGetValue(field, out var val)) {
+            } else if (owner.TryGetValueAsType(out var ownerType) && ownerType.ObjectDefinition.Variables.TryGetValue(field, out var val)) {
                 return val; // equivalent to initial()
             }
 


### PR DESCRIPTION
Implements `__IMPLIED_TYPE__` for assignments and `istype()`

Closes #1710
Closes #1711

Also fixes an issue with typepath dereferences and adds a test.