### PR TITLE
Don't emit `PointlessParentCall` if lateral overrides exist

### DIFF
--- a/Content.Tests/DMProject/Tests/Call/LateralPointlessOverride.dm
+++ b/Content.Tests/DMProject/Tests/Call/LateralPointlessOverride.dm
@@ -1,0 +1,11 @@
+#pragma PointlessParentCall error
+
+// don't emit the pragma if lateral overrides exist
+/datum/foo()
+	return
+/datum/proc/foo()
+	..()
+	return
+
+/proc/RunTest()
+	return

--- a/Content.Tests/DMProject/Tests/Call/PointlessParentCall.dm
+++ b/Content.Tests/DMProject/Tests/Call/PointlessParentCall.dm
@@ -1,0 +1,9 @@
+// COMPILE ERROR
+#pragma PointlessParentCall error
+
+/datum/proc/foo()
+	..()
+	return
+
+/proc/RunTest()
+	return

--- a/DMCompiler/DM/Expressions/Procs.cs
+++ b/DMCompiler/DM/Expressions/Procs.cs
@@ -83,7 +83,11 @@ namespace DMCompiler.DM.Expressions {
         public override DMReference EmitReference(DMObject dmObject, DMProc proc, string endLabel, ShortCircuitMode shortCircuitMode) {
             if ((proc.Attributes & ProcAttributes.IsOverride) != ProcAttributes.IsOverride)
             {
-                DMCompiler.Emit(WarningCode.PointlessParentCall, Location, "Calling parents via ..() in a proc definition does nothing");
+                // Don't emit if lateral proc overrides exist
+                if (dmObject.GetProcs(proc.Name)!.Count == 1) {
+                    DMCompiler.Emit(WarningCode.PointlessParentCall, Location, "Calling parents via ..() in a proc definition does nothing");
+                }
+
             }
             return DMReference.SuperProc;
         }


### PR DESCRIPTION
MSO pointed this out, I thought we already accounted for it but we didn't.