### PR TITLE
Implement `::` for procs

### DIFF
--- a/Content.Tests/DMProject/Tests/Operators/scope_proc_name.dm
+++ b/Content.Tests/DMProject/Tests/Operators/scope_proc_name.dm
@@ -1,4 +1,5 @@
 /datum/proc/foo()
+	set name = "abc"
 	return
 
 /proc/RunTest()

--- a/Content.Tests/DMProject/Tests/Operators/scope_proc_name.dm
+++ b/Content.Tests/DMProject/Tests/Operators/scope_proc_name.dm
@@ -1,0 +1,5 @@
+/datum/proc/foo()
+	return
+
+/proc/RunTest()
+	ASSERT((/datum/proc/foo::name) == "foo")

--- a/Content.Tests/DMProject/Tests/Operators/scope_proc_pointless.dm
+++ b/Content.Tests/DMProject/Tests/Operators/scope_proc_pointless.dm
@@ -2,6 +2,7 @@
 #pragma PointlessScopeOperator error
 
 /datum/proc/foo()
+	set desc = "abc"
 	return
 
 /proc/RunTest()

--- a/Content.Tests/DMProject/Tests/Operators/scope_proc_pointless.dm
+++ b/Content.Tests/DMProject/Tests/Operators/scope_proc_pointless.dm
@@ -1,0 +1,8 @@
+// COMPILE ERROR
+#pragma PointlessScopeOperator error
+
+/datum/proc/foo()
+	return
+
+/proc/RunTest()
+	var/desc = (/datum/proc/foo::desc)

--- a/DMCompiler/Compiler/CompilerError.cs
+++ b/DMCompiler/Compiler/CompilerError.cs
@@ -46,6 +46,7 @@ public enum WarningCode {
     PointlessBuiltinCall = 2206, // For pointless calls to issaved() or initial()
     SuspiciousMatrixCall = 2207, // Calling matrix() with seemingly the wrong arguments
     FallbackBuiltinArgument = 2208, // A builtin (sin(), cos(), etc) with an invalid/fallback argument
+    PointlessScopeOperator = 2209,
     MalformedRange = 2300,
     InvalidRange = 2301,
     InvalidSetStatement = 2302,

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -20,6 +20,7 @@
 #pragma PointlessBuiltinCall warning
 #pragma SuspiciousMatrixCall warning
 #pragma FallbackBuiltinArgument warning
+#pragma PointlessScopeOperator warning
 #pragma MalformedRange warning
 #pragma InvalidRange error
 #pragma InvalidSetStatement error


### PR DESCRIPTION
Wixoa's testing indicates that, oddly enough, this only seems to work for `name`

Added a `PointlessScopeOperator` pragma for other uses. I'll update the wiki when this is merged.