### PR TITLE
Fix EmptyProc applying to code existing before it was enabled

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -248,6 +248,10 @@ namespace DMCompiler.Compiler.DM {
                         }
                     }
 
+                    if (procBlock?.Statements.Length is 0 or null) {
+                        DMCompiler.Emit(WarningCode.EmptyProc, loc, "Empty proc detected - add an explicit \"return\" statement");
+                    }
+
                     if(path.IsOperator) {
                         DMCompiler.UnimplementedWarning(procBlock.Location, "Operator overloads are not implemented. They will be defined but never called.");
 

--- a/DMCompiler/DM/Builders/DMProcBuilder.cs
+++ b/DMCompiler/DM/Builders/DMProcBuilder.cs
@@ -55,10 +55,6 @@ namespace DMCompiler.DM.Builders {
                 }
             }
 
-            if (procDefinition.Body.Statements.Length == 0) {
-                DMCompiler.Emit(WarningCode.EmptyProc, _proc.Location,"Empty proc detected - add an explicit \"return\" statement");
-            }
-
             ProcessBlockInner(procDefinition.Body, silenceEmptyBlockWarning : true);
             _proc.ResolveLabels();
         }


### PR DESCRIPTION
I moved the emission of EmptyProc from compilation to parsing. Just a workaround to a larger problem though.