### PR TITLE
Fix line counting with long strings

### DIFF
--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -313,14 +313,16 @@ internal sealed class DMPreprocessorLexer {
 
                         if(nextCharCanTerm && c == '}')
                             break;
-                        else {
+
+                        if (HandleLineEnd()) {
+                            TokenTextBuilder.Append('\n');
+                        } else {
                             TokenTextBuilder.Append(c);
                             nextCharCanTerm = false;
                         }
 
                         if (c == '"')
                             nextCharCanTerm = true;
-
                     } while (!AtEndOfSource());
                 } else {
                     while (c != delimiter && !AtLineEnd() && !AtEndOfSource()) {
@@ -492,7 +494,9 @@ internal sealed class DMPreprocessorLexer {
         while (!(!isLong && AtLineEnd()) && !AtEndOfSource()) {
             char stringC = GetCurrent();
 
-            if (stringC == '[') {
+            if (HandleLineEnd()) {
+                textBuilder.Append('\n');
+            } else if (stringC == '[') {
                 textBuilder.Append(stringC);
                 stringTokens.Enqueue(isConstant // First case of '['
                     ? CreateToken(TokenType.DM_Preproc_StringBegin, tokenTextStart + textBuilder, textBuilder.ToString())


### PR DESCRIPTION
Long strings (raw or not) weren't having their lines counted by the lexer so token locations would be off. This would say the warning was on line 2:
```dm
var/str = {"A
B
C"}
#warn Message
```

Now it's correctly on line 4