### PR TITLE
Revert "Converts empty strings to `null` in savefile serialization"

### DIFF
--- a/Content.Tests/DMProject/Tests/Savefile/BasicReadAndWrite.dm
+++ b/Content.Tests/DMProject/Tests/Savefile/BasicReadAndWrite.dm
@@ -19,10 +19,6 @@
 	ASSERT(V == 10)
 	S["notakey"] >> V
 	ASSERT(V == null)
-
-	// "" is converted into null if entered into a savefile
-	S["nullcheck"] = ""
-	ASSERT(S["nullcheck"] == null)
 	
 	// test path
 	S["pathymcpathface"] << /datum/foobar
@@ -53,11 +49,11 @@
 	//Test dir
 	S.cd = "/"
 	var/dir = S.dir
-	ASSERT(dir ~= list("ABC", "DEF", "notakey", "nullcheck", "pathymcpathface", "pie", "pie2"))
+	ASSERT(dir ~= list("ABC", "DEF", "notakey", "pathymcpathface", "pie", "pie2"))
 
 	//test add
 	dir += "test/beep"
-	ASSERT(dir ~= list("ABC", "DEF", "notakey", "nullcheck", "pathymcpathface", "pie", "pie2", "test"))
+	ASSERT(dir ~= list("ABC", "DEF", "notakey", "pathymcpathface", "pie", "pie2", "test"))
 	ASSERT(S["test"] == null)
 	S.cd = "test"
 	ASSERT(dir ~= list("beep"))
@@ -65,11 +61,11 @@
 	//test del
 	S.cd = "/"
 	dir -= "test"
-	ASSERT(dir ~= list("ABC", "DEF", "notakey", "nullcheck", "pathymcpathface", "pie", "pie2"))
+	ASSERT(dir ~= list("ABC", "DEF", "notakey", "pathymcpathface", "pie", "pie2"))
 
 	//test rename and null
 	dir[1] = "CBA"
-	ASSERT(dir ~= list("CBA", "DEF", "notakey", "nullcheck", "pathymcpathface", "pie", "pie2"))
+	ASSERT(dir ~= list("CBA", "DEF", "notakey", "pathymcpathface", "pie", "pie2"))
 	ASSERT(S["CBA"] == null)
 
 	fdel("savefile.sav")

--- a/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
@@ -398,9 +398,6 @@ public sealed class DreamObjectSavefile : DreamObject {
     public SFDreamJsonValue SerializeDreamValue(DreamValue val, int objectCount = 0) {
         switch (val.Type) {
             case DreamValue.DreamValueType.String:
-                if(val.TryGetValueAsString(out var valString) && string.IsNullOrEmpty(valString)) 
-                        val = DreamValue.Null;
-                return new SFDreamPrimitive { Value = val };
             case DreamValue.DreamValueType.Float:
                 return new SFDreamPrimitive { Value = val };
             case DreamValue.DreamValueType.DreamType:


### PR DESCRIPTION
Reverts OpenDreamProject/OpenDream#1709

turns out it was a BYOND bug, go figure