### PR TITLE
Use master SS13 branches in CI

### DIFF
--- a/.github/workflows/compiler-test.yml
+++ b/.github/workflows/compiler-test.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Compile Goonstation Master
       run: |
         New-Item goon\+secret\__secret.dme -type file
-        main\bin\DMCompiler\DMCompiler.exe goon\goonstation.dme --version=514.1584
+        main\bin\DMCompiler\DMCompiler.exe goon\goonstation.dme
     - name: Checkout Paradise Master
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/compiler-test.yml
+++ b/.github/workflows/compiler-test.yml
@@ -34,29 +34,29 @@ jobs:
       run: dotnet build main/DMCompiler/DMCompiler.csproj --configuration Release --no-restore /m
     - name: Compile TestGame
       run: main\bin\DMCompiler\DMCompiler.exe main\TestGame\environment.dme
-    - name: Checkout /tg/station 88bdabe
+    - name: Checkout /tg/station Master
       uses: actions/checkout@v2
       with:
         repository: tgstation/tgstation
-        ref: 88bdabe53bb85f2a7f54e479f6c4a243650043d5
+        ref: master
         path: tg
-    - name: Compile /tg/station 88bdabe
+    - name: Compile /tg/station Master
       run: main\bin\DMCompiler\DMCompiler.exe tg\tgstation.dme
-    - name: Checkout Goonstation 8c8b527
+    - name: Checkout Goonstation Master
       uses: actions/checkout@v2
       with:
         repository: goonstation/goonstation
-        ref: 8c8b5276f231ae42b3b2390d837cab68af138fa6
+        ref: master
         path: goon
-    - name: Compile Goonstation 8c8b527
+    - name: Compile Goonstation Master
       run: |
         New-Item goon\+secret\__secret.dme -type file
         main\bin\DMCompiler\DMCompiler.exe goon\goonstation.dme --version=514.1584
-    - name: Checkout 64-bit Paradise
+    - name: Checkout Paradise Master
       uses: actions/checkout@v2
       with:
-        repository: ike709/Paradise
-        ref: rustg_64
+        repository: ParadiseSS13/Paradise
+        ref: master
         path: para
-    - name: Compile 64-bit Paradise
+    - name: Compile Paradise Master
       run: main\bin\DMCompiler\DMCompiler.exe para\paradise.dme


### PR DESCRIPTION
Now that these codebases use OD in their CI workflows, we should test against their latest master on our end to minimize breaking changes (or to find them so we can adequately communicate them).