### PR TITLE
Add Nebula dev branch to OpenDream CI

### DIFF
--- a/.github/workflows/compiler-test.yml
+++ b/.github/workflows/compiler-test.yml
@@ -60,3 +60,11 @@ jobs:
         path: para
     - name: Compile Paradise Master
       run: main\bin\DMCompiler\DMCompiler.exe para\paradise.dme
+    - name: Checkout Nebula Dev
+      uses: actions/checkout@v2
+      with:
+        repository: NebulaSS13/Nebula
+        ref: dev
+        path: nebula
+    - name: Compile Nebula Dev
+      run: main\bin\DMCompiler\DMCompiler.exe nebula\nebula.dme


### PR DESCRIPTION
Adds Nebula's dev branch to CI to make sure support for at least one Bay-based codebase doesn't break with changes.