### PR TITLE
Adds vscode tasks and removes them from git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,6 +264,7 @@ __pycache__/
 # Visual Studio Code workspace settings.
 .vscode/*
 !.vscode/extensions.json
+!.vscode/tasks.json
 
 # Release package files go here:
 release/

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,33 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Compile for OpenDream",
+            "type": "shell",
+            "command": "dotnet run -c release --project ./DMCompiler --suppress-unimplemented ${input:path_to_repo}.dme",
+            "group": "build"
+        },
+        {
+            "label": "Run the server",
+            "type": "shell",
+            "command": "dotnet run -c release --project ./OpenDreamServer --cvar opendream.json_path=${input:path_to_repo}.json",
+            "group": "build"
+        },
+        {
+            "label": "Run the client",
+            "type": "shell",
+            "command": "dotnet run -c release --project ./OpenDreamClient",
+            "group": "build"
+        },
+    ],
+    "inputs": [
+        {
+            "id" : "path_to_repo",
+            "description": "Contains the path to the repo you want to run the compile on",
+            "default": "",
+            "type": "promptString"
+        },
+    ]
+}


### PR DESCRIPTION
Adds VSC Tasks for compiling a repo, and running the server and client, via the ctrl. + shift + B shortcut for build tasks in VSC.
Compiling and running the server use an input, whose default has been left blank, but for a repository contained with in the Opendream repo, the input could look like this `./Citadel-Station-13-RP/citadel` the citadel at the end being the name of the .dme and later the .json file, with the ending/extension being added by the command 