### PR TITLE
Attempting to read the "hidden" field on a proc will return null and emit a warning

### DIFF
--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -83,6 +83,9 @@ namespace OpenDreamRuntime {
                     return (_verbDesc != null) ? new DreamValue(_verbDesc) : DreamValue.Null;
                 case "invisibility":
                     return new DreamValue(Invisibility);
+                case "hidden":
+                    Logger.GetSawmill("opendream.dmproc").Warning("The 'hidden' field on verbs will always return null.");
+                    return DreamValue.Null;
                 default:
                     throw new Exception($"Cannot get field \"{field}\" from {OwningType.ToString()}.{Name}()");
             }


### PR DESCRIPTION
Closes #1787 
The "hidden" field is inaccessible in BYOND and will always return `null`.
![image](https://github.com/OpenDreamProject/OpenDream/assets/75460809/b8d15880-76c4-48d9-8364-c332827f6abc)

Per wixoa's suggestion, this pr.
![image](https://github.com/OpenDreamProject/OpenDream/assets/75460809/4971a0db-b716-4a3c-bba4-8166364ae677)
