### PR TITLE
lint using resharper

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Resharper
         run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
       - name: Run Linter
-        run: jb inspectcode OpenDream.sln -o="output.json" --project="OpenDream*;DM*" --no-swea --no-build
+        run: jb inspectcode OpenDream.sln -o="output.json" --project="OpenDream*;DM*" --exclude="*.xaml" --no-swea --no-build
       - uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: output.json

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,9 +22,7 @@ jobs:
       - name: Setup Resharper
         run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
       - name: Run Linter
-        run: jb inspectcode OpenDream.sln -o="output.json" --project="OpenDream*;DM*" --no-swea
-      - name: Annotate Lints
-        uses: equisoft-actions/sarif-annotator@v1.5.0
+        run: jb inspectcode OpenDream.sln -o="output.json" --project="OpenDream*;DM*" --no-swea --no-build
+      - uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif-path: ./output.json
-          limit: 200
+          sarif_file: output.json

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,8 +22,9 @@ jobs:
       - name: Setup Resharper
         run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
       - name: Run Linter
-        run: jb inspectcode OpenDream.sln -o="output.json" --project="OpenDream*"
+        run: jb inspectcode OpenDream.sln -o="output.json" --project="OpenDream*;DM*" --no-swea
       - name: Annotate Lints
         uses: equisoft-actions/sarif-annotator@v1.5.0
         with:
           sarif-path: ./output.json
+          limit: 200

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,12 +19,10 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 8.0.100
-      - name: Install dependencies
-        run: dotnet restore
       - name: Setup Resharper
         run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
       - name: Run Linter
-        run: jb inspectcode OpenDream.sln -o="output.json" --project="OpenDream*;DM*" --no-swea --no-build
+        run: jb inspectcode OpenDream.sln -o="output.json" --project="OpenDream*;DM*" --no-swea
       - uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: output.json

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,6 @@
 name: Lint
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: Lint
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    runs-on: linux
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup submodule
+        run: |
+          git submodule update --init --recursive
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 8.0.100
+      - name: Setup Resharper
+        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
+      - name: Run Linter
+        run: jb inspectcode OpenDream.sln -o="output.json" --project="OpenDream*"
+      - name: Annotate Lints
+        uses: equisoft-actions/sarif-annotator@v1.5.0
+        with:
+          sarif-path: ./output.json

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,10 +19,12 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 8.0.100
+      - name: Install dependencies
+        run: dotnet restore
       - name: Setup Resharper
         run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
       - name: Run Linter
-        run: jb inspectcode OpenDream.sln -o="output.json" --project="OpenDream*;DM*" --exclude="*.xaml" --no-swea --no-build
+        run: jb inspectcode OpenDream.sln -o="output.json" --project="OpenDream*;DM*" --no-swea --no-build
       - uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: output.json

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: linux
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -154,11 +154,11 @@ internal sealed class DreamViewOverlay : Overlay {
         }
 
         var eyeTile = _mapSystem.GetTileRef(gridUid, grid, eyeCoords);
-        var tiles = CalculateTileVisibility(gridUid, grid, eyeTile, seeVis);
+        var Tiles = CalculateTileVisibility(gridUid, grid, eyeTile, seeVis);
 
         RefreshRenderTargets(args.WorldHandle, viewportSize);
 
-        CollectVisibleSprites(tiles, gridUid, grid, eyeTile, seeVis, sight, args.WorldAABB);
+        CollectVisibleSprites(Tiles, gridUid, grid, eyeTile, seeVis, sight, args.WorldAABB);
         ClearPlanes();
         ProcessSprites(worldHandle, viewportSize, args.WorldAABB);
 

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -154,11 +154,11 @@ internal sealed class DreamViewOverlay : Overlay {
         }
 
         var eyeTile = _mapSystem.GetTileRef(gridUid, grid, eyeCoords);
-        var Tiles = CalculateTileVisibility(gridUid, grid, eyeTile, seeVis);
+        var tiles = CalculateTileVisibility(gridUid, grid, eyeTile, seeVis);
 
         RefreshRenderTargets(args.WorldHandle, viewportSize);
 
-        CollectVisibleSprites(Tiles, gridUid, grid, eyeTile, seeVis, sight, args.WorldAABB);
+        CollectVisibleSprites(tiles, gridUid, grid, eyeTile, seeVis, sight, args.WorldAABB);
         ClearPlanes();
         ProcessSprites(worldHandle, viewportSize, args.WorldAABB);
 


### PR DESCRIPTION
implements linting using rider's annotation tool, resharper. these lints aren't annotated using standard github pattern as there is a Ton of them, and resharper outputs them in SARIF. the best fitting tool for this seems to be the codeql security analysis tool, which is odd for a linter, but i think it still provides handy annotation

oh no! new bad code!! (only shows new inspections on the pr, not existing ones)
![CleanShot 2024-05-22 at 23 21 59@2x](https://github.com/OpenDreamProject/OpenDream/assets/55142896/96947a58-13f5-4409-9dc7-7de31c96e85e)

new commit addresses the issue, the issue is flagged as fixed and minimised
![CleanShot 2024-05-22 at 23 27 08@2x](https://github.com/OpenDreamProject/OpenDream/assets/55142896/0c14a9ca-b33d-4720-aa87-7f7af68bdb63)
