### PR TITLE
Ignore attempts to set `mob.client = null`

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamObjectMob.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectMob.cs
@@ -62,10 +62,9 @@ public sealed class DreamObjectMob : DreamObjectMovable {
             case "client":
                 value.TryGetValueAsDreamObject<DreamObjectClient>(out var newClient);
 
+                // An invalid client or a null does nothing here
                 if (newClient != null) {
                     newClient.Connection.Mob = this;
-                } else if (Connection != null) {
-                    Connection.Mob = null;
                 }
 
                 break;


### PR DESCRIPTION
Doing `mob.client = null` does not do anything.

Fixes trying to observe a round on tg, due to this code:
```dm
observer.key = key
observer.client = client
```