### PR TITLE
Return true for any atom type in `isloc()`

### DIFF
--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1077,15 +1077,10 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("Loc1", Type = DreamValueTypeFlag.DreamObject)]
         public static DreamValue NativeProc_isloc(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
             foreach (var arg in bundle.Arguments) {
-                if (!arg.TryGetValueAsDreamObject(out var loc))
-                    return DreamValue.False;
-                if (loc is null)
-                    return DreamValue.False;
-
-                bool isLoc = loc is DreamObjectMob or DreamObjectTurf or DreamObjectArea ||
-                             loc.IsSubtypeOf(bundle.ObjectTree.Obj);
-
-                if (!isLoc)
+                // The DM reference says "mobs, objs, turfs, or areas"
+                // You might think this excludes /atom/movable, but it does not
+                // So test for any DreamObjectAtom type
+                if (!arg.TryGetValueAsDreamObject<DreamObjectAtom>(out _))
                     return DreamValue.False;
             }
 


### PR DESCRIPTION
The DM reference says this tests for "mobs, objs, turfs, or areas" but turns out it tests for /atom/movable too.