### PR TITLE
Animate Defines Cleanup

### DIFF
--- a/DMCompiler/DMStandard/Defines.dm
+++ b/DMCompiler/DMStandard/Defines.dm
@@ -31,12 +31,27 @@
 #define NEUTER "neuter"
 #define PLURAL "plural"
 
+//animate() flags arg
 #define ANIMATION_END_NOW 1
 #define ANIMATION_LINEAR_TRANSFORM 2
 #define ANIMATION_PARALLEL 4
+#define ANIMATION_SLICE 8
+#define ANIMATION_RELATIVE 256
+#define ANIMATION_CONTINUE 512
+
+//animate() easing arg
+#define LINEAR_EASING	0
+#define SINE_EASING		1
+#define CIRCULAR_EASING	2
+#define CUBIC_EASING	3
+#define BOUNCE_EASING	4
+#define ELASTIC_EASING	5
+#define BACK_EASING		6
+#define QUAD_EASING		7
+#define JUMP_EASING		8
+//flags applied to the animate() easing arg
 #define EASE_IN 64
 #define EASE_OUT 128
-#define ANIMATION_RELATIVE 256
 
 #define NO_STEPS 0
 #define FORWARD_STEPS 1
@@ -122,17 +137,6 @@
 #define PIXEL_SCALE 	(1<<9)
 #define PASS_MOUSE 		(1<<10)
 #define TILE_MOVER		(1<<11)
-
-//animate() easing arg
-#define LINEAR_EASING	0
-#define SINE_EASING		1
-#define CIRCULAR_EASING	2
-#define CUBIC_EASING	3
-#define BOUNCE_EASING	4
-#define ELASTIC_EASING	5
-#define BACK_EASING		6
-#define QUAD_EASING		7
-#define JUMP_EASING		8
 
 //Undocumented matrix defines (see https://www.byond.com/forum/post/1881375)
 #define MATRIX_COPY 0


### PR DESCRIPTION
Actually defines ANIMATE_CONTINUE and ANIMATE_SLICE

Moves easing flags up next to the animation flags

Moves EASE_IN and EASE_OUT to easing flags instead of blockin em in with the animation flags.

Broke my unit tests REEEEEEEEEEEE