### PR TITLE
Fix inferred type expressions

### DIFF
--- a/Content.Tests/DMProject/Tests/Expression/InferredType.dm
+++ b/Content.Tests/DMProject/Tests/Expression/InferredType.dm
@@ -1,0 +1,8 @@
+/proc/RunTest()
+    var/matrix/M1 = new()
+    var/matrix/M2 = new()
+
+    (M1 * M2).Multiply(1)
+
+    var/list/test = list(M1,M2)
+    (locate(/matrix) in test).Multiply(1)

--- a/Content.Tests/DMProject/Tests/Expression/InferredType.dm
+++ b/Content.Tests/DMProject/Tests/Expression/InferredType.dm
@@ -1,3 +1,5 @@
+// issue #1752
+
 /proc/RunTest()
     var/matrix/M1 = new()
     var/matrix/M2 = new()

--- a/DMCompiler/DM/Expressions/Binary.cs
+++ b/DMCompiler/DM/Expressions/Binary.cs
@@ -7,6 +7,7 @@ namespace DMCompiler.DM.Expressions {
         protected DMExpression LHS { get; } = lhs;
         protected DMExpression RHS { get; } = rhs;
         public override DMComplexValueType ValType => LHS.ValType;
+        public override bool PathIsFuzzy => true;
     }
 
     #region Simple

--- a/DMCompiler/DM/Expressions/Builtins.cs
+++ b/DMCompiler/DM/Expressions/Builtins.cs
@@ -154,6 +154,7 @@ namespace DMCompiler.DM.Expressions {
     sealed class Locate : DMExpression {
         private readonly DMExpression _path;
         private readonly DMExpression? _container;
+        public override bool PathIsFuzzy => true;
 
         public Locate(Location location, DMExpression path, DMExpression? container) : base(location) {
             _path = path;


### PR DESCRIPTION
Fixes  #1752

also fixes `locate()` doing the same. There are probably some other built-ins that will need the same, I guess we can just fix them as they come up.