### PR TITLE
Implement a few easy operator overloads

### DIFF
--- a/Content.Tests/DMProject/Tests/Operators/Overloads/complex_numbers.dm
+++ b/Content.Tests/DMProject/Tests/Operators/Overloads/complex_numbers.dm
@@ -18,14 +18,20 @@
 		else if(isnum(C)) 
 			a += C
 
-	proc/operator-()
-		return new /datum/complex(a*-1, b*-1)
+	proc/operator-(datum/complex/C)
+		if(isnull(C)) return new /datum/complex(a*-1, b*-1)
+		if(istype(C)) return new /datum/complex(a-C.a, b-C.b)
+		if(isnum(C)) return new /datum/complex(a-C, b)
 		 
 	proc/operator*(datum/complex/C) 
 		if(isnum(C))
 			return new /datum/complex(a*C, b*C)
 		else
 			return new /datum/complex((src.a * C.a) - (src.b * C.b), (src.a * C.b) + (src.b * C.a))
+	
+	proc/operator|(datum/complex/C)
+		//nonsense, used for testing
+		src.a = C.a
 
 	proc/operator[](index) 
 		switch(index)
@@ -51,4 +57,26 @@
 /proc/RunTest()
 	var/datum/complex/A = new /datum/complex(5,-1)
 	var/datum/complex/B = new /datum/complex(3,-9.5)
-	//Just compile for now
+	//test implemented
+	//+
+	var/datum/complex/result = A + B
+	ASSERT(result.a == 8 && result.b == -10.5)
+	result = A + 5
+	ASSERT(result.a == 10 && result.b == -1)
+	//-
+	result = A - B
+	ASSERT(result.a == 2 && result.b == 8.5)
+	result = A - 5
+	ASSERT(result.a == 0 && result.b == -1)
+
+	//Unary operators need their own proc, it's not just subtract(null)
+	//result = -A
+	//ASSERT(result.a == -5 && result.b == 1)
+	//*
+	result = A * B
+	ASSERT(result.a == 5.5 && result.b == -50.5)
+	result = A * 2
+	ASSERT(result.a == 10 && result.b == -2)
+	//|
+	result = A | B
+	ASSERT(result.a == 3 && result.b == -1)

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -143,6 +143,15 @@ namespace DMCompiler.Compiler.DM {
             TokenType.DM_ConstantString
         ];
 
+        // TEMPORARY - REMOVE WHEN IT MATCHES THE ABOVE
+        private static readonly TokenType[] ImplementedOperatorOverloadTypes = [
+            TokenType.DM_Plus,
+            TokenType.DM_Minus,
+            TokenType.DM_Star,
+            TokenType.DM_Slash,
+            TokenType.DM_Bar,
+        ];
+
         public DMASTFile File() {
             var loc = Current().Location;
             List<DMASTStatement> statements = new();
@@ -244,9 +253,6 @@ namespace DMCompiler.Compiler.DM {
                 }
 
                 if (path.IsOperator) {
-                    DMCompiler.UnimplementedWarning(procBlock.Location,
-                        "Most operator overloads are not implemented. They will be defined but never called.");
-
                     List<DMASTProcStatement> procStatements = procBlock.Statements.ToList();
                     Location tokenLoc = procBlock.Location;
                     //add ". = src" as the first expression in the operator
@@ -374,6 +380,11 @@ namespace DMCompiler.Compiler.DM {
                                 if (operatorToken is { Type: TokenType.DM_ConstantString, Value: not "" }) {
                                     DMCompiler.Emit(WarningCode.BadToken, operatorToken.Location,
                                         "The quotes in a stringify overload must be empty");
+                                }
+
+                                if (!ImplementedOperatorOverloadTypes.Contains(operatorToken.Type)) {
+                                    DMCompiler.UnimplementedWarning(operatorToken.Location,
+                                        $"operator{operatorToken.PrintableText} overloads are not implemented. They will be defined but never called.");
                                 }
 
                                 operatorFlag = true;

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -245,7 +245,7 @@ namespace DMCompiler.Compiler.DM {
 
                 if (path.IsOperator) {
                     DMCompiler.UnimplementedWarning(procBlock.Location,
-                        "Operator overloads are not implemented. They will be defined but never called.");
+                        "Most operator overloads are not implemented. They will be defined but never called.");
 
                     List<DMASTProcStatement> procStatements = procBlock.Statements.ToList();
                     Location tokenLoc = procBlock.Location;

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -368,11 +368,11 @@ namespace OpenDreamRuntime.Objects {
 
         #region Operators
         // +
-        public virtual ProcStatus OperatorAdd(DreamValue b, DMProcState state, out DreamValue? result) {
+        public virtual ProcStatus OperatorAdd(DreamValue b, DMProcState state, out DreamValue result) {
             if(TryGetProc("operator+", out var proc)) {
                 var operatorProcState = proc.CreateState(state.Thread, this, state.Usr, new DreamProcArguments(b));
                 state.Thread.PushProcState(operatorProcState);
-                result = null;
+                result = DreamValue.Null;
                 return ProcStatus.Called;
             }
 
@@ -380,11 +380,11 @@ namespace OpenDreamRuntime.Objects {
         }
 
         // -
-        public virtual ProcStatus OperatorSubtract(DreamValue b, DMProcState state, out DreamValue? result) {
+        public virtual ProcStatus OperatorSubtract(DreamValue b, DMProcState state, out DreamValue result) {
             if(TryGetProc("operator-", out var proc)) {
                 var operatorProcState = proc.CreateState(state.Thread, this, state.Usr, new DreamProcArguments(b));
                 state.Thread.PushProcState(operatorProcState);
-                result = null;
+                result = DreamValue.Null;
                 return ProcStatus.Called;
             }
 
@@ -392,22 +392,22 @@ namespace OpenDreamRuntime.Objects {
         }
 
         // *
-        public virtual ProcStatus OperatorMultiply(DreamValue b, DMProcState state, out DreamValue? result) {
+        public virtual ProcStatus OperatorMultiply(DreamValue b, DMProcState state, out DreamValue result) {
             if(TryGetProc("operator*", out var proc)) {
                 var operatorProcState = proc.CreateState(state.Thread, this, state.Usr, new DreamProcArguments(b));
                 state.Thread.PushProcState(operatorProcState);
-                result = null;
+                result = DreamValue.Null;
                 return ProcStatus.Called;
             }
 
             throw new InvalidOperationException($"Multiplication cannot be done between {this} and {b}");
         }
 
-        public virtual ProcStatus OperatorDivide(DreamValue b, DMProcState state, out DreamValue? result) {
+        public virtual ProcStatus OperatorDivide(DreamValue b, DMProcState state, out DreamValue result) {
             if(TryGetProc("operator/", out var proc)) {
                 var operatorProcState = proc.CreateState(state.Thread, this, state.Usr, new DreamProcArguments(b));
                 state.Thread.PushProcState(operatorProcState);
-                result = null;
+                result = DreamValue.Null;
                 return ProcStatus.Called;
             }
 
@@ -415,11 +415,11 @@ namespace OpenDreamRuntime.Objects {
         }
 
         // |
-        public virtual ProcStatus OperatorOr(DreamValue b, DMProcState state, out DreamValue? result) {
+        public virtual ProcStatus OperatorOr(DreamValue b, DMProcState state, out DreamValue result) {
             if(TryGetProc("operator|", out var proc)) {
                 var operatorProcState = proc.CreateState(state.Thread, this, state.Usr, new DreamProcArguments(b));
                 state.Thread.PushProcState(operatorProcState);
-                result = null;
+                result = DreamValue.Null;
                 return ProcStatus.Called;
             }
 

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -400,6 +400,16 @@ namespace OpenDreamRuntime.Objects {
             throw new InvalidOperationException($"Multiplication cannot be done between {this} and {b}");
         }
 
+        public virtual ProcStatus OperatorDivide(DreamValue b, DMProcState state, out DreamValue? result) {
+            if(TryGetProc("operator/", out var proc)) {
+                var operatorProcState = proc.CreateState(state.Thread, this, state.Usr, new DreamProcArguments(b));
+                state.Thread.PushProcState(operatorProcState);
+                result = null;
+                return ProcStatus.Called;
+            }
+            throw new InvalidOperationException($"Division cannot be done between {this} and {b}");
+        }
+
         // |
         public virtual ProcStatus OperatorOr(DreamValue b, DMProcState state, out DreamValue? result) {
             if(TryGetProc("operator|", out var proc)) {

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -360,22 +360,46 @@ namespace OpenDreamRuntime.Objects {
 
         #region Operators
         // +
-        public virtual DreamValue OperatorAdd(DreamValue b) {
+        public virtual ProcStatus OperatorAdd(DreamValue b, DMProcState state, out DreamValue? result) {
+            if(TryGetProc("operator+", out var proc)) {
+                var operatorProcState = proc.CreateState(state.Thread, this, state.Usr, new DreamProcArguments(b));
+                state.Thread.PushProcState(operatorProcState);
+                result = null;
+                return ProcStatus.Called;
+            }
             throw new InvalidOperationException($"Addition cannot be done between {this} and {b}");
         }
 
         // -
-        public virtual DreamValue OperatorSubtract(DreamValue b) {
+        public virtual ProcStatus OperatorSubtract(DreamValue b, DMProcState state, out DreamValue? result) {
+            if(TryGetProc("operator-", out var proc)) {
+                var operatorProcState = proc.CreateState(state.Thread, this, state.Usr, new DreamProcArguments(b));
+                state.Thread.PushProcState(operatorProcState);
+                result = null;
+                return ProcStatus.Called;
+            }
             throw new InvalidOperationException($"Subtraction cannot be done between {this} and {b}");
         }
 
         // *
-        public virtual DreamValue OperatorMultiply(DreamValue b) {
+        public virtual ProcStatus OperatorMultiply(DreamValue b, DMProcState state, out DreamValue? result) {
+            if(TryGetProc("operator*", out var proc)) {
+                var operatorProcState = proc.CreateState(state.Thread, this, state.Usr, new DreamProcArguments(b));
+                state.Thread.PushProcState(operatorProcState);
+                result = null;
+                return ProcStatus.Called;
+            }
             throw new InvalidOperationException($"Multiplication cannot be done between {this} and {b}");
         }
 
         // |
-        public virtual DreamValue OperatorOr(DreamValue b) {
+        public virtual ProcStatus OperatorOr(DreamValue b, DMProcState state, out DreamValue? result) {
+            if(TryGetProc("operator|", out var proc)) {
+                var operatorProcState = proc.CreateState(state.Thread, this, state.Usr, new DreamProcArguments(b));
+                state.Thread.PushProcState(operatorProcState);
+                result = null;
+                return ProcStatus.Called;
+            }
             throw new InvalidOperationException($"Cannot or {this} and {b}");
         }
 

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -375,6 +375,7 @@ namespace OpenDreamRuntime.Objects {
                 result = null;
                 return ProcStatus.Called;
             }
+
             throw new InvalidOperationException($"Addition cannot be done between {this} and {b}");
         }
 
@@ -386,6 +387,7 @@ namespace OpenDreamRuntime.Objects {
                 result = null;
                 return ProcStatus.Called;
             }
+
             throw new InvalidOperationException($"Subtraction cannot be done between {this} and {b}");
         }
 
@@ -397,6 +399,7 @@ namespace OpenDreamRuntime.Objects {
                 result = null;
                 return ProcStatus.Called;
             }
+
             throw new InvalidOperationException($"Multiplication cannot be done between {this} and {b}");
         }
 
@@ -407,6 +410,7 @@ namespace OpenDreamRuntime.Objects {
                 result = null;
                 return ProcStatus.Called;
             }
+
             throw new InvalidOperationException($"Division cannot be done between {this} and {b}");
         }
 
@@ -418,6 +422,7 @@ namespace OpenDreamRuntime.Objects {
                 result = null;
                 return ProcStatus.Called;
             }
+
             throw new InvalidOperationException($"Cannot or {this} and {b}");
         }
 

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -247,7 +247,7 @@ public class DreamList : DreamObject {
         SetValue(index, value);
     }
 
-    public override ProcStatus OperatorAdd(DreamValue b, DMProcState state, out DreamValue? result) {
+    public override ProcStatus OperatorAdd(DreamValue b, DMProcState state, out DreamValue result) {
         DreamList listCopy = CreateCopy();
 
         if (b.TryGetValueAsDreamList(out var bList)) {
@@ -266,7 +266,7 @@ public class DreamList : DreamObject {
         return ProcStatus.Continue;
     }
 
-    public override ProcStatus OperatorSubtract(DreamValue b, DMProcState state, out DreamValue? result) {
+    public override ProcStatus OperatorSubtract(DreamValue b, DMProcState state, out DreamValue result) {
         DreamList listCopy = CreateCopy();
 
         if (b.TryGetValueAsDreamList(out var bList)) {
@@ -281,7 +281,7 @@ public class DreamList : DreamObject {
         return ProcStatus.Continue;
     }
 
-    public override ProcStatus OperatorOr(DreamValue b, DMProcState state, out DreamValue? result) {
+    public override ProcStatus OperatorOr(DreamValue b, DMProcState state, out DreamValue result) {
         DreamList list;
 
         if (b.TryGetValueAsDreamList(out var bList)) {  // List | List

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -247,7 +247,7 @@ public class DreamList : DreamObject {
         SetValue(index, value);
     }
 
-    public override DreamValue OperatorAdd(DreamValue b) {
+    public override ProcStatus OperatorAdd(DreamValue b, DMProcState state, out DreamValue? result) {
         DreamList listCopy = CreateCopy();
 
         if (b.TryGetValueAsDreamList(out var bList)) {
@@ -262,10 +262,11 @@ public class DreamList : DreamObject {
             listCopy.AddValue(b);
         }
 
-        return new(listCopy);
+        result = new DreamValue(listCopy);
+        return ProcStatus.Continue;
     }
 
-    public override DreamValue OperatorSubtract(DreamValue b) {
+    public override ProcStatus OperatorSubtract(DreamValue b, DMProcState state, out DreamValue? result) {
         DreamList listCopy = CreateCopy();
 
         if (b.TryGetValueAsDreamList(out var bList)) {
@@ -276,10 +277,11 @@ public class DreamList : DreamObject {
             listCopy.RemoveValue(b);
         }
 
-        return new(listCopy);
+        result = new DreamValue(listCopy);
+        return ProcStatus.Continue;
     }
 
-    public override DreamValue OperatorOr(DreamValue b) {
+    public override ProcStatus OperatorOr(DreamValue b, DMProcState state, out DreamValue? result) {
         DreamList list;
 
         if (b.TryGetValueAsDreamList(out var bList)) {  // List | List
@@ -289,7 +291,8 @@ public class DreamList : DreamObject {
             list.AddValue(b);
         }
 
-        return new(list);
+        result = new DreamValue(list);
+        return ProcStatus.Continue;
     }
 
     public override DreamValue OperatorAppend(DreamValue b) {

--- a/OpenDreamRuntime/Objects/Types/DreamObjectMatrix.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectMatrix.cs
@@ -53,7 +53,7 @@ public sealed class DreamObjectMatrix : DreamObject {
     }
 
     #region Operators
-    public override DreamValue OperatorAdd(DreamValue b) {
+    public override ProcStatus OperatorAdd(DreamValue b, DMProcState state, out DreamValue? result) {
         GetVariable("a").TryGetValueAsFloat(out float lA);
         GetVariable("b").TryGetValueAsFloat(out float lB);
         GetVariable("c").TryGetValueAsFloat(out float lC);
@@ -78,13 +78,14 @@ public sealed class DreamObjectMatrix : DreamObject {
                 lF + rF  // f
             );
 
-            return new DreamValue(output);
+            result = new DreamValue(output);
+            return ProcStatus.Continue;
         }
 
-        return base.OperatorAdd(b);
+        return base.OperatorAdd(b, state, out result);
     }
 
-    public override DreamValue OperatorSubtract(DreamValue b) {
+    public override ProcStatus OperatorSubtract(DreamValue b, DMProcState state, out DreamValue? result) {
         GetVariable("a").TryGetValueAsFloat(out float lA);
         GetVariable("b").TryGetValueAsFloat(out float lB);
         GetVariable("c").TryGetValueAsFloat(out float lC);
@@ -109,13 +110,14 @@ public sealed class DreamObjectMatrix : DreamObject {
                 lF - rF  // f
             );
 
-            return new DreamValue(output);
+            result = new DreamValue(output);
+            return ProcStatus.Continue;
         }
 
-        return base.OperatorSubtract(b);
+        return base.OperatorSubtract(b, state, out result);
     }
 
-    public override DreamValue OperatorMultiply(DreamValue b) {
+    public override ProcStatus OperatorMultiply(DreamValue b, DMProcState state, out DreamValue? result) {
         GetVariable("a").TryGetValueAsFloat(out float lA);
         GetVariable("b").TryGetValueAsFloat(out float lB);
         GetVariable("c").TryGetValueAsFloat(out float lC);
@@ -128,7 +130,8 @@ public sealed class DreamObjectMatrix : DreamObject {
                     lA * bFloat,lB * bFloat,lC * bFloat,
                     lD * bFloat,lE * bFloat,lF * bFloat
                 );
-            return new(output);
+            result = new DreamValue(output);
+            return ProcStatus.Continue;
         } else if (b.TryGetValueAsDreamObject<DreamObjectMatrix>(out var right)) {
             right.GetVariable("a").TryGetValueAsFloat(out float rA);
             right.GetVariable("b").TryGetValueAsFloat(out float rB);
@@ -146,10 +149,11 @@ public sealed class DreamObjectMatrix : DreamObject {
                 rC * lD + rF * lE + lF // f
             );
 
-            return new(output);
+            result = new DreamValue(output);
+            return ProcStatus.Continue;
         }
 
-        return base.OperatorMultiply(b);
+        return base.OperatorMultiply(b, state, out result);
     }
 
     public override DreamValue OperatorEquivalent(DreamValue b) {

--- a/OpenDreamRuntime/Objects/Types/DreamObjectMatrix.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectMatrix.cs
@@ -54,7 +54,7 @@ public sealed class DreamObjectMatrix : DreamObject {
 
     #region Operators
 
-    public override ProcStatus OperatorAdd(DreamValue b, DMProcState state, out DreamValue? result) {
+    public override ProcStatus OperatorAdd(DreamValue b, DMProcState state, out DreamValue result) {
         GetVariable("a").TryGetValueAsFloat(out float lA);
         GetVariable("b").TryGetValueAsFloat(out float lB);
         GetVariable("c").TryGetValueAsFloat(out float lC);
@@ -86,7 +86,7 @@ public sealed class DreamObjectMatrix : DreamObject {
         return base.OperatorAdd(b, state, out result);
     }
 
-    public override ProcStatus OperatorSubtract(DreamValue b, DMProcState state, out DreamValue? result) {
+    public override ProcStatus OperatorSubtract(DreamValue b, DMProcState state, out DreamValue result) {
         GetVariable("a").TryGetValueAsFloat(out float lA);
         GetVariable("b").TryGetValueAsFloat(out float lB);
         GetVariable("c").TryGetValueAsFloat(out float lC);
@@ -118,7 +118,7 @@ public sealed class DreamObjectMatrix : DreamObject {
         return base.OperatorSubtract(b, state, out result);
     }
 
-    public override ProcStatus OperatorMultiply(DreamValue b, DMProcState state, out DreamValue? result) {
+    public override ProcStatus OperatorMultiply(DreamValue b, DMProcState state, out DreamValue result) {
         GetVariable("a").TryGetValueAsFloat(out float lA);
         GetVariable("b").TryGetValueAsFloat(out float lB);
         GetVariable("c").TryGetValueAsFloat(out float lC);

--- a/OpenDreamRuntime/Objects/Types/DreamObjectMatrix.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectMatrix.cs
@@ -53,6 +53,7 @@ public sealed class DreamObjectMatrix : DreamObject {
     }
 
     #region Operators
+
     public override ProcStatus OperatorAdd(DreamValue b, DMProcState state, out DreamValue? result) {
         GetVariable("a").TryGetValueAsFloat(out float lA);
         GetVariable("b").TryGetValueAsFloat(out float lB);

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1041,6 +1041,7 @@ namespace OpenDreamRuntime.Procs {
                 if (secondFloat == 0) {
                     throw new Exception("Division by zero");
                 }
+
                 state.Push(new(firstFloat / secondFloat));
             } else if (first.TryGetValueAsDreamObject(out var firstDreamObject)) {
                 ProcStatus result = firstDreamObject!.OperatorMultiply(second, state, out DreamValue? maybeOutput);

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1044,7 +1044,7 @@ namespace OpenDreamRuntime.Procs {
 
                 state.Push(new(firstFloat / secondFloat));
             } else if (first.TryGetValueAsDreamObject<DreamObject>(out var firstDreamObject)) {
-                ProcStatus result = firstDreamObject!.OperatorMultiply(second, state, out DreamValue maybeOutput);
+                ProcStatus result = firstDreamObject.OperatorMultiply(second, state, out DreamValue maybeOutput);
                 if (result == ProcStatus.Continue) {
                     state.Push(maybeOutput);
                 } else {

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -685,10 +685,10 @@ namespace OpenDreamRuntime.Procs {
                 output = second;
             } else if (first.TryGetValueAsDreamResource(out _) || first.TryGetValueAsDreamObject<DreamObjectIcon>(out _)) {
                 output = IconOperationAdd(state, first, second);
-            } else if (first.TryGetValueAsDreamObject(out var firstDreamObject)) {
-                ProcStatus result = firstDreamObject!.OperatorAdd(second, state, out DreamValue? maybeOutput);
+            } else if (first.TryGetValueAsDreamObject<DreamObject>(out var firstDreamObject)) {
+                ProcStatus result = firstDreamObject.OperatorAdd(second, state, out DreamValue maybeOutput);
                 if (result == ProcStatus.Continue) {
-                    output = maybeOutput!.Value;
+                    output = maybeOutput;
                 } else {
                     return result;
                 }
@@ -847,11 +847,11 @@ namespace OpenDreamRuntime.Procs {
             DreamValue second = state.Pop();
             DreamValue first = state.Pop();
 
-            if (first.TryGetValueAsDreamObject(out DreamObject? firstDreamObject)) {              // Object | y
+            if (first.TryGetValueAsDreamObject<DreamObject>(out var firstDreamObject)) {              // Object | y
                 if (!first.IsNull) {
-                    ProcStatus result = firstDreamObject!.OperatorOr(second, state, out DreamValue? maybeOutput);
+                    ProcStatus result = firstDreamObject.OperatorOr(second, state, out DreamValue maybeOutput);
                     if (result == ProcStatus.Continue) {
-                        state.Push(maybeOutput!.Value);
+                        state.Push(maybeOutput);
                     } else {
                         return result;
                     }
@@ -1043,10 +1043,10 @@ namespace OpenDreamRuntime.Procs {
                 }
 
                 state.Push(new(firstFloat / secondFloat));
-            } else if (first.TryGetValueAsDreamObject(out var firstDreamObject)) {
-                ProcStatus result = firstDreamObject!.OperatorMultiply(second, state, out DreamValue? maybeOutput);
+            } else if (first.TryGetValueAsDreamObject<DreamObject>(out var firstDreamObject)) {
+                ProcStatus result = firstDreamObject!.OperatorMultiply(second, state, out DreamValue maybeOutput);
                 if (result == ProcStatus.Continue) {
-                    state.Push(maybeOutput!.Value);
+                    state.Push(maybeOutput);
                 } else {
                     return result;
                 }
@@ -1140,10 +1140,10 @@ namespace OpenDreamRuntime.Procs {
             if (first.TryGetValueAsFloat(out var firstFloat) || first.IsNull) {
                 var secondFloat = second.UnsafeGetValueAsFloat(); // Non-numbers are always treated as 0 here
                 state.Push(new DreamValue(firstFloat * secondFloat));
-            } else if (first.TryGetValueAsDreamObject(out var firstDreamObject)) {
-                ProcStatus result = firstDreamObject!.OperatorMultiply(second, state, out DreamValue? maybeOutput);
+            } else if (first.TryGetValueAsDreamObject<DreamObject>(out var firstDreamObject)) {
+                ProcStatus result = firstDreamObject.OperatorMultiply(second, state, out DreamValue maybeOutput);
                 if (result == ProcStatus.Continue) {
-                    state.Push(maybeOutput!.Value);
+                    state.Push(maybeOutput);
                 } else {
                     return result;
                 }
@@ -1227,10 +1227,10 @@ namespace OpenDreamRuntime.Procs {
                 if (second.TryGetValueAsFloat(out var secondFloat) || second.IsNull) {
                     output = new(firstFloat - secondFloat);
                 }
-            } else if (first.TryGetValueAsDreamObject(out var firstObject)) {
-                ProcStatus result = firstObject!.OperatorSubtract(second, state, out DreamValue? maybeOutput);
+            } else if (first.TryGetValueAsDreamObject<DreamObject>(out var firstObject)) {
+                ProcStatus result = firstObject.OperatorSubtract(second, state, out DreamValue maybeOutput);
                 if (result == ProcStatus.Continue) {
-                    output = maybeOutput!.Value;
+                    output = maybeOutput;
                 } else {
                     return result;
                 }

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1035,8 +1035,23 @@ namespace OpenDreamRuntime.Procs {
         public static ProcStatus Divide(DMProcState state) {
             DreamValue second = state.Pop();
             DreamValue first = state.Pop();
-
-            state.Push(DivideValues(first, second));
+            if (first.IsNull) {
+                state.Push(new(0));
+            } else if (first.TryGetValueAsFloat(out var firstFloat) && second.TryGetValueAsFloat(out var secondFloat)) {
+                if (secondFloat == 0) {
+                    throw new Exception("Division by zero");
+                }
+                state.Push(new(firstFloat / secondFloat));
+            } else if (first.TryGetValueAsDreamObject(out var firstDreamObject)) {
+                ProcStatus result = firstDreamObject!.OperatorMultiply(second, state, out DreamValue? maybeOutput);
+                if (result == ProcStatus.Continue) {
+                    state.Push(maybeOutput!.Value);
+                } else {
+                    return result;
+                }
+            } else {
+                throw new Exception($"Invalid multiply operation on {first} and {second}");
+            }
             return ProcStatus.Continue;
         }
 


### PR DESCRIPTION
I swore I wouldn't do this again, but here we are.

Implements +, -, *,/, and | operator overloads because they were very easy.

I'm gonna do it in small parts this time. Next PR I'll clean up some of DMOpcodeHandler

Cleans up the emitted warning so that it tells you what operator is not implemented ie 
```
Warning OD0000 at Camera.dm:132:18: operator"" overloads are not implemented. They will be defined but never called.
```
