### PR TITLE
Make `browse_rsc()` respect cache

### DIFF
--- a/OpenDreamClient/Interface/Controls/ControlBrowser.cs
+++ b/OpenDreamClient/Interface/Controls/ControlBrowser.cs
@@ -113,7 +113,10 @@ internal sealed class ControlBrowser : InterfaceControl {
             Stream stream;
             HttpStatusCode status;
             var path = new ResPath(newUri.AbsolutePath);
-            try {
+            if(!_dreamResource.EnsureCacheFile(newUri.AbsolutePath)) {
+                stream = Stream.Null;
+                status = HttpStatusCode.NotFound;
+            } else try {
                 stream = _resourceManager.UserData.OpenRead(_dreamResource.GetCacheFilePath(newUri.AbsolutePath));
                 status = HttpStatusCode.OK;
             } catch (FileNotFoundException) {

--- a/OpenDreamClient/Interface/Controls/ControlBrowser.cs
+++ b/OpenDreamClient/Interface/Controls/ControlBrowser.cs
@@ -116,16 +116,18 @@ internal sealed class ControlBrowser : InterfaceControl {
             if(!_dreamResource.EnsureCacheFile(newUri.AbsolutePath)) {
                 stream = Stream.Null;
                 status = HttpStatusCode.NotFound;
-            } else try {
-                stream = _resourceManager.UserData.OpenRead(_dreamResource.GetCacheFilePath(newUri.AbsolutePath));
-                status = HttpStatusCode.OK;
-            } catch (FileNotFoundException) {
-                stream = Stream.Null;
-                status = HttpStatusCode.NotFound;
-            } catch (Exception e) {
-                _sawmill.Error($"Exception while loading file from {newUri}:\n{e}");
-                stream = Stream.Null;
-                status = HttpStatusCode.InternalServerError;
+            } else {
+                try {
+                    stream = _resourceManager.UserData.OpenRead(_dreamResource.GetCacheFilePath(newUri.AbsolutePath));
+                    status = HttpStatusCode.OK;
+                } catch (FileNotFoundException) {
+                    stream = Stream.Null;
+                    status = HttpStatusCode.NotFound;
+                } catch (Exception e) {
+                    _sawmill.Error($"Exception while loading file from {newUri}:\n{e}");
+                    stream = Stream.Null;
+                    status = HttpStatusCode.InternalServerError;
+                }
             }
 
             if (!FileExtensionMimeTypes.TryGetValue(path.Extension, out var mimeType))

--- a/OpenDreamClient/Resources/DreamResourceManager.cs
+++ b/OpenDreamClient/Resources/DreamResourceManager.cs
@@ -70,7 +70,6 @@ namespace OpenDreamClient.Resources {
             _sawmill.Debug($"Received cache check for {message.Filename}");
             if(_resourceManager.UserData.Exists(GetCacheFilePath(message.Filename))){ //TODO CHECK HASH
                 _sawmill.Debug($"Cache hit for {message.Filename}");
-                return;
             } else {
                 _sawmill.Debug($"Cache miss for {message.Filename}, requesting from server.");
                 _activeBrowseRscRequests.Add(message.Filename);

--- a/OpenDreamClient/Resources/DreamResourceManager.cs
+++ b/OpenDreamClient/Resources/DreamResourceManager.cs
@@ -4,7 +4,6 @@ using OpenDreamClient.Resources.ResourceTypes;
 using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
 using Robust.Shared.Network;
-using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace OpenDreamClient.Resources {
@@ -23,6 +22,7 @@ namespace OpenDreamClient.Resources {
         /// <typeparam name="T">The type of resource to load as.</typeparam>
         void LoadResourceAsync<T>(int resourceId, Action<T> onLoadCallback) where T : DreamResource;
         ResPath GetCacheFilePath(string filename);
+        public bool EnsureCacheFile(string filename, int timeoutSeconds = 5);
     }
 
     internal sealed class DreamResourceManager : IDreamResourceManager {
@@ -38,11 +38,14 @@ namespace OpenDreamClient.Resources {
 
         private ISawmill _sawmill = default!;
 
+        private readonly HashSet<string> _activeBrowseRscRequests = new();
+
         public void Initialize() {
             _sawmill = Logger.GetSawmill("opendream.res");
             InitCacheDirectory();
 
             _netManager.RegisterNetMessage<MsgBrowseResource>(RxBrowseResource);
+            _netManager.RegisterNetMessage<MsgBrowseResourceResponse>(RxBrowseResourceResponse);
             _netManager.RegisterNetMessage<MsgRequestResource>();
             _netManager.RegisterNetMessage<MsgResource>(RxResource);
         }
@@ -64,7 +67,24 @@ namespace OpenDreamClient.Resources {
         }
 
         private void RxBrowseResource(MsgBrowseResource message) {
-            CreateCacheFile(message.Filename, message.Data);
+            _sawmill.Debug($"Received cache check for {message.Filename}");
+            if(_resourceManager.UserData.Exists(GetCacheFilePath(message.Filename))){ //TODO CHECK HASH
+                _sawmill.Debug($"Cache hit for {message.Filename}");
+                return;
+            } else {
+                _sawmill.Debug($"Cache miss for {message.Filename}, requesting from server.");
+                _activeBrowseRscRequests.Add(message.Filename);
+                _netManager.ServerChannel?.SendMessage(new MsgBrowseResourceRequest(){ Filename = message.Filename});
+            }
+        }
+
+        private void RxBrowseResourceResponse(MsgBrowseResourceResponse message) {
+            if(_activeBrowseRscRequests.Contains(message.Filename)) {
+                _activeBrowseRscRequests.Remove(message.Filename);
+                CreateCacheFile(message.Filename, message.Data);
+            } else {
+                _sawmill.Error($"Recieved a browse_rsc response for a file we didn't ask for: {message.Filename}");
+            }
         }
 
         private void RxResource(MsgResource message) {
@@ -121,7 +141,7 @@ namespace OpenDreamClient.Resources {
                 _netManager.ClientSendMessage(msg);
 
                 var timeout = _cfg.GetCVar(OpenDreamCVars.DownloadTimeout);
-                Timer.Spawn(TimeSpan.FromSeconds(timeout), () => {
+                Robust.Shared.Timing.Timer.Spawn(TimeSpan.FromSeconds(timeout), () => {
                     if (_loadingResources.ContainsKey(resourceId)) {
                         _sawmill.Warning(
                             $"Resource id {resourceId} was requested, but is still not received {timeout} seconds later.");
@@ -161,6 +181,31 @@ namespace OpenDreamClient.Resources {
             var path = _cacheDirectory / new ResPath(filename).Filename;
             _resourceManager.UserData.WriteAllBytes(path, data);
             return new ResPath(filename);
+        }
+
+        /// <summary>
+        /// Blocking check for the existence of a cached file from `browse_rsc()`. Returns true when the file is ready, or returns false if the file is not ready within timeoutSeconds.
+        /// </summary>
+        /// <param name="filename">filepath of the cached resource (eg `./foo.png`)</param>
+        /// <param name="timeoutSeconds">how long to block for while waiting for the resource. Default 5 seconds.</param>
+        /// <returns></returns>
+        public bool EnsureCacheFile(string filename, int timeoutSeconds = 5) {
+            var actualPath = GetCacheFilePath(filename);
+            if(_resourceManager.UserData.Exists(actualPath)) {
+                return true;
+            } else {
+                if(_activeBrowseRscRequests.Contains(actualPath.Filename)) {
+                    //block until the file arrives for like 5 seconds, then give up
+                    DateTime thresholdTime = DateTime.Now.AddSeconds(timeoutSeconds);
+                    while(!_resourceManager.UserData.Exists(actualPath) && DateTime.Now < thresholdTime) {
+                        _netManager.ProcessPackets(); //todo this should be sleep
+                    }
+                    return _resourceManager.UserData.Exists(actualPath);
+                } else {
+                    _sawmill.Error("Cache was ensured for a file that does not exist in cache and is not requested. Probably someobody called browse() without browse_rsc() first.");
+                    return false;
+                }
+            }
         }
 
         private DreamResource? GetCachedResource(int resourceId) {

--- a/OpenDreamRuntime/DreamManager.Connections.cs
+++ b/OpenDreamRuntime/DreamManager.Connections.cs
@@ -54,6 +54,8 @@ namespace OpenDreamRuntime {
             _netManager.RegisterNetMessage<MsgPromptList>();
             _netManager.RegisterNetMessage<MsgPromptResponse>(RxPromptResponse);
             _netManager.RegisterNetMessage<MsgBrowseResource>();
+            _netManager.RegisterNetMessage<MsgBrowseResourceRequest>(RxBrowseResourceRequest);
+            _netManager.RegisterNetMessage<MsgBrowseResourceResponse>();
             _netManager.RegisterNetMessage<MsgBrowse>();
             _netManager.RegisterNetMessage<MsgTopic>(RxTopic);
             _netManager.RegisterNetMessage<MsgWinSet>();
@@ -222,6 +224,11 @@ namespace OpenDreamRuntime {
             // Once the client loaded the interface, move them to in-game.
             var player = _playerManager.GetSessionByChannel(message.MsgChannel);
             _playerManager.JoinGame(player);
+        }
+
+        private void RxBrowseResourceRequest(MsgBrowseResourceRequest message) {
+            var connection = ConnectionForChannel(message.MsgChannel);
+            connection.HandleBrowseResourceRequest(message.Filename);
         }
 
         private DreamConnection ConnectionForChannel(INetChannel channel) {

--- a/OpenDreamShared/Network/Messages/MsgBrowseResource.cs
+++ b/OpenDreamShared/Network/Messages/MsgBrowseResource.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Lidgren.Network;
+﻿using Lidgren.Network;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 

--- a/OpenDreamShared/Network/Messages/MsgBrowseResource.cs
+++ b/OpenDreamShared/Network/Messages/MsgBrowseResource.cs
@@ -8,7 +8,7 @@ public sealed class MsgBrowseResource : NetMessage {
     // TODO: Browse should be on its own channel or something.
     public override MsgGroups MsgGroup => MsgGroups.EntityEvent;
 
-    public string Filename = String.Empty;
+    public string Filename = string.Empty;
     public int DataHash;
 
     public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer) {

--- a/OpenDreamShared/Network/Messages/MsgBrowseResourceRequest.cs
+++ b/OpenDreamShared/Network/Messages/MsgBrowseResourceRequest.cs
@@ -1,4 +1,3 @@
-using System;
 using Lidgren.Network;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;

--- a/OpenDreamShared/Network/Messages/MsgBrowseResourceRequest.cs
+++ b/OpenDreamShared/Network/Messages/MsgBrowseResourceRequest.cs
@@ -1,23 +1,20 @@
-﻿using System;
+using System;
 using Lidgren.Network;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
 namespace OpenDreamShared.Network.Messages;
-public sealed class MsgBrowseResource : NetMessage {
+public sealed class MsgBrowseResourceRequest : NetMessage {
     // TODO: Browse should be on its own channel or something.
     public override MsgGroups MsgGroup => MsgGroups.EntityEvent;
 
     public string Filename = String.Empty;
-    public int DataHash;
 
     public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer) {
         Filename = buffer.ReadString();
-        DataHash = buffer.ReadVariableInt32();
     }
 
     public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer) {
         buffer.Write(Filename);
-        buffer.WriteVariableInt32(DataHash);
     }
 }

--- a/OpenDreamShared/Network/Messages/MsgBrowseResourceRequest.cs
+++ b/OpenDreamShared/Network/Messages/MsgBrowseResourceRequest.cs
@@ -8,7 +8,7 @@ public sealed class MsgBrowseResourceRequest : NetMessage {
     // TODO: Browse should be on its own channel or something.
     public override MsgGroups MsgGroup => MsgGroups.EntityEvent;
 
-    public string Filename = String.Empty;
+    public string Filename = string.Empty;
 
     public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer) {
         Filename = buffer.ReadString();

--- a/OpenDreamShared/Network/Messages/MsgBrowseResourceResponse.cs
+++ b/OpenDreamShared/Network/Messages/MsgBrowseResourceResponse.cs
@@ -8,8 +8,8 @@ public sealed class MsgBrowseResourceResponse : NetMessage {
     // TODO: Browse should be on its own channel or something.
     public override MsgGroups MsgGroup => MsgGroups.EntityEvent;
 
-    public string Filename = String.Empty;
-    public byte[] Data = Array.Empty<byte>();
+    public string Filename = string.Empty;
+    public byte[] Data = [];
 
     public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer) {
         Filename = buffer.ReadString();

--- a/OpenDreamShared/Network/Messages/MsgBrowseResourceResponse.cs
+++ b/OpenDreamShared/Network/Messages/MsgBrowseResourceResponse.cs
@@ -1,23 +1,25 @@
-﻿using System;
+using System;
 using Lidgren.Network;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
 namespace OpenDreamShared.Network.Messages;
-public sealed class MsgBrowseResource : NetMessage {
+public sealed class MsgBrowseResourceResponse : NetMessage {
     // TODO: Browse should be on its own channel or something.
     public override MsgGroups MsgGroup => MsgGroups.EntityEvent;
 
     public string Filename = String.Empty;
-    public int DataHash;
+    public byte[] Data = Array.Empty<byte>();
 
     public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer) {
         Filename = buffer.ReadString();
-        DataHash = buffer.ReadVariableInt32();
+        var bytes = buffer.ReadVariableInt32();
+        Data = buffer.ReadBytes(bytes);
     }
 
     public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer) {
         buffer.Write(Filename);
-        buffer.WriteVariableInt32(DataHash);
+        buffer.WriteVariableInt32(Data.Length);
+        buffer.Write(Data);
     }
 }

--- a/OpenDreamShared/Network/Messages/MsgBrowseResourceResponse.cs
+++ b/OpenDreamShared/Network/Messages/MsgBrowseResourceResponse.cs
@@ -1,4 +1,3 @@
-using System;
 using Lidgren.Network;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -48,6 +48,9 @@
 		usr << "menus: [json_encode(winget(usr, null, "menus"))]"
 		usr << "macros: [json_encode(winget(usr, null, "macros"))]"
 
+	verb/browse_rsc_test()
+		usr << browse_rsc('icons/mob.dmi', "mobicon.png")
+		usr << browse("<p><img src=mobicon.png></p>Oh look, it's you!","window=honk")
 
 	verb/rotate()
 		for(var/i in 1 to 8)


### PR DESCRIPTION
For BYOND, calling `browse_rsc()` should be basically free if the resource already exists on the client. For OD, we were sending the whole file every time. This was very bad for goonstation's performance when a client joined, because it would basically send 40mb of crap every time and hang the client while it was doing so.

Note that `browse()` is supposed to block until `browse_rsc()` is complete, while `output()` is not (according to searches of the BYOND discord).

It's hard to test how much impact this will have locally, but from my testing it should probably shave off like 60 seconds from subsequent joins. Now we just need to sort out the shedload of appearances that get sent.