### PR TITLE
Add new optional lint for weighted pick() syntax

### DIFF
--- a/DMCompiler/Compiler/CompilerError.cs
+++ b/DMCompiler/Compiler/CompilerError.cs
@@ -69,6 +69,7 @@ public enum WarningCode {
     UnsafeClientAccess = 3200,
     SuspiciousSwitchCase = 3201, // "else if" cases are actually valid DM, they just spontaneously end the switch context and begin an if-else ladder within the else case of the switch
     AssignmentInConditional = 3202,
+    PickWeightedSyntax = 3203,
 
     // 4000 - 4999 are reserved for runtime configuration. (TODO: Runtime doesn't know about configs yet!)
 }

--- a/DMCompiler/DM/Expressions/Builtins.cs
+++ b/DMCompiler/DM/Expressions/Builtins.cs
@@ -263,6 +263,8 @@ namespace DMCompiler.DM.Expressions {
                     DMCompiler.ForcedWarning(Location, "Weighted pick() with one argument");
                 }
 
+                DMCompiler.Emit(WarningCode.PickWeightedSyntax, Location, "Use of weighted pick() syntax");
+
                 foreach (PickValue pickValue in _values) {
                     DMExpression weight = pickValue.Weight ?? DMExpression.Create(dmObject, proc, new DMASTConstantInteger(Location, 100)); //Default of 100
 

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -45,3 +45,4 @@
 #pragma EmptyProc disabled // NOTE: If you enable this in OD's default pragma config file, it will emit for OD's DMStandard. Put it in your codebase's pragma config file.
 #pragma UnsafeClientAccess disabled // NOTE: Only checks for unsafe accesses like "client.foobar" and doesn't consider if the client was already null-checked earlier in the proc
 #pragma AssignmentInConditional warning 
+#pragma PickWeightedSyntax disabled


### PR DESCRIPTION
This adds a new opinionated lint, PickWeightedSyntax / 3203, that is thrown whenever the "weighted" pick syntax, such as `pick(4;0, 3;1, 2;2, 1;3)`, is used.

It's disabled by default.

![2024-06-01 (1717291388) ~ WindowsTerminal](https://github.com/OpenDreamProject/OpenDream/assets/65794972/e480c4ed-5341-4271-8f5c-9a9986af92d1)
