### PR TITLE
Cache icon renders between frames

### DIFF
--- a/OpenDreamClient/Input/ContextMenu/ContextMenuItem.xaml.cs
+++ b/OpenDreamClient/Input/ContextMenu/ContextMenuItem.xaml.cs
@@ -25,7 +25,7 @@ internal sealed partial class ContextMenuItem : PanelContainer {
         NameLabel.Margin = new Thickness(2, 0, 4, 0);
         NameLabel.Text = metadata.EntityName;
 
-        Icon.Texture = sprite.Icon.CurrentFrame;
+        Icon.Texture = sprite.Icon.CachedTexture;
     }
 
     protected override void MouseEntered() {

--- a/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
+++ b/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
@@ -19,6 +19,7 @@ internal sealed class ClientAppearanceSystem : SharedAppearanceSystem {
     [Dependency] private readonly IDreamResourceManager _dreamResourceManager = default!;
     [Dependency] private readonly TransformSystem _transformSystem = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly IClyde _clyde = default!;
 
     public override void Initialize() {
         SubscribeNetworkEvent<AllAppearancesEvent>(OnAllAppearances);
@@ -49,7 +50,7 @@ internal sealed class ClientAppearanceSystem : SharedAppearanceSystem {
         int appearanceId = turfId - 1;
 
         if (!_turfIcons.TryGetValue(appearanceId, out var icon)) {
-            icon = new DreamIcon(_gameTiming, this, appearanceId);
+            icon = new DreamIcon(_gameTiming, _clyde, this, appearanceId);
             _turfIcons.Add(appearanceId, icon);
         }
 

--- a/OpenDreamClient/Rendering/DMISpriteSystem.cs
+++ b/OpenDreamClient/Rendering/DMISpriteSystem.cs
@@ -15,6 +15,7 @@ public sealed class DMISpriteSystem : EntitySystem {
     public override void Initialize() {
         SubscribeLocalEvent<DMISpriteComponent, ComponentAdd>(HandleComponentAdd);
         SubscribeLocalEvent<DMISpriteComponent, ComponentHandleState>(HandleComponentState);
+        SubscribeLocalEvent<DMISpriteComponent, ComponentRemove>(HandleComponentRemove);
     }
 
     private void OnIconSizeChanged(EntityUid uid) {
@@ -34,5 +35,9 @@ public sealed class DMISpriteSystem : EntitySystem {
 
         component.ScreenLocation = state.ScreenLocation;
         component.Icon.SetAppearance(state.AppearanceId);
+    }
+
+    private static void HandleComponentRemove(EntityUid uid, DMISpriteComponent component, ref ComponentRemove args) {
+        component.Icon.Dispose();
     }
 }

--- a/OpenDreamClient/Rendering/DMISpriteSystem.cs
+++ b/OpenDreamClient/Rendering/DMISpriteSystem.cs
@@ -1,4 +1,5 @@
 ﻿using OpenDreamShared.Rendering;
+using Robust.Client.Graphics;
 using Robust.Shared.GameStates;
 using Robust.Shared.Timing;
 
@@ -9,6 +10,7 @@ public sealed class DMISpriteSystem : EntitySystem {
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly EntityLookupSystem _lookupSystem = default!;
     [Dependency] private readonly ClientAppearanceSystem _appearanceSystem = default!;
+    [Dependency] private readonly IClyde _clyde = default!;
 
     public override void Initialize() {
         SubscribeLocalEvent<DMISpriteComponent, ComponentAdd>(HandleComponentAdd);
@@ -21,7 +23,7 @@ public sealed class DMISpriteSystem : EntitySystem {
     }
 
     private void HandleComponentAdd(EntityUid uid, DMISpriteComponent component, ref ComponentAdd args) {
-        component.Icon = new DreamIcon(_gameTiming, _appearanceSystem);
+        component.Icon = new DreamIcon(_gameTiming, _clyde, _appearanceSystem);
         component.Icon.SizeChanged += () => OnIconSizeChanged(uid);
     }
 

--- a/OpenDreamClient/Rendering/DreamIcon.cs
+++ b/OpenDreamClient/Rendering/DreamIcon.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace OpenDreamClient.Rendering;
 
-internal sealed class DreamIcon(IGameTiming gameTiming, ClientAppearanceSystem appearanceSystem) {
+internal sealed class DreamIcon(IGameTiming gameTiming, IClyde clyde, ClientAppearanceSystem appearanceSystem) {
     public delegate void SizeChangedEventHandler();
 
     public List<DreamIcon> Overlays { get; } = new();
@@ -34,24 +34,89 @@ internal sealed class DreamIcon(IGameTiming gameTiming, ClientAppearanceSystem a
     public IconAppearance? Appearance {
         get => CalculateAnimatedAppearance();
         private set {
+            if (_appearance?.Equals(value) is true)
+                return;
+
             _appearance = value;
             UpdateIcon();
         }
     }
     private IconAppearance? _appearance;
 
-    public AtlasTexture? CurrentFrame => (Appearance == null || DMI == null)
-        ? null
-        : DMI.GetState(Appearance.IconState)?.GetFrames(Appearance.Direction)[AnimationFrame];
+    public Texture? CachedTexture => _pong?.Texture;
 
     private int _animationFrame;
     private TimeSpan _animationFrameTime = gameTiming.CurTime;
     private List<AppearanceAnimation>? _appearanceAnimations;
     private Box2? _cachedAABB;
+    private IRenderTexture? _ping, _pong;
+    private bool _textureDirty = true;
 
-    public DreamIcon(IGameTiming gameTiming, ClientAppearanceSystem appearanceSystem, int appearanceId,
-        AtomDirection? parentDir = null) : this(gameTiming, appearanceSystem) {
+    public DreamIcon(IGameTiming gameTiming, IClyde clyde, ClientAppearanceSystem appearanceSystem, int appearanceId,
+        AtomDirection? parentDir = null) : this(gameTiming, clyde, appearanceSystem) {
         SetAppearance(appearanceId, parentDir);
+    }
+
+    public Texture? GetTexture(DreamViewOverlay viewOverlay, DrawingHandleWorld handle, RendererMetaData iconMetaData) {
+        if (Appearance == null || DMI == null)
+            return null;
+
+        var animationFrame = AnimationFrame;
+        if (_pong != null && !_textureDirty)
+            return _pong.Texture;
+
+        var frame = DMI.GetState(Appearance.IconState)?.GetFrames(Appearance.Direction)[animationFrame];
+        if (frame == null)
+            return null;
+        if ((Appearance.Filters.Count == 0 && iconMetaData.ColorToApply == Color.White &&
+             iconMetaData.ColorMatrixToApply.Equals(ColorMatrix.Identity)))
+            return frame;
+
+        _textureDirty = false;
+
+        return GetTextureInner(viewOverlay, handle, iconMetaData, frame);
+    }
+
+    private Texture GetTextureInner(DreamViewOverlay viewOverlay, DrawingHandleWorld handle, RendererMetaData iconMetaData, AtlasTexture frame) {
+        //first we do ping pong rendering for the multiple filters
+        if (_ping?.Size != frame.Size * 2 || _pong == null) {
+            // TODO: This should determine the size from the filters and their settings, not just double the original
+            _ping = clyde.CreateRenderTarget(frame.Size * 2, new(RenderTargetColorFormat.Rgba8Srgb));
+            _pong = clyde.CreateRenderTarget(_ping.Size, new(RenderTargetColorFormat.Rgba8Srgb));
+        }
+
+        handle.RenderInRenderTarget(_pong, () => {
+            //we can use the color matrix shader here, since we don't need to blend
+            //also because blend mode is none, we don't need to clear
+            var colorMatrix = iconMetaData.ColorMatrixToApply.Equals(ColorMatrix.Identity)
+                ? new ColorMatrix(iconMetaData.ColorToApply.WithAlpha(iconMetaData.AlphaToApply))
+                : iconMetaData.ColorMatrixToApply;
+
+            ShaderInstance colorShader = DreamViewOverlay.ColorInstance.Duplicate();
+            colorShader.SetParameter("colorMatrix", colorMatrix.GetMatrix4());
+            colorShader.SetParameter("offsetVector", colorMatrix.GetOffsetVector());
+            colorShader.SetParameter("isPlaneMaster",iconMetaData.IsPlaneMaster);
+            handle.UseShader(colorShader);
+
+            handle.SetTransform(DreamViewOverlay.CreateRenderTargetFlipMatrix(_pong.Size, frame.Size / 2));
+            handle.DrawTextureRect(frame, new Box2(Vector2.Zero, frame.Size));
+        }, Color.Black.WithAlpha(0));
+
+        foreach (DreamFilter filterId in iconMetaData.MainIcon!.Appearance!.Filters) {
+            ShaderInstance s = appearanceSystem.GetFilterShader(filterId, viewOverlay.RenderSourceLookup);
+
+            handle.RenderInRenderTarget(_ping, () => {
+                handle.UseShader(s);
+
+                // Technically this should be ping.Size, but they are the same size so avoid the extra closure alloc
+                handle.SetTransform(DreamViewOverlay.CreateRenderTargetFlipMatrix(_pong.Size, Vector2.Zero));
+                handle.DrawTextureRect(_pong.Texture, new Box2(Vector2.Zero, _pong.Size));
+            }, Color.Black.WithAlpha(0));
+
+            (_ping, _pong) = (_pong, _ping);
+        }
+
+        return _pong.Texture;
     }
 
     public void SetAppearance(int? appearanceId, AtomDirection? parentDir = null) {
@@ -138,6 +203,7 @@ internal sealed class DreamIcon(IGameTiming gameTiming, ClientAppearanceSystem a
             return;
         DMIParser.ParsedDMIFrame[] frames = dmiState.GetFrames(Appearance.Direction);
 
+        if (frames.Length <= 1) return;
         if (_animationFrame == frames.Length - 1 && !dmiState.Loop) return;
 
         TimeSpan elapsedTime = gameTiming.CurTime.Subtract(_animationFrameTime);
@@ -145,6 +211,7 @@ internal sealed class DreamIcon(IGameTiming gameTiming, ClientAppearanceSystem a
             elapsedTime -= frames[_animationFrame].Delay;
             _animationFrameTime += frames[_animationFrame].Delay;
             _animationFrame++;
+            _textureDirty = true;
 
             if (_animationFrame >= frames.Length) _animationFrame -= frames.Length;
         }
@@ -350,6 +417,8 @@ internal sealed class DreamIcon(IGameTiming gameTiming, ClientAppearanceSystem a
     }
 
     private void UpdateIcon() {
+        _textureDirty = true;
+
         if (Appearance == null) {
             DMI = null;
             return;
@@ -369,7 +438,7 @@ internal sealed class DreamIcon(IGameTiming gameTiming, ClientAppearanceSystem a
 
         Overlays.Clear();
         foreach (int overlayId in Appearance.Overlays) {
-            DreamIcon overlay = new DreamIcon(gameTiming, appearanceSystem, overlayId, Appearance.Direction);
+            DreamIcon overlay = new DreamIcon(gameTiming, clyde, appearanceSystem, overlayId, Appearance.Direction);
             overlay.SizeChanged += CheckSizeChange;
 
             Overlays.Add(overlay);
@@ -377,7 +446,7 @@ internal sealed class DreamIcon(IGameTiming gameTiming, ClientAppearanceSystem a
 
         Underlays.Clear();
         foreach (int underlayId in Appearance.Underlays) {
-            DreamIcon underlay = new DreamIcon(gameTiming, appearanceSystem, underlayId, Appearance.Direction);
+            DreamIcon underlay = new DreamIcon(gameTiming, clyde, appearanceSystem, underlayId, Appearance.Direction);
             underlay.SizeChanged += CheckSizeChange;
 
             Underlays.Add(underlay);

--- a/OpenDreamClient/Rendering/DreamIcon.cs
+++ b/OpenDreamClient/Rendering/DreamIcon.cs
@@ -70,7 +70,7 @@ internal sealed class DreamIcon(IGameTiming gameTiming, IClyde clyde, ClientAppe
         if (frame == null) {
             CachedTexture = null;
         } else if ((Appearance.Filters.Count == 0 && iconMetaData.ColorToApply == Color.White &&
-             iconMetaData.ColorMatrixToApply.Equals(ColorMatrix.Identity))) {
+             iconMetaData.ColorMatrixToApply.Equals(ColorMatrix.Identity)) && iconMetaData.AlphaToApply.Equals(1.0f)) {
             TextureRenderOffset = Vector2.Zero;
             CachedTexture = frame;
         } else {

--- a/OpenDreamClient/Rendering/DreamIcon.cs
+++ b/OpenDreamClient/Rendering/DreamIcon.cs
@@ -58,15 +58,15 @@ internal sealed class DreamIcon(IGameTiming gameTiming, IClyde clyde, ClientAppe
         SetAppearance(appearanceId, parentDir);
     }
 
-    public Texture? GetTexture(DreamViewOverlay viewOverlay, DrawingHandleWorld handle, RendererMetaData iconMetaData) {
+    public Texture? GetTexture(DreamViewOverlay viewOverlay, DrawingHandleWorld handle, RendererMetaData iconMetaData, Texture? textureOverride = null) {
         if (Appearance == null || DMI == null)
-            return null;
+            return textureOverride;
 
         var animationFrame = AnimationFrame;
-        if (CachedTexture != null && !_textureDirty)
+        if (textureOverride == null && CachedTexture != null && !_textureDirty)
             return CachedTexture;
 
-        var frame = DMI.GetState(Appearance.IconState)?.GetFrames(Appearance.Direction)[animationFrame];
+        var frame = textureOverride ?? DMI.GetState(Appearance.IconState)?.GetFrames(Appearance.Direction)[animationFrame];
         if (frame == null) {
             CachedTexture = null;
         } else if ((Appearance.Filters.Count == 0 && iconMetaData.ColorToApply == Color.White &&
@@ -77,11 +77,13 @@ internal sealed class DreamIcon(IGameTiming gameTiming, IClyde clyde, ClientAppe
             CachedTexture = GetTextureInner(viewOverlay, handle, iconMetaData, frame);
         }
 
-        _textureDirty = false;
+        if (textureOverride == null)
+            _textureDirty = false;
+
         return CachedTexture;
     }
 
-    private Texture GetTextureInner(DreamViewOverlay viewOverlay, DrawingHandleWorld handle, RendererMetaData iconMetaData, AtlasTexture frame) {
+    private Texture GetTextureInner(DreamViewOverlay viewOverlay, DrawingHandleWorld handle, RendererMetaData iconMetaData, Texture frame) {
         if (_ping?.Size != frame.Size * 2 || _pong == null) {
             // TODO: This should determine the size from the filters and their settings, not just double the original
             _ping = clyde.CreateRenderTarget(frame.Size * 2, new(RenderTargetColorFormat.Rgba8Srgb));

--- a/OpenDreamClient/Rendering/DreamIcon.cs
+++ b/OpenDreamClient/Rendering/DreamIcon.cs
@@ -430,6 +430,9 @@ internal sealed class DreamIcon(IGameTiming gameTiming, IClyde clyde, ClientAppe
     /// <returns>The final texture</returns>
     private Texture FullRenderTexture(DreamViewOverlay viewOverlay, DrawingHandleWorld handle, RendererMetaData iconMetaData, Texture frame) {
         if (_ping?.Size != frame.Size * 2 || _pong == null) {
+            _ping?.Dispose();
+            _pong?.Dispose();
+
             // TODO: This should determine the size from the filters and their settings, not just double the original
             _ping = clyde.CreateRenderTarget(frame.Size * 2, new(RenderTargetColorFormat.Rgba8Srgb));
             _pong = clyde.CreateRenderTarget(_ping.Size, new(RenderTargetColorFormat.Rgba8Srgb));

--- a/OpenDreamClient/Rendering/DreamPlane.cs
+++ b/OpenDreamClient/Rendering/DreamPlane.cs
@@ -77,7 +77,7 @@ internal sealed class DreamPlane(IRenderTexture mainRenderTarget) : IDisposable 
             if (sprite.MouseOpacity == MouseOpacity.Transparent || sprite.ShouldPassMouse)
                 continue;
 
-            var texture = sprite.Texture;
+            var texture = sprite.GetTexture(overlay, handle);
             if (texture == null)
                 continue;
 

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -433,7 +433,6 @@ internal sealed class DreamViewOverlay : Overlay {
         if (iconMetaData.MainIcon != null)
             pixelPosition += iconMetaData.MainIcon.TextureRenderOffset;
 
-
         handle.UseShader(GetBlendAndColorShader(iconMetaData, ignoreColor: true));
 
         //extract scale component of transform

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -871,7 +871,7 @@ internal sealed class RendererMetaData : IComparable<RendererMetaData> {
     }
 
     public Texture? GetTexture(DreamViewOverlay viewOverlay, DrawingHandleWorld handle) =>
-        TextureOverride ?? MainIcon?.GetTexture(viewOverlay, handle, this);
+        MainIcon?.GetTexture(viewOverlay, handle, this, TextureOverride);
 
     public int CompareTo(RendererMetaData? other) {
         if (other == null)

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -430,6 +430,9 @@ internal sealed class DreamViewOverlay : Overlay {
         if (frame == null)
             return;
 
+        if (iconMetaData.MainIcon != null)
+            pixelPosition += iconMetaData.MainIcon.TextureRenderOffset;
+
         DrawIconFast(handle, renderTargetSize, frame, pixelPosition, iconMetaData.TransformToApply,
             GetBlendAndColorShader(iconMetaData, ignoreColor: true));
     }


### PR DESCRIPTION
The texture for an atom is now only re-rendered once its appearance or animation frame changes. This same texture is reused between frames instead of performing the entire render process again. This leads to massive improvements in client performance, in both render times and allocation rate.

Observing this same spot on Paradise brought allocations per frame down ~350KB (~20.5MB per second at 60FPS!). FPS is more difficult to get a hard number for, but this brought it much closer to a stable 60FPS on my laptop's integrated graphics.

Before:
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/3b77fa10-bad3-4528-a883-c70578e80d0f)
After:
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/354f1b44-7154-4e6f-9540-ea1aeff0d0f6)

~~Did a lot of playing around with things that led to some dirty code, so I'd like to clean things up some before merging. There are also some minor bugs (there are so many magic numbers & steps in the renderer) and I need to test how this plays with `animate()`.~~ All looks good.