### PR TITLE
Fix duplicate `browse_rsc()` calls

### DIFF
--- a/OpenDreamClient/Resources/DreamResourceManager.cs
+++ b/OpenDreamClient/Resources/DreamResourceManager.cs
@@ -71,6 +71,8 @@ namespace OpenDreamClient.Resources {
             if(_resourceManager.UserData.Exists(GetCacheFilePath(message.Filename))){ //TODO CHECK HASH
                 _sawmill.Debug($"Cache hit for {message.Filename}");
             } else {
+                if(_activeBrowseRscRequests.Contains(message.Filename)) //we've already requested it, don't need to do it again
+                    return;
                 _sawmill.Debug($"Cache miss for {message.Filename}, requesting from server.");
                 _activeBrowseRscRequests.Add(message.Filename);
                 _netManager.ServerChannel?.SendMessage(new MsgBrowseResourceRequest(){ Filename = message.Filename});

--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -401,7 +401,7 @@ public sealed class DreamConnection {
             Filename = filename,
             DataHash = resource.ResourceData.Length //TODO: make a quick hash that can work clientside too
         };
-        _permittedBrowseRscFiles.Add(filename, resource);
+        _permittedBrowseRscFiles[filename] = resource;
 
         Session?.Channel.SendMessage(msg);
     }

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -50,6 +50,7 @@
 
 	verb/browse_rsc_test()
 		usr << browse_rsc('icons/mob.dmi', "mobicon.png")
+		usr << browse_rsc('icons/mob.dmi', "mobicon.png")
 		usr << browse("<p><img src=mobicon.png></p>Oh look, it's you!","window=honk")
 
 	verb/rotate()


### PR DESCRIPTION
if a file was already ready for sending, we were erroring. We shouldn't have been.

Also made a similar check on the client, where `browse_rsc()` calls that were duplicated were sending requests twice.