### PR TITLE
Improvements to the CHILD control

### DIFF
--- a/OpenDream.sln
+++ b/OpenDream.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TestGame", "TestGame", "{72
 		TestGame\map_z1.dmm = TestGame\map_z1.dmm
 		TestGame\map_z2.dmm = TestGame\map_z2.dmm
 		TestGame\map_z3.dmm = TestGame\map_z3.dmm
+		TestGame\TestInterface.dmf = TestGame\TestInterface.dmf
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "icons", "icons", "{4F1F4C68-4117-4ECC-8174-D399C1D6C409}"

--- a/OpenDreamClient/Input/MouseInputSystem.cs
+++ b/OpenDreamClient/Input/MouseInputSystem.cs
@@ -1,6 +1,7 @@
 ﻿using OpenDreamClient.Input.ContextMenu;
 using OpenDreamClient.Interface;
 using OpenDreamClient.Interface.Controls;
+using OpenDreamClient.Interface.Controls.UI;
 using OpenDreamClient.Rendering;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Input;

--- a/OpenDreamClient/Interface/Controls/ControlChild.cs
+++ b/OpenDreamClient/Interface/Controls/ControlChild.cs
@@ -1,25 +1,20 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using OpenDreamClient.Interface.Controls.UI;
 using OpenDreamClient.Interface.Descriptors;
 using OpenDreamClient.Interface.DMF;
 using Robust.Client.UserInterface;
-using Robust.Client.UserInterface.Controls;
 
 namespace OpenDreamClient.Interface.Controls;
 
-// todo: robust needs GridSplitter.
-// and a non-shit grid control.
-internal sealed class ControlChild : InterfaceControl {
+internal sealed class ControlChild(ControlDescriptor controlDescriptor, ControlWindow window) : InterfaceControl(controlDescriptor, window) {
     private ControlDescriptorChild ChildDescriptor => (ControlDescriptorChild)ElementDescriptor;
 
-    private SplitContainer _grid;
-    private Control? _leftElement, _rightElement;
-
-    public ControlChild(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor, window) { }
+    private Splitter _splitter;
 
     protected override Control CreateUIElement() {
-        _grid = new SplitContainer();
+        _splitter = new Splitter();
 
-        return _grid;
+        return _splitter;
     }
 
     protected override void UpdateElementDescriptor() {
@@ -32,44 +27,10 @@ internal sealed class ControlChild : InterfaceControl {
             ? rightWindow.UIElement
             : null;
 
-        if (newLeftElement != _leftElement || _grid.ChildCount == 1) {
-            if (_leftElement != null)
-                _grid.Children.Remove(_leftElement);
-
-            if (newLeftElement != null) {
-                _leftElement = newLeftElement;
-                _leftElement.HorizontalExpand = true;
-                _leftElement.VerticalExpand = true;
-            } else {
-                // SplitContainer will have a size of 0x0 if there aren't 2 controls
-                _leftElement = new Control();
-            }
-
-            _grid.Children.Add(_leftElement);
-        }
-
-        if (newRightElement != _rightElement || _grid.ChildCount == 2) {
-            if (_rightElement != null)
-                _grid.Children.Remove(_rightElement);
-
-            if (newRightElement != null) {
-                _rightElement = newRightElement;
-                _rightElement.HorizontalExpand = true;
-                _rightElement.VerticalExpand = true;
-            } else {
-                // SplitContainer will have a size of 0x0 if there aren't 2 controls
-                _rightElement = new Control();
-            }
-
-            _grid.Children.Add(_rightElement);
-        }
-
-        if(_leftElement is not null)
-            _leftElement.SetPositionInParent(0);
-        if (_rightElement is not null)
-            _rightElement.SetPositionInParent(1);
-
-        UpdateGrid();
+        _splitter.Left = newLeftElement;
+        _splitter.Right = newRightElement;
+        _splitter.Vertical = ChildDescriptor.IsVert.Value;
+        _splitter.SplitterPercentage = ChildDescriptor.Splitter.Value / 100f;
     }
 
     public override void Shutdown() {
@@ -79,21 +40,10 @@ internal sealed class ControlChild : InterfaceControl {
             right.Shutdown();
     }
 
-    private void UpdateGrid() {
-        _grid.Orientation = ChildDescriptor.IsVert.Value
-            ? SplitContainer.SplitOrientation.Horizontal
-            : SplitContainer.SplitOrientation.Vertical;
-
-        if (_grid.Size == Vector2.Zero)
-            return;
-
-        _grid.SplitFraction = ChildDescriptor.Splitter.Value / 100f;
-    }
-
     public override bool TryGetProperty(string property, [NotNullWhen(true)] out IDMFProperty? value) {
         switch (property) {
             case "splitter":
-                value = new DMFPropertyNum(_grid.SplitFraction * 100);
+                value = new DMFPropertyNum(_splitter.SplitterPercentage * 100);
                 return true;
             default:
                 return base.TryGetProperty(property, out value);

--- a/OpenDreamClient/Interface/Controls/ControlInfo.cs
+++ b/OpenDreamClient/Interface/Controls/ControlInfo.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using OpenDreamShared.Network.Messages;
 using OpenDreamClient.Input;
+using OpenDreamClient.Interface.Controls.UI;
 using OpenDreamClient.Interface.Descriptors;
 using OpenDreamClient.Interface.Html;
 using OpenDreamShared.Dream;

--- a/OpenDreamClient/Interface/Controls/ControlMap.cs
+++ b/OpenDreamClient/Interface/Controls/ControlMap.cs
@@ -1,4 +1,5 @@
 ﻿using OpenDreamClient.Input;
+using OpenDreamClient.Interface.Controls.UI;
 using OpenDreamClient.Interface.Descriptors;
 using OpenDreamShared.Dream;
 using Robust.Client.Graphics;

--- a/OpenDreamClient/Interface/Controls/UI/ScalingViewport.cs
+++ b/OpenDreamClient/Interface/Controls/UI/ScalingViewport.cs
@@ -7,9 +7,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Utility;
 using SixLabors.ImageSharp.PixelFormats;
 
-#nullable enable
-
-namespace OpenDreamClient.Interface.Controls;
+namespace OpenDreamClient.Interface.Controls.UI;
 
 /// <summary>
 ///     Viewport control that has a fixed viewport size and scales it appropriately.

--- a/OpenDreamClient/Interface/Controls/UI/Splitter.cs
+++ b/OpenDreamClient/Interface/Controls/UI/Splitter.cs
@@ -163,6 +163,11 @@ public sealed class Splitter : Container {
     }
 
     private sealed class DragControl : Control {
+        private static readonly StyleBox DragControlStyleBox = new StyleBoxFlat(Color.DarkGray) {
+            BorderColor = Color.Gray,
+            BorderThickness = new(1)
+        };
+
         public event Action<GUIBoundKeyEventArgs>? OnMouseDown;
         public event Action<GUIBoundKeyEventArgs>? OnMouseUp;
         public event Action<GUIMouseMoveEventArgs>? OnMouseMove;
@@ -189,7 +194,7 @@ public sealed class Splitter : Container {
         }
 
         protected override void Draw(DrawingHandleScreen handle) {
-            handle.DrawRect(UIBox2.FromDimensions(Vector2.Zero, PixelSize), Color.Gray, filled: false);
+            DragControlStyleBox.Draw(handle, UIBox2.FromDimensions(Vector2.Zero, PixelSize), UIScale);
         }
     }
 }

--- a/OpenDreamClient/Interface/Controls/UI/Splitter.cs
+++ b/OpenDreamClient/Interface/Controls/UI/Splitter.cs
@@ -1,0 +1,195 @@
+﻿using Robust.Client.Graphics;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Input;
+
+namespace OpenDreamClient.Interface.Controls.UI;
+
+/// <summary>
+/// A splitter control that gives 2 children a resizable amount of space.
+/// Equivalent to BYOND's CHILD control.
+/// </summary>
+/// <remarks>Do not add children directly! Use <see cref="Left"/> and <see cref="Right"/>.</remarks>
+public sealed class Splitter : Container {
+    public float SplitterWidth {
+        get => _splitterWidth;
+        set {
+            _splitterWidth = value;
+            InvalidateMeasure();
+        }
+    }
+
+    public Control? Left {
+        get => _left;
+        set {
+            if (_left == value)
+                return;
+
+            if (_left != null)
+                RemoveChild(_left);
+
+            _left = value;
+            if (_left != null)
+                AddChild(_left);
+        }
+    }
+
+    public Control? Right {
+        get => _right;
+        set {
+            if (_right == value)
+                return;
+
+            if (_right != null)
+                RemoveChild(_right);
+
+            _right = value;
+            if (_right != null)
+                AddChild(_right);
+        }
+    }
+
+    public float SplitterPercentage {
+        get => _splitterPercentage;
+        set {
+            _splitterPercentage = Math.Clamp(value, 0.1f, 0.9f);
+            InvalidateMeasure();
+        }
+    }
+
+    public bool Vertical {
+        get => _vertical;
+        set {
+            _vertical = value;
+            _drag.DefaultCursorShape = value ? CursorShape.HResize : CursorShape.VResize;
+            InvalidateMeasure();
+        }
+    }
+
+    private readonly DragControl _drag = new();
+
+    private float _splitterWidth = 5f;
+    private float _splitterPercentage = 0.5f;
+    private bool _vertical;
+    private bool _dragging;
+    private Control? _left, _right;
+
+    public Splitter() {
+        MouseFilter = MouseFilterMode.Stop;
+
+        _drag.OnMouseMove += MouseMove;
+        _drag.OnMouseDown += StartDragging;
+        _drag.OnMouseUp += StopDragging;
+        AddChild(_drag);
+    }
+
+    protected override Vector2 MeasureOverride(Vector2 availableSize) {
+        var space = CalculateSpace(availableSize);
+
+        _left?.Measure(space.LeftBox.Size);
+        _drag.Measure(space.DragBox.Size);
+        _right?.Measure(space.RightBox.Size);
+
+        // Always take the full space
+        return availableSize;
+    }
+
+    protected override Vector2 ArrangeOverride(Vector2 finalSize) {
+        var space = CalculateSpace(finalSize);
+
+        _left?.Arrange(space.LeftBox);
+        _drag.Arrange(space.DragBox);
+        _right?.Arrange(space.RightBox);
+
+        // Always take the full space
+        return finalSize;
+    }
+
+    protected override void MouseMove(GUIMouseMoveEventArgs args) {
+        if (!_dragging)
+            return;
+
+        var relative = args.GlobalPosition - GlobalPosition;
+
+        if (Vertical) {
+            SplitterPercentage = relative.X / Size.X;
+        } else {
+            SplitterPercentage = relative.Y / Size.Y;
+        }
+    }
+
+    private void StartDragging(GUIBoundKeyEventArgs args) {
+        if (_dragging)
+            return;
+
+        _dragging = true;
+        DefaultCursorShape = Vertical ? CursorShape.HResize : CursorShape.VResize;
+    }
+
+    private void StopDragging(GUIBoundKeyEventArgs args) {
+        _dragging = false;
+        DefaultCursorShape = CursorShape.Arrow;
+    }
+
+    private (UIBox2 LeftBox, UIBox2 DragBox, UIBox2 RightBox) CalculateSpace(Vector2 available) {
+        if (_left != null && _right == null)
+            return (UIBox2.FromDimensions(Vector2.Zero, available), default, default);
+        if (_left == null && _right != null)
+            return (default, default, UIBox2.FromDimensions(Vector2.Zero, available));
+        if (_left == null && _right == null)
+            return (default, default, default);
+
+        var leftSize = Vertical
+            ? available with { X = available.X * SplitterPercentage - SplitterWidth/2 }
+            : available with { Y = available.Y * SplitterPercentage - SplitterWidth/2 };
+        var rightSize = Vertical
+            ? available with { X = available.X * (1f - SplitterPercentage) - SplitterWidth/2 }
+            : available with { Y = available.Y * (1f - SplitterPercentage) - SplitterWidth/2 };
+        var dragSize = Vertical
+            ? available with { X = SplitterWidth }
+            : available with { Y = SplitterWidth };
+        var dragPos = Vertical
+            ? leftSize with { Y = 0f }
+            : leftSize with { X = 0f };
+        var rightPos = Vertical
+            ? new Vector2(leftSize.X + SplitterWidth, 0f)
+            : new Vector2(0f, leftSize.Y + SplitterWidth);
+
+        return (
+            UIBox2.FromDimensions(Vector2.Zero, leftSize),
+            UIBox2.FromDimensions(dragPos, dragSize),
+            UIBox2.FromDimensions(rightPos, rightSize)
+        );
+    }
+
+    private sealed class DragControl : Control {
+        public event Action<GUIBoundKeyEventArgs>? OnMouseDown;
+        public event Action<GUIBoundKeyEventArgs>? OnMouseUp;
+        public event Action<GUIMouseMoveEventArgs>? OnMouseMove;
+
+        public DragControl() {
+            MouseFilter = MouseFilterMode.Stop;
+        }
+
+        protected override void MouseMove(GUIMouseMoveEventArgs args) {
+            base.MouseMove(args);
+            OnMouseMove?.Invoke(args);
+        }
+
+        protected override void KeyBindDown(GUIBoundKeyEventArgs args) {
+            base.KeyBindDown(args);
+            if (args.Function == EngineKeyFunctions.UIClick)
+                OnMouseDown?.Invoke(args);
+        }
+
+        protected override void KeyBindUp(GUIBoundKeyEventArgs args) {
+            base.KeyBindUp(args);
+            if (args.Function == EngineKeyFunctions.UIClick)
+                OnMouseUp?.Invoke(args);
+        }
+
+        protected override void Draw(DrawingHandleScreen handle) {
+            handle.DrawRect(UIBox2.FromDimensions(Vector2.Zero, PixelSize), Color.Gray, filled: false);
+        }
+    }
+}

--- a/OpenDreamClient/Interface/Controls/UI/VerbPanelGrid.cs
+++ b/OpenDreamClient/Interface/Controls/UI/VerbPanelGrid.cs
@@ -1,6 +1,6 @@
 using Robust.Client.UserInterface.Controls;
 
-namespace OpenDreamClient.Interface.Controls;
+namespace OpenDreamClient.Interface.Controls.UI;
 
 /// <summary>
 /// The control responsible for sizing & layout of verb panels in INFO controls

--- a/OpenDreamClient/Interface/Descriptors/ControlDescriptors.cs
+++ b/OpenDreamClient/Interface/Descriptors/ControlDescriptors.cs
@@ -116,7 +116,6 @@ public sealed partial class WindowDescriptor : ControlDescriptor {
             return this;
         }
 
-
         Type? descriptorType = elementTypeValue.Value switch {
             "MAP" => typeof(ControlDescriptorMap),
             "CHILD" => typeof(ControlDescriptorChild),
@@ -134,6 +133,16 @@ public sealed partial class WindowDescriptor : ControlDescriptor {
 
         if (descriptorType == null)
             return null;
+
+        if (descriptorType == typeof(ControlDescriptorChild)) {
+            // CHILD's top/bottom attributes alias to left/right
+            // Code is duplicated in InterfaceElement.PopulateElementDescriptor()
+            // TODO: A bit hacky. Remove this (may be worth abandoning RT's serialization manager)
+            if (attributes.TryGet("top", out var topValue))
+                attributes["left"] = topValue;
+            if (attributes.TryGet("bottom", out var bottomValue))
+                attributes["right"] = bottomValue;
+        }
 
         var child = (ControlDescriptor?)serializationManager.Read(descriptorType, attributes);
         if (child == null)

--- a/OpenDreamClient/Interface/InterfaceElement.cs
+++ b/OpenDreamClient/Interface/InterfaceElement.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using OpenDreamClient.Interface.Controls;
 using OpenDreamClient.Interface.Descriptors;
 using OpenDreamClient.Interface.DMF;
 using Robust.Shared.Serialization.Manager;
@@ -22,6 +23,16 @@ public class InterfaceElement {
     }
 
     public void PopulateElementDescriptor(MappingDataNode node, ISerializationManager serializationManager) {
+        if (GetType() == typeof(ControlChild)) {
+            // CHILD's top/bottom attributes alias to left/right
+            // Code is duplicated in WindowDescriptor.CreateChildDescriptor()
+            // TODO: A bit hacky. Remove this (may be worth abandoning RT's serialization manager)
+            if (node.TryGet("top", out var topValue))
+                node["left"] = topValue;
+            if (node.TryGet("bottom", out var bottomValue))
+                node["right"] = bottomValue;
+        }
+
         try {
             MappingDataNode original =
                 (MappingDataNode)serializationManager.WriteValue(ElementDescriptor.GetType(), ElementDescriptor);

--- a/Resources/OpenDream/DefaultInterface.dmf
+++ b/Resources/OpenDream/DefaultInterface.dmf
@@ -116,7 +116,7 @@ window "mainwindow"
 		icon = "icons/mob.dmi"
 	elem "split"
 		type = CHILD
-		pos = 3,0
+		pos = 0,0
 		size = 0x0
 		anchor1 = 0,0
 		anchor2 = 100,100

--- a/TestGame/TestInterface.dmf
+++ b/TestGame/TestInterface.dmf
@@ -132,7 +132,7 @@ window "mainwindow"
 		icon = "icons/mob.dmi"
 	elem "split"
 		type = CHILD
-		pos = 3,0
+		pos = 0,0
 		size = 0x0
 		anchor1 = 0,0
 		anchor2 = 100,100


### PR DESCRIPTION
Our CHILD control now uses a custom Splitter control rather than the SplitContainer provided by RT. This simplifies a lot of the code in `ControlChild` and allows us to more closely emulate BYOND appearance and behavior.

It now also has a color and border to more clearly separate panes.

Before:
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/88941ada-4f79-402e-8abf-d3221e41b1a2)

After:
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/30dd482a-d2af-4007-8a50-9fe1d71f46da)

I also made the `top`/`bottom` attributes alias to `left`/`right` as they do in BYOND. This fixes the top-left Text and Info buttons on Paradise.