### PR TITLE
Reduce size of appearances being sent over the network

### DIFF
--- a/OpenDreamClient/EntryPoint.cs
+++ b/OpenDreamClient/EntryPoint.cs
@@ -1,9 +1,11 @@
 using System.Globalization;
 using OpenDreamClient.Audio;
 using OpenDreamClient.Interface;
+using OpenDreamClient.Rendering;
 using OpenDreamClient.Resources;
 using OpenDreamClient.States;
 using OpenDreamShared;
+using OpenDreamShared.Network.Messages;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Map;
@@ -12,103 +14,117 @@ using Robust.Client.WebView;
 using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
+using Robust.Shared.Network;
 using Robust.Shared.Timing;
 
-namespace OpenDreamClient {
-    public sealed class EntryPoint : GameClient {
-        [Dependency] private readonly IDreamInterfaceManager _dreamInterface = default!;
-        [Dependency] private readonly IDreamResourceManager _dreamResource = default!;
-        [Dependency] private readonly IDreamSoundEngine _soundEngine = default!;
-        [Dependency] private readonly IOverlayManager _overlayManager = default!;
-        [Dependency] private readonly ILightManager _lightManager = default!;
-        [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+namespace OpenDreamClient;
 
-        private const string UserAgent =
-            "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729)";
+public sealed class EntryPoint : GameClient {
+    [Dependency] private readonly IDreamInterfaceManager _dreamInterface = default!;
+    [Dependency] private readonly IDreamResourceManager _dreamResource = default!;
+    [Dependency] private readonly IDreamSoundEngine _soundEngine = default!;
+    [Dependency] private readonly IOverlayManager _overlayManager = default!;
+    [Dependency] private readonly ILightManager _lightManager = default!;
+    [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+    [Dependency] private readonly IClientNetManager _netManager = default!;
+    [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
 
-        public override void PreInit() {
-            var config = IoCManager.Resolve<IConfigurationManager>();
+    private const string UserAgent =
+        "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729)";
 
-            // We share settings with other RT games, such as SS14.
-            // SS14 supports fullscreen, but it breaks us horribly. This disables fullscreen if it's already set.
-            config.SetCVar(CVars.DisplayWindowMode, 0);
+    public override void PreInit() {
+        var config = IoCManager.Resolve<IConfigurationManager>();
 
-            if (config.GetCVar(OpenDreamCVars.SpoofIEUserAgent)) {
-                config.OverrideDefault(WCVars.WebUserAgentOverride, UserAgent);
-            }
+        // We share settings with other RT games, such as SS14.
+        // SS14 supports fullscreen, but it breaks us horribly. This disables fullscreen if it's already set.
+        config.SetCVar(CVars.DisplayWindowMode, 0);
 
-            IoCManager.Resolve<IEntitySystemManager>().SystemLoaded += OnEntitySystemLoaded;
+        if (config.GetCVar(OpenDreamCVars.SpoofIEUserAgent)) {
+            config.OverrideDefault(WCVars.WebUserAgentOverride, UserAgent);
         }
 
-        public override void Init() {
-            IoCManager.Resolve<IConfigurationManager>().OverrideDefault(CVars.NetPredict, false);
+        IoCManager.Resolve<IEntitySystemManager>().SystemLoaded += OnEntitySystemLoaded;
+    }
 
-            IComponentFactory componentFactory = IoCManager.Resolve<IComponentFactory>();
-            componentFactory.DoAutoRegistrations();
+    public override void Init() {
+        IoCManager.Resolve<IConfigurationManager>().OverrideDefault(CVars.NetPredict, false);
 
-            ClientContentIoC.Register();
+        IComponentFactory componentFactory = IoCManager.Resolve<IComponentFactory>();
+        componentFactory.DoAutoRegistrations();
 
-            // This needs to happen after all IoC registrations, but before IoC.BuildGraph();
-            foreach (var callback in TestingCallbacks) {
-                var cast = (ClientModuleTestingCallbacks) callback;
-                cast.ClientBeforeIoC?.Invoke();
-            }
+        ClientContentIoC.Register();
 
-            IoCManager.BuildGraph();
-            IoCManager.InjectDependencies(this);
-
-            IoCManager.Resolve<DreamUserInterfaceStateManager>().Initialize();
-
-            componentFactory.GenerateNetIds();
-
-            _dreamResource.Initialize();
-
-            // Load localization. Needed for some engine texts, such as the ones in Robust ViewVariables.
-            IoCManager.Resolve<ILocalizationManager>().LoadCulture(new CultureInfo("en-US"));
-
-            IoCManager.Resolve<IClyde>().SetWindowTitle("OpenDream");
+        // This needs to happen after all IoC registrations, but before IoC.BuildGraph();
+        foreach (var callback in TestingCallbacks) {
+            var cast = (ClientModuleTestingCallbacks) callback;
+            cast.ClientBeforeIoC?.Invoke();
         }
 
-        public override void PostInit() {
-            _lightManager.Enabled = false;
+        IoCManager.BuildGraph();
+        IoCManager.InjectDependencies(this);
 
-            // In PostInit() since the engine stylesheet gets set in Init()
-            IoCManager.Resolve<IUserInterfaceManager>().Stylesheet = DreamStylesheet.Make();
+        IoCManager.Resolve<DreamUserInterfaceStateManager>().Initialize();
 
-            _dreamInterface.Initialize();
-            IoCManager.Resolve<IDreamSoundEngine>().Initialize();
+        componentFactory.GenerateNetIds();
 
-            if (_configurationManager.GetCVar(CVars.DisplayCompat))
-                _dreamInterface.OpenAlert(
-                    "Compatibility Mode Warning",
-                    "You are using compatibility mode. Clicking in-game objects is not supported in this mode.",
-                    "Ok", null, null, null);
+        _dreamResource.Initialize();
+
+        // Load localization. Needed for some engine texts, such as the ones in Robust ViewVariables.
+        IoCManager.Resolve<ILocalizationManager>().LoadCulture(new CultureInfo("en-US"));
+
+        IoCManager.Resolve<IClyde>().SetWindowTitle("OpenDream");
+    }
+
+    public override void PostInit() {
+        _lightManager.Enabled = false;
+
+        // In PostInit() since the engine stylesheet gets set in Init()
+        IoCManager.Resolve<IUserInterfaceManager>().Stylesheet = DreamStylesheet.Make();
+
+        _dreamInterface.Initialize();
+        IoCManager.Resolve<IDreamSoundEngine>().Initialize();
+
+        _netManager.RegisterNetMessage<MsgAllAppearances>(RxAllAppearances);
+
+        if (_configurationManager.GetCVar(CVars.DisplayCompat))
+            _dreamInterface.OpenAlert(
+                "Compatibility Mode Warning",
+                "You are using compatibility mode. Clicking in-game objects is not supported in this mode.",
+                "Ok", null, null, null);
+    }
+
+    protected override void Dispose(bool disposing) {
+        _dreamResource.Shutdown();
+    }
+
+    public override void Update(ModUpdateLevel level, FrameEventArgs frameEventArgs) {
+        switch (level) {
+            case ModUpdateLevel.FramePostEngine:
+                _dreamInterface.FrameUpdate(frameEventArgs);
+                break;
+            case ModUpdateLevel.PostEngine:
+                _soundEngine.StopFinishedChannels();
+                break;
+        }
+    }
+
+    private void RxAllAppearances(MsgAllAppearances message) {
+        if (!_entitySystemManager.TryGetEntitySystem<ClientAppearanceSystem>(out var clientAppearanceSystem)) {
+            Logger.GetSawmill("opendream").Error("Received MsgAllAppearances before initializing entity systems");
+            return;
         }
 
-        protected override void Dispose(bool disposing) {
-            _dreamResource.Shutdown();
-        }
+        clientAppearanceSystem.SetAllAppearances(message.AllAppearances);
+    }
 
-        public override void Update(ModUpdateLevel level, FrameEventArgs frameEventArgs) {
-            switch (level) {
-                case ModUpdateLevel.FramePostEngine:
-                    _dreamInterface.FrameUpdate(frameEventArgs);
-                    break;
-                case ModUpdateLevel.PostEngine:
-                    _soundEngine.StopFinishedChannels();
-                    break;
-            }
-        }
+    // As of RobustToolbox v0.90.0.0 there's a TileEdgeOverlay that breaks our rendering
+    // because we don't have an ITileDefinition for each tile.
+    // This removes that overlay immediately after MapSystem adds it.
+    // TODO: Fix this engine-side
+    private void OnEntitySystemLoaded(object? sender, SystemChangedArgs e) {
+        if (e.System is not MapSystem)
+            return;
 
-        // As of RobustToolbox v0.90.0.0 there's a TileEdgeOverlay that breaks our rendering
-        // because we don't have an ITileDefinition for each tile.
-        // This removes that overlay immediately after MapSystem adds it.
-        // TODO: Fix this engine-side
-        private void OnEntitySystemLoaded(object? sender, SystemChangedArgs e) {
-            if (e.System is not MapSystem)
-                return;
-
-            _overlayManager.RemoveOverlay<TileEdgeOverlay>();
-        }
+        _overlayManager.RemoveOverlay<TileEdgeOverlay>();
     }
 }

--- a/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
+++ b/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
@@ -5,6 +5,7 @@ using Robust.Client.Graphics;
 using Robust.Shared.Prototypes;
 using OpenDreamClient.Resources;
 using OpenDreamClient.Resources.ResourceTypes;
+using OpenDreamShared.Network.Messages;
 using Robust.Shared.Timing;
 
 namespace OpenDreamClient.Rendering;
@@ -22,7 +23,6 @@ internal sealed class ClientAppearanceSystem : SharedAppearanceSystem {
     [Dependency] private readonly IClyde _clyde = default!;
 
     public override void Initialize() {
-        SubscribeNetworkEvent<AllAppearancesEvent>(OnAllAppearances);
         SubscribeNetworkEvent<NewAppearanceEvent>(OnNewAppearance);
         SubscribeNetworkEvent<AnimationEvent>(OnAnimation);
         SubscribeLocalEvent<DMISpriteComponent, WorldAABBEvent>(OnWorldAABB);
@@ -32,6 +32,16 @@ internal sealed class ClientAppearanceSystem : SharedAppearanceSystem {
         _appearances.Clear();
         _appearanceLoadCallbacks.Clear();
         _turfIcons.Clear();
+    }
+
+    public void SetAllAppearances(Dictionary<int, IconAppearance> appearances) {
+        _appearances = appearances;
+
+        foreach (KeyValuePair<int, IconAppearance> pair in _appearances) {
+            if (_appearanceLoadCallbacks.TryGetValue(pair.Key, out var callbacks)) {
+                foreach (var callback in callbacks) callback(pair.Value);
+            }
+        }
     }
 
     public void LoadAppearance(int appearanceId, Action<IconAppearance> loadCallback) {
@@ -55,16 +65,6 @@ internal sealed class ClientAppearanceSystem : SharedAppearanceSystem {
         }
 
         return icon;
-    }
-
-    private void OnAllAppearances(AllAppearancesEvent e, EntitySessionEventArgs session) {
-        _appearances = e.Appearances;
-
-        foreach (KeyValuePair<int, IconAppearance> pair in _appearances) {
-            if (_appearanceLoadCallbacks.TryGetValue(pair.Key, out var callbacks)) {
-                foreach (var callback in callbacks) callback(pair.Value);
-            }
-        }
     }
 
     private void OnNewAppearance(NewAppearanceEvent e) {

--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -289,7 +289,7 @@ public sealed class AtomManager {
             case "invisibility":
                 value.TryGetValueAsInteger(out int vis);
                 vis = Math.Clamp(vis, -127, 127); // DM ref says [0, 101]. BYOND compiler says [-127, 127]
-                appearance.Invisibility = vis;
+                appearance.Invisibility = (sbyte)vis;
                 break;
             case "opacity":
                 value.TryGetValueAsInteger(out var opacity);

--- a/OpenDreamRuntime/DreamManager.Connections.cs
+++ b/OpenDreamRuntime/DreamManager.Connections.cs
@@ -67,6 +67,7 @@ namespace OpenDreamRuntime {
             _netManager.RegisterNetMessage<MsgAckLoadInterface>(RxAckLoadInterface);
             _netManager.RegisterNetMessage<MsgSound>();
             _netManager.RegisterNetMessage<MsgUpdateClientInfo>();
+            _netManager.RegisterNetMessage<MsgAllAppearances>();
 
             var topicPort = _config.GetCVar(OpenDreamCVars.TopicPort);
             var worldTopicAddress = new IPEndPoint(IPAddress.Loopback, topicPort);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -293,7 +293,8 @@ namespace OpenDreamRuntime.Procs.Native {
 
                 if (!invisibility.IsNull) {
                     obj.SetVariableValue("invisibility", invisibility);
-                    invisibility.TryGetValueAsInteger(out appearance.Invisibility);
+                    invisibility.TryGetValueAsInteger(out var invisibilityValue);
+                    appearance.Invisibility = (sbyte)Math.Clamp(invisibilityValue, -127, 127);
                 }
 
                 /* TODO suffix

--- a/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
+++ b/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
@@ -3,6 +3,7 @@ using Robust.Server.Player;
 using Robust.Shared.Enums;
 using SharedAppearanceSystem = OpenDreamShared.Rendering.SharedAppearanceSystem;
 using System.Diagnostics.CodeAnalysis;
+using OpenDreamShared.Network.Messages;
 using Robust.Shared.Player;
 
 namespace OpenDreamRuntime.Rendering;
@@ -33,7 +34,9 @@ public sealed class ServerAppearanceSystem : SharedAppearanceSystem {
 
     private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs e) {
         if (e.NewStatus == SessionStatus.InGame) {
-            RaiseNetworkEvent(new AllAppearancesEvent(_idToAppearance), e.Session.ConnectedClient);
+            e.Session.Channel.SendMessage(new MsgAllAppearances {
+                AllAppearances = _idToAppearance
+            });
         }
     }
 

--- a/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
+++ b/OpenDreamRuntime/Rendering/ServerAppearanceSystem.cs
@@ -34,9 +34,7 @@ public sealed class ServerAppearanceSystem : SharedAppearanceSystem {
 
     private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs e) {
         if (e.NewStatus == SessionStatus.InGame) {
-            e.Session.Channel.SendMessage(new MsgAllAppearances {
-                AllAppearances = _idToAppearance
-            });
+            e.Session.Channel.SendMessage(new MsgAllAppearances(_idToAppearance));
         }
     }
 

--- a/OpenDreamShared/Dream/ColorMatrix.cs
+++ b/OpenDreamShared/Dream/ColorMatrix.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using JetBrains.Annotations;
 
 namespace OpenDreamShared.Dream;
 /// <summary>
@@ -168,17 +169,18 @@ public struct ColorMatrix {
     /// Gets the diagonal values in this matrix. Used for detecting whether this matrix is convertible into a Color.
     /// </summary>
     /// <returns></returns>
+    [Pure]
     public IEnumerable<float> GetDiagonal() {
         yield return c11;
         yield return c22;
         yield return c33;
         yield return c44;
-        yield break;
     }
 
     /// <summary>
     /// Returns all of the values in this struct, in order.
     /// </summary>
+    [Pure]
     public IEnumerable<float> GetValues() {
         yield return c11;
         yield return c12;

--- a/OpenDreamShared/Dream/IconAppearance.cs
+++ b/OpenDreamShared/Dream/IconAppearance.cs
@@ -21,18 +21,6 @@ public sealed class IconAppearance : IEquatable<IconAppearance> {
     [ViewVariables] public Color Color = Color.White;
     [ViewVariables] public byte Alpha = 255;
     [ViewVariables] public float GlideSize;
-    /// <summary>
-    /// An appearance can gain a color matrix filter by two possible forces: <br/>
-    /// 1. the /atom.color var is modified. <br/>
-    /// 2. the /atom.filters var gets a new filter of type "color". <br/>
-    /// DM crashes in some circumstances of this but we, as an extension :^), should try not to. <br/>
-    /// So, this exists as a way for the appearance to remember whether it's coloured by .color, specifically.
-    /// </summary>
-    /// <remarks>
-    /// The reason we don't just take the slow path and always use this filter is not just for optimization,<br/>
-    /// it's also for parity! See <see cref="TryRepresentMatrixAsRGBAColor(in ColorMatrix, out Color?)"/> for more.
-    /// </remarks>
-    [ViewVariables] public ColorMatrix ColorMatrix = ColorMatrix.Identity;
     [ViewVariables] public float Layer = -1f;
     [ViewVariables] public int Plane = -32767;
     [ViewVariables] public BlendMode BlendMode = BlendMode.Default;
@@ -48,6 +36,20 @@ public sealed class IconAppearance : IEquatable<IconAppearance> {
     [ViewVariables] public List<NetEntity> VisContents;
     [ViewVariables] public List<DreamFilter> Filters;
     [ViewVariables] public List<int> Verbs;
+
+    /// <summary>
+    /// An appearance can gain a color matrix filter by two possible forces: <br/>
+    /// 1. the /atom.color var is modified. <br/>
+    /// 2. the /atom.filters var gets a new filter of type "color". <br/>
+    /// DM crashes in some circumstances of this but we, as an extension :^), should try not to. <br/>
+    /// So, this exists as a way for the appearance to remember whether it's coloured by .color, specifically.
+    /// </summary>
+    /// <remarks>
+    /// The reason we don't just take the slow path and always use this filter is not just for optimization,<br/>
+    /// it's also for parity! See <see cref="TryRepresentMatrixAsRgbaColor"/> for more.
+    /// </remarks>
+    [ViewVariables] public ColorMatrix ColorMatrix = ColorMatrix.Identity;
+
     /// <summary> The Transform property of this appearance, in [a,d,b,e,c,f] order</summary>
     [ViewVariables] public float[] Transform = [
         1, 0,   // a d
@@ -82,11 +84,11 @@ public sealed class IconAppearance : IEquatable<IconAppearance> {
         Invisibility = appearance.Invisibility;
         Opacity = appearance.Opacity;
         MouseOpacity = appearance.MouseOpacity;
-        Overlays = new(appearance.Overlays);
-        Underlays = new(appearance.Underlays);
-        VisContents = new(appearance.VisContents);
-        Filters = new(appearance.Filters);
-        Verbs = new(appearance.Verbs);
+        Overlays = [..appearance.Overlays];
+        Underlays = [..appearance.Underlays];
+        VisContents = [..appearance.VisContents];
+        Filters = [..appearance.Filters];
+        Verbs = [..appearance.Verbs];
         Override = appearance.Override;
 
         for (int i = 0; i < 6; i++) {
@@ -106,7 +108,7 @@ public sealed class IconAppearance : IEquatable<IconAppearance> {
         if (appearance.PixelOffset != PixelOffset) return false;
         if (appearance.Color != Color) return false;
         if (appearance.Alpha != Alpha) return false;
-        if (appearance.GlideSize != GlideSize) return false;
+        if (!appearance.GlideSize.Equals(GlideSize)) return false;
         if (!appearance.ColorMatrix.Equals(ColorMatrix)) return false;
         if (!appearance.Layer.Equals(Layer)) return false;
         if (appearance.Plane != Plane) return false;
@@ -157,8 +159,9 @@ public sealed class IconAppearance : IEquatable<IconAppearance> {
     /// then it is coerced into one internally before being saved onto some appearance. <br/>
     /// This does the linear algebra madness necessary to determine whether this is the case or not.
     /// </summary>
-    private static bool TryRepresentMatrixAsRGBAColor(in ColorMatrix matrix, [NotNullWhen(true)] out Color? maybeColor) {
+    private static bool TryRepresentMatrixAsRgbaColor(in ColorMatrix matrix, [NotNullWhen(true)] out Color? maybeColor) {
         maybeColor = null;
+
         // The R G B A values need to be bounded [0,1] for a color conversion to work;
         // anything higher implies trying to render "superblue" or something.
         float diagonalSum = 0f;
@@ -167,6 +170,7 @@ public sealed class IconAppearance : IEquatable<IconAppearance> {
                 return false;
             diagonalSum += diagonalValue;
         }
+
         // and then all of the other values need to be zero, including the offset vector.
         float sum = 0f;
         foreach (float value in matrix.GetValues()) {
@@ -174,6 +178,7 @@ public sealed class IconAppearance : IEquatable<IconAppearance> {
                 return false;
             sum += value;
         }
+
         if (sum - diagonalSum == 0) // PREEETTY sure I can trust the floating-point math here. Not 100% though
             maybeColor = new Color(matrix.c11, matrix.c22, matrix.c33, matrix.c44);
         return maybeColor is not null;
@@ -245,7 +250,7 @@ public sealed class IconAppearance : IEquatable<IconAppearance> {
     /// Sets the 'color' attribute to a color matrix, which will be used on the icon later on by a shader.
     /// </summary>
     public void SetColor(in ColorMatrix matrix) {
-        if (TryRepresentMatrixAsRGBAColor(matrix, out var matrixColor)) {
+        if (TryRepresentMatrixAsRgbaColor(matrix, out var matrixColor)) {
             Color = matrixColor.Value;
             ColorMatrix = ColorMatrix.Identity;
             return;
@@ -305,6 +310,5 @@ public enum AnimationFlags {
     AnimationParallel = 4,
     AnimationSlice = 8,
     AnimationRelative = 256,
-    AnimationContinue = 512,
-
+    AnimationContinue = 512
 }

--- a/OpenDreamShared/Dream/IconAppearance.cs
+++ b/OpenDreamShared/Dream/IconAppearance.cs
@@ -6,302 +6,305 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.GameObjects;
 
-namespace OpenDreamShared.Dream {
-    // TODO: Wow this is huge! Probably look into splitting this by most used/least used to reduce the size of these
-    [Serializable, NetSerializable]
-    public sealed class IconAppearance : IEquatable<IconAppearance> {
-        [ViewVariables] public int? Icon;
-        [ViewVariables] public string? IconState;
-        [ViewVariables] public AtomDirection Direction = AtomDirection.South;
-        [ViewVariables] public bool InheritsDirection = true; // Inherits direction when used as an overlay
-        [ViewVariables] public Vector2i PixelOffset;
-        [ViewVariables] public Color Color = Color.White;
-        [ViewVariables] public byte Alpha = 255;
-        [ViewVariables] public float GlideSize;
-        /// <summary>
-        /// An appearance can gain a color matrix filter by two possible forces: <br/>
-        /// 1. the /atom.color var is modified. <br/>
-        /// 2. the /atom.filters var gets a new filter of type "color". <br/>
-        /// DM crashes in some circumstances of this but we, as an extension :^), should try not to. <br/>
-        /// So, this exists as a way for the appearance to remember whether it's coloured by .color, specifically.
-        /// </summary>
-        /// <remarks>
-        /// The reason we don't just take the slow path and always use this filter is not just for optimization,<br/>
-        /// it's also for parity! See <see cref="TryRepresentMatrixAsRGBAColor(in ColorMatrix, out Color?)"/> for more.
-        /// </remarks>
-        [ViewVariables] public ColorMatrix ColorMatrix = ColorMatrix.Identity;
-        [ViewVariables] public float Layer = -1f;
-        [ViewVariables] public int Plane = -32767;
-        [ViewVariables] public BlendMode BlendMode = BlendMode.Default;
-        [ViewVariables] public AppearanceFlags AppearanceFlags = AppearanceFlags.None;
-        [ViewVariables] public int Invisibility;
-        [ViewVariables] public bool Opacity;
-        [ViewVariables] public bool Override;
-        [ViewVariables] public string? RenderSource;
-        [ViewVariables] public string? RenderTarget;
-        [ViewVariables] public MouseOpacity MouseOpacity = MouseOpacity.PixelOpaque;
-        [ViewVariables] public List<int> Overlays;
-        [ViewVariables] public List<int> Underlays;
-        [ViewVariables] public List<NetEntity> VisContents;
-        [ViewVariables] public List<DreamFilter> Filters;
-        [ViewVariables] public List<int> Verbs;
-        /// <summary> The Transform property of this appearance, in [a,d,b,e,c,f] order</summary>
-        [ViewVariables] public float[] Transform = [
-            1, 0,   // a d
-            0, 1,   // b e
-            0, 0    // c f
-        ];
+namespace OpenDreamShared.Dream;
 
-        public IconAppearance() {
-            Overlays = new();
-            Underlays = new();
-            VisContents = new();
-            Filters = new();
-            Verbs = new();
+// TODO: Wow this is huge! Probably look into splitting this by most used/least used to reduce the size of these
+[Serializable, NetSerializable]
+public sealed class IconAppearance : IEquatable<IconAppearance> {
+    public static readonly IconAppearance Default = new();
+
+    [ViewVariables] public int? Icon;
+    [ViewVariables] public string? IconState;
+    [ViewVariables] public AtomDirection Direction = AtomDirection.South;
+    [ViewVariables] public bool InheritsDirection = true; // Inherits direction when used as an overlay
+    [ViewVariables] public Vector2i PixelOffset;
+    [ViewVariables] public Color Color = Color.White;
+    [ViewVariables] public byte Alpha = 255;
+    [ViewVariables] public float GlideSize;
+    /// <summary>
+    /// An appearance can gain a color matrix filter by two possible forces: <br/>
+    /// 1. the /atom.color var is modified. <br/>
+    /// 2. the /atom.filters var gets a new filter of type "color". <br/>
+    /// DM crashes in some circumstances of this but we, as an extension :^), should try not to. <br/>
+    /// So, this exists as a way for the appearance to remember whether it's coloured by .color, specifically.
+    /// </summary>
+    /// <remarks>
+    /// The reason we don't just take the slow path and always use this filter is not just for optimization,<br/>
+    /// it's also for parity! See <see cref="TryRepresentMatrixAsRGBAColor(in ColorMatrix, out Color?)"/> for more.
+    /// </remarks>
+    [ViewVariables] public ColorMatrix ColorMatrix = ColorMatrix.Identity;
+    [ViewVariables] public float Layer = -1f;
+    [ViewVariables] public int Plane = -32767;
+    [ViewVariables] public BlendMode BlendMode = BlendMode.Default;
+    [ViewVariables] public AppearanceFlags AppearanceFlags = AppearanceFlags.None;
+    [ViewVariables] public sbyte Invisibility;
+    [ViewVariables] public bool Opacity;
+    [ViewVariables] public bool Override;
+    [ViewVariables] public string? RenderSource;
+    [ViewVariables] public string? RenderTarget;
+    [ViewVariables] public MouseOpacity MouseOpacity = MouseOpacity.PixelOpaque;
+    [ViewVariables] public List<int> Overlays;
+    [ViewVariables] public List<int> Underlays;
+    [ViewVariables] public List<NetEntity> VisContents;
+    [ViewVariables] public List<DreamFilter> Filters;
+    [ViewVariables] public List<int> Verbs;
+    /// <summary> The Transform property of this appearance, in [a,d,b,e,c,f] order</summary>
+    [ViewVariables] public float[] Transform = [
+        1, 0,   // a d
+        0, 1,   // b e
+        0, 0    // c f
+    ];
+
+    public IconAppearance() {
+        Overlays = new();
+        Underlays = new();
+        VisContents = new();
+        Filters = new();
+        Verbs = new();
+    }
+
+    public IconAppearance(IconAppearance appearance) {
+        Icon = appearance.Icon;
+        IconState = appearance.IconState;
+        Direction = appearance.Direction;
+        InheritsDirection = appearance.InheritsDirection;
+        PixelOffset = appearance.PixelOffset;
+        Color = appearance.Color;
+        Alpha = appearance.Alpha;
+        GlideSize = appearance.GlideSize;
+        ColorMatrix = appearance.ColorMatrix;
+        Layer = appearance.Layer;
+        Plane = appearance.Plane;
+        RenderSource = appearance.RenderSource;
+        RenderTarget = appearance.RenderTarget;
+        BlendMode = appearance.BlendMode;
+        AppearanceFlags = appearance.AppearanceFlags;
+        Invisibility = appearance.Invisibility;
+        Opacity = appearance.Opacity;
+        MouseOpacity = appearance.MouseOpacity;
+        Overlays = new(appearance.Overlays);
+        Underlays = new(appearance.Underlays);
+        VisContents = new(appearance.VisContents);
+        Filters = new(appearance.Filters);
+        Verbs = new(appearance.Verbs);
+        Override = appearance.Override;
+
+        for (int i = 0; i < 6; i++) {
+            Transform[i] = appearance.Transform[i];
+        }
+    }
+
+    public override bool Equals(object? obj) => obj is IconAppearance appearance && Equals(appearance);
+
+    public bool Equals(IconAppearance? appearance) {
+        if (appearance == null) return false;
+
+        if (appearance.Icon != Icon) return false;
+        if (appearance.IconState != IconState) return false;
+        if (appearance.Direction != Direction) return false;
+        if (appearance.InheritsDirection != InheritsDirection) return false;
+        if (appearance.PixelOffset != PixelOffset) return false;
+        if (appearance.Color != Color) return false;
+        if (appearance.Alpha != Alpha) return false;
+        if (appearance.GlideSize != GlideSize) return false;
+        if (!appearance.ColorMatrix.Equals(ColorMatrix)) return false;
+        if (!appearance.Layer.Equals(Layer)) return false;
+        if (appearance.Plane != Plane) return false;
+        if (appearance.RenderSource != RenderSource) return false;
+        if (appearance.RenderTarget != RenderTarget) return false;
+        if (appearance.BlendMode != BlendMode) return false;
+        if (appearance.AppearanceFlags != AppearanceFlags) return false;
+        if (appearance.Invisibility != Invisibility) return false;
+        if (appearance.Opacity != Opacity) return false;
+        if (appearance.MouseOpacity != MouseOpacity) return false;
+        if (appearance.Overlays.Count != Overlays.Count) return false;
+        if (appearance.Underlays.Count != Underlays.Count) return false;
+        if (appearance.VisContents.Count != VisContents.Count) return false;
+        if (appearance.Filters.Count != Filters.Count) return false;
+        if (appearance.Verbs.Count != Verbs.Count) return false;
+        if (appearance.Override != Override) return false;
+
+        for (int i = 0; i < Filters.Count; i++) {
+            if (appearance.Filters[i] != Filters[i]) return false;
         }
 
-        public IconAppearance(IconAppearance appearance) {
-            Icon = appearance.Icon;
-            IconState = appearance.IconState;
-            Direction = appearance.Direction;
-            InheritsDirection = appearance.InheritsDirection;
-            PixelOffset = appearance.PixelOffset;
-            Color = appearance.Color;
-            Alpha = appearance.Alpha;
-            GlideSize = appearance.GlideSize;
-            ColorMatrix = appearance.ColorMatrix;
-            Layer = appearance.Layer;
-            Plane = appearance.Plane;
-            RenderSource = appearance.RenderSource;
-            RenderTarget = appearance.RenderTarget;
-            BlendMode = appearance.BlendMode;
-            AppearanceFlags = appearance.AppearanceFlags;
-            Invisibility = appearance.Invisibility;
-            Opacity = appearance.Opacity;
-            MouseOpacity = appearance.MouseOpacity;
-            Overlays = new(appearance.Overlays);
-            Underlays = new(appearance.Underlays);
-            VisContents = new(appearance.VisContents);
-            Filters = new(appearance.Filters);
-            Verbs = new(appearance.Verbs);
-            Override = appearance.Override;
-
-            for (int i = 0; i < 6; i++) {
-                Transform[i] = appearance.Transform[i];
-            }
+        for (int i = 0; i < Overlays.Count; i++) {
+            if (appearance.Overlays[i] != Overlays[i]) return false;
         }
 
-        public override bool Equals(object? obj) => obj is IconAppearance appearance && Equals(appearance);
-
-        public bool Equals(IconAppearance? appearance) {
-            if (appearance == null) return false;
-
-            if (appearance.Icon != Icon) return false;
-            if (appearance.IconState != IconState) return false;
-            if (appearance.Direction != Direction) return false;
-            if (appearance.InheritsDirection != InheritsDirection) return false;
-            if (appearance.PixelOffset != PixelOffset) return false;
-            if (appearance.Color != Color) return false;
-            if (appearance.Alpha != Alpha) return false;
-            if (appearance.GlideSize != GlideSize) return false;
-            if (!appearance.ColorMatrix.Equals(ColorMatrix)) return false;
-            if (!appearance.Layer.Equals(Layer)) return false;
-            if (appearance.Plane != Plane) return false;
-            if (appearance.RenderSource != RenderSource) return false;
-            if (appearance.RenderTarget != RenderTarget) return false;
-            if (appearance.BlendMode != BlendMode) return false;
-            if (appearance.AppearanceFlags != AppearanceFlags) return false;
-            if (appearance.Invisibility != Invisibility) return false;
-            if (appearance.Opacity != Opacity) return false;
-            if (appearance.MouseOpacity != MouseOpacity) return false;
-            if (appearance.Overlays.Count != Overlays.Count) return false;
-            if (appearance.Underlays.Count != Underlays.Count) return false;
-            if (appearance.VisContents.Count != VisContents.Count) return false;
-            if (appearance.Filters.Count != Filters.Count) return false;
-            if (appearance.Verbs.Count != Verbs.Count) return false;
-            if (appearance.Override != Override) return false;
-
-            for (int i = 0; i < Filters.Count; i++) {
-                if (appearance.Filters[i] != Filters[i]) return false;
-            }
-
-            for (int i = 0; i < Overlays.Count; i++) {
-                if (appearance.Overlays[i] != Overlays[i]) return false;
-            }
-
-            for (int i = 0; i < Underlays.Count; i++) {
-                if (appearance.Underlays[i] != Underlays[i]) return false;
-            }
-
-            for (int i = 0; i < VisContents.Count; i++) {
-                if (appearance.VisContents[i] != VisContents[i]) return false;
-            }
-
-            for (int i = 0; i < Verbs.Count; i++) {
-                if (appearance.Verbs[i] != Verbs[i]) return false;
-            }
-
-            for (int i = 0; i < 6; i++) {
-                if (!appearance.Transform[i].Equals(Transform[i])) return false;
-            }
-
-            return true;
+        for (int i = 0; i < Underlays.Count; i++) {
+            if (appearance.Underlays[i] != Underlays[i]) return false;
         }
 
-        /// <summary>
-        /// This is a helper used for both optimization and parity. <br/>
-        /// In BYOND, if a color matrix is representable as an RGBA color string, <br/>
-        /// then it is coerced into one internally before being saved onto some appearance. <br/>
-        /// This does the linear algebra madness necessary to determine whether this is the case or not.
-        /// </summary>
-        private static bool TryRepresentMatrixAsRGBAColor(in ColorMatrix matrix, [NotNullWhen(true)] out Color? maybeColor) {
-            maybeColor = null;
-            // The R G B A values need to be bounded [0,1] for a color conversion to work;
-            // anything higher implies trying to render "superblue" or something.
-            float diagonalSum = 0f;
-            foreach (float diagonalValue in matrix.GetDiagonal()) {
-                if (diagonalValue < 0 || diagonalValue > 1)
-                    return false;
-                diagonalSum += diagonalValue;
-            }
-            // and then all of the other values need to be zero, including the offset vector.
-            float sum = 0f;
-            foreach (float value in matrix.GetValues()) {
-                if (value < 0f) // To avoid situations like negatives and positives cancelling out this checksum.
-                    return false;
-                sum += value;
-            }
-            if (sum - diagonalSum == 0) // PREEETTY sure I can trust the floating-point math here. Not 100% though
-                maybeColor = new Color(matrix.c11, matrix.c22, matrix.c33, matrix.c44);
-            return maybeColor is not null;
+        for (int i = 0; i < VisContents.Count; i++) {
+            if (appearance.VisContents[i] != VisContents[i]) return false;
         }
 
-        public override int GetHashCode() {
-            HashCode hashCode = new HashCode();
-
-            hashCode.Add(Icon);
-            hashCode.Add(IconState);
-            hashCode.Add(Direction);
-            hashCode.Add(InheritsDirection);
-            hashCode.Add(PixelOffset);
-            hashCode.Add(Color);
-            hashCode.Add(ColorMatrix);
-            hashCode.Add(Layer);
-            hashCode.Add(Invisibility);
-            hashCode.Add(Opacity);
-            hashCode.Add(MouseOpacity);
-            hashCode.Add(Alpha);
-            hashCode.Add(GlideSize);
-            hashCode.Add(Plane);
-            hashCode.Add(RenderSource);
-            hashCode.Add(RenderTarget);
-            hashCode.Add(BlendMode);
-            hashCode.Add(AppearanceFlags);
-
-            foreach (int overlay in Overlays) {
-                hashCode.Add(overlay);
-            }
-
-            foreach (int underlay in Underlays) {
-                hashCode.Add(underlay);
-            }
-
-            foreach (int visContent in VisContents) {
-                hashCode.Add(visContent);
-            }
-
-            foreach (DreamFilter filter in Filters) {
-                hashCode.Add(filter);
-            }
-
-            foreach (int verb in Verbs) {
-                hashCode.Add(verb);
-            }
-
-            for (int i = 0; i < 6; i++) {
-                hashCode.Add(Transform[i]);
-            }
-
-            return hashCode.ToHashCode();
+        for (int i = 0; i < Verbs.Count; i++) {
+            if (appearance.Verbs[i] != Verbs[i]) return false;
         }
 
-        /// <summary>
-        /// Parses the given colour string and sets this appearance to use it.
-        /// </summary>
-        /// <exception cref="ArgumentException">Thrown if color is not valid.</exception>
-        public void SetColor(string color) {
-            // TODO: the BYOND compiler enforces valid colors *unless* it's a map edit, in which case an empty string is allowed
-            ColorMatrix = ColorMatrix.Identity; // reset our color matrix if we had one
-
-            if (!ColorHelpers.TryParseColor(color, out Color)) {
-                Color = Color.White;
-            }
+        for (int i = 0; i < 6; i++) {
+            if (!appearance.Transform[i].Equals(Transform[i])) return false;
         }
-        /// <summary>
-        /// Sets the 'color' attribute to a color matrix, which will be used on the icon later on by a shader.
-        /// </summary>
-        public void SetColor(in ColorMatrix matrix) {
 
-            if (TryRepresentMatrixAsRGBAColor(matrix, out var matrixColor)) {
-                Color = matrixColor.Value;
-                ColorMatrix = ColorMatrix.Identity;
-                return;
-            }
+        return true;
+    }
+
+    /// <summary>
+    /// This is a helper used for both optimization and parity. <br/>
+    /// In BYOND, if a color matrix is representable as an RGBA color string, <br/>
+    /// then it is coerced into one internally before being saved onto some appearance. <br/>
+    /// This does the linear algebra madness necessary to determine whether this is the case or not.
+    /// </summary>
+    private static bool TryRepresentMatrixAsRGBAColor(in ColorMatrix matrix, [NotNullWhen(true)] out Color? maybeColor) {
+        maybeColor = null;
+        // The R G B A values need to be bounded [0,1] for a color conversion to work;
+        // anything higher implies trying to render "superblue" or something.
+        float diagonalSum = 0f;
+        foreach (float diagonalValue in matrix.GetDiagonal()) {
+            if (diagonalValue < 0 || diagonalValue > 1)
+                return false;
+            diagonalSum += diagonalValue;
+        }
+        // and then all of the other values need to be zero, including the offset vector.
+        float sum = 0f;
+        foreach (float value in matrix.GetValues()) {
+            if (value < 0f) // To avoid situations like negatives and positives cancelling out this checksum.
+                return false;
+            sum += value;
+        }
+        if (sum - diagonalSum == 0) // PREEETTY sure I can trust the floating-point math here. Not 100% though
+            maybeColor = new Color(matrix.c11, matrix.c22, matrix.c33, matrix.c44);
+        return maybeColor is not null;
+    }
+
+    public override int GetHashCode() {
+        HashCode hashCode = new HashCode();
+
+        hashCode.Add(Icon);
+        hashCode.Add(IconState);
+        hashCode.Add(Direction);
+        hashCode.Add(InheritsDirection);
+        hashCode.Add(PixelOffset);
+        hashCode.Add(Color);
+        hashCode.Add(ColorMatrix);
+        hashCode.Add(Layer);
+        hashCode.Add(Invisibility);
+        hashCode.Add(Opacity);
+        hashCode.Add(MouseOpacity);
+        hashCode.Add(Alpha);
+        hashCode.Add(GlideSize);
+        hashCode.Add(Plane);
+        hashCode.Add(RenderSource);
+        hashCode.Add(RenderTarget);
+        hashCode.Add(BlendMode);
+        hashCode.Add(AppearanceFlags);
+
+        foreach (int overlay in Overlays) {
+            hashCode.Add(overlay);
+        }
+
+        foreach (int underlay in Underlays) {
+            hashCode.Add(underlay);
+        }
+
+        foreach (int visContent in VisContents) {
+            hashCode.Add(visContent);
+        }
+
+        foreach (DreamFilter filter in Filters) {
+            hashCode.Add(filter);
+        }
+
+        foreach (int verb in Verbs) {
+            hashCode.Add(verb);
+        }
+
+        for (int i = 0; i < 6; i++) {
+            hashCode.Add(Transform[i]);
+        }
+
+        return hashCode.ToHashCode();
+    }
+
+    /// <summary>
+    /// Parses the given colour string and sets this appearance to use it.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown if color is not valid.</exception>
+    public void SetColor(string color) {
+        // TODO: the BYOND compiler enforces valid colors *unless* it's a map edit, in which case an empty string is allowed
+        ColorMatrix = ColorMatrix.Identity; // reset our color matrix if we had one
+
+        if (!ColorHelpers.TryParseColor(color, out Color)) {
             Color = Color.White;
-            ColorMatrix = matrix;
         }
     }
 
-    public enum BlendMode {
-        Default,
-        Overlay,
-        Add,
-        Subtract,
-        Multiply,
-        InsertOverlay
-    }
+    /// <summary>
+    /// Sets the 'color' attribute to a color matrix, which will be used on the icon later on by a shader.
+    /// </summary>
+    public void SetColor(in ColorMatrix matrix) {
+        if (TryRepresentMatrixAsRGBAColor(matrix, out var matrixColor)) {
+            Color = matrixColor.Value;
+            ColorMatrix = ColorMatrix.Identity;
+            return;
+        }
 
-    [Flags]
-    public enum AppearanceFlags {
-        None = 0,
-        LongGlide = 1,
-        ResetColor = 2,
-        ResetAlpha = 4,
-        ResetTransform = 8,
-        NoClientColor = 16,
-        KeepTogether = 32,
-        KeepApart = 64,
-        PlaneMaster = 128,
-        TileBound = 256,
-        PixelScale = 512,
-        PassMouse = 1024,
-        TileMover = 2048
+        Color = Color.White;
+        ColorMatrix = matrix;
     }
+}
 
-    [Flags] //kinda, but only EASE_IN and EASE_OUT are used as bitflags, everything else is an enum
-    public enum AnimationEasing {
-        Linear = 0,
-        Sine = 1,
-        Circular = 2,
-        Cubic = 3,
-        Bounce = 4,
-        Elastic = 5,
-        Back = 6,
-        Quad = 7,
-        Jump = 8,
-        EaseIn = 64,
-        EaseOut = 128,
-    }
+public enum BlendMode {
+    Default,
+    Overlay,
+    Add,
+    Subtract,
+    Multiply,
+    InsertOverlay
+}
 
-    [Flags]
-    public enum AnimationFlags {
-        None = 0,
-        AnimationEndNow = 1,
-        AnimationLinearTransform = 2,
-        AnimationParallel = 4,
-        AnimationSlice = 8,
-        AnimationRelative = 256,
-        AnimationContinue = 512,
+[Flags]
+public enum AppearanceFlags {
+    None = 0,
+    LongGlide = 1,
+    ResetColor = 2,
+    ResetAlpha = 4,
+    ResetTransform = 8,
+    NoClientColor = 16,
+    KeepTogether = 32,
+    KeepApart = 64,
+    PlaneMaster = 128,
+    TileBound = 256,
+    PixelScale = 512,
+    PassMouse = 1024,
+    TileMover = 2048
+}
 
-    }
+[Flags] //kinda, but only EASE_IN and EASE_OUT are used as bitflags, everything else is an enum
+public enum AnimationEasing {
+    Linear = 0,
+    Sine = 1,
+    Circular = 2,
+    Cubic = 3,
+    Bounce = 4,
+    Elastic = 5,
+    Back = 6,
+    Quad = 7,
+    Jump = 8,
+    EaseIn = 64,
+    EaseOut = 128,
+}
+
+[Flags]
+public enum AnimationFlags {
+    None = 0,
+    AnimationEndNow = 1,
+    AnimationLinearTransform = 2,
+    AnimationParallel = 4,
+    AnimationSlice = 8,
+    AnimationRelative = 256,
+    AnimationContinue = 512,
+
 }

--- a/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
+++ b/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
@@ -9,7 +9,7 @@ using Robust.Shared.Serialization;
 
 namespace OpenDreamShared.Network.Messages;
 
-public sealed class MsgAllAppearances : NetMessage {
+public sealed class MsgAllAppearances(Dictionary<int, IconAppearance> allAppearances) : NetMessage {
     public override MsgGroups MsgGroup => MsgGroups.EntityEvent;
 
     private enum Property : byte {
@@ -43,7 +43,9 @@ public sealed class MsgAllAppearances : NetMessage {
         End
     }
 
-    public Dictionary<int, IconAppearance> AllAppearances;
+    public Dictionary<int, IconAppearance> AllAppearances = allAppearances;
+
+    public MsgAllAppearances() : this(new()) { }
 
     public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer) {
         var count = buffer.ReadInt32();

--- a/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
+++ b/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
@@ -117,6 +117,16 @@ public sealed class MsgAllAppearances : NetMessage {
                     case Property.MouseOpacity:
                         appearance.MouseOpacity = (MouseOpacity)buffer.ReadByte();
                         break;
+                    case Property.ColorMatrix:
+                        appearance.ColorMatrix = new(
+                            buffer.ReadSingle(), buffer.ReadSingle(), buffer.ReadSingle(), buffer.ReadSingle(),
+                            buffer.ReadSingle(), buffer.ReadSingle(), buffer.ReadSingle(), buffer.ReadSingle(),
+                            buffer.ReadSingle(), buffer.ReadSingle(), buffer.ReadSingle(), buffer.ReadSingle(),
+                            buffer.ReadSingle(), buffer.ReadSingle(), buffer.ReadSingle(), buffer.ReadSingle(),
+                            buffer.ReadSingle(), buffer.ReadSingle(), buffer.ReadSingle(), buffer.ReadSingle()
+                        );
+
+                        break;
                     case Property.Overlays: {
                         var overlaysCount = buffer.ReadVariableInt32();
 
@@ -249,8 +259,10 @@ public sealed class MsgAllAppearances : NetMessage {
             }
 
             if (!appearance.ColorMatrix.Equals(IconAppearance.Default.ColorMatrix)) {
-                /*buffer.Write((byte)Property.ColorMatrix);
-                buffer.Write(appearance.ColorMatrix);*/
+                buffer.Write((byte)Property.ColorMatrix);
+
+                foreach (var value in appearance.ColorMatrix.GetValues())
+                    buffer.Write(value);
             }
 
             if (!appearance.Layer.Equals(IconAppearance.Default.Layer)) {

--- a/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
+++ b/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
@@ -295,7 +295,7 @@ public sealed class MsgAllAppearances(Dictionary<int, IconAppearance> allAppeara
             }
 
             if (appearance.Override != IconAppearance.Default.Override) {
-                buffer.Write((byte)Property.BlendMode);
+                buffer.Write((byte)Property.Override);
                 buffer.Write(appearance.Override);
             }
 

--- a/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
+++ b/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
@@ -1,0 +1,369 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Lidgren.Network;
+using OpenDreamShared.Dream;
+using Robust.Shared.Log;
+using Robust.Shared.Network;
+using Robust.Shared.Serialization;
+
+namespace OpenDreamShared.Network.Messages;
+
+public sealed class MsgAllAppearances : NetMessage {
+    public override MsgGroups MsgGroup => MsgGroups.EntityEvent;
+
+    private enum Property : byte {
+        Icon,
+        IconState,
+        Direction,
+        DoesntInheritDirection,
+        PixelOffset,
+        Color,
+        Alpha,
+        GlideSize,
+        ColorMatrix,
+        Layer,
+        Plane,
+        BlendMode,
+        AppearanceFlags,
+        Invisibility,
+        Opacity,
+        Override,
+        RenderSource,
+        RenderTarget,
+        MouseOpacity,
+        Overlays,
+        Underlays,
+        VisContents,
+        Filters,
+        Verbs,
+        Transform,
+
+        Id,
+        End
+    }
+
+    public Dictionary<int, IconAppearance> AllAppearances;
+
+    public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer) {
+        var count = buffer.ReadInt32();
+        var appearanceId = -1;
+
+        AllAppearances = new(count);
+
+        for (int i = 0; i < count; i++) {
+            var appearance = new IconAppearance();
+            var property = (Property)buffer.ReadByte();
+
+            appearanceId++;
+
+            while (property != Property.End) {
+                switch (property) {
+                    case Property.Id:
+                        appearanceId = buffer.ReadVariableInt32();
+                        break;
+                    case Property.Icon:
+                        appearance.Icon = buffer.ReadVariableInt32();
+                        break;
+                    case Property.IconState:
+                        appearance.IconState = buffer.ReadString();
+                        break;
+                    case Property.Direction:
+                        appearance.Direction = (AtomDirection)buffer.ReadByte();
+                        break;
+                    case Property.DoesntInheritDirection:
+                        appearance.InheritsDirection = false;
+                        break;
+                    case Property.PixelOffset:
+                        appearance.PixelOffset = (buffer.ReadVariableInt32(), buffer.ReadVariableInt32());
+                        break;
+                    case Property.Color:
+                        appearance.Color = buffer.ReadColor();
+                        break;
+                    case Property.Alpha:
+                        appearance.Alpha = buffer.ReadByte();
+                        break;
+                    case Property.GlideSize:
+                        appearance.GlideSize = buffer.ReadFloat();
+                        break;
+                    case Property.Layer:
+                        appearance.Layer = buffer.ReadFloat();
+                        break;
+                    case Property.Plane:
+                        appearance.Plane = buffer.ReadVariableInt32();
+                        break;
+                    case Property.BlendMode:
+                        appearance.BlendMode = (BlendMode)buffer.ReadByte();
+                        break;
+                    case Property.AppearanceFlags:
+                        appearance.AppearanceFlags = (AppearanceFlags)buffer.ReadInt32();
+                        break;
+                    case Property.Invisibility:
+                        appearance.Invisibility = buffer.ReadSByte();
+                        break;
+                    case Property.Opacity:
+                        appearance.Opacity = buffer.ReadBoolean();
+                        break;
+                    case Property.Override:
+                        appearance.Override = buffer.ReadBoolean();
+                        break;
+                    case Property.RenderSource:
+                        appearance.RenderSource = buffer.ReadString();
+                        break;
+                    case Property.RenderTarget:
+                        appearance.RenderTarget = buffer.ReadString();
+                        break;
+                    case Property.MouseOpacity:
+                        appearance.MouseOpacity = (MouseOpacity)buffer.ReadByte();
+                        break;
+                    case Property.Overlays: {
+                        var overlaysCount = buffer.ReadVariableInt32();
+
+                        appearance.Overlays.EnsureCapacity(overlaysCount);
+                        for (int overlaysI = 0; overlaysI < overlaysCount; overlaysI++) {
+                            appearance.Overlays.Add(buffer.ReadVariableInt32());
+                        }
+
+                        break;
+                    }
+                    case Property.Underlays: {
+                        var underlaysCount = buffer.ReadVariableInt32();
+
+                        appearance.Underlays.EnsureCapacity(underlaysCount);
+                        for (int underlaysI = 0; underlaysI < underlaysCount; underlaysI++) {
+                            appearance.Underlays.Add(buffer.ReadVariableInt32());
+                        }
+
+                        break;
+                    }
+                    case Property.VisContents: {
+                        var visContentsCount = buffer.ReadVariableInt32();
+
+                        appearance.VisContents.EnsureCapacity(visContentsCount);
+                        for (int visContentsI = 0; visContentsI < visContentsCount; visContentsI++) {
+                            appearance.VisContents.Add(buffer.ReadNetEntity());
+                        }
+
+                        break;
+                    }
+                    case Property.Filters: {
+                        var filtersCount = buffer.ReadInt32();
+
+                        appearance.Filters.EnsureCapacity(filtersCount);
+                        for (int filtersI = 0; filtersI < filtersCount; filtersI++) {
+                            var filterLength = buffer.ReadVariableInt32();
+                            var filterData = buffer.ReadBytes(filterLength);
+                            using var filterStream = new MemoryStream(filterData);
+                            var filter = serializer.Deserialize<DreamFilter>(filterStream);
+
+                            appearance.Filters.Add(filter);
+                        }
+
+                        break;
+                    }
+                    case Property.Verbs: {
+                        var verbsCount = buffer.ReadVariableInt32();
+
+                        appearance.Verbs.EnsureCapacity(verbsCount);
+                        for (int verbsI = 0; verbsI < verbsCount; verbsI++) {
+                            appearance.Verbs.Add(buffer.ReadVariableInt32());
+                        }
+
+                        break;
+                    }
+                    case Property.Transform: {
+                        appearance.Transform = [
+                            buffer.ReadSingle(), buffer.ReadSingle(),
+                            buffer.ReadSingle(), buffer.ReadSingle(),
+                            buffer.ReadSingle(), buffer.ReadSingle()
+                        ];
+
+                        break;
+                    }
+                    default:
+                        throw new Exception($"Invalid property {property}");
+                }
+
+                property = (Property)buffer.ReadByte();
+            }
+
+            AllAppearances.Add(appearanceId, appearance);
+        }
+
+        Logger.Debug($"Received {AllAppearances.Count} appearances");
+    }
+
+    public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer) {
+        int lastId = -1;
+
+        buffer.Write(AllAppearances.Count);
+        foreach (var pair in AllAppearances) {
+            var appearance = pair.Value;
+
+            if (pair.Key != lastId + 1) {
+                buffer.Write((byte)Property.Id);
+                buffer.WriteVariableInt32(pair.Key);
+            }
+
+            lastId = pair.Key;
+
+            if (appearance.Icon != null) {
+                buffer.Write((byte)Property.Icon);
+                buffer.WriteVariableInt32(appearance.Icon.Value);
+            }
+
+            if (appearance.IconState != null) {
+                buffer.Write((byte)Property.IconState);
+                buffer.Write(appearance.IconState);
+            }
+
+            if (appearance.Direction != IconAppearance.Default.Direction) {
+                buffer.Write((byte)Property.Direction);
+                buffer.Write((byte)appearance.Direction);
+            }
+
+            if (appearance.InheritsDirection != true) {
+                buffer.Write((byte)Property.DoesntInheritDirection);
+            }
+
+            if (appearance.PixelOffset != IconAppearance.Default.PixelOffset) {
+                buffer.Write((byte)Property.PixelOffset);
+                buffer.WriteVariableInt32(appearance.PixelOffset.X);
+                buffer.WriteVariableInt32(appearance.PixelOffset.Y);
+            }
+
+            if (appearance.Color != IconAppearance.Default.Color) {
+                buffer.Write((byte)Property.Color);
+                buffer.Write(appearance.Color);
+            }
+
+            if (appearance.Alpha != IconAppearance.Default.Alpha) {
+                buffer.Write((byte)Property.Alpha);
+                buffer.Write(appearance.Alpha);
+            }
+
+            if (!appearance.GlideSize.Equals(IconAppearance.Default.GlideSize)) {
+                buffer.Write((byte)Property.GlideSize);
+                buffer.Write(appearance.GlideSize);
+            }
+
+            if (!appearance.ColorMatrix.Equals(IconAppearance.Default.ColorMatrix)) {
+                /*buffer.Write((byte)Property.ColorMatrix);
+                buffer.Write(appearance.ColorMatrix);*/
+            }
+
+            if (!appearance.Layer.Equals(IconAppearance.Default.Layer)) {
+                buffer.Write((byte)Property.Layer);
+                buffer.Write(appearance.Layer);
+            }
+
+            if (appearance.Plane != IconAppearance.Default.Plane) {
+                buffer.Write((byte)Property.Plane);
+                buffer.WriteVariableInt32(appearance.Plane);
+            }
+
+            if (appearance.BlendMode != IconAppearance.Default.BlendMode) {
+                buffer.Write((byte)Property.BlendMode);
+                buffer.Write((byte)appearance.BlendMode);
+            }
+
+            if (appearance.AppearanceFlags != IconAppearance.Default.AppearanceFlags) {
+                buffer.Write((byte)Property.AppearanceFlags);
+                buffer.Write((int)appearance.AppearanceFlags);
+            }
+
+            if (appearance.Invisibility != IconAppearance.Default.Invisibility) {
+                buffer.Write((byte)Property.Invisibility);
+                buffer.Write(appearance.Invisibility);
+            }
+
+            if (appearance.Opacity != IconAppearance.Default.Opacity) {
+                buffer.Write((byte)Property.Opacity);
+                buffer.Write(appearance.Opacity);
+            }
+
+            if (appearance.Override != IconAppearance.Default.Override) {
+                buffer.Write((byte)Property.BlendMode);
+                buffer.Write(appearance.Override);
+            }
+
+            if (!string.IsNullOrWhiteSpace(appearance.RenderSource)) {
+                buffer.Write((byte)Property.RenderSource);
+                buffer.Write(appearance.RenderSource);
+            }
+
+            if (!string.IsNullOrWhiteSpace(appearance.RenderTarget)) {
+                buffer.Write((byte)Property.RenderTarget);
+                buffer.Write(appearance.RenderTarget);
+            }
+
+            if (appearance.MouseOpacity != IconAppearance.Default.MouseOpacity) {
+                buffer.Write((byte)Property.MouseOpacity);
+                buffer.Write((byte)appearance.MouseOpacity);
+            }
+
+            if (appearance.Overlays.Count != 0) {
+                buffer.Write((byte)Property.Overlays);
+
+                buffer.WriteVariableInt32(appearance.Overlays.Count);
+                foreach (var overlay in appearance.Overlays) {
+                    buffer.WriteVariableInt32(overlay);
+                }
+            }
+
+            if (appearance.Underlays.Count != 0) {
+                buffer.Write((byte)Property.Underlays);
+
+                buffer.WriteVariableInt32(appearance.Underlays.Count);
+                foreach (var underlay in appearance.Underlays) {
+                    buffer.WriteVariableInt32(underlay);
+                }
+            }
+
+            if (appearance.VisContents.Count != 0) {
+                buffer.Write((byte)Property.VisContents);
+
+                buffer.WriteVariableInt32(appearance.VisContents.Count);
+                foreach (var item in appearance.VisContents) {
+                    buffer.Write(item);
+                }
+            }
+
+            if (appearance.Filters.Count != 0) {
+                buffer.Write((byte)Property.Filters);
+
+                buffer.Write(appearance.Filters.Count);
+                foreach (var filter in appearance.Filters) {
+                    using var filterStream = new MemoryStream();
+
+                    serializer.Serialize(filterStream, filter);
+                    buffer.WriteVariableInt32((int)filterStream.Length);
+                    filterStream.TryGetBuffer(out var filterBuffer);
+                    buffer.Write(filterBuffer);
+                }
+            }
+
+            if (appearance.Verbs.Count != 0) {
+                buffer.Write((byte)Property.Verbs);
+
+                buffer.WriteVariableInt32(appearance.Verbs.Count);
+                foreach (var verb in appearance.Verbs) {
+                    buffer.WriteVariableInt32(verb);
+                }
+            }
+
+            if (!appearance.Transform.SequenceEqual(IconAppearance.Default.Transform)) {
+                buffer.Write((byte)Property.Transform);
+
+                for (int i = 0; i < 6; i++) {
+                    buffer.Write(appearance.Transform[i]);
+                }
+            }
+
+            buffer.Write((byte)Property.End);
+        }
+
+        Logger.Debug($"Final size {buffer.LengthBytes}");
+    }
+}

--- a/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
+++ b/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using Lidgren.Network;
 using OpenDreamShared.Dream;
-using Robust.Shared.Log;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
@@ -200,8 +199,6 @@ public sealed class MsgAllAppearances : NetMessage {
 
             AllAppearances.Add(appearanceId, appearance);
         }
-
-        Logger.Debug($"Received {AllAppearances.Count} appearances");
     }
 
     public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer) {
@@ -375,7 +372,5 @@ public sealed class MsgAllAppearances : NetMessage {
 
             buffer.Write((byte)Property.End);
         }
-
-        Logger.Debug($"Final size {buffer.LengthBytes}");
     }
 }

--- a/OpenDreamShared/Rendering/SharedAppearanceSystem.cs
+++ b/OpenDreamShared/Rendering/SharedAppearanceSystem.cs
@@ -2,16 +2,10 @@
 using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization;
 using System;
-using System.Collections.Generic;
 
 namespace OpenDreamShared.Rendering;
 
 public abstract class SharedAppearanceSystem : EntitySystem {
-    [Serializable, NetSerializable]
-    public sealed class AllAppearancesEvent(Dictionary<int, IconAppearance> appearances) : EntityEventArgs {
-        public Dictionary<int, IconAppearance> Appearances = appearances;
-    }
-
     [Serializable, NetSerializable]
     public sealed class NewAppearanceEvent(int appearanceId, IconAppearance appearance) : EntityEventArgs {
         public int AppearanceId { get; } = appearanceId;


### PR DESCRIPTION
The AllAppearancesEvent was changed to a custom NetMessage that doesn't include values that haven't changed from the default. This greatly reduces the amount of data the client needs to download to have all the appearances.