### PR TITLE
Peephole optimize proc returns

### DIFF
--- a/DMCompiler/Bytecode/DreamProcOpcode.cs
+++ b/DMCompiler/Bytecode/DreamProcOpcode.cs
@@ -296,7 +296,9 @@ public enum DreamProcOpcode : byte {
     [OpcodeMetadata(0, OpcodeArgType.TypeId)]
     IsTypeDirect = 0x95,
     [OpcodeMetadata(0, OpcodeArgType.Reference)]
-    NullRef = 0x96
+    NullRef = 0x96,
+    [OpcodeMetadata(0, OpcodeArgType.Reference)]
+    ReturnReferenceValue = 0x97,
 }
 
 /// <summary>

--- a/DMCompiler/Optimizer/PeepholeOptimizations.cs
+++ b/DMCompiler/Optimizer/PeepholeOptimizations.cs
@@ -72,37 +72,9 @@ internal sealed class PushField : IPeepholeOptimization {
         ];
     }
 
-    // PushReferenceValue [ref]
-    // Return
-    // -> ReturnReferenceValue [ref]
-    internal class ReturnReferenceValue : IPeepholeOptimization {
-        public ReadOnlySpan<DreamProcOpcode> GetOpcodes() {
-            return [
-                DreamProcOpcode.PushReferenceValue,
-                DreamProcOpcode.Return
-            ];
-        }
-
-        public void Apply(List<IAnnotatedBytecode> input, int index) {
-            var range = input.GetRange(index, 2).Select(x => (AnnotatedBytecodeInstruction)x).ToList();
-            AnnotatedBytecodeReference? pushVal = (range[0].GetArgs()[0] as AnnotatedBytecodeReference);
-            input.RemoveRange(index, 2);
-            input.Insert(index,
-                new AnnotatedBytecodeInstruction(DreamProcOpcode.ReturnReferenceValue,
-                    new List<IAnnotatedBytecode> { pushVal }));
-        }
-    }
-
-    // PushString [string]
-    // ...
-    // PushString [string]
-    // -> PushNStrings [count] [string] ... [string]
-    internal class PushNStrings : IPeepholeOptimization {
-        public ReadOnlySpan<DreamProcOpcode> GetOpcodes() {
-            return [
-                DreamProcOpcode.PushString,
-                DreamProcOpcode.PushString
-            ];
+    public void Apply(List<IAnnotatedBytecode> input, int index) {
+        if (index + 1 >= input.Count) {
+            throw new ArgumentOutOfRangeException("Index plus one is outside the bounds of the input list.");
         }
 
         AnnotatedBytecodeInstruction firstInstruction = (AnnotatedBytecodeInstruction)(input[index]);
@@ -115,6 +87,27 @@ internal sealed class PushField : IPeepholeOptimization {
             new List<IAnnotatedBytecode> { pushVal, derefField }));
     }
 
+}
+
+// PushReferenceValue [ref]
+// Return
+// -> ReturnReferenceValue [ref]
+internal class ReturnReferenceValue : IPeepholeOptimization {
+    public ReadOnlySpan<DreamProcOpcode> GetOpcodes() {
+        return [
+            DreamProcOpcode.PushReferenceValue,
+            DreamProcOpcode.Return
+        ];
+    }
+
+    public void Apply(List<IAnnotatedBytecode> input, int index) {
+        AnnotatedBytecodeInstruction firstInstruction = (AnnotatedBytecodeInstruction)(input[index]);
+        AnnotatedBytecodeReference? pushVal = (firstInstruction.GetArgs()[0] as AnnotatedBytecodeReference);
+        input.RemoveRange(index, 2);
+        input.Insert(index,
+            new AnnotatedBytecodeInstruction(DreamProcOpcode.ReturnReferenceValue,
+                new List<IAnnotatedBytecode> { pushVal }));
+    }
 }
 
 // PushReferenceValue [ref]

--- a/DMCompiler/Optimizer/PeepholeOptimizations.cs
+++ b/DMCompiler/Optimizer/PeepholeOptimizations.cs
@@ -72,9 +72,37 @@ internal sealed class PushField : IPeepholeOptimization {
         ];
     }
 
-    public void Apply(List<IAnnotatedBytecode> input, int index) {
-        if (index + 1 >= input.Count) {
-            throw new ArgumentOutOfRangeException("Index plus one is outside the bounds of the input list.");
+    // PushReferenceValue [ref]
+    // Return
+    // -> ReturnReferenceValue [ref]
+    internal class ReturnReferenceValue : IPeepholeOptimization {
+        public ReadOnlySpan<DreamProcOpcode> GetOpcodes() {
+            return [
+                DreamProcOpcode.PushReferenceValue,
+                DreamProcOpcode.Return
+            ];
+        }
+
+        public void Apply(List<IAnnotatedBytecode> input, int index) {
+            var range = input.GetRange(index, 2).Select(x => (AnnotatedBytecodeInstruction)x).ToList();
+            AnnotatedBytecodeReference? pushVal = (range[0].GetArgs()[0] as AnnotatedBytecodeReference);
+            input.RemoveRange(index, 2);
+            input.Insert(index,
+                new AnnotatedBytecodeInstruction(DreamProcOpcode.ReturnReferenceValue,
+                    new List<IAnnotatedBytecode> { pushVal }));
+        }
+    }
+
+    // PushString [string]
+    // ...
+    // PushString [string]
+    // -> PushNStrings [count] [string] ... [string]
+    internal class PushNStrings : IPeepholeOptimization {
+        public ReadOnlySpan<DreamProcOpcode> GetOpcodes() {
+            return [
+                DreamProcOpcode.PushString,
+                DreamProcOpcode.PushString
+            ];
         }
 
         AnnotatedBytecodeInstruction firstInstruction = (AnnotatedBytecodeInstruction)(input[index]);

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -24,13 +24,6 @@ namespace OpenDreamRuntime.Procs {
             return ProcStatus.Continue;
         }
 
-        public static ProcStatus ReturnReferenceValue(DMProcState state) {
-            DreamReference reference = state.ReadReference();
-
-            state.SetReturn(state.GetReferenceValue(reference));
-            return ProcStatus.Returned;
-        }
-
         public static ProcStatus Assign(DMProcState state) {
             DreamReference reference = state.ReadReference();
             DreamValue value = state.Pop();
@@ -1720,6 +1713,13 @@ namespace OpenDreamRuntime.Procs {
 
         public static ProcStatus DebuggerBreakpoint(DMProcState state) {
             return state.DebugManager.HandleBreakpoint(state);
+        }
+
+        public static ProcStatus ReturnReferenceValue(DMProcState state) {
+            DreamReference reference = state.ReadReference();
+
+            state.SetReturn(state.GetReferenceValue(reference));
+            return ProcStatus.Returned;
         }
         #endregion Flow
 

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -24,6 +24,13 @@ namespace OpenDreamRuntime.Procs {
             return ProcStatus.Continue;
         }
 
+        public static ProcStatus ReturnReferenceValue(DMProcState state) {
+            DreamReference reference = state.ReadReference();
+
+            state.SetReturn(state.GetReferenceValue(reference));
+            return ProcStatus.Returned;
+        }
+
         public static ProcStatus Assign(DMProcState state) {
             DreamReference reference = state.ReadReference();
             DreamValue value = state.Pop();

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -321,6 +321,7 @@ namespace OpenDreamRuntime.Procs {
             {DreamProcOpcode.CreateListNResources, DMOpcodeHandlers.CreateListNResources},
             {DreamProcOpcode.JumpIfNotNull, DMOpcodeHandlers.JumpIfNotNull},
             {DreamProcOpcode.IsTypeDirect, DMOpcodeHandlers.IsTypeDirect},
+            {DreamProcOpcode.ReturnReferenceValue, DMOpcodeHandlers.ReturnReferenceValue}
         };
 
         public static readonly unsafe delegate*<DMProcState, ProcStatus>[] OpcodeHandlers;


### PR DESCRIPTION
`(PushReferenceValue, Return) -> ReturnReferenceValue`

Per my frequency analysis this pattern occurs ~16k times in Paradise and ~25k times in goon and TG. It is a top-ten offender on all codebases tested.

However, this optimization is heavily kneecapped by #1842 which causes it to only be applied 664 times in Paradise bytecode. Once that issue is fixed this will become much more significant, as a large number of procs will no longer modify their stack when they return.