### PR TITLE
Implement multiplyref & divideref operator overloads

### DIFF
--- a/Content.Tests/DMProject/Tests/Operators/Overloads/complex_numbers.dm
+++ b/Content.Tests/DMProject/Tests/Operators/Overloads/complex_numbers.dm
@@ -28,6 +28,12 @@
 			return new /datum/complex(a*C, b*C)
 		else
 			return new /datum/complex((src.a * C.a) - (src.b * C.b), (src.a * C.b) + (src.b * C.a))
+
+	proc/operator/=(datum/complex/C)
+		if(isnum(C))
+			return new /datum/complex(a/C, b/C)
+		else
+			return new /datum/complex((src.a * C.a) - (src.b * C.b), (src.a * C.b) + (src.b * C.a))
 	
 	proc/operator|(datum/complex/C)
 		//nonsense, used for testing
@@ -79,4 +85,10 @@
 	ASSERT(result.a == 10 && result.b == -2)
 	//|
 	result = A | B
+	ASSERT(result.a == 3 && result.b == -1)
+
+	result *= 2
+	ASSERT(result.a == 6 && result.b == -2)
+
+	result /= 2
 	ASSERT(result.a == 3 && result.b == -1)

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -148,7 +148,9 @@ namespace DMCompiler.Compiler.DM {
             TokenType.DM_Plus,
             TokenType.DM_Minus,
             TokenType.DM_Star,
+            TokenType.DM_StarEquals,
             TokenType.DM_Slash,
+            TokenType.DM_SlashEquals,
             TokenType.DM_Bar,
         ];
 

--- a/DMCompiler/DreamPath.cs
+++ b/DMCompiler/DreamPath.cs
@@ -113,6 +113,16 @@ public struct DreamPath {
     public void SetFromString(string rawPath) {
         char pathTypeChar = rawPath[0];
         string[] tempElements = rawPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                //operator/ and operator/= need special handling
+        if(rawPath.EndsWith("operator/"))
+            tempElements[^1] = "operator/";
+                //operator/ and operator/= need special handling
+        if(rawPath.EndsWith("operator/=")) {
+            tempElements[^2] = "operator/=";
+            tempElements = tempElements[..^1]; //clip the last element (=)
+        }
+
+
         bool skipFirstChar = false;
 
         switch (pathTypeChar) {

--- a/DMCompiler/DreamPath.cs
+++ b/DMCompiler/DreamPath.cs
@@ -113,15 +113,14 @@ public struct DreamPath {
     public void SetFromString(string rawPath) {
         char pathTypeChar = rawPath[0];
         string[] tempElements = rawPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
-                // operator/ and operator/= need special handling
+       // operator/ and operator/= need special handling
         if(rawPath.EndsWith("operator/"))
             tempElements[^1] = "operator/";
-                // operator/ and operator/= need special handling
+        // operator/ and operator/= need special handling
         if(rawPath.EndsWith("operator/=")) {
             tempElements[^2] = "operator/=";
             tempElements = tempElements[..^1]; //clip the last element (=)
         }
-
 
         bool skipFirstChar = false;
 

--- a/DMCompiler/DreamPath.cs
+++ b/DMCompiler/DreamPath.cs
@@ -113,10 +113,10 @@ public struct DreamPath {
     public void SetFromString(string rawPath) {
         char pathTypeChar = rawPath[0];
         string[] tempElements = rawPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
-                //operator/ and operator/= need special handling
+                // operator/ and operator/= need special handling
         if(rawPath.EndsWith("operator/"))
             tempElements[^1] = "operator/";
-                //operator/ and operator/= need special handling
+                // operator/ and operator/= need special handling
         if(rawPath.EndsWith("operator/=")) {
             tempElements[^2] = "operator/=";
             tempElements = tempElements[..^1]; //clip the last element (=)

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -403,6 +403,30 @@ namespace OpenDreamRuntime.Objects {
             throw new InvalidOperationException($"Multiplication cannot be done between {this} and {b}");
         }
 
+        // *=
+        public virtual ProcStatus OperatorMultiplyRef(DreamValue b, DMProcState state, out DreamValue result, in DreamReference reference) {
+            if(TryGetProc("operator*=", out var proc)) {
+                if(!AssignRefProcState.Pool.TryPop(out var operatorProcState)){
+                    operatorProcState = new AssignRefProcState();
+                }
+                operatorProcState.Initialize(state, proc, this, state.Usr, new DreamProcArguments(b), reference);
+                state.Thread.PushProcState(operatorProcState);
+                result = DreamValue.Null;
+                return ProcStatus.Called;
+            } else if(TryGetProc("operator*", out var multiplyProc)) {
+                if(!AssignRefProcState.Pool.TryPop(out var operatorProcState)){
+                    operatorProcState = new AssignRefProcState();
+                }
+                operatorProcState.Initialize(state, multiplyProc, this, state.Usr, new DreamProcArguments(b), reference);
+                state.Thread.PushProcState(operatorProcState);
+                result = DreamValue.Null;
+                return ProcStatus.Called;
+            } else {
+                throw new InvalidOperationException($"Multiplication cannot be done between {this} and {b}");
+            }
+        }
+
+        // /
         public virtual ProcStatus OperatorDivide(DreamValue b, DMProcState state, out DreamValue result) {
             if(TryGetProc("operator/", out var proc)) {
                 var operatorProcState = proc.CreateState(state.Thread, this, state.Usr, new DreamProcArguments(b));
@@ -412,6 +436,29 @@ namespace OpenDreamRuntime.Objects {
             }
 
             throw new InvalidOperationException($"Division cannot be done between {this} and {b}");
+        }
+
+        // /=
+        public virtual ProcStatus OperatorDivideRef(DreamValue b, DMProcState state, out DreamValue result, in DreamReference reference) {
+            if(TryGetProc("operator/=", out var proc)) {
+                if(!AssignRefProcState.Pool.TryPop(out var operatorProcState)){
+                    operatorProcState = new AssignRefProcState();
+                }
+                operatorProcState.Initialize(state, proc, this, state.Usr, new DreamProcArguments(b), reference);
+                state.Thread.PushProcState(operatorProcState);
+                result = DreamValue.Null;
+                return ProcStatus.Called;
+            } else if(TryGetProc("operator/", out var divideProc)) {
+                if(!AssignRefProcState.Pool.TryPop(out var operatorProcState)){
+                    operatorProcState = new AssignRefProcState();
+                }
+                operatorProcState.Initialize(state, divideProc, this, state.Usr, new DreamProcArguments(b), reference);
+                state.Thread.PushProcState(operatorProcState);
+                result = DreamValue.Null;
+                return ProcStatus.Called;
+            } else {
+                throw new InvalidOperationException($"Division cannot be done between {this} and {b}");
+            }
         }
 
         // |

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -409,6 +409,7 @@ namespace OpenDreamRuntime.Objects {
                 if(!AssignRefProcState.Pool.TryPop(out var operatorProcState)){
                     operatorProcState = new AssignRefProcState();
                 }
+
                 operatorProcState.Initialize(state, proc, this, state.Usr, new DreamProcArguments(b), reference);
                 state.Thread.PushProcState(operatorProcState);
                 result = DreamValue.Null;
@@ -417,6 +418,7 @@ namespace OpenDreamRuntime.Objects {
                 if(!AssignRefProcState.Pool.TryPop(out var operatorProcState)){
                     operatorProcState = new AssignRefProcState();
                 }
+
                 operatorProcState.Initialize(state, multiplyProc, this, state.Usr, new DreamProcArguments(b), reference);
                 state.Thread.PushProcState(operatorProcState);
                 result = DreamValue.Null;
@@ -444,6 +446,7 @@ namespace OpenDreamRuntime.Objects {
                 if(!AssignRefProcState.Pool.TryPop(out var operatorProcState)){
                     operatorProcState = new AssignRefProcState();
                 }
+
                 operatorProcState.Initialize(state, proc, this, state.Usr, new DreamProcArguments(b), reference);
                 state.Thread.PushProcState(operatorProcState);
                 result = DreamValue.Null;
@@ -452,6 +455,7 @@ namespace OpenDreamRuntime.Objects {
                 if(!AssignRefProcState.Pool.TryPop(out var operatorProcState)){
                     operatorProcState = new AssignRefProcState();
                 }
+
                 operatorProcState.Initialize(state, divideProc, this, state.Usr, new DreamProcArguments(b), reference);
                 state.Thread.PushProcState(operatorProcState);
                 result = DreamValue.Null;

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -405,7 +405,7 @@ namespace OpenDreamRuntime.Objects {
 
         // *=
         public virtual ProcStatus OperatorMultiplyRef(DreamValue b, DMProcState state, out DreamValue result, in DreamReference reference) {
-            if(TryGetProc("operator*=", out var proc)) {
+            if (TryGetProc("operator*=", out var proc) || TryGetProc("operator*", out proc)) {
                 if(!AssignRefProcState.Pool.TryPop(out var operatorProcState)){
                     operatorProcState = new AssignRefProcState();
                 }
@@ -414,18 +414,9 @@ namespace OpenDreamRuntime.Objects {
                 state.Thread.PushProcState(operatorProcState);
                 result = DreamValue.Null;
                 return ProcStatus.Called;
-            } else if(TryGetProc("operator*", out var multiplyProc)) {
-                if(!AssignRefProcState.Pool.TryPop(out var operatorProcState)){
-                    operatorProcState = new AssignRefProcState();
-                }
-
-                operatorProcState.Initialize(state, multiplyProc, this, state.Usr, new DreamProcArguments(b), reference);
-                state.Thread.PushProcState(operatorProcState);
-                result = DreamValue.Null;
-                return ProcStatus.Called;
-            } else {
-                throw new InvalidOperationException($"Multiplication cannot be done between {this} and {b}");
             }
+
+            throw new InvalidOperationException($"Multiplication cannot be done between {this} and {b}");
         }
 
         // /
@@ -442,7 +433,7 @@ namespace OpenDreamRuntime.Objects {
 
         // /=
         public virtual ProcStatus OperatorDivideRef(DreamValue b, DMProcState state, out DreamValue result, in DreamReference reference) {
-            if(TryGetProc("operator/=", out var proc)) {
+            if(TryGetProc("operator/=", out var proc) || TryGetProc("operator/", out proc)) {
                 if(!AssignRefProcState.Pool.TryPop(out var operatorProcState)){
                     operatorProcState = new AssignRefProcState();
                 }
@@ -451,18 +442,9 @@ namespace OpenDreamRuntime.Objects {
                 state.Thread.PushProcState(operatorProcState);
                 result = DreamValue.Null;
                 return ProcStatus.Called;
-            } else if(TryGetProc("operator/", out var divideProc)) {
-                if(!AssignRefProcState.Pool.TryPop(out var operatorProcState)){
-                    operatorProcState = new AssignRefProcState();
-                }
-
-                operatorProcState.Initialize(state, divideProc, this, state.Usr, new DreamProcArguments(b), reference);
-                state.Thread.PushProcState(operatorProcState);
-                result = DreamValue.Null;
-                return ProcStatus.Called;
-            } else {
-                throw new InvalidOperationException($"Division cannot be done between {this} and {b}");
             }
+
+            throw new InvalidOperationException($"Division cannot be done between {this} and {b}");
         }
 
         // |

--- a/OpenDreamRuntime/Objects/Types/DreamObjectMatrix.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectMatrix.cs
@@ -182,6 +182,7 @@ public sealed class DreamObjectMatrix : DreamObject {
                 throw new ArgumentException("Matrix does not have a valid inversion for Invert()");
             return OperatorMultiply(new(rightCopy), state, out result); //returns ProcStatus.Continue, so the assignref can be handled in the opcode
         }
+
         return base.OperatorDivide(b, state, out result);
     }
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectMatrix.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectMatrix.cs
@@ -176,8 +176,12 @@ public sealed class DreamObjectMatrix : DreamObject {
                 );
             result = new DreamValue(output);
             return ProcStatus.Continue;
-        } //matrix divided by matrix isn't a thing
-
+        } else if(b.TryGetValueAsDreamObject<DreamObjectMatrix>(out var right)) { //matrix divided by matrix isn't a thing, but in BYOND it's apparently multiplication by the inverse, because of course it is
+            DreamObjectMatrix rightCopy = MatrixClone(ObjectTree, right);
+            if (!TryInvert(rightCopy))
+                throw new ArgumentException("Matrix does not have a valid inversion for Invert()");
+            return OperatorMultiply(new(rightCopy), state, out result); //returns ProcStatus.Continue, so the assignref can be handled in the opcode
+        }
         return base.OperatorDivide(b, state, out result);
     }
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectMatrix.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectMatrix.cs
@@ -157,6 +157,34 @@ public sealed class DreamObjectMatrix : DreamObject {
         return base.OperatorMultiply(b, state, out result);
     }
 
+    public override ProcStatus OperatorMultiplyRef(DreamValue b, DMProcState state, out DreamValue result, in DreamReference reference) {
+        return OperatorMultiply(b, state, out result); //returns ProcStatus.Continue, so the assignref can be handled in the opcode
+    }
+
+    public override ProcStatus OperatorDivide(DreamValue b, DMProcState state, out DreamValue result) {
+        GetVariable("a").TryGetValueAsFloat(out float lA);
+        GetVariable("b").TryGetValueAsFloat(out float lB);
+        GetVariable("c").TryGetValueAsFloat(out float lC);
+        GetVariable("d").TryGetValueAsFloat(out float lD);
+        GetVariable("e").TryGetValueAsFloat(out float lE);
+        GetVariable("f").TryGetValueAsFloat(out float lF);
+
+        if (b.TryGetValueAsFloat(out float bFloat)) {
+            DreamObjectMatrix output = MakeMatrix(ObjectTree,
+                    lA / bFloat,lB / bFloat,lC / bFloat,
+                    lD / bFloat,lE / bFloat,lF / bFloat
+                );
+            result = new DreamValue(output);
+            return ProcStatus.Continue;
+        } //matrix divided by matrix isn't a thing
+
+        return base.OperatorDivide(b, state, out result);
+    }
+
+    public override ProcStatus OperatorDivideRef(DreamValue b, DMProcState state, out DreamValue result, in DreamReference reference) {
+        return OperatorDivide(b, state, out result); //returns ProcStatus.Continue, so the assignref can be handled in the opcode
+    }
+
     public override DreamValue OperatorEquivalent(DreamValue b) {
         if (!b.TryGetValueAsDreamObject<DreamObjectMatrix>(out var right))
             return DreamValue.False;

--- a/OpenDreamRuntime/Procs/AssignRefProcState.cs
+++ b/OpenDreamRuntime/Procs/AssignRefProcState.cs
@@ -1,0 +1,80 @@
+using System.Text;
+using OpenDreamRuntime.Objects;
+
+namespace OpenDreamRuntime.Procs;
+internal sealed class AssignRefProcState : ProcState {
+    public static readonly Stack<AssignRefProcState> Pool = new();
+    private enum Stage {
+        // Call the associated proc
+        Call,
+
+        // Handle the assignment
+        AssignRef,
+    }
+
+    private DreamObject _dreamObject;
+    private DreamObject? _usr;
+    private readonly DreamValue[] _arguments = new DreamValue[256];
+    private int _argumentCount;
+    private Stage _stage = Stage.Call;
+    public override DreamProc? Proc => null;
+    private DreamProc _overloadProc;
+    private DMProcState _parentState;
+    private DreamReference _assignRef;
+
+    public AssignRefProcState() {
+    }
+
+    public void Initialize(DMProcState state, DreamProc overloadProc, DreamObject dreamObject, DreamObject? usr, DreamProcArguments arguments, DreamReference assignRef) {
+        base.Initialize(state.Thread, true);
+        _parentState = state;
+        _overloadProc = overloadProc;
+        _dreamObject = dreamObject;
+        _usr = usr;
+        arguments.Values.CopyTo(_arguments);
+        _argumentCount = arguments.Count;
+        _stage = Stage.Call;
+        _assignRef = assignRef;
+    }
+
+
+    public override void AppendStackFrame(StringBuilder builder) {
+        builder.AppendLine($"Operator overload: {_overloadProc}");
+    }
+
+    public override void Dispose() {
+        base.Dispose();
+        _overloadProc = null!;
+        _dreamObject = null!;
+        _usr = null;
+        _argumentCount = 0;
+        _parentState = null!;
+
+        Pool.Push(this);
+    }
+
+    public override ProcStatus Resume() {
+        var src = _dreamObject;
+
+        switch (_stage) {
+            case Stage.Call: {
+                _stage = Stage.AssignRef;
+                ProcState overloadProcState = _overloadProc.CreateState(Thread, src, _usr, new DreamProcArguments(_arguments.AsSpan(0, _argumentCount)));
+                Thread.PushProcState(overloadProcState);
+                return ProcStatus.Called;
+            }
+            case Stage.AssignRef: {
+                //the assignment is handled in ReturnedInto()
+                return ProcStatus.Returned;
+            }
+        }
+
+        throw new InvalidOperationException();
+    }
+
+    public override void ReturnedInto(DreamValue value) {
+        _parentState.AssignReference(_assignRef, value);
+        _parentState.Push(value);
+    }
+}
+

--- a/OpenDreamRuntime/Procs/AssignRefProcState.cs
+++ b/OpenDreamRuntime/Procs/AssignRefProcState.cs
@@ -16,7 +16,7 @@ internal sealed class AssignRefProcState : ProcState {
 
     private DreamObject _dreamObject;
     private DreamObject? _usr;
-    private readonly DreamValue[] _arguments = new DreamValue[256];
+    private readonly DreamValue[] _arguments = new DreamValue[3]; // 3 is the maximum number of arguments an operator overload can take
     private int _argumentCount;
     private Stage _stage = Stage.Call;
     public override DreamProc? Proc => null;

--- a/OpenDreamRuntime/Procs/AssignRefProcState.cs
+++ b/OpenDreamRuntime/Procs/AssignRefProcState.cs
@@ -2,8 +2,10 @@ using System.Text;
 using OpenDreamRuntime.Objects;
 
 namespace OpenDreamRuntime.Procs;
+
 internal sealed class AssignRefProcState : ProcState {
     public static readonly Stack<AssignRefProcState> Pool = new();
+
     private enum Stage {
         // Call the associated proc
         Call,
@@ -36,7 +38,6 @@ internal sealed class AssignRefProcState : ProcState {
         _stage = Stage.Call;
         _assignRef = assignRef;
     }
-
 
     public override void AppendStackFrame(StringBuilder builder) {
         builder.AppendLine($"Operator overload: {_overloadProc}");

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -2639,19 +2639,6 @@ namespace OpenDreamRuntime.Procs {
             }
         }
 
-        private static DreamValue DivideValues(DreamValue first, DreamValue second) {
-            if (first.IsNull) {
-                return new(0);
-            } else if (first.TryGetValueAsFloat(out var firstFloat) && second.TryGetValueAsFloat(out var secondFloat)) {
-                if (secondFloat == 0) {
-                    throw new Exception("Division by zero");
-                }
-                return new(firstFloat / secondFloat);
-            } else {
-                throw new Exception("Invalid divide operation on " + first + " and " + second);
-            }
-        }
-
         private static DreamValue BitXorValues(DreamObjectTree objectTree, DreamValue first, DreamValue second) {
             if (first.TryGetValueAsDreamList(out var list)) {
                 DreamList newList = objectTree.CreateList();


### PR DESCRIPTION
implements `operator*=` and `operator/=`, with appropriate calls to `operator*` and `operator/` when needed