### PR TITLE
Fix /mutable_appearance/New() named args

### DIFF
--- a/Content.Tests/DMProject/Tests/Image/mutableappearance_arguments.dm
+++ b/Content.Tests/DMProject/Tests/Image/mutableappearance_arguments.dm
@@ -1,0 +1,10 @@
+/mutable_appearance/New(var/to_copy)
+	..()
+
+/proc/RunTest()
+	// /mutable_appearance/New()'s args are special in that named arguments ignore any overrides
+	// Normally this wouldn't be allowed since the override only has to_copy
+	var/mutable_appearance/MA = new(icon = 'icons.dmi', icon_state = "mob")
+	
+	ASSERT(MA.icon == 'icons.dmi')
+	ASSERT(MA.icon_state == "mob")

--- a/DMCompiler/DMStandard/Types/Mutable_Appearance.dm
+++ b/DMCompiler/DMStandard/Types/Mutable_Appearance.dm
@@ -3,5 +3,3 @@
 
 	var/animate_movement = 1 as opendream_unimplemented
 	var/screen_loc as opendream_unimplemented
-
-	New(var/copy_from)

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -1008,6 +1008,10 @@ namespace OpenDreamRuntime.Procs {
                     if (proc == null)
                         throw new Exception("Cannot use named arguments here");
 
+                    // new /mutable_appearance(...) always uses /image/New()'s arguments, despite any overrides
+                    if (proc.OwningType == Proc.ObjectTree.MutableAppearance && proc.Name == "New")
+                        proc = Proc.DreamManager.ImageConstructor;
+
                     var argumentCount = argumentStackSize / 2;
                     var arguments = new DreamValue[Math.Max(argumentCount, proc.ArgumentNames.Count)];
                     var skippingArg = false;
@@ -1046,6 +1050,10 @@ namespace OpenDreamRuntime.Procs {
                         throw new Exception("Cannot use an arglist here");
                     if (!values[0].TryGetValueAsDreamList(out var argList))
                         return new DreamProcArguments(); // Using a non-list gives you no arguments
+
+                    // new /mutable_appearance(...) always uses /image/New()'s arguments, despite any overrides
+                    if (proc.OwningType == Proc.ObjectTree.MutableAppearance && proc.Name == "New")
+                        proc = Proc.DreamManager.ImageConstructor;
 
                     var listValues = argList.GetValues();
                     var arguments = new DreamValue[Math.Max(listValues.Count, proc.ArgumentNames.Count)];


### PR DESCRIPTION
Fixes things like `new /mutable_appearance(icon = 'abc.dmi', icon_state = "abc")`

This was breaking global init on tgstation.