### PR TITLE
Optimize `new /icon(icon)`

### DIFF
--- a/OpenDreamRuntime/Objects/DreamIcon.cs
+++ b/OpenDreamRuntime/Objects/DreamIcon.cs
@@ -15,13 +15,11 @@ using ParsedDMIFrame = OpenDreamShared.Resources.DMIParser.ParsedDMIFrame;
 
 namespace OpenDreamRuntime.Objects;
 
-public sealed class DreamIcon {
+public sealed class DreamIcon(DreamResourceManager resourceManager) {
     private static readonly ArrayPool<Rgba32> PixelArrayPool = ArrayPool<Rgba32>.Shared;
 
     public int Width, Height;
     public readonly Dictionary<string, IconState> States = new();
-
-    private readonly DreamResourceManager _resourceManager;
 
     private IconResource? _cachedDMI;
 
@@ -38,39 +36,58 @@ public sealed class DreamIcon {
     public sealed class IconState {
         public int Frames;
         public readonly Dictionary<AtomDirection, List<IconFrame>> Directions = new();
+
+        public IconState Copy() {
+            var copy = new IconState { Frames = Frames };
+
+            copy.Directions.EnsureCapacity(Directions.Count);
+            foreach (var pair in Directions) {
+                copy.Directions.Add(pair.Key, pair.Value);
+            }
+
+            return copy;
+        }
     }
 
     /// <summary>
     /// Represents one of the icon frames an icon is made of.<br/>
     /// Contains everything needed to create a new DMI in <see cref="DreamIcon.GenerateDMI()"/>
     /// </summary>
-    public sealed class IconFrame {
+    public sealed class IconFrame(Image<Rgba32>? image, ParsedDMIFrame dmiFrame, int width, int height) {
         /// <summary>
         /// The image this icon frame originally comes from<br/>
         /// Null if empty
         /// </summary>
-        public readonly Image<Rgba32>? Image;
+        public readonly Image<Rgba32>? Image = image;
 
         /// <summary>
         /// The DMI information about this icon frame
         /// </summary>
-        public readonly ParsedDMIFrame DMIFrame;
+        public readonly ParsedDMIFrame DMIFrame = dmiFrame;
 
         /// <summary>
         /// The size of the original icon frame
         /// </summary>
-        public readonly int Width, Height;
-
-        public IconFrame(Image<Rgba32>? image, ParsedDMIFrame dmiFrame, int width, int height) {
-            Image = image;
-            DMIFrame = dmiFrame;
-            Width = width;
-            Height = height;
-        }
+        public readonly int Width = width, Height = height;
     }
 
-    public DreamIcon(DreamResourceManager resourceManager) {
-        _resourceManager = resourceManager;
+    public void CopyFrom(DreamIcon other) {
+        Width = other.Width;
+        Height = other.Height;
+
+        States.Clear();
+        States.EnsureCapacity(other.States.Count);
+        foreach (var pair in other.States) {
+            States.Add(pair.Key, pair.Value.Copy());
+        }
+
+        _operations.Clear();
+        _operations.EnsureCapacity(other._operations.Count);
+        foreach (var operation in other._operations) {
+            _operations.Add(operation);
+        }
+
+        _cachedDMI = other._cachedDMI;
     }
 
     /// <summary>
@@ -131,7 +148,7 @@ public sealed class DreamIcon {
 
         dmiImage.SaveAsPng(dmiImageStream);
 
-        IconResource newResource = _resourceManager.CreateIconResource(dmiImageStream.GetBuffer(), dmiImage, newDescription);
+        IconResource newResource = resourceManager.CreateIconResource(dmiImageStream.GetBuffer(), dmiImage, newDescription);
         _cachedDMI = newResource;
         return _cachedDMI;
     }
@@ -343,6 +360,7 @@ public class DreamIconOperationBlend : IDreamIconOperation {
                     pixels[dstPixelPosition].A = src.A;
                     break;
                 }
+
                 pixels[dstPixelPosition].R = (byte) (dst.R + (src.R - dst.R) * src.A / 255);
                 pixels[dstPixelPosition].G = (byte) (dst.G + (src.G - dst.G) * src.A / 255);
                 pixels[dstPixelPosition].B = (byte) (dst.B + (src.B - dst.B) * src.A / 255);
@@ -426,12 +444,8 @@ public sealed class DreamIconOperationBlendImage : DreamIconOperationBlend {
     }
 }
 
-public sealed class DreamIconOperationBlendColor : DreamIconOperationBlend {
-    private readonly Rgba32 _color;
-
-    public DreamIconOperationBlendColor(BlendType type, int xOffset, int yOffset, Color color) : base(type, xOffset, yOffset) {
-        _color = new Rgba32(color.RByte, color.GByte, color.BByte, color.AByte);
-    }
+public sealed class DreamIconOperationBlendColor(DreamIconOperationBlend.BlendType type, int xOffset, int yOffset, Color color) : DreamIconOperationBlend(type, xOffset, yOffset) {
+    private readonly Rgba32 _color = new(color.RByte, color.GByte, color.BByte, color.AByte);
 
     public override void ApplyToFrame(Rgba32[] pixels, int imageSpan, int frame, AtomDirection dir, UIBox2i bounds) {
         // TODO: x & y offsets

--- a/OpenDreamRuntime/Objects/Types/DreamObjectIcon.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectIcon.cs
@@ -20,11 +20,15 @@ public sealed class DreamObjectIcon : DreamObject {
         DreamValue moving = args.GetArgument(4);
 
         if (!icon.IsNull) {
-            // TODO: Could maybe have an alternative path for /icon values so the DMI doesn't have to be generated
-            if (!DreamResourceManager.TryLoadIcon(icon, out var iconRsc))
-                throw new Exception($"Cannot create an icon from {icon}");
+            if (icon.TryGetValueAsDreamObject<DreamObjectIcon>(out var iconObj)) {
+                // Copy the DreamIcon rather than create the entire DMI from it
+                Icon.CopyFrom(iconObj.Icon);
+            } else {
+                if (!DreamResourceManager.TryLoadIcon(icon, out var iconRsc))
+                    throw new Exception($"Cannot create an icon from {icon}");
 
-            Icon.InsertStates(iconRsc, state, dir, frame, isConstructor: true);
+                Icon.InsertStates(iconRsc, state, dir, frame, isConstructor: true);
+            }
         }
     }
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectImage.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectImage.cs
@@ -98,7 +98,6 @@ public sealed class DreamObjectImage : DreamObject {
         }
     }
 
-
     protected override void SetVar(string varName, DreamValue value) {
         switch (varName) {
             case "appearance": // Appearance var is mutable, don't use AtomManager.SetAppearanceVar()
@@ -113,6 +112,7 @@ public sealed class DreamObjectImage : DreamObject {
                     DMISpriteComponent sprite = EntityManager.GetComponent<DMISpriteComponent>(_entity);
                     sprite.SetAppearance(Appearance!);
                 }
+
                 break;
             case "loc":
                 value.TryGetValueAsDreamObject(out _loc);
@@ -211,6 +211,7 @@ public sealed class DreamObjectImage : DreamObject {
                         DMISpriteComponent sprite = EntityManager.GetComponent<DMISpriteComponent>(_entity);
                         sprite.SetAppearance(Appearance!);
                     }
+
                     break;
                 }
 
@@ -233,6 +234,7 @@ public sealed class DreamObjectImage : DreamObject {
             DMISpriteComponent sprite = EntityManager.AddComponent<DMISpriteComponent>(_entity);
             sprite.SetAppearance(Appearance!);
         }
+
         return _entity;
     }
 


### PR DESCRIPTION
In the following code:
```
var/icon/I1 = new /icon('icons.dmi')
I1.DrawBox("#ff0000", 0, 0, 16, 16)
var/icon/I2 = new /icon(I1)
```

`new /icon(I1)` would generate I1's entire DMI and use that to create `I2`. Now it instead only copies the queued operations. This massively improves its performance and memory usage (several GBs over /tg/ init, and more over the round).