### PR TITLE
Fix `goto` inside multiple enumerator loops

### DIFF
--- a/DMCompiler/Bytecode/DreamProcOpcode.cs
+++ b/DMCompiler/Bytecode/DreamProcOpcode.cs
@@ -60,7 +60,7 @@ public enum DreamProcOpcode : byte {
     Modulus = 0x19,
     [OpcodeMetadata(0, OpcodeArgType.Reference)]
     Append = 0x1A,
-    [OpcodeMetadata(-3)]
+    [OpcodeMetadata(-3, OpcodeArgType.EnumeratorId)]
     CreateRangeEnumerator = 0x1B,
     [OpcodeMetadata(0, OpcodeArgType.Reference, OpcodeArgType.Reference)]
     Input = 0x1C,
@@ -119,11 +119,11 @@ public enum DreamProcOpcode : byte {
     PushFloat = 0x38,
     [OpcodeMetadata(0, OpcodeArgType.Reference)]
     ModulusReference = 0x39,
-    [OpcodeMetadata(-1)]
+    [OpcodeMetadata(-1, OpcodeArgType.EnumeratorId)]
     CreateListEnumerator = 0x3A,
-    [OpcodeMetadata(0, OpcodeArgType.Reference, OpcodeArgType.Label)]
+    [OpcodeMetadata(0, Bytecode.OpcodeArgType.EnumeratorId, OpcodeArgType.Reference, OpcodeArgType.Label)]
     Enumerate = 0x3B,
-    [OpcodeMetadata]
+    [OpcodeMetadata(0, OpcodeArgType.EnumeratorId)]
     DestroyEnumerator = 0x3C,
     [OpcodeMetadata(-3)]
     Browse = 0x3D,
@@ -133,7 +133,7 @@ public enum DreamProcOpcode : byte {
     OutputControl = 0x3F,
     [OpcodeMetadata(-1)]
     BitShiftRight = 0x40,
-    [OpcodeMetadata(-1, OpcodeArgType.FilterId)]
+    [OpcodeMetadata(-1, OpcodeArgType.EnumeratorId, OpcodeArgType.FilterId)]
     CreateFilteredListEnumerator = 0x41,
     [OpcodeMetadata(-1)]
     Power = 0x42,
@@ -185,7 +185,7 @@ public enum DreamProcOpcode : byte {
     IsInRange = 0x5B,
     [OpcodeMetadata(0, OpcodeArgType.ConcatCount)]
     MassConcatenation = 0x5C,
-    [OpcodeMetadata(-1)]
+    [OpcodeMetadata(-1, OpcodeArgType.EnumeratorId)]
     CreateTypeEnumerator = 0x5D,
     //0x5E
     [OpcodeMetadata(1)]
@@ -223,7 +223,7 @@ public enum DreamProcOpcode : byte {
     TryNoValue = 0x70,
     [OpcodeMetadata]
     EndTry = 0x71,
-    [OpcodeMetadata(0, OpcodeArgType.Label)]
+    [OpcodeMetadata(0, Bytecode.OpcodeArgType.EnumeratorId, OpcodeArgType.Label)]
     EnumerateNoAssign = 0x72,
     [OpcodeMetadata(0, OpcodeArgType.ArgType, OpcodeArgType.StackDelta)]
     Gradient = 0x73,
@@ -567,6 +567,7 @@ public enum OpcodeArgType {
     Resource,
     TypeId,
     ProcId,
+    EnumeratorId,
     FilterId,
     ListSize,
     Int,

--- a/DMCompiler/Bytecode/DreamProcOpcode.cs
+++ b/DMCompiler/Bytecode/DreamProcOpcode.cs
@@ -121,7 +121,7 @@ public enum DreamProcOpcode : byte {
     ModulusReference = 0x39,
     [OpcodeMetadata(-1, OpcodeArgType.EnumeratorId)]
     CreateListEnumerator = 0x3A,
-    [OpcodeMetadata(0, Bytecode.OpcodeArgType.EnumeratorId, OpcodeArgType.Reference, OpcodeArgType.Label)]
+    [OpcodeMetadata(0, OpcodeArgType.EnumeratorId, OpcodeArgType.Reference, OpcodeArgType.Label)]
     Enumerate = 0x3B,
     [OpcodeMetadata(0, OpcodeArgType.EnumeratorId)]
     DestroyEnumerator = 0x3C,

--- a/DMCompiler/Bytecode/DreamProcOpcode.cs
+++ b/DMCompiler/Bytecode/DreamProcOpcode.cs
@@ -223,7 +223,7 @@ public enum DreamProcOpcode : byte {
     TryNoValue = 0x70,
     [OpcodeMetadata]
     EndTry = 0x71,
-    [OpcodeMetadata(0, Bytecode.OpcodeArgType.EnumeratorId, OpcodeArgType.Label)]
+    [OpcodeMetadata(0, OpcodeArgType.EnumeratorId, OpcodeArgType.Label)]
     EnumerateNoAssign = 0x72,
     [OpcodeMetadata(0, OpcodeArgType.ArgType, OpcodeArgType.StackDelta)]
     Gradient = 0x73,

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -84,6 +84,7 @@ namespace DMCompiler.DM {
         private readonly Stack<DMProcScope> _scopes = new();
         private readonly Dictionary<string, LocalVariable> _parameters = new();
         private int _labelIdCounter;
+        private int _enumeratorIdCounter;
 
         private readonly List<string> _localVariableNames = new();
         private int _localVariableIdCounter;
@@ -99,7 +100,6 @@ namespace DMCompiler.DM {
         public AnnotatedByteCodeWriter AnnotatedBytecode = new();
 
         private Location _writerLocation;
-
 
         public DMProc(int id, DMObject dmObject, DMASTProcDefinition? astDefinition) {
             Id = id;
@@ -363,24 +363,29 @@ namespace DMCompiler.DM {
 
         public void CreateListEnumerator() {
             WriteOpcode(DreamProcOpcode.CreateListEnumerator);
+            WriteEnumeratorId(_enumeratorIdCounter++);
         }
 
         public void CreateFilteredListEnumerator(int filterTypeId, DreamPath filterType) {
             WriteOpcode(DreamProcOpcode.CreateFilteredListEnumerator);
+            WriteEnumeratorId(_enumeratorIdCounter++);
             WriteFilterID(filterTypeId, filterType);
         }
 
         public void CreateTypeEnumerator() {
             WriteOpcode(DreamProcOpcode.CreateTypeEnumerator);
+            WriteEnumeratorId(_enumeratorIdCounter++);
         }
 
         public void CreateRangeEnumerator() {
             WriteOpcode(DreamProcOpcode.CreateRangeEnumerator);
+            WriteEnumeratorId(_enumeratorIdCounter++);
         }
 
         public void Enumerate(DMReference reference) {
             if (_loopStack?.TryPeek(out var peek) ?? false) {
                 WriteOpcode(DreamProcOpcode.Enumerate);
+                WriteEnumeratorId(_enumeratorIdCounter - 1);
                 WriteReference(reference);
                 WriteLabel($"{peek}_end");
             } else {
@@ -391,6 +396,7 @@ namespace DMCompiler.DM {
         public void EnumerateNoAssign() {
             if (_loopStack?.TryPeek(out var peek) ?? false) {
                 WriteOpcode(DreamProcOpcode.EnumerateNoAssign);
+                WriteEnumeratorId(_enumeratorIdCounter - 1);
                 WriteLabel($"{peek}_end");
             } else {
                 DMCompiler.ForcedError(Location, "Cannot peek empty loop stack");
@@ -399,6 +405,7 @@ namespace DMCompiler.DM {
 
         public void DestroyEnumerator() {
             WriteOpcode(DreamProcOpcode.DestroyEnumerator);
+            WriteEnumeratorId(--_enumeratorIdCounter);
         }
 
         public void CreateList(int size) {
@@ -454,6 +461,7 @@ namespace DMCompiler.DM {
             } else {
                 DMCompiler.ForcedError(Location, "Cannot pop empty loop stack");
             }
+
             EndScope();
         }
 
@@ -509,6 +517,7 @@ namespace DMCompiler.DM {
                 if (!LabelExists(codeLabel)) {
                     DMCompiler.Emit(WarningCode.ItemDoesntExist, label.Location, $"Unknown label {label.Identifier}");
                 }
+
                 Jump(codeLabel + "_end");
             } else if (_loopStack?.TryPeek(out var peek) ?? false) {
                 Jump(peek + "_end");
@@ -685,6 +694,7 @@ namespace DMCompiler.DM {
             WriteOpcode(DreamProcOpcode.Assign);
             WriteReference(reference);
         }
+
         public void AssignInto(DMReference reference) {
             WriteOpcode(DreamProcOpcode.AssignInto);
             WriteReference(reference);
@@ -1074,6 +1084,10 @@ namespace DMCompiler.DM {
 
         private void WriteProcId(int procId) {
             AnnotatedBytecode.WriteProcId(procId, _writerLocation);
+        }
+
+        private void WriteEnumeratorId(int enumeratorId) {
+            AnnotatedBytecode.WriteEnumeratorId(enumeratorId, _writerLocation);
         }
 
         private void WriteFloat(float value) {

--- a/DMCompiler/Optimizer/AnnotatedByteCodeWriter.cs
+++ b/DMCompiler/Optimizer/AnnotatedByteCodeWriter.cs
@@ -188,7 +188,6 @@ internal class AnnotatedByteCodeWriter {
         _unresolvedLabelsInAnnotatedBytecode.Add((_annotatedBytecode.Count - 1, s));
     }
 
-
     public void ResolveCodeLabelReferences(Stack<DMProc.CodeLabelReference> pendingLabelReferences) {
         while (pendingLabelReferences.Count > 0) {
             DMProc.CodeLabelReference reference = pendingLabelReferences.Pop();
@@ -211,8 +210,7 @@ internal class AnnotatedByteCodeWriter {
             }
 
             // Found it.
-            _labels.Add(reference.Placeholder, label.AnnotatedByteOffset);
-            AddLabel(reference.Placeholder);
+            AddLabel(reference.Placeholder, (int)label.AnnotatedByteOffset);
 
             // I was thinking about going through to replace all the placeholders
             // with the actual label.LabelName, but it means I need to modify
@@ -285,6 +283,16 @@ internal class AnnotatedByteCodeWriter {
 
         _requiredArgs.Pop();
         _annotatedBytecode[^1].AddArg(new AnnotatedBytecodeProcId(procId, location));
+    }
+
+    public void WriteEnumeratorId(int enumeratorId, Location location) {
+        _location = location;
+        if (_requiredArgs.Count == 0 || _requiredArgs.Peek() != OpcodeArgType.EnumeratorId) {
+            DMCompiler.ForcedError(location, "Expected EnumeratorID argument");
+        }
+
+        _requiredArgs.Pop();
+        _annotatedBytecode[^1].AddArg(new AnnotatedBytecodeEnumeratorId(enumeratorId, location));
     }
 
     public void WriteFormatCount(int formatCount, Location location) {
@@ -372,8 +380,13 @@ internal class AnnotatedByteCodeWriter {
     }
 
     public void AddLabel(string name) {
-        _labels.TryAdd(name, _annotatedBytecode.Count);
+        _labels.Add(name, _annotatedBytecode.Count);
         _annotatedBytecode.Add(new AnnotatedBytecodeLabel(name, _location));
+    }
+
+    public void AddLabel(string name, int position) {
+        _labels.Add(name, position);
+        _annotatedBytecode.Insert(position, new AnnotatedBytecodeLabel(name, _location));
     }
 
     public bool LabelExists(string name) {

--- a/DMCompiler/Optimizer/AnnotatedBytecode.cs
+++ b/DMCompiler/Optimizer/AnnotatedBytecode.cs
@@ -119,12 +119,12 @@ internal sealed class AnnotatedBytecodeInstruction : IAnnotatedBytecode {
         if (_location != null) return;
         _location = loc.GetLocation();
     }
-    
+
     public void SetLocation(Location loc) {
         if (_location != null) return;
         _location = loc;
     }
-    
+
     public Location GetLocation() {
         return _location ?? Location;
     }
@@ -321,14 +321,30 @@ internal sealed class AnnotatedBytecodeTypeId : IAnnotatedBytecode {
     }
 }
 
-internal sealed class AnnotatedBytecodeProcId : IAnnotatedBytecode {
-    public Location Location;
-    public int ProcId;
+internal sealed class AnnotatedBytecodeProcId(int procId, Location location) : IAnnotatedBytecode {
+    public Location Location = location;
+    public int ProcId = procId;
 
-    public AnnotatedBytecodeProcId(int procId, Location location) {
-        ProcId = procId;
-        Location = location;
+    public void AddArg(IAnnotatedBytecode arg) {
+        DMCompiler.ForcedError(Location, "Cannot add args to a type");
     }
+
+    public void SetLocation(IAnnotatedBytecode loc) {
+        Location = loc.GetLocation();
+    }
+
+    public void SetLocation(Location loc) {
+        Location = loc;
+    }
+
+    public Location GetLocation() {
+        return Location;
+    }
+}
+
+internal sealed class AnnotatedBytecodeEnumeratorId(int enumeratorId, Location location) : IAnnotatedBytecode {
+    public Location Location = location;
+    public int EnumeratorId = enumeratorId;
 
     public void AddArg(IAnnotatedBytecode arg) {
         DMCompiler.ForcedError(Location, "Cannot add args to a type");

--- a/DMCompiler/Optimizer/AnnotatedBytecodeSerializer.cs
+++ b/DMCompiler/Optimizer/AnnotatedBytecodeSerializer.cs
@@ -119,6 +119,9 @@ internal class AnnotatedBytecodeSerializer {
                 case AnnotatedBytecodeProcId annotatedBytecodeProcId:
                     _bytecodeWriter.Write(annotatedBytecodeProcId.ProcId);
                     break;
+                case AnnotatedBytecodeEnumeratorId annotatedBytecodeEnumeratorId:
+                    _bytecodeWriter.Write(annotatedBytecodeEnumeratorId.EnumeratorId);
+                    break;
                 case AnnotatedBytecodeReference annotatedBytecodeReference:
                     WriteReference(annotatedBytecodeReference);
                     break;

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -338,8 +338,7 @@ namespace OpenDreamRuntime.Procs {
         private readonly Stack<int> _catchPosition = new();
         private readonly Stack<int> _catchVarIndex = new();
         public const int NoTryCatchVar = -1;
-        private Stack<IDreamValueEnumerator>? _enumeratorStack;
-        public Stack<IDreamValueEnumerator> EnumeratorStack => _enumeratorStack ??= new(1);
+        public IDreamValueEnumerator?[] Enumerators = new IDreamValueEnumerator?[16];
 
         private int _pc = 0;
         public int ProgramCounter => _pc;
@@ -532,7 +531,7 @@ namespace OpenDreamRuntime.Procs {
             Instance = null;
             Usr = null;
             ArgumentCount = 0;
-            _enumeratorStack = null;
+            Array.Clear(Enumerators);
             _pc = 0;
             _proc = null;
 

--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -111,7 +111,6 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
             case DreamProcOpcode.Call:
                 return (opcode, ReadReference(), (DMCallArgumentsType)ReadByte(), ReadInt());
 
-            case DreamProcOpcode.EnumerateNoAssign:
             case DreamProcOpcode.CreateList:
             case DreamProcOpcode.CreateAssociativeList:
             case DreamProcOpcode.CreateFilteredListEnumerator:
@@ -130,15 +129,24 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
             case DreamProcOpcode.JumpIfNull:
             case DreamProcOpcode.JumpIfNullNoPop:
             case DreamProcOpcode.TryNoValue:
+            case DreamProcOpcode.CreateListEnumerator:
+            case DreamProcOpcode.CreateRangeEnumerator:
+            case DreamProcOpcode.CreateTypeEnumerator:
+            case DreamProcOpcode.DestroyEnumerator:
                 return (opcode, ReadInt());
 
             case DreamProcOpcode.JumpIfTrueReference:
             case DreamProcOpcode.JumpIfFalseReference:
-            case DreamProcOpcode.Enumerate:
                 return (opcode, ReadReference(), ReadInt());
 
             case DreamProcOpcode.Try:
                 return (opcode, ReadInt(), ReadReference());
+
+            case DreamProcOpcode.Enumerate:
+                return (opcode, ReadInt(), ReadReference(), ReadInt());
+
+            case DreamProcOpcode.EnumerateNoAssign:
+                return (opcode, ReadInt(), ReadInt());
 
             default:
                 return ValueTuple.Create(opcode);


### PR DESCRIPTION
Fixes #154

Each DMProcState now has 16 slots for enumerators instead of them being a stack. Opcodes using enumerators must refer to which slot they're using.