### PR TITLE
Fix `filters = list("type"=...)`

### DIFF
--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -130,7 +130,7 @@ namespace OpenDreamRuntime {
             return MustGetValueAsString();
         }
 
-        public bool TryGetValueAsString([NotNullWhen(true)] out string? value) {
+        public readonly bool TryGetValueAsString([NotNullWhen(true)] out string? value) {
             if (Type == DreamValueType.String) {
                 value = Unsafe.As<string>(_refValue)!;
                 return true;

--- a/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
@@ -157,11 +157,12 @@ public class DreamObjectAtom : DreamObject {
             case "filters": {
                 Filters.Cut();
 
-                if (value.TryGetValueAsDreamList(out var valueList)) {
-                    // TODO: This should postpone UpdateAppearance until after everything is added
-                    foreach (DreamValue filterValue in valueList.GetValues()) {
-                        Filters.AddValue(filterValue);
-                    }
+                if (value.TryGetValueAsDreamList(out var valueList)) { // filters = list("type"=...)
+                    var filterObject = DreamObjectFilter.TryCreateFilter(ObjectTree, valueList);
+                    if (filterObject == null) // list() with invalid properties is ignored
+                        break;
+
+                    Filters.AddValue(new(filterObject));
                 } else if (!value.IsNull) {
                     Filters.AddValue(value);
                 }

--- a/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
@@ -159,7 +159,7 @@ public class DreamObjectAtom : DreamObject {
 
                 if (value.TryGetValueAsDreamList(out var valueList)) { // filters = list("type"=...)
                     var filterObject = DreamObjectFilter.TryCreateFilter(ObjectTree, valueList);
-                    if (filterObject == null) // list() with invalid properties is ignored
+                    if (filterObject == null) // list() with invalid "type" is ignored
                         break;
 
                     Filters.AddValue(new(filterObject));

--- a/OpenDreamRuntime/Objects/Types/DreamObjectFilter.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectFilter.cs
@@ -1,18 +1,15 @@
 ﻿using OpenDreamShared.Dream;
+using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Markdown.Mapping;
 
 namespace OpenDreamRuntime.Objects.Types;
 
-public sealed class DreamObjectFilter : DreamObject {
+public sealed class DreamObjectFilter(DreamObjectDefinition objectDefinition) : DreamObject(objectDefinition) {
     public static readonly Dictionary<DreamFilter, DreamFilterList> FilterAttachedTo = new();
 
     public override bool ShouldCallNew => false;
 
     public DreamFilter Filter;
-
-    public DreamObjectFilter(DreamObjectDefinition objectDefinition) : base(objectDefinition) {
-
-    }
 
     protected override void HandleDeletion() {
         base.HandleDeletion();
@@ -39,5 +36,51 @@ public sealed class DreamObjectFilter : DreamObject {
             Filter = newFilter;
             attachedTo.SetFilter(index, newFilter);
         }
+    }
+
+    public static DreamObjectFilter? TryCreateFilter(DreamObjectTree objectTree, IEnumerable<(string Name, DreamValue Value)> properties) {
+        Type? filterType = null;
+        MappingDataNode attributes = new();
+
+        foreach (var property in properties) {
+            if (property.Value.IsNull)
+                continue;
+
+            if (property.Name == "type" && property.Value.TryGetValueAsString(out var filterTypeName)) {
+                filterType = DreamFilter.GetType(filterTypeName);
+            }
+
+            attributes.Add(property.Name, new DreamValueDataNode(property.Value));
+        }
+
+        if (filterType == null)
+            return null;
+
+        var serializationManager = IoCManager.Resolve<ISerializationManager>();
+
+        DreamFilter? filter = serializationManager.Read(filterType, attributes) as DreamFilter;
+        if (filter is null)
+            throw new Exception($"Failed to create filter of type {filterType}");
+
+        var filterObject = objectTree.CreateObject<DreamObjectFilter>(objectTree.Filter);
+        filterObject.Filter = filter;
+        return filterObject;
+    }
+
+    public static DreamObjectFilter? TryCreateFilter(DreamObjectTree objectTree, DreamList list) {
+        static IEnumerable<(string, DreamValue)> EnumerateProperties(DreamList list) {
+            foreach (var key in list.GetValues()) {
+                if (!key.TryGetValueAsString(out var keyStr))
+                    continue;
+
+                var value = list.GetValue(key);
+                if (value.IsNull)
+                    continue;
+
+                yield return (keyStr, value);
+            }
+        }
+
+        return TryCreateFilter(objectTree, EnumerateProperties(list));
     }
 }

--- a/OpenDreamRuntime/Objects/Types/DreamObjectImage.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectImage.cs
@@ -189,11 +189,12 @@ public sealed class DreamObjectImage : DreamObject {
 
                 _filters.Cut();
 
-                if (valueList != null) {
-                    // TODO: This should postpone UpdateAppearance until after everything is added
-                    foreach (DreamValue filterValue in valueList.GetValues()) {
-                        _filters.AddValue(filterValue);
-                    }
+                if (valueList != null) { // filters = list("type"=...)
+                    var filterObject = DreamObjectFilter.TryCreateFilter(ObjectTree, valueList);
+                    if (filterObject == null) // list() with invalid properties is ignored
+                        break;
+
+                    _filters.AddValue(new(filterObject));
                 } else if (!value.IsNull) {
                     _filters.AddValue(value);
                 }

--- a/OpenDreamRuntime/Objects/Types/DreamObjectImage.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectImage.cs
@@ -191,7 +191,7 @@ public sealed class DreamObjectImage : DreamObject {
 
                 if (valueList != null) { // filters = list("type"=...)
                     var filterObject = DreamObjectFilter.TryCreateFilter(ObjectTree, valueList);
-                    if (filterObject == null) // list() with invalid properties is ignored
+                    if (filterObject == null) // list() with invalid "type" is ignored
                         break;
 
                     _filters.AddValue(new(filterObject));

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
@@ -10,13 +10,14 @@ namespace OpenDreamRuntime.Procs.Native;
 /// A container of procs that act as helpers for a few native procs.
 /// </summary>
 internal static partial class DreamProcNativeHelpers {
-    private static readonly char[] radixArray = new char[36] {
+    private static readonly char[] RadixArray = [
         '0', '1', '2', '3', '4', '5', '6', '7',
         '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
         'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
         'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
         'w', 'x', 'y', 'z'
-    };
+    ];
+
     /// <summary>
     /// This is a helper proc for oview, view, orange, and range to do their strange iteration with.<br/>
     /// BYOND has a very strange, kinda-spiralling iteration pattern for the above procs, <br/>
@@ -386,7 +387,7 @@ internal static partial class DreamProcNativeHelpers {
         }
 
         while (value > 0) {
-            resString.Insert(0, radixArray[value % radix]);
+            resString.Insert(0, RadixArray[value % radix]);
             value /= radix;
         }
 


### PR DESCRIPTION
`filters = list("type"=...)` is the same as `filters = filter("type"=...)`. Interestingly, `filters += list("type"=...)` does not work.

Fixes #1651