### PR TITLE
Const-fold some proc statements

### DIFF
--- a/DMCompiler/DM/Builders/DMASTFolder.cs
+++ b/DMCompiler/DM/Builders/DMASTFolder.cs
@@ -51,27 +51,11 @@ public class DMASTFolder {
 
                 FoldAst(procDef.Body);
                 break;
-            case DMASTProcStatementIf statementIf:
-                statementIf.Condition = FoldExpression(statementIf.Condition);
-                FoldAst(statementIf.Body);
-                FoldAst(statementIf.ElseBody);
-
-                break;
             case DMASTProcStatementFor statementFor:
                 statementFor.Expression1 = FoldExpression(statementFor.Expression1);
                 statementFor.Expression2 = FoldExpression(statementFor.Expression2);
                 statementFor.Expression3 = FoldExpression(statementFor.Expression3);
                 FoldAst(statementFor.Body);
-
-                break;
-            case DMASTProcStatementWhile statementWhile:
-                statementWhile.Conditional = FoldExpression(statementWhile.Conditional);
-                FoldAst(statementWhile.Body);
-
-                break;
-            case DMASTProcStatementDoWhile statementDoWhile:
-                statementDoWhile.Conditional = FoldExpression(statementDoWhile.Conditional);
-                FoldAst(statementDoWhile.Body);
 
                 break;
             case DMASTProcStatementInfLoop statementInfLoop:

--- a/DMCompiler/DM/Builders/DMProcBuilder.cs
+++ b/DMCompiler/DM/Builders/DMProcBuilder.cs
@@ -795,9 +795,13 @@ namespace DMCompiler.DM.Builders {
 
             // Const-fold the common pattern of "do {} while(0)" in preprocessor macros
             if (expr.TryAsConstant(out var constant) && !constant.IsTruthy()) {
+                // We still need to handle "break" statements
+                proc.FoldedLoopStart(proc.NewLabelName()); // Allocates the loop stack
+
                 proc.StartScope();
                 ProcessBlockInner(statementDoWhile.Body);
-                proc.EndScope();
+
+                proc.LoopEnd(); // Appends the end label
                 return;
             }
 

--- a/DMCompiler/DM/DMExpression.cs
+++ b/DMCompiler/DM/DMExpression.cs
@@ -22,7 +22,7 @@ internal abstract class DMExpression(Location location) {
         expr.EmitPushValue(dmObject, proc);
     }
 
-    public static bool TryConstant(DMObject dmObject, DMProc proc, DMASTExpression expression, out Expressions.Constant? constant) {
+    public static bool TryConstant(DMObject dmObject, DMProc proc, DMASTExpression expression, [NotNullWhen(true)] out Expressions.Constant? constant) {
         var expr = Create(dmObject, proc, expression);
         return expr.TryAsConstant(out constant);
     }

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -432,6 +432,17 @@ namespace DMCompiler.DM {
             StartScope();
         }
 
+        /// <summary>
+        /// For loops that have been const-folded, such as "do {} while(0)"
+        /// </summary>
+        /// <param name="loopLabel">Name of the label without positional postfix</param>
+        public void FoldedLoopStart(string loopLabel) {
+            // TODO: Don't create a loop stack just for supporting "break" in a const-folded do-while(0) loop
+            _loopStack ??= new Stack<string>(2); // start and end
+            _loopStack.Push(loopLabel);
+            StartScope();
+        }
+
         public void MarkLoopContinue(string loopLabel) {
             AddLabel($"{loopLabel}_continue");
         }


### PR DESCRIPTION
Const-folds `if(FALSE)` and `do {} while(FALSE)`. I also confirmed that folding `while(FALSE)` is pointless since it never occurs.

To test this I compiled Paradise and confirmed that I can wander around without things being horribly broken, and there wasn't any runtime spam.