### PR TITLE
Add missing instructions to ProcDecoder

### DIFF
--- a/DMCompiler/Bytecode/DreamProcOpcode.cs
+++ b/DMCompiler/Bytecode/DreamProcOpcode.cs
@@ -511,12 +511,12 @@ public struct DMReference {
             case Type.Global:
             case Type.Argument:
             case Type.GlobalProc:
-                return $"{RefType} {Index}";
+                return $"{RefType}({Index})";
 
             case Type.SrcField:
             case Type.Field:
             case Type.SrcProc:
-                return $"{RefType} \"{Name}\"";
+                return $"{RefType}(\"{Name}\")";
 
             default: return RefType.ToString();
         }

--- a/OpenDreamRuntime/Procs/DebugAdapter/DebugAdapter.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/DebugAdapter.cs
@@ -1,5 +1,4 @@
-﻿using System.Net;
-using System.Net.Sockets;
+﻿using System.Net.Sockets;
 using OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter;
@@ -9,21 +8,9 @@ public sealed class DebugAdapter {
 
     public event OnClientConnectedHandler? OnClientConnected;
 
-    private TcpListener? _listener;
     private readonly List<DebugAdapterClient> _clients = new();
 
-    public DebugAdapter() {
-    }
-
     public bool AnyClientsConnected() => _clients.Count > 0;
-
-    public void StartListening(string? host = null, int? port = null) {
-        if (!IPAddress.TryParse(host, out IPAddress? hostAddress)) {
-            hostAddress = IPAddress.Any;
-        }
-        _listener = new TcpListener(hostAddress, port ?? 25567);
-        _listener.Start();
-    }
 
     public void ConnectOut(string? host = null, int? port = null) {
         var client = new DebugAdapterClient(new TcpClient(host ?? "127.0.0.1", port ?? 25567));
@@ -32,15 +19,6 @@ public sealed class DebugAdapter {
     }
 
     public void HandleMessages() {
-        if (_listener != null) {
-            while (_listener.Pending()) {
-                var client = new DebugAdapterClient(_listener.AcceptTcpClient());
-
-                _clients.Add(client);
-                OnClientConnected?.Invoke(client);
-            }
-        }
-
         for (int i = 0; i < _clients.Count; i++) {
             DebugAdapterClient client = _clients[i];
 

--- a/OpenDreamRuntime/Procs/DebugAdapter/DebugAdapterClient.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/DebugAdapterClient.cs
@@ -108,7 +108,7 @@ public sealed class DebugAdapterClient {
         int contentLength = -1;
 
         string? headerLine;
-        while ((headerLine = _netReader.ReadLine()) != String.Empty && headerLine != null) {
+        while ((headerLine = _netReader.ReadLine()) != string.Empty && headerLine != null) {
             string[] split = headerLine.Split(": ");
             string field = split[0];
             string value = split[1];
@@ -144,7 +144,7 @@ public sealed class DebugAdapterClient {
             return null;
         }
 
-        string content = new String(buffer);
+        string content = new string(buffer);
         _sawmill.Log(LogLevel.Verbose, $"Received {contentLength} {content}");
 
         return content;

--- a/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
@@ -800,9 +800,9 @@ internal sealed class DreamDebugManager : IDreamDebugManager {
         DisassembledInstruction? previousInstruction = null;
         int previousOffset = 0;
         foreach (var (offset, instruction) in new ProcDecoder(_objectTree.Strings, proc.Bytecode).Disassemble()) {
-            if (previousInstruction != null) {
+            /*if (previousInstruction != null) {
                 previousInstruction.InstructionBytes = BitConverter.ToString(proc.Bytecode, previousOffset, offset - previousOffset).Replace("-", " ").ToLowerInvariant();
-            }
+            }*/
 
             previousOffset = offset;
             previousInstruction = new DisassembledInstruction {
@@ -817,9 +817,9 @@ internal sealed class DreamDebugManager : IDreamDebugManager {
             output.Add(previousInstruction);
         }
 
-        if (previousInstruction != null) {
+        /*if (previousInstruction != null) {
             previousInstruction.InstructionBytes = BitConverter.ToString(proc.Bytecode, previousOffset).Replace("-", " ").ToLowerInvariant();
-        }
+        }*/
 
         // ... and THEN strip everything outside the requested range.
         int requestedPoint = output.FindIndex(di => di.Address == requestDisassemble.Arguments.MemoryReference);

--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -37,8 +37,8 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
     }
 
     public string ReadString() {
-        int stringID = ReadInt();
-        return Strings[stringID];
+        int stringId = ReadInt();
+        return Strings[stringId];
     }
 
     public DMReference ReadReference() {
@@ -68,6 +68,9 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
             case DreamProcOpcode.FormatString:
                 return (opcode, ReadString(), ReadInt());
 
+            case DreamProcOpcode.PushStringFloat:
+                return (opcode, ReadString(), ReadFloat());
+
             case DreamProcOpcode.PushString:
             case DreamProcOpcode.PushResource:
             case DreamProcOpcode.DereferenceField:
@@ -81,6 +84,12 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
 
             case DreamProcOpcode.PushFloat:
                 return (opcode, ReadFloat());
+
+            case DreamProcOpcode.SwitchOnFloat:
+                return (opcode, ReadFloat(), ReadInt());
+
+            case DreamProcOpcode.SwitchOnString:
+                return (opcode, ReadString(), ReadInt());
 
             case DreamProcOpcode.Assign:
             case DreamProcOpcode.Append:
@@ -98,14 +107,20 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
             case DreamProcOpcode.OutputReference:
             case DreamProcOpcode.PushReferenceValue:
             case DreamProcOpcode.PopReference:
+            case DreamProcOpcode.AssignPop:
+            case DreamProcOpcode.ReturnReferenceValue:
                 return (opcode, ReadReference());
 
             case DreamProcOpcode.Input:
                 return (opcode, ReadReference(), ReadReference());
 
+            case DreamProcOpcode.PushRefAndDereferenceField:
+                return (opcode, ReadReference(), ReadString());
+
             case DreamProcOpcode.CallStatement:
             case DreamProcOpcode.CreateObject:
             case DreamProcOpcode.Gradient:
+            case DreamProcOpcode.Rgb:
                 return (opcode, (DMCallArgumentsType)ReadByte(), ReadInt());
 
             case DreamProcOpcode.Call:
@@ -113,7 +128,6 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
 
             case DreamProcOpcode.CreateList:
             case DreamProcOpcode.CreateAssociativeList:
-            case DreamProcOpcode.CreateFilteredListEnumerator:
             case DreamProcOpcode.PickWeighted:
             case DreamProcOpcode.PickUnweighted:
             case DreamProcOpcode.Spawn:
@@ -133,10 +147,12 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
             case DreamProcOpcode.CreateRangeEnumerator:
             case DreamProcOpcode.CreateTypeEnumerator:
             case DreamProcOpcode.DestroyEnumerator:
+            case DreamProcOpcode.IsTypeDirect:
                 return (opcode, ReadInt());
 
             case DreamProcOpcode.JumpIfTrueReference:
             case DreamProcOpcode.JumpIfFalseReference:
+            case DreamProcOpcode.JumpIfReferenceFalse:
                 return (opcode, ReadReference(), ReadInt());
 
             case DreamProcOpcode.Try:
@@ -145,8 +161,57 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
             case DreamProcOpcode.Enumerate:
                 return (opcode, ReadInt(), ReadReference(), ReadInt());
 
+            case DreamProcOpcode.CreateFilteredListEnumerator:
             case DreamProcOpcode.EnumerateNoAssign:
                 return (opcode, ReadInt(), ReadInt());
+
+            case DreamProcOpcode.CreateListNRefs:
+            case DreamProcOpcode.PushNRefs: {
+                var count = ReadInt();
+                var values = new DMReference[count];
+
+                for (int i = 0; i < count; i++) {
+                    values[i] = ReadReference();
+                }
+
+                return (opcode, values);
+            }
+
+            case DreamProcOpcode.CreateListNStrings:
+            case DreamProcOpcode.PushNStrings: {
+                var count = ReadInt();
+                var values = new string[count];
+
+                for (int i = 0; i < count; i++) {
+                    values[i] = ReadString();
+                }
+
+                return (opcode, values);
+            }
+
+            case DreamProcOpcode.CreateListNFloats:
+            case DreamProcOpcode.PushNFloats: {
+                var count = ReadInt();
+                var values = new float[count];
+
+                for (int i = 0; i < count; i++) {
+                    values[i] = ReadFloat();
+                }
+
+                return (opcode, values);
+            }
+
+            case DreamProcOpcode.CreateListNResources:
+            case DreamProcOpcode.PushNResources: {
+                var count = ReadInt();
+                var values = new string[count];
+
+                for (int i = 0; i < count; i++) {
+                    values[i] = ReadString();
+                }
+
+                return (opcode, values);
+            }
 
             default:
                 return ValueTuple.Create(opcode);
@@ -172,12 +237,6 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
                 text.Append('"');
                 break;
 
-            case (DreamProcOpcode.PushString, string str):
-                text.Append('"');
-                text.Append(str);
-                text.Append('"');
-                break;
-
             case (DreamProcOpcode.PushResource, string str):
                 text.Append('\'');
                 text.Append(str);
@@ -194,23 +253,101 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
                 text.AppendFormat("0x{0:x}", jumpPosition);
                 break;
 
+            case (DreamProcOpcode.SwitchOnFloat, float value, int jumpPosition):
+                text.Append(value);
+                text.AppendFormat(" 0x{0:x}", jumpPosition);
+                break;
+
+            case (DreamProcOpcode.SwitchOnString, string value, int jumpPosition):
+                text.Append('"');
+                text.Append(value);
+                text.Append("\" ");
+                text.AppendFormat(" 0x{0:x}", jumpPosition);
+                break;
+
+            case (DreamProcOpcode.JumpIfFalseReference
+                    or DreamProcOpcode.JumpIfTrueReference
+                    or DreamProcOpcode.JumpIfReferenceFalse, DMReference reference, int jumpPosition):
+                text.Append(reference.ToString());
+                text.AppendFormat(" 0x{0:x}", jumpPosition);
+                break;
+
             case (DreamProcOpcode.Enumerate, DMReference reference, int jumpPosition):
                 text.Append(reference);
                 text.Append(' ');
                 text.Append(jumpPosition);
                 break;
 
-            case (DreamProcOpcode.PushType, int type):
+            case (DreamProcOpcode.PushType
+                    or DreamProcOpcode.IsTypeDirect, int type):
                 text.Append(getTypePath(type));
                 break;
 
-            default:
-                for (int i = 1; i < instruction.Length; ++i) {
-                    text.Append(instruction[i]);
+            case (DreamProcOpcode.CreateFilteredListEnumerator, int enumeratorId, int type):
+                text.Append(enumeratorId);
+                text.Append(' ');
+                text.Append(getTypePath(type));
+                break;
+
+            case (DreamProcOpcode.CreateListNRefs
+                    or DreamProcOpcode.PushNRefs, DMReference[] refs): {
+                foreach (var reference in refs) {
+                    text.Append(reference.ToString());
                     text.Append(' ');
                 }
+
+                break;
+            }
+
+            case (DreamProcOpcode.CreateListNStrings
+                    or DreamProcOpcode.PushNStrings, string[] strings): {
+                foreach (var value in strings) {
+                    text.Append('"');
+                    text.Append(value);
+                    text.Append("\" ");
+                }
+
+                break;
+            }
+
+            case (DreamProcOpcode.CreateListNFloats
+                    or DreamProcOpcode.PushNFloats, float[] floats): {
+                foreach (var value in floats) {
+                    text.Append(value);
+                    text.Append(' ');
+                }
+
+                break;
+            }
+
+            case (DreamProcOpcode.CreateListNResources
+                    or DreamProcOpcode.PushNResources, string[] resources): {
+                foreach (var value in resources) {
+                    text.Append('\'');
+                    text.Append(value);
+                    text.Append("' ");
+                }
+
+                break;
+            }
+
+            default:
+                for (int i = 1; i < instruction.Length; ++i) {
+                    var arg = instruction[i];
+
+                    if (arg is string) {
+                        text.Append('"');
+                        text.Append(arg);
+                        text.Append("\" ");
+                    } else {
+                        text.Append(instruction[i]);
+                        text.Append(' ');
+                    }
+                }
+
                 break;
         }
+
         return text.ToString();
     }
 
@@ -225,9 +362,16 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
                     or DreamProcOpcode.JumpIfFalse
                     or DreamProcOpcode.TryNoValue, int jumpPosition):
                 return jumpPosition;
-            case (DreamProcOpcode.Try, int jumpPosition, DMReference dmReference):
+            case (DreamProcOpcode.JumpIfFalseReference
+                    or DreamProcOpcode.JumpIfTrueReference
+                    or DreamProcOpcode.JumpIfReferenceFalse, DMReference, int jumpPosition):
                 return jumpPosition;
-            case (DreamProcOpcode.Enumerate, DMReference reference, int jumpPosition):
+            case (DreamProcOpcode.SwitchOnFloat
+                    or DreamProcOpcode.SwitchOnString, float or string, int jumpPosition):
+                return jumpPosition;
+            case (DreamProcOpcode.Try, int jumpPosition, DMReference):
+                return jumpPosition;
+            case (DreamProcOpcode.Enumerate, DMReference, int jumpPosition):
                 return jumpPosition;
             default:
                 return null;


### PR DESCRIPTION
The peephole changes brought a bunch of new opcodes that didn't get added to ProcDecoder. This fixes DMDisassembler and the VSC debugger's disassembly view.