### PR TITLE
Implement `byond://winget?...`

### DIFF
--- a/OpenDreamClient/EntryPoint.cs
+++ b/OpenDreamClient/EntryPoint.cs
@@ -47,8 +47,6 @@ public sealed class EntryPoint : GameClient {
     }
 
     public override void Init() {
-        IoCManager.Resolve<IConfigurationManager>().OverrideDefault(CVars.NetPredict, false);
-
         IComponentFactory componentFactory = IoCManager.Resolve<IComponentFactory>();
         componentFactory.DoAutoRegistrations();
 
@@ -62,6 +60,9 @@ public sealed class EntryPoint : GameClient {
 
         IoCManager.BuildGraph();
         IoCManager.InjectDependencies(this);
+
+        _configurationManager.OverrideDefault(CVars.NetPredict, false);
+        _configurationManager.OverrideDefault(CVars.ResAutoScaleEnabled, false); // Fixes weird scaling when sizing windows too small
 
         IoCManager.Resolve<DreamUserInterfaceStateManager>().Initialize();
 

--- a/OpenDreamClient/Interface/Controls/ControlBrowser.cs
+++ b/OpenDreamClient/Interface/Controls/ControlBrowser.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Diagnostics;
+using System.IO;
 using System.Net;
 using System.Web;
 using OpenDreamClient.Interface.Descriptors;
@@ -11,6 +12,7 @@ using Robust.Client.WebView;
 using Robust.Shared.Console;
 using Robust.Shared.ContentPack;
 using Robust.Shared.Network;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace OpenDreamClient.Interface.Controls;
@@ -106,13 +108,19 @@ internal sealed class ControlBrowser : InterfaceControl {
             if (newUri.Scheme == "byond" || (newUri.AbsolutePath == oldUri.AbsolutePath && newUri.Query != string.Empty)) {
                 context.DoCancel();
 
-                if (newUri.Host == "winset") {
-                    HandleEmbeddedWinset(newUri.Query);
-                    return;
+                switch (newUri.Host) {
+                    case "winset":
+                        HandleEmbeddedWinset(newUri.Query);
+                        return;
+                    case "winget":
+                        HandleEmbeddedWinget(newUri.Query);
+                        return;
+                    default: {
+                        var msg = new MsgTopic { Query = newUri.Query };
+                        _netManager.ClientSendMessage(msg);
+                        break;
+                    }
                 }
-
-                var msg = new MsgTopic() { Query = newUri.Query };
-                _netManager.ClientSendMessage(msg);
             }
         } catch (Exception e) {
             _sawmill.Error($"Exception in BeforeBrowseHandler: {e}");
@@ -179,6 +187,44 @@ internal sealed class ControlBrowser : InterfaceControl {
 
         // We can finally call winset
         _interfaceManager.WinSet(element, modifiedQuery);
+    }
+
+    /// <summary>
+    /// Handles an embedded winget
+    /// </summary>
+    /// <param name="query">The query portion of the embedded winget</param>
+    // Example: byond://winget?id=browseroutput&property=size&callback=JSFunction
+    // (Not in the XML comment because '&' breaks that apparently)
+    private void HandleEmbeddedWinget(string query) {
+        // Run this later to ensure any pending UI measurements have occured
+        IoCManager.Resolve<ITimerManager>().AddTimer(new Timer(200, false, () => {
+            // Strip the question mark out before parsing
+            var queryParams = HttpUtility.ParseQueryString(query.Substring(1));
+
+            var elementId = queryParams.Get("id");
+            var property = queryParams.Get("property");
+            var callback = queryParams.Get("callback");
+            if (elementId == null || property == null || callback == null) {
+                _sawmill.Error($"Required arg 'id', 'property', or 'callback' not provided in embedded winget ({query})");
+                return;
+            }
+
+            // TG uses property=* but really just wants size
+            // TODO: Actual winget * support
+            bool forceJson = true;
+            if (property == "*") {
+                property = "size";
+                forceJson = false; // property=* does not return "as json" values (why?!)
+            }
+
+            var result = _interfaceManager.WinGet(elementId, property, forceJson: forceJson);
+
+            // Execute the callback
+            var propertyEncoded = HttpUtility.JavaScriptStringEncode(property);
+            var resultEncoded = HttpUtility.JavaScriptStringEncode(result);
+            var jsonArgument = $"{{ \"{propertyEncoded}\": \"{resultEncoded}\" }}";
+            _webView.ExecuteJavaScript($"{callback}({jsonArgument})");
+        }));
     }
 
     private void OnShowEvent() {

--- a/OpenDreamClient/Interface/Controls/ControlWindow.cs
+++ b/OpenDreamClient/Interface/Controls/ControlWindow.cs
@@ -302,6 +302,9 @@ public sealed class ControlWindow : InterfaceControl {
 
     public override bool TryGetProperty(string property, [NotNullWhen(true)] out IDMFProperty? value) {
         switch (property) {
+            case "size": // ControlWindow has its own getter for this because it doesn't use SetSize
+                value = new DMFPropertySize(UIElement.Size);
+                return true;
             case "inner-size":
                 value = new DMFPropertySize((int)_canvas.Width, (int)_canvas.Height);
                 return true;

--- a/OpenDreamClient/Interface/Controls/ControlWindow.cs
+++ b/OpenDreamClient/Interface/Controls/ControlWindow.cs
@@ -100,6 +100,7 @@ public sealed class ControlWindow : InterfaceControl {
             _myWindow.osWindow.Close();
             UIElement.Orphan();
         }
+
         _myWindow = (null, window);
         UpdateWindowAttributes(_myWindow);
     }
@@ -151,8 +152,9 @@ public sealed class ControlWindow : InterfaceControl {
             }
 
             if (control.Anchor1.HasValue) {
-                var offset1X = elementPos.X - (windowSize.X * control.Anchor1.Value.X / 100f);
-                var offset1Y = elementPos.Y - (windowSize.Y * control.Anchor1.Value.Y / 100f);
+                var anchoredToSize = control.AnchoredToSize ?? _canvas.Size;
+                var offset1X = elementPos.X - (anchoredToSize.X * control.Anchor1.Value.X / 100f);
+                var offset1Y = elementPos.Y - (anchoredToSize.Y * control.Anchor1.Value.Y / 100f);
                 var left = (_canvas.Width * control.Anchor1.Value.X / 100) + offset1X;
                 var top = (_canvas.Height * control.Anchor1.Value.Y / 100) + offset1Y;
                 LayoutContainer.SetMarginLeft(element, Math.Max(left, 0));
@@ -164,9 +166,9 @@ public sealed class ControlWindow : InterfaceControl {
                         _sawmill.Warning($"Invalid anchor2 value in DMF for element {control.Id}. Ignoring.");
                     else {
                         var offset2X = (elementPos.X + elementSize.X) -
-                                       (windowSize.X * control.Anchor2.Value.X / 100);
+                                       (anchoredToSize.X * control.Anchor2.Value.X / 100);
                         var offset2Y = (elementPos.Y + elementSize.Y) -
-                                       (windowSize.Y * control.Anchor2.Value.Y / 100);
+                                       (anchoredToSize.Y * control.Anchor2.Value.Y / 100);
                         var width = (_canvas.Width * control.Anchor2.Value.X / 100) + offset2X - left;
                         var height = (_canvas.Height * control.Anchor2.Value.Y / 100) + offset2Y - top;
                         element.SetWidth = Math.Max(width, 0);
@@ -215,7 +217,6 @@ public sealed class ControlWindow : InterfaceControl {
         } else if (clydeWindow != null) {
             clydeWindow.IsVisible = WindowDescriptor.IsVisible.Value;
         }
-
     }
 
     public void CreateChildControls() {

--- a/OpenDreamClient/Interface/Controls/ControlWindow.cs
+++ b/OpenDreamClient/Interface/Controls/ControlWindow.cs
@@ -112,49 +112,23 @@ public sealed class ControlWindow : InterfaceControl {
         if (windowSize.Y == 0)
             windowSize.Y = _canvas.PixelHeight;
 
-        ChildControls.Sort((a, b) => { //need a resort if size and pos have changed
-            if(a.Pos.X <= b.Pos.X || a.Pos.Y <= b.Pos.Y)
-                return 1;
-            else
-                return -1;
-        });
-
         for (int i = 0; i < ChildControls.Count; i++) {
             InterfaceControl control = ChildControls[i];
             var element = control.UIElement;
             var elementPos = control.Pos;
             var elementSize = control.Size;
 
-            if (control.Size.Y == 0) {
-                elementSize.Y = (windowSize.Y - elementPos.Y);
-                if (ChildControls.Count - 1 > i) {
-                    if (ChildControls[i + 1].UIElement.Visible) {
-                        var nextElementPos = ChildControls[i + 1].Pos;
-                        elementSize.Y = nextElementPos.Y - elementPos.Y;
-                    }
-                }
-
-                element.SetHeight = ((float)elementSize.Y / windowSize.Y) * _canvas.Height;
-            }
-
-            if (control.Size.X == 0) {
-                elementSize.X = (windowSize.X - elementPos.X);
-                if (ChildControls.Count - 1 > i) {
-                    if (ChildControls[i + 1].UIElement.Visible) {
-                        var nextElementPos = ChildControls[i + 1].Pos;
-                        if (nextElementPos.X < (elementSize.X + elementPos.X) &&
-                            nextElementPos.Y < (elementSize.Y + elementPos.Y))
-                            elementSize.X = nextElementPos.X - elementPos.X;
-                    }
-                }
-
-                element.SetWidth = ((float)elementSize.X / windowSize.X) * _canvas.Width;
-            }
-
             if (control.Anchor1.HasValue) {
-                var anchoredToSize = control.AnchoredToSize ?? _canvas.Size;
-                var offset1X = elementPos.X - (anchoredToSize.X * control.Anchor1.Value.X / 100f);
-                var offset1Y = elementPos.Y - (anchoredToSize.Y * control.Anchor1.Value.Y / 100f);
+                var anchorTo = control.AnchorPosition;
+
+                // Defaults to anchoring relative to the DMF-defined size
+                if (anchorTo.X == 0)
+                    anchorTo.X = Size.X;
+                if (anchorTo.Y == 0)
+                    anchorTo.Y = Size.Y;
+
+                var offset1X = elementPos.X - (anchorTo.X * control.Anchor1.Value.X / 100f);
+                var offset1Y = elementPos.Y - (anchorTo.Y * control.Anchor1.Value.Y / 100f);
                 var left = (_canvas.Width * control.Anchor1.Value.X / 100) + offset1X;
                 var top = (_canvas.Height * control.Anchor1.Value.Y / 100) + offset1Y;
                 LayoutContainer.SetMarginLeft(element, Math.Max(left, 0));
@@ -162,13 +136,13 @@ public sealed class ControlWindow : InterfaceControl {
 
                 if (control.Anchor2.HasValue) {
                     if (control.Anchor2.Value.X < control.Anchor1.Value.X ||
-                        control.Anchor2.Value.Y < control.Anchor1.Value.Y)
+                        control.Anchor2.Value.Y < control.Anchor1.Value.Y) {
                         _sawmill.Warning($"Invalid anchor2 value in DMF for element {control.Id}. Ignoring.");
-                    else {
+                    } else {
                         var offset2X = (elementPos.X + elementSize.X) -
-                                       (anchoredToSize.X * control.Anchor2.Value.X / 100);
+                                       (anchorTo.X * control.Anchor2.Value.X / 100);
                         var offset2Y = (elementPos.Y + elementSize.Y) -
-                                       (anchoredToSize.Y * control.Anchor2.Value.Y / 100);
+                                       (anchorTo.Y * control.Anchor2.Value.Y / 100);
                         var width = (_canvas.Width * control.Anchor2.Value.X / 100) + offset2X - left;
                         var height = (_canvas.Height * control.Anchor2.Value.Y / 100) + offset2Y - top;
                         element.SetWidth = Math.Max(width, 0);
@@ -177,6 +151,25 @@ public sealed class ControlWindow : InterfaceControl {
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Updates the control's anchoring position to the window's current size.
+    /// Also updates other controls' anchoring position if they have a size of 0.
+    /// </summary>
+    /// <param name="control"></param>
+    public void UpdateAnchorSize(InterfaceControl control) {
+        control.AnchorPosition = _canvas.PixelSize;
+
+        // Also update the anchor position for anything with a size of 0
+        foreach (var child in ChildControls) {
+            if (child.UIElement.SetWidth == 0)
+                child.AnchorPosition = child.AnchorPosition with {X = _canvas.PixelWidth + child.Size.X};
+            if (child.UIElement.SetHeight == 0)
+                child.AnchorPosition = child.AnchorPosition with {Y = _canvas.PixelHeight + child.Size.Y};
+        }
+
+        UpdateAnchors();
     }
 
     private void UpdateWindowAttributes((OSWindow? osWindow, IClydeWindow? clydeWindow) windowRoot) {
@@ -209,7 +202,7 @@ public sealed class ControlWindow : InterfaceControl {
         if (root != null) {
             root.BackgroundColor = (WindowDescriptor.BackgroundColor.Value != Color.Transparent)
                 ? WindowDescriptor.BackgroundColor.Value
-                : null;
+                : DreamStylesheet.DefaultBackgroundColor;
         }
 
         if (osWindow != null && osWindow.ClydeWindow != null) {
@@ -344,5 +337,12 @@ public sealed class ControlWindow : InterfaceControl {
             default:
                 return base.TryGetProperty(property, out value);
         }
+    }
+
+    public override void SetProperty(string property, string value, bool manualWinset = false) {
+        if (property is "size" or "pos")
+            return; // TODO: RT offers no ability to resize or position windows
+
+        base.SetProperty(property, value, manualWinset);
     }
 }

--- a/OpenDreamClient/Interface/Controls/ControlWindow.cs
+++ b/OpenDreamClient/Interface/Controls/ControlWindow.cs
@@ -157,8 +157,8 @@ public sealed class ControlWindow : InterfaceControl {
     /// Updates the control's anchoring position to the window's current size.
     /// Also updates other controls' anchoring position if they have a size of 0.
     /// </summary>
-    /// <param name="control"></param>
-    public void UpdateAnchorSize(InterfaceControl control) {
+    /// <param name="control">The control triggering the anchor update</param>
+    public void UpdateAnchorPosition(InterfaceControl control) {
         control.AnchorPosition = _canvas.PixelSize;
 
         // Also update the anchor position for anything with a size of 0

--- a/OpenDreamClient/Interface/Controls/InterfaceControl.cs
+++ b/OpenDreamClient/Interface/Controls/InterfaceControl.cs
@@ -20,7 +20,7 @@ public abstract class InterfaceControl : InterfaceElement {
     /// Updates when this control's size/pos is winset,
     /// or when this control's size is 0 and a sibling control's size/pos is winset
     /// </summary>
-    public Vector2i? AnchoredToSize;
+    public Vector2i AnchorPosition = Vector2i.Zero;
 
     protected ControlDescriptor ControlDescriptor => (ControlDescriptor) ElementDescriptor;
 

--- a/OpenDreamClient/Interface/Controls/InterfaceControl.cs
+++ b/OpenDreamClient/Interface/Controls/InterfaceControl.cs
@@ -105,7 +105,7 @@ public abstract class InterfaceControl : InterfaceElement {
                 UIElement.SetSize = size.Vector;
 
                 if (manualWinset)
-                    _window?.UpdateAnchorSize(this);
+                    _window?.UpdateAnchorPosition(this);
                 break;
             case "pos":
                 var pos = new DMFPropertyPos(value);
@@ -114,7 +114,7 @@ public abstract class InterfaceControl : InterfaceElement {
                 LayoutContainer.SetMarginTop(UIElement, pos.Y);
 
                 if (manualWinset)
-                    _window?.UpdateAnchorSize(this);
+                    _window?.UpdateAnchorPosition(this);
                 break;
         }
 

--- a/OpenDreamClient/Interface/Controls/InterfaceControl.cs
+++ b/OpenDreamClient/Interface/Controls/InterfaceControl.cs
@@ -30,9 +30,9 @@ public abstract class InterfaceControl : InterfaceElement {
         IoCManager.InjectDependencies(this);
 
         _window = window;
+        AnchoredToSize = (_window != null) ? new Vector2i(_window.Size.X, _window.Size.Y) : null;
         UIElement = CreateUIElement();
 
-        UpdateAnchoredToSize();
         UpdateElementDescriptor();
     }
 

--- a/OpenDreamClient/Interface/Controls/InterfaceControl.cs
+++ b/OpenDreamClient/Interface/Controls/InterfaceControl.cs
@@ -15,17 +15,24 @@ public abstract class InterfaceControl : InterfaceElement {
     public DMFPropertyPos? Anchor1 => ControlDescriptor.Anchor1;
     public DMFPropertyPos? Anchor2 => ControlDescriptor.Anchor2;
 
+    /// <summary>
+    /// The size that anchor1 and anchor2 anchor themselves to.
+    /// Updates when this control's size is winset, to keep them relative to the window's size.
+    /// </summary>
+    public Vector2i? AnchoredToSize;
+
     protected ControlDescriptor ControlDescriptor => (ControlDescriptor) ElementDescriptor;
 
-    private readonly ControlWindow _window;
+    private readonly ControlWindow? _window;
 
     [SuppressMessage("ReSharper", "VirtualMemberCallInConstructor")]
-    protected InterfaceControl(ControlDescriptor controlDescriptor, ControlWindow window) : base(controlDescriptor) {
+    protected InterfaceControl(ControlDescriptor controlDescriptor, ControlWindow? window) : base(controlDescriptor) {
         IoCManager.InjectDependencies(this);
 
         _window = window;
         UIElement = CreateUIElement();
 
+        UpdateAnchoredToSize();
         UpdateElementDescriptor();
     }
 
@@ -77,7 +84,8 @@ public abstract class InterfaceControl : InterfaceElement {
     public override bool TryGetProperty(string property, [NotNullWhen(true)] out IDMFProperty? value) {
         switch (property) {
             case "size":
-                value = new DMFPropertySize(UIElement.Size);
+                // SetSize because Size won't update if the element isn't visible
+                value = new DMFPropertySize(UIElement.SetSize);
                 return true;
             case "pos":
                 value = new DMFPropertyPos(UIElement.Position);
@@ -88,5 +96,9 @@ public abstract class InterfaceControl : InterfaceElement {
     }
 
     public virtual void Output(string value, string? data) {
+    }
+
+    public void UpdateAnchoredToSize() {
+        AnchoredToSize = (_window != null) ? (Vector2i)_window.UIElement.Size : null;
     }
 }

--- a/OpenDreamClient/Interface/Controls/InterfaceControl.cs
+++ b/OpenDreamClient/Interface/Controls/InterfaceControl.cs
@@ -91,7 +91,6 @@ public abstract class InterfaceControl : InterfaceElement {
     }
 
     public override void SetProperty(string property, string value, bool manualWinset = false) {
-        Logger.Debug($"Winset {property} on {Id.Value} to {value}");
         switch (property) {
             case "size":
                 var size = new DMFPropertySize(value);

--- a/OpenDreamClient/Interface/DMF/DMFParser.cs
+++ b/OpenDreamClient/Interface/DMF/DMFParser.cs
@@ -266,6 +266,26 @@ public sealed class DMFParser(DMFLexer lexer, ISerializationManager serializatio
         return node;
     }
 
+    // TODO: Replace Attributes() with this
+    public Dictionary<string, string> AttributesValues() {
+        var attributes = new Dictionary<string, string>();
+
+        while (TryGetAttribute(out var winset)) {
+            if (winset.Element != null) {
+                Error($"Element id \"{winset.Element}\" is not valid here");
+                continue;
+            }
+
+            //TODO implement the conditional check
+            if (winset.Value == "none")
+                continue;
+
+            attributes.Add(winset.Attribute, winset.Value);
+        }
+
+        return attributes;
+    }
+
     private void Newline() {
         while (Check(TokenType.Newline) || Check(TokenType.Semicolon)) {
         }

--- a/OpenDreamClient/Interface/DMF/IDMFProperty.cs
+++ b/OpenDreamClient/Interface/DMF/IDMFProperty.cs
@@ -272,6 +272,9 @@ public struct DMFPropertySize : IDMFProperty {
     public bool Equals(string comparison) {
         return _value.Equals(comparison);
     }
+
+    public static bool operator ==(DMFPropertySize a, DMFPropertySize b) => a.X == b.X && a.Y == b.Y;
+    public static bool operator !=(DMFPropertySize a, DMFPropertySize b) => a.X != b.X || a.Y != b.Y;
 }
 
 public struct DMFPropertyPos : IDMFProperty {

--- a/OpenDreamClient/Interface/DMF/IDMFProperty.cs
+++ b/OpenDreamClient/Interface/DMF/IDMFProperty.cs
@@ -145,6 +145,8 @@ public struct DMFPropertyVec2 : IDMFProperty {
     public int Y;
     public char Delim = ',';
 
+    public Vector2i Vector => new(X, Y);
+
     public DMFPropertyVec2(int x, int y) {
         X = x;
         Y = y;
@@ -215,6 +217,7 @@ public struct DMFPropertySize : IDMFProperty {
     private DMFPropertyVec2 _value;
     public int X {get => _value.X; set => _value.X = value;}
     public int Y {get => _value.Y; set => _value.Y = value;}
+    public Vector2i Vector => _value.Vector;
     private const char Delim = 'x';
 
     public DMFPropertySize(int x, int y) {
@@ -273,14 +276,15 @@ public struct DMFPropertySize : IDMFProperty {
         return _value.Equals(comparison);
     }
 
-    public static bool operator ==(DMFPropertySize a, DMFPropertySize b) => a.X == b.X && a.Y == b.Y;
-    public static bool operator !=(DMFPropertySize a, DMFPropertySize b) => a.X != b.X || a.Y != b.Y;
+    public static bool operator ==(DMFPropertySize a, DMFPropertySize b) => a.Vector == b.Vector;
+    public static bool operator !=(DMFPropertySize a, DMFPropertySize b) => a.Vector != b.Vector;
 }
 
 public struct DMFPropertyPos : IDMFProperty {
     private DMFPropertyVec2 _value;
-    public int X {get => _value.X; set => _value.X = value;}
-    public int Y {get => _value.Y; set => _value.Y = value;}
+    public int X => _value.X;
+    public int Y => _value.Y;
+    public Vector2i Vector => _value.Vector;
     private const char Delim = ',';
 
     public DMFPropertyPos(int x, int y) {
@@ -338,6 +342,9 @@ public struct DMFPropertyPos : IDMFProperty {
     public bool Equals(string comparison) {
         return _value.Equals(comparison);
     }
+
+    public static bool operator ==(DMFPropertyPos a, DMFPropertyPos b) => a.Vector == b.Vector;
+    public static bool operator !=(DMFPropertyPos a, DMFPropertyPos b) => a.Vector != b.Vector;
 }
 
 public struct DMFPropertyColor : IDMFProperty {

--- a/OpenDreamClient/Interface/Descriptors/InterfaceDescriptor.cs
+++ b/OpenDreamClient/Interface/Descriptors/InterfaceDescriptor.cs
@@ -49,6 +49,16 @@ public partial class ElementDescriptor {
         throw new InvalidOperationException($"{this} cannot create a child descriptor");
     }
 
+    public ElementDescriptor? CreateChildDescriptor(ISerializationManager serializationManager, Dictionary<string, string> attributes) {
+        var node = new MappingDataNode();
+
+        foreach (var pair in attributes) {
+            node.Add(pair.Key, pair.Value);
+        }
+
+        return CreateChildDescriptor(serializationManager, node);
+    }
+
     public virtual ElementDescriptor CreateCopy(ISerializationManager serializationManager, string id) {
         throw new InvalidOperationException($"{this} cannot create a copy of itself");
     }

--- a/OpenDreamClient/Interface/DummyDreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DummyDreamInterfaceManager.cs
@@ -9,7 +9,6 @@ namespace OpenDreamClient.Interface;
 /// Used in unit testing to run a headless client.
 /// </summary>
 public sealed class DummyDreamInterfaceManager : IDreamInterfaceManager {
-    public (string, string, string)[] AvailableVerbs => Array.Empty<(string, string, string)>();
     public Dictionary<string, ControlWindow> Windows { get; } = new();
     public Dictionary<string, InterfaceMenu> Menus { get; } = new();
     public Dictionary<string, InterfaceMacroSet> MacroSets { get; } = new();
@@ -17,15 +16,12 @@ public sealed class DummyDreamInterfaceManager : IDreamInterfaceManager {
     public ControlOutput? DefaultOutput => null;
     public ControlInfo? DefaultInfo => null;
     public ControlMap? DefaultMap => null;
-    public InterfaceDescriptor InterfaceDescriptor { get; }
     public ViewRange View => new(5);
 
     public void Initialize() {
-
     }
 
     public void FrameUpdate(FrameEventArgs frameEventArgs) {
-
     }
 
     public InterfaceElement? FindElementWithId(string id) {
@@ -33,34 +29,30 @@ public sealed class DummyDreamInterfaceManager : IDreamInterfaceManager {
     }
 
     public void SaveScreenshot(bool openDialog) {
-
     }
 
     public void LoadInterfaceFromSource(string source) {
-
     }
 
     public void WinSet(string? controlId, string winsetParams) {
+    }
 
+    public string WinGet(string controlId, string queryValue, bool forceJson = false) {
+        return string.Empty;
     }
 
     public void OpenAlert(string title, string message, string button1, string? button2, string? button3, Action<DreamValueType, object?>? onClose) {
-
     }
 
     public void Prompt(DreamValueType types, string title, string message, string defaultValue, Action<DreamValueType, object?>? onClose) {
-
     }
 
     public void RunCommand(string fullCommand) {
-
     }
 
     public void StartRepeatingCommand(string command) {
-
     }
 
     public void StopRepeatingCommand(string command) {
-
     }
 }

--- a/OpenDreamClient/Interface/InterfaceElement.cs
+++ b/OpenDreamClient/Interface/InterfaceElement.cs
@@ -41,7 +41,16 @@ public class InterfaceElement {
             }
 
             MappingDataNode newNode = original.Merge(node);
-            ElementDescriptor = (ElementDescriptor)serializationManager.Read(ElementDescriptor.GetType(), newNode);
+            var newDescriptor = (ElementDescriptor)serializationManager.Read(ElementDescriptor.GetType(), newNode);
+
+            // A little hacky. Updates the control's AnchoredToSize if its size has been updated, so the anchors stay
+            //      relative to the window's size.
+            if (this is InterfaceControl control && newDescriptor is ControlDescriptor newControlDescriptor &&
+                control.Size != newControlDescriptor.Size) {
+                control.UpdateAnchoredToSize();
+            }
+
+            ElementDescriptor = newDescriptor;
             UpdateElementDescriptor();
         } catch (Exception e) {
             Logger.GetSawmill("opendream.interface").Error($"Error while populating values of \"{Id}\": {e}");

--- a/OpenDreamClient/Interface/InterfaceElement.cs
+++ b/OpenDreamClient/Interface/InterfaceElement.cs
@@ -41,16 +41,8 @@ public class InterfaceElement {
             }
 
             MappingDataNode newNode = original.Merge(node);
-            var newDescriptor = (ElementDescriptor)serializationManager.Read(ElementDescriptor.GetType(), newNode);
 
-            // A little hacky. Updates the control's AnchoredToSize if its size has been updated, so the anchors stay
-            //      relative to the window's size.
-            if (this is InterfaceControl control && newDescriptor is ControlDescriptor newControlDescriptor &&
-                control.Size != newControlDescriptor.Size) {
-                control.UpdateAnchoredToSize();
-            }
-
-            ElementDescriptor = newDescriptor;
+            ElementDescriptor = (ElementDescriptor)serializationManager.Read(ElementDescriptor.GetType(), newNode);
             UpdateElementDescriptor();
         } catch (Exception e) {
             Logger.GetSawmill("opendream.interface").Error($"Error while populating values of \"{Id}\": {e}");
@@ -73,8 +65,16 @@ public class InterfaceElement {
         return false;
     }
 
-    protected virtual void UpdateElementDescriptor() {
+    // TODO: Replace PopulateElementDescriptor with this
+    public virtual void SetProperty(string property, string value, bool manualWinset = false) {
+        MappingDataNode node = new() {
+            {property, value}
+        };
 
+        PopulateElementDescriptor(node, _serializationManager);
+    }
+
+    protected virtual void UpdateElementDescriptor() {
     }
 
     public virtual void AddChild(ElementDescriptor descriptor) {
@@ -82,6 +82,5 @@ public class InterfaceElement {
     }
 
     public virtual void Shutdown() {
-
     }
 }


### PR DESCRIPTION
Setting `window.location` to `byond://winget?id=output&property=size&callback=JSFunction` does a winget for `output`'s size and executes JSFunction with the result.

Other interface-related fixes:
- winget() on an invisible control no longer returns 0
- winset() on an anchored control's size/pos now more closely matches BYOND behavior
- The CVar `interface.resolutionAutoScaleEnabled` is disabled by default, which fixes weird scaling behaviors when resizing a window too small
- Size 0x0 now more closely matches BYOND behavior

This fixes tg's chat extending over the command bar.
![image](https://github.com/OpenDreamProject/OpenDream/assets/30789242/0c0bb113-f893-40db-8b70-1381e0c3bc05)

~~Currently breaks goonstation's and paradise's interfaces. I suspect the changes to anchoring.~~ Fixed