### PR TITLE
Lint for invalid datum[] indexing

### DIFF
--- a/Content.Tests/DMProject/Tests/Dereference/DatumIndex.dm
+++ b/Content.Tests/DMProject/Tests/Dereference/DatumIndex.dm
@@ -1,0 +1,8 @@
+// COMPILE ERROR
+#pragma InvalidIndexOperation error
+
+// Indexing a datum (e.g. datum["foo"]) is not valid in BYOND 515.1641+
+
+/proc/RunTest()
+	var/datum/meep = new
+	ASSERT(isnull(meep["foo"]))

--- a/DMCompiler/Compiler/CompilerError.cs
+++ b/DMCompiler/Compiler/CompilerError.cs
@@ -54,6 +54,7 @@ public enum WarningCode {
     InvalidRange = 2301,
     InvalidSetStatement = 2302,
     InvalidOverride = 2303,
+    InvalidIndexOperation = 2304,
     DanglingVarType = 2401, // For types inferred by a particular var definition and nowhere else, that ends up not existing (not forced-fatal because BYOND doesn't always error)
     MissingInterpolatedExpression = 2500, // A text macro is missing a required interpolated expression
     AmbiguousResourcePath = 2600,

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -114,8 +114,11 @@ namespace DMCompiler.DM.Expressions {
                     break;
 
                 case IndexOperation indexOperation:
-                    if (NestedPath is not null && NestedPath.Value.IsDescendantOf(DreamPath.Datum)) {
-                        DMCompiler.Emit(WarningCode.InvalidIndexOperation, Location, "Invalid index operation. datum[] index operations are not valid starting in BYOND 515.1641");
+                    if (NestedPath is not null) {
+                        var obj = DMObjectTree.GetDMObject(NestedPath.Value, false);
+                        if (obj is not null && obj.IsSubtypeOf(DreamPath.Datum) && !obj.HasProc("operator[]")) {
+                            DMCompiler.Emit(WarningCode.InvalidIndexOperation, Location, "Invalid index operation. datum[] index operations are not valid starting in BYOND 515.1641");
+                        }
                     }
 
                     indexOperation.Index.EmitPushValue(dmObject, proc);

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -166,12 +166,21 @@ namespace DMCompiler.DM.Expressions {
                     if (fieldOperation.Safe) {
                         ShortCircuitHandler(proc, endLabel, shortCircuitMode);
                     }
+
                     return DMReference.CreateField(fieldOperation.Identifier);
 
                 case IndexOperation indexOperation:
+                    if (NestedPath is not null) {
+                        var obj = DMObjectTree.GetDMObject(NestedPath.Value, false);
+                        if (obj is not null && obj.IsSubtypeOf(DreamPath.Datum) && !obj.HasProc("operator[]=")) {
+                            DMCompiler.Emit(WarningCode.InvalidIndexOperation, Location, "Invalid index operation. datum[] index operations are not valid starting in BYOND 515.1641");
+                        }
+                    }
+
                     if (indexOperation.Safe) {
                         ShortCircuitHandler(proc, endLabel, shortCircuitMode);
                     }
+
                     indexOperation.Index.EmitPushValue(dmObject, proc);
                     return DMReference.ListIndex;
 

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -114,6 +114,10 @@ namespace DMCompiler.DM.Expressions {
                     break;
 
                 case IndexOperation indexOperation:
+                    if (NestedPath is not null && NestedPath.Value.IsDescendantOf(DreamPath.Datum)) {
+                        DMCompiler.Emit(WarningCode.InvalidIndexOperation, Location, "Invalid index operation. datum[] index operations are not valid starting in BYOND 515.1641");
+                    }
+
                     indexOperation.Index.EmitPushValue(dmObject, proc);
                     proc.DereferenceIndex();
                     break;

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -25,6 +25,7 @@
 #pragma InvalidRange error
 #pragma InvalidSetStatement error
 #pragma InvalidOverride warning
+#pragma InvalidIndexOperation warning
 #pragma DanglingVarType warning
 #pragma MissingInterpolatedExpression warning
 #pragma AmbiguousResourcePath warning


### PR DESCRIPTION
Closes #1876 

Invalid in BYOND 515.1641+

Don't want to make it fatal since it'd brick OD compilation of codebases targeting older versions.