### PR TITLE
Use an IRenderTexture pool in DreamIcon

### DIFF
--- a/OpenDreamClient/DreamClientSystem.cs
+++ b/OpenDreamClient/DreamClientSystem.cs
@@ -1,30 +1,13 @@
 ﻿using OpenDreamClient.Interface;
-using OpenDreamClient.Rendering;
-using Robust.Client.GameObjects;
-using Robust.Client.Graphics;
 using Robust.Shared.Player;
 
 namespace OpenDreamClient;
 
 internal sealed class DreamClientSystem : EntitySystem {
     [Dependency] private readonly IDreamInterfaceManager _interfaceManager = default!;
-    [Dependency] private readonly IOverlayManager _overlayManager = default!;
-    [Dependency] private readonly TransformSystem _transformSystem = default!;
-    [Dependency] private readonly MapSystem _mapSystem = default!;
-    [Dependency] private readonly EntityLookupSystem _lookupSystem = default!;
-    [Dependency] private readonly ClientAppearanceSystem _appearanceSystem = default!;
-    [Dependency] private readonly ClientScreenOverlaySystem _screenOverlaySystem = default!;
-    [Dependency] private readonly ClientImagesSystem _clientImagesSystem = default!;
 
     public override void Initialize() {
         SubscribeLocalEvent<LocalPlayerAttachedEvent>(OnPlayerAttached);
-
-        var mapOverlay = new DreamViewOverlay(_transformSystem, _mapSystem, _lookupSystem, _appearanceSystem, _screenOverlaySystem, _clientImagesSystem);
-        _overlayManager.AddOverlay(mapOverlay);
-    }
-
-    public override void Shutdown() {
-        _overlayManager.RemoveOverlay<DreamViewOverlay>();
     }
 
     private void OnPlayerAttached(LocalPlayerAttachedEvent e) {

--- a/OpenDreamClient/Input/ContextMenu/ContextMenuItem.xaml.cs
+++ b/OpenDreamClient/Input/ContextMenu/ContextMenuItem.xaml.cs
@@ -25,7 +25,7 @@ internal sealed partial class ContextMenuItem : PanelContainer {
         NameLabel.Margin = new Thickness(2, 0, 4, 0);
         NameLabel.Text = metadata.EntityName;
 
-        Icon.Texture = sprite.Icon.CachedTexture;
+        Icon.Texture = sprite.Icon.CachedTexture?.Texture;
     }
 
     protected override void MouseEntered() {

--- a/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
+++ b/OpenDreamClient/Rendering/ClientAppearanceSystem.cs
@@ -5,7 +5,6 @@ using Robust.Client.Graphics;
 using Robust.Shared.Prototypes;
 using OpenDreamClient.Resources;
 using OpenDreamClient.Resources.ResourceTypes;
-using OpenDreamShared.Network.Messages;
 using Robust.Shared.Timing;
 
 namespace OpenDreamClient.Rendering;
@@ -21,6 +20,7 @@ internal sealed class ClientAppearanceSystem : SharedAppearanceSystem {
     [Dependency] private readonly TransformSystem _transformSystem = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly IClyde _clyde = default!;
+    [Dependency] private readonly DMISpriteSystem _spriteSystem = default!;
 
     public override void Initialize() {
         SubscribeNetworkEvent<NewAppearanceEvent>(OnNewAppearance);
@@ -60,7 +60,7 @@ internal sealed class ClientAppearanceSystem : SharedAppearanceSystem {
         int appearanceId = turfId - 1;
 
         if (!_turfIcons.TryGetValue(appearanceId, out var icon)) {
-            icon = new DreamIcon(_gameTiming, _clyde, this, appearanceId);
+            icon = new DreamIcon(_spriteSystem.RenderTargetPool, _gameTiming, _clyde, this, appearanceId);
             _turfIcons.Add(appearanceId, icon);
         }
 

--- a/OpenDreamClient/Rendering/DMISpriteSystem.cs
+++ b/OpenDreamClient/Rendering/DMISpriteSystem.cs
@@ -1,4 +1,5 @@
 ﻿using OpenDreamShared.Rendering;
+using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Shared.GameStates;
 using Robust.Shared.Timing;
@@ -10,12 +11,31 @@ public sealed class DMISpriteSystem : EntitySystem {
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly EntityLookupSystem _lookupSystem = default!;
     [Dependency] private readonly ClientAppearanceSystem _appearanceSystem = default!;
+    [Dependency] private readonly IOverlayManager _overlayManager = default!;
     [Dependency] private readonly IClyde _clyde = default!;
+    [Dependency] private readonly TransformSystem _transformSystem = default!;
+    [Dependency] private readonly MapSystem _mapSystem = default!;
+    [Dependency] private readonly ClientScreenOverlaySystem _screenOverlaySystem = default!;
+    [Dependency] private readonly ClientImagesSystem _clientImagesSystem = default!;
+
+    public RenderTargetPool RenderTargetPool = default!;
+
+    private DreamViewOverlay _mapOverlay = default!;
 
     public override void Initialize() {
         SubscribeLocalEvent<DMISpriteComponent, ComponentAdd>(HandleComponentAdd);
         SubscribeLocalEvent<DMISpriteComponent, ComponentHandleState>(HandleComponentState);
         SubscribeLocalEvent<DMISpriteComponent, ComponentRemove>(HandleComponentRemove);
+
+        RenderTargetPool = new(_clyde);
+        _mapOverlay = new DreamViewOverlay(RenderTargetPool, _transformSystem, _mapSystem, _lookupSystem, _appearanceSystem, _screenOverlaySystem, _clientImagesSystem);
+        _overlayManager.AddOverlay(_mapOverlay);
+    }
+
+    public override void Shutdown() {
+        RenderTargetPool = default!;
+        _overlayManager.RemoveOverlay<DreamViewOverlay>();
+        _mapOverlay = default!;
     }
 
     private void OnIconSizeChanged(EntityUid uid) {
@@ -24,7 +44,7 @@ public sealed class DMISpriteSystem : EntitySystem {
     }
 
     private void HandleComponentAdd(EntityUid uid, DMISpriteComponent component, ref ComponentAdd args) {
-        component.Icon = new DreamIcon(_gameTiming, _clyde, _appearanceSystem);
+        component.Icon = new DreamIcon(RenderTargetPool, _gameTiming, _clyde, _appearanceSystem);
         component.Icon.SizeChanged += () => OnIconSizeChanged(uid);
     }
 

--- a/OpenDreamClient/Rendering/DreamIcon.cs
+++ b/OpenDreamClient/Rendering/DreamIcon.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace OpenDreamClient.Rendering;
 
-internal sealed class DreamIcon(IGameTiming gameTiming, IClyde clyde, ClientAppearanceSystem appearanceSystem) : IDisposable {
+internal sealed class DreamIcon(RenderTargetPool renderTargetPool, IGameTiming gameTiming, IClyde clyde, ClientAppearanceSystem appearanceSystem) : IDisposable {
     public delegate void SizeChangedEventHandler();
 
     public List<DreamIcon> Overlays { get; } = new();
@@ -45,24 +45,30 @@ internal sealed class DreamIcon(IGameTiming gameTiming, IClyde clyde, ClientAppe
     private IconAppearance? _appearance;
 
     // TODO: We could cache these per-appearance instead of per-atom
-    public Texture? CachedTexture { get; private set; }
+    public IRenderTexture? CachedTexture {
+        get => _cachedTexture;
+        private set {
+            if (_cachedTexture != null)
+                renderTargetPool.Return(_cachedTexture);
+            _cachedTexture = value;
+        }
+    }
+
     public Vector2 TextureRenderOffset = Vector2.Zero;
 
     private int _animationFrame;
     private TimeSpan _animationFrameTime = gameTiming.CurTime;
     private List<AppearanceAnimation>? _appearanceAnimations;
     private Box2? _cachedAABB;
-    private IRenderTexture? _ping, _pong;
     private bool _textureDirty = true;
+    private IRenderTexture? _cachedTexture;
 
-    public DreamIcon(IGameTiming gameTiming, IClyde clyde, ClientAppearanceSystem appearanceSystem, int appearanceId,
-        AtomDirection? parentDir = null) : this(gameTiming, clyde, appearanceSystem) {
+    public DreamIcon(RenderTargetPool renderTargetPool, IGameTiming gameTiming, IClyde clyde, ClientAppearanceSystem appearanceSystem, int appearanceId,
+        AtomDirection? parentDir = null) : this(renderTargetPool, gameTiming, clyde, appearanceSystem) {
         SetAppearance(appearanceId, parentDir);
     }
 
     public void Dispose() {
-        _ping?.Dispose();
-        _pong?.Dispose();
         DMI = null; //triggers the removal of the onUpdateCallback
     }
 
@@ -75,7 +81,7 @@ internal sealed class DreamIcon(IGameTiming gameTiming, IClyde clyde, ClientAppe
 
             var animationFrame = AnimationFrame;
             if (CachedTexture != null && !_textureDirty)
-                return CachedTexture;
+                return CachedTexture.Texture;
 
             _textureDirty = false;
             frame = DMI.GetState(Appearance.IconState)?.GetFrames(Appearance.Direction)[animationFrame];
@@ -92,12 +98,12 @@ internal sealed class DreamIcon(IGameTiming gameTiming, IClyde clyde, ClientAppe
             CachedTexture = null;
         } else if (canSkipFullRender) {
             TextureRenderOffset = Vector2.Zero;
-            CachedTexture = frame;
+            return frame;
         } else {
             CachedTexture = FullRenderTexture(viewOverlay, handle, iconMetaData, frame);
         }
 
-        return CachedTexture;
+        return CachedTexture?.Texture;
     }
 
     public void SetAppearance(int? appearanceId, AtomDirection? parentDir = null) {
@@ -421,7 +427,7 @@ internal sealed class DreamIcon(IGameTiming gameTiming, IClyde clyde, ClientAppe
 
         Overlays.Clear();
         foreach (int overlayId in Appearance.Overlays) {
-            DreamIcon overlay = new DreamIcon(gameTiming, clyde, appearanceSystem, overlayId, Appearance.Direction);
+            DreamIcon overlay = new DreamIcon(renderTargetPool, gameTiming, clyde, appearanceSystem, overlayId, Appearance.Direction);
             overlay.SizeChanged += CheckSizeChange;
 
             Overlays.Add(overlay);
@@ -429,7 +435,7 @@ internal sealed class DreamIcon(IGameTiming gameTiming, IClyde clyde, ClientAppe
 
         Underlays.Clear();
         foreach (int underlayId in Appearance.Underlays) {
-            DreamIcon underlay = new DreamIcon(gameTiming, clyde, appearanceSystem, underlayId, Appearance.Direction);
+            DreamIcon underlay = new DreamIcon(renderTargetPool, gameTiming, clyde, appearanceSystem, underlayId, Appearance.Direction);
             underlay.SizeChanged += CheckSizeChange;
 
             Underlays.Add(underlay);
@@ -441,17 +447,12 @@ internal sealed class DreamIcon(IGameTiming gameTiming, IClyde clyde, ClientAppe
     /// </summary>
     /// <remarks>In a separate method to avoid closure allocations when not executed</remarks>
     /// <returns>The final texture</returns>
-    private Texture FullRenderTexture(DreamViewOverlay viewOverlay, DrawingHandleWorld handle, RendererMetaData iconMetaData, Texture frame) {
-        if (_ping?.Size != frame.Size * 2 || _pong == null) {
-            _ping?.Dispose();
-            _pong?.Dispose();
+    private IRenderTexture FullRenderTexture(DreamViewOverlay viewOverlay, DrawingHandleWorld handle, RendererMetaData iconMetaData, Texture frame) {
+        // TODO: This should determine the size from the filters and their settings, not just double the original
+        var ping = renderTargetPool.Rent(frame.Size * 2);
+        var pong = renderTargetPool.Rent(ping.Size);
 
-            // TODO: This should determine the size from the filters and their settings, not just double the original
-            _ping = clyde.CreateRenderTarget(frame.Size * 2, new(RenderTargetColorFormat.Rgba8Srgb));
-            _pong = clyde.CreateRenderTarget(_ping.Size, new(RenderTargetColorFormat.Rgba8Srgb));
-        }
-
-        handle.RenderInRenderTarget(_pong, () => {
+        handle.RenderInRenderTarget(pong, () => {
             //we can use the color matrix shader here, since we don't need to blend
             //also because blend mode is none, we don't need to clear
             var colorMatrix = iconMetaData.ColorMatrixToApply.Equals(ColorMatrix.Identity)
@@ -464,26 +465,27 @@ internal sealed class DreamIcon(IGameTiming gameTiming, IClyde clyde, ClientAppe
             colorShader.SetParameter("isPlaneMaster",iconMetaData.IsPlaneMaster);
             handle.UseShader(colorShader);
 
-            handle.SetTransform(DreamViewOverlay.CreateRenderTargetFlipMatrix(_pong.Size, frame.Size / 2));
+            handle.SetTransform(DreamViewOverlay.CreateRenderTargetFlipMatrix(pong.Size, frame.Size / 2));
             handle.DrawTextureRect(frame, new Box2(Vector2.Zero, frame.Size));
         }, Color.Black.WithAlpha(0));
 
         foreach (DreamFilter filterId in iconMetaData.MainIcon!.Appearance!.Filters) {
             ShaderInstance s = appearanceSystem.GetFilterShader(filterId, viewOverlay.RenderSourceLookup);
 
-            handle.RenderInRenderTarget(_ping, () => {
+            handle.RenderInRenderTarget(ping, () => {
                 handle.UseShader(s);
 
                 // Technically this should be ping.Size, but they are the same size so avoid the extra closure alloc
-                handle.SetTransform(DreamViewOverlay.CreateRenderTargetFlipMatrix(_pong.Size, Vector2.Zero));
-                handle.DrawTextureRect(_pong.Texture, new Box2(Vector2.Zero, _pong.Size));
+                handle.SetTransform(DreamViewOverlay.CreateRenderTargetFlipMatrix(pong.Size, Vector2.Zero));
+                handle.DrawTextureRect(pong.Texture, new Box2(Vector2.Zero, pong.Size));
             }, Color.Black.WithAlpha(0));
 
-            (_ping, _pong) = (_pong, _ping);
+            (ping, pong) = (pong, ping);
         }
 
-        TextureRenderOffset = -(_pong.Texture.Size / 2 - frame.Size / 2);
-        return _pong.Texture;
+        renderTargetPool.Return(ping);
+        TextureRenderOffset = -(pong.Texture.Size / 2 - frame.Size / 2);
+        return pong;
     }
 
     private void CheckSizeChange() {

--- a/OpenDreamClient/Rendering/DreamIcon.cs
+++ b/OpenDreamClient/Rendering/DreamIcon.cs
@@ -69,6 +69,7 @@ internal sealed class DreamIcon(RenderTargetPool renderTargetPool, IGameTiming g
     }
 
     public void Dispose() {
+        CachedTexture = null;
         DMI = null; //triggers the removal of the onUpdateCallback
     }
 

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using System.Runtime.CompilerServices;
 using OpenDreamClient.Interface;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
@@ -13,7 +12,6 @@ using Robust.Client.GameObjects;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Profiling;
 using Vector3 = Robust.Shared.Maths.Vector3;
-using Dependency = Robust.Shared.IoC.DependencyAttribute;
 using Matrix3x2 = System.Numerics.Matrix3x2;
 
 namespace OpenDreamClient.Rendering;
@@ -62,11 +60,9 @@ internal sealed class DreamViewOverlay : Overlay {
     private readonly Dictionary<BlendMode, ShaderInstance> _blendModeInstances;
     public static ShaderInstance ColorInstance = default!;
 
-    private readonly Dictionary<Vector2i, List<IRenderTexture>> _renderTargetCache = new();
-
     private IRenderTexture? _mouseMapRenderTarget;
     private IRenderTexture? _baseRenderTarget;
-    private readonly Stack<IRenderTexture> _renderTargetsToReturn = new();
+    private readonly RenderTargetPool _renderTargetPool;
     private readonly Stack<RendererMetaData> _rendererMetaDataRental = new();
     private readonly Stack<RendererMetaData> _rendererMetaDataToReturn = new();
 
@@ -77,9 +73,10 @@ internal sealed class DreamViewOverlay : Overlay {
     // Defined here so it isn't recreated every frame
     private ViewAlgorithm.Tile?[,]? _tileInfo;
 
-    public DreamViewOverlay(TransformSystem transformSystem, MapSystem mapSystem, EntityLookupSystem lookupSystem,
+    public DreamViewOverlay(RenderTargetPool renderTargetPool, TransformSystem transformSystem, MapSystem mapSystem, EntityLookupSystem lookupSystem,
         ClientAppearanceSystem appearanceSystem, ClientScreenOverlaySystem screenOverlaySystem, ClientImagesSystem clientImagesSystem) {
         IoCManager.InjectDependencies(this);
+        _renderTargetPool = renderTargetPool;
         _transformSystem = transformSystem;
         _mapSystem = mapSystem;
         _lookupSystem = lookupSystem;
@@ -125,9 +122,7 @@ internal sealed class DreamViewOverlay : Overlay {
 
         RenderSourceLookup.Clear();
 
-        //some render targets need to be kept until the end of the render cycle, so return them here.
-        while(_renderTargetsToReturn.Count > 0)
-            ReturnRenderTarget(_renderTargetsToReturn.Pop());
+        _renderTargetPool.HandleEndOfFrame();
 
         //RendererMetaData objects get reused instead of garbage collected
         while (_rendererMetaDataToReturn.Count > 0)
@@ -358,32 +353,6 @@ internal sealed class DreamViewOverlay : Overlay {
         result.Add(current);
     }
 
-    private IRenderTexture RentRenderTarget(Vector2i size) {
-        IRenderTexture result;
-
-        if (!_renderTargetCache.TryGetValue(size, out var listResult)) {
-            result = _clyde.CreateRenderTarget(size, new(RenderTargetColorFormat.Rgba8Srgb));
-        } else {
-            if (listResult.Count > 0) {
-                result = listResult[0]; //pop a value
-                listResult.Remove(result);
-            } else {
-                result = _clyde.CreateRenderTarget(size, new(RenderTargetColorFormat.Rgba8Srgb));
-            }
-        }
-
-        return result;
-    }
-
-    private void ReturnRenderTarget(IRenderTexture rental) {
-        if (!_renderTargetCache.TryGetValue(rental.Size, out var storeList)) {
-            storeList = new List<IRenderTexture>(4);
-            _renderTargetCache.Add(rental.Size, storeList);
-        }
-
-        storeList.Add(rental);
-    }
-
     private void ClearRenderTarget(IRenderTexture target, DrawingHandleWorld handle, Color clearColor) {
         handle.RenderInRenderTarget(target, () => {}, clearColor);
     }
@@ -516,10 +485,10 @@ internal sealed class DreamViewOverlay : Overlay {
             if (!string.IsNullOrEmpty(sprite.RenderTarget)) {
                 //if this sprite has a render target, draw it to a slate instead. If it needs to be drawn on the map, a second sprite instance will already have been created for that purpose
                 if (!RenderSourceLookup.TryGetValue(sprite.RenderTarget, out var tmpRenderTarget)) {
-                    tmpRenderTarget = RentRenderTarget(viewportSize);
+                    tmpRenderTarget = _renderTargetPool.Rent(viewportSize);
                     ClearRenderTarget(tmpRenderTarget, handle, new Color());
                     RenderSourceLookup.Add(sprite.RenderTarget, tmpRenderTarget);
-                    _renderTargetsToReturn.Push(tmpRenderTarget);
+                    _renderTargetPool.ReturnAtEndOfFrame(tmpRenderTarget);
                 }
 
                 if (sprite.IsPlaneMaster) { //if this is also a plane master
@@ -768,7 +737,7 @@ internal sealed class DreamViewOverlay : Overlay {
 
         ktItems.Sort();
         //draw it onto an additional render target that we can return immediately for correction of transform
-        IRenderTexture tempTexture = RentRenderTarget(size);
+        IRenderTexture tempTexture = _renderTargetPool.Rent(size);
 
         handle.RenderInRenderTarget(tempTexture, () => {
             foreach (RendererMetaData ktItem in ktItems) {
@@ -777,13 +746,13 @@ internal sealed class DreamViewOverlay : Overlay {
         }, Color.Transparent);
 
         //but keep the handle to the final KT group's render target so we don't override it later in the render cycle
-        IRenderTexture ktTexture = RentRenderTarget(tempTexture.Size);
+        IRenderTexture ktTexture = _renderTargetPool.Rent(tempTexture.Size);
         handle.RenderInRenderTarget(ktTexture, () => {
             handle.SetTransform(CreateRenderTargetFlipMatrix(tempTexture.Size, Vector2.Zero));
             handle.DrawTextureRect(tempTexture.Texture, new Box2(Vector2.Zero, tempTexture.Size));
         }, Color.Transparent);
 
-        _renderTargetsToReturn.Push(tempTexture);
+        _renderTargetPool.ReturnAtEndOfFrame(tempTexture);
 
         //now restore the original color, alpha, blend, and transform so they can be applied to the render target as a whole
         iconMetaData.TransformToApply = ktParentTransform;
@@ -791,7 +760,7 @@ internal sealed class DreamViewOverlay : Overlay {
         iconMetaData.AlphaToApply = ktParentAlpha;
         iconMetaData.BlendMode = ktParentBlendMode;
 
-        _renderTargetsToReturn.Push(ktTexture);
+        _renderTargetPool.ReturnAtEndOfFrame(ktTexture);
         return ktTexture.Texture;
     }
 
@@ -940,6 +909,7 @@ internal sealed class RendererMetaData : IComparable<RendererMetaData> {
 }
 
 #region Render Toggle Commands
+
 public sealed class ToggleScreenOverlayCommand : IConsoleCommand {
     // ReSharper disable once StringLiteralTypo
     public string Command => "togglescreenoverlay";
@@ -979,4 +949,5 @@ public sealed class ToggleMouseOverlayCommand : IConsoleCommand {
         }
     }
 }
+
 #endregion

--- a/OpenDreamClient/Rendering/RenderTargetPool.cs
+++ b/OpenDreamClient/Rendering/RenderTargetPool.cs
@@ -1,0 +1,43 @@
+using Robust.Client.Graphics;
+using Robust.Shared.Utility;
+
+namespace OpenDreamClient.Rendering;
+
+public sealed class RenderTargetPool(IClyde clyde) {
+    private readonly Dictionary<Vector2i, List<IRenderTexture>> _renderTargets = new();
+    private readonly Stack<IRenderTexture> _renderTargetsToReturn = new();
+
+    public IRenderTexture Rent(Vector2i size) {
+        IRenderTexture result;
+
+        if (!_renderTargets.TryGetValue(size, out var listResult)) {
+            result = clyde.CreateRenderTarget(size, new(RenderTargetColorFormat.Rgba8Srgb));
+        } else {
+            result = listResult.Count > 0
+                ? listResult.Pop()
+                : clyde.CreateRenderTarget(size, new(RenderTargetColorFormat.Rgba8Srgb));
+        }
+
+        return result;
+    }
+
+    public void ReturnAtEndOfFrame(IRenderTexture rental) {
+        _renderTargetsToReturn.Push(rental);
+    }
+
+    public void Return(IRenderTexture rental) {
+        if (!_renderTargets.TryGetValue(rental.Size, out var storeList)) {
+            storeList = new List<IRenderTexture>(4);
+            _renderTargets.Add(rental.Size, storeList);
+        }
+
+        storeList.Add(rental);
+    }
+
+    [Access(typeof(DreamViewOverlay))]
+    public void HandleEndOfFrame() {
+        //some render targets need to be kept until the end of the render cycle, so return them here.
+        while (_renderTargetsToReturn.TryPop(out var toReturn))
+            Return(toReturn);
+    }
+}


### PR DESCRIPTION
DreamIcon now pools its render targets instead of holding onto them for their entire lifetime.