### PR TITLE
Handle appending `null` to `vis_contents`

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -827,7 +827,9 @@ public sealed class DreamVisContentsList : DreamList {
                 return; // vis_contents cannot contain duplicates
             _visContents.Add(turf);
             entity = EntityUid.Invalid; // TODO: Support turfs in vis_contents
-        } else {
+        } else if (value == DreamValue.Null) {
+            return; // vis_contents cannot contain nulls
+        }else {
             throw new Exception($"Cannot add {value} to a vis_contents list");
         }
 

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -829,7 +829,7 @@ public sealed class DreamVisContentsList : DreamList {
             entity = EntityUid.Invalid; // TODO: Support turfs in vis_contents
         } else if (value == DreamValue.Null) {
             return; // vis_contents cannot contain nulls
-        }else {
+        } else {
             throw new Exception($"Cannot add {value} to a vis_contents list");
         }
 


### PR DESCRIPTION
Appears to be a no-op in BYOND:

![image](https://github.com/OpenDreamProject/OpenDream/assets/5714543/ee000be5-40c5-4126-8441-208f1eab47fe)
