### PR TITLE
Implement `/world/Error()`'s default `..()` behavior

### DIFF
--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -393,9 +393,6 @@ namespace OpenDreamRuntime {
 
             var msg = builder.ToString();
 
-            // TODO: Defining world.Error() causes byond to no longer print exceptions to the log unless ..() is called
-            dreamMan.WriteWorldLog(msg, LogLevel.Error);
-
             // Instantiate an /exception and invoke world.Error()
             string file = string.Empty;
             int line = 0;
@@ -404,8 +401,8 @@ namespace OpenDreamRuntime {
                 file = source.Item1;
                 line = source.Item2;
             }
-            dreamMan.HandleException(exception, msg, file, line);
 
+            dreamMan.HandleException(exception, msg, file, line);
             IoCManager.Resolve<IDreamDebugManager>().HandleException(this, exception);
         }
 
@@ -413,6 +410,7 @@ namespace OpenDreamRuntime {
             if (_current is not null) {
                 yield return _current;
             }
+
             foreach (var entry in _stack) {
                 yield return entry;
             }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -151,6 +151,7 @@ internal static class DreamProcNative {
         objectTree.SetNativeProc(objectTree.World, DreamProcNativeWorld.NativeProc_ODHotReloadInterface);
         objectTree.SetNativeProc(objectTree.World, DreamProcNativeWorld.NativeProc_ODHotReloadResource);
 
+        SetOverridableNativeProc(objectTree, objectTree.World, DreamProcNativeWorld.NativeProc_Error);
         SetOverridableNativeProc(objectTree, objectTree.World, DreamProcNativeWorld.NativeProc_Reboot);
     }
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -1,175 +1,175 @@
 ﻿using OpenDreamRuntime.Objects;
 
-namespace OpenDreamRuntime.Procs.Native {
-    internal static class DreamProcNative {
-        public static void SetupNativeProcs(DreamObjectTree objectTree) {
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_alert);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_animate);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ascii2text);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_block);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ceil);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ckey);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ckeyEx);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_clamp);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_cmptext);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_copytext);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_copytext_char);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_CRASH);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_fcopy);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_fcopy_rsc);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_fdel);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_fexists);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_file);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_file2text);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_filter);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_findtext);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_findtextEx);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_findlasttext);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_findlasttextEx);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_flick);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_flist);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_floor);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_fract);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ftime);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_hascall);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_html_decode);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_html_encode);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_icon_states);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_image);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isarea);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isfile);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isicon);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isinf);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_islist);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isloc);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ismob);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isobj);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ismovable);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isnan);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isnull);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isnum);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ispath);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_istext);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isturf);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_json_decode);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_json_encode);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_length_char);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_list2params);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_lowertext);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_matrix);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_max);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_md5);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_min);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_nonspantext);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_num2text);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_orange);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_oview);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_oviewers);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_params2list);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_rand);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_rand_seed);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_range);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ref);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_regex);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_replacetext);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_replacetextEx);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_rgb2num);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_roll);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_round);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_sha1);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_shutdown);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_sleep);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_sorttext);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_sorttextEx);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_sound);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_spantext);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_spantext_char);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_splicetext);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_splicetext_char);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_splittext);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_stat);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_statpanel);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_text2ascii);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_text2ascii_char);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_text2file);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_text2num);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_text2path);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_time2text);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_trimtext);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_trunc);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_turn);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_typesof);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_uppertext);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_url_decode);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_url_encode);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_view);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_viewers);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_walk);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_walk_to);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_walk_towards);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_winclone);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_winexists);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_winget);
-            objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_winset);
+namespace OpenDreamRuntime.Procs.Native;
 
-            objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Add);
-            objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Copy);
-            objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Cut);
-            objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Find);
-            objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Insert);
-            objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Join);
-            objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Remove);
-            objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_RemoveAll);
-            objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Swap);
+internal static class DreamProcNative {
+    public static void SetupNativeProcs(DreamObjectTree objectTree) {
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_alert);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_animate);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ascii2text);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_block);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ceil);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ckey);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ckeyEx);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_clamp);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_cmptext);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_copytext);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_copytext_char);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_CRASH);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_fcopy);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_fcopy_rsc);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_fdel);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_fexists);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_file);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_file2text);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_filter);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_findtext);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_findtextEx);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_findlasttext);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_findlasttextEx);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_flick);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_flist);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_floor);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_fract);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ftime);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_hascall);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_html_decode);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_html_encode);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_icon_states);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_image);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isarea);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isfile);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isicon);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isinf);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_islist);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isloc);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ismob);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isobj);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ismovable);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isnan);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isnull);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isnum);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ispath);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_istext);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_isturf);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_json_decode);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_json_encode);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_length_char);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_list2params);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_lowertext);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_matrix);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_max);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_md5);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_min);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_nonspantext);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_num2text);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_orange);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_oview);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_oviewers);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_params2list);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_rand);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_rand_seed);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_range);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_ref);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_regex);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_replacetext);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_replacetextEx);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_rgb2num);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_roll);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_round);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_sha1);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_shutdown);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_sleep);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_sorttext);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_sorttextEx);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_sound);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_spantext);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_spantext_char);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_splicetext);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_splicetext_char);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_splittext);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_stat);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_statpanel);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_text2ascii);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_text2ascii_char);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_text2file);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_text2num);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_text2path);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_time2text);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_trimtext);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_trunc);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_turn);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_typesof);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_uppertext);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_url_decode);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_url_encode);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_view);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_viewers);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_walk);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_walk_to);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_walk_towards);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_winclone);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_winexists);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_winget);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_winset);
 
-            objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Add);
-            objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Invert);
-            objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Multiply);
-            objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Scale);
-            objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Subtract);
-            objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Translate);
-            objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Turn);
+        objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Add);
+        objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Copy);
+        objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Cut);
+        objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Find);
+        objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Insert);
+        objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Join);
+        objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Remove);
+        objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_RemoveAll);
+        objectTree.SetNativeProc(objectTree.List, DreamProcNativeList.NativeProc_Swap);
 
-            objectTree.SetNativeProc(objectTree.Regex, DreamProcNativeRegex.NativeProc_Find);
-            objectTree.SetNativeProc(objectTree.Regex, DreamProcNativeRegex.NativeProc_Replace);
+        objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Add);
+        objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Invert);
+        objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Multiply);
+        objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Scale);
+        objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Subtract);
+        objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Translate);
+        objectTree.SetNativeProc(objectTree.Matrix, DreamProcNativeMatrix.NativeProc_Turn);
 
-            objectTree.SetNativeProc(objectTree.Icon, DreamProcNativeIcon.NativeProc_Width);
-            objectTree.SetNativeProc(objectTree.Icon, DreamProcNativeIcon.NativeProc_Height);
-            objectTree.SetNativeProc(objectTree.Icon, DreamProcNativeIcon.NativeProc_Insert);
-            objectTree.SetNativeProc(objectTree.Icon, DreamProcNativeIcon.NativeProc_Blend);
-            objectTree.SetNativeProc(objectTree.Icon, DreamProcNativeIcon.NativeProc_Scale);
-            objectTree.SetNativeProc(objectTree.Icon, DreamProcNativeIcon.NativeProc_Turn);
+        objectTree.SetNativeProc(objectTree.Regex, DreamProcNativeRegex.NativeProc_Find);
+        objectTree.SetNativeProc(objectTree.Regex, DreamProcNativeRegex.NativeProc_Replace);
 
-            objectTree.SetNativeProc(objectTree.Savefile, DreamProcNativeSavefile.NativeProc_ExportText);
-            objectTree.SetNativeProc(objectTree.Savefile, DreamProcNativeSavefile.NativeProc_Flush);
+        objectTree.SetNativeProc(objectTree.Icon, DreamProcNativeIcon.NativeProc_Width);
+        objectTree.SetNativeProc(objectTree.Icon, DreamProcNativeIcon.NativeProc_Height);
+        objectTree.SetNativeProc(objectTree.Icon, DreamProcNativeIcon.NativeProc_Insert);
+        objectTree.SetNativeProc(objectTree.Icon, DreamProcNativeIcon.NativeProc_Blend);
+        objectTree.SetNativeProc(objectTree.Icon, DreamProcNativeIcon.NativeProc_Scale);
+        objectTree.SetNativeProc(objectTree.Icon, DreamProcNativeIcon.NativeProc_Turn);
 
-            objectTree.SetNativeProc(objectTree.World, DreamProcNativeWorld.NativeProc_Export);
-            objectTree.SetNativeProc(objectTree.World, DreamProcNativeWorld.NativeProc_GetConfig);
-            objectTree.SetNativeProc(objectTree.World, DreamProcNativeWorld.NativeProc_Profile);
-            objectTree.SetNativeProc(objectTree.World, DreamProcNativeWorld.NativeProc_SetConfig);
-            objectTree.SetNativeProc(objectTree.World, DreamProcNativeWorld.NativeProc_ODHotReloadInterface);
-            objectTree.SetNativeProc(objectTree.World, DreamProcNativeWorld.NativeProc_ODHotReloadResource);
+        objectTree.SetNativeProc(objectTree.Savefile, DreamProcNativeSavefile.NativeProc_ExportText);
+        objectTree.SetNativeProc(objectTree.Savefile, DreamProcNativeSavefile.NativeProc_Flush);
 
-            SetOverridableNativeProc(objectTree, objectTree.World, DreamProcNativeWorld.NativeProc_Reboot);
+        objectTree.SetNativeProc(objectTree.World, DreamProcNativeWorld.NativeProc_Export);
+        objectTree.SetNativeProc(objectTree.World, DreamProcNativeWorld.NativeProc_GetConfig);
+        objectTree.SetNativeProc(objectTree.World, DreamProcNativeWorld.NativeProc_Profile);
+        objectTree.SetNativeProc(objectTree.World, DreamProcNativeWorld.NativeProc_SetConfig);
+        objectTree.SetNativeProc(objectTree.World, DreamProcNativeWorld.NativeProc_ODHotReloadInterface);
+        objectTree.SetNativeProc(objectTree.World, DreamProcNativeWorld.NativeProc_ODHotReloadResource);
+
+        SetOverridableNativeProc(objectTree, objectTree.World, DreamProcNativeWorld.NativeProc_Reboot);
+    }
+
+    /// <summary>
+    /// Sets a native proc that can be overriden by DM code
+    /// </summary>
+    private static void SetOverridableNativeProc(DreamObjectTree objectTree, TreeEntry type, NativeProc.HandlerFn func) {
+        var nativeProc = objectTree.CreateNativeProc(type, func);
+
+        var proc = objectTree.World.ObjectDefinition.GetProc(nativeProc.Name);
+        if (proc.SuperProc == null) { // This proc was never overriden so just replace it
+            type.ObjectDefinition.SetProcDefinition(proc.Name, proc.Id);
+            return;
         }
 
-        /// <summary>
-        /// Sets a native proc that can be overriden by DM code
-        /// </summary>
-        private static void SetOverridableNativeProc(DreamObjectTree objectTree, TreeEntry type, NativeProc.HandlerFn func) {
-            var nativeProc = objectTree.CreateNativeProc(type, func);
+        // Find the first override of the proc, we're replacing that one's super
+        while (proc.SuperProc?.SuperProc != null)
+            proc = proc.SuperProc;
 
-            var proc = objectTree.World.ObjectDefinition.GetProc(nativeProc.Name);
-            if (proc.SuperProc == null) { // This proc was never overriden so just replace it
-                type.ObjectDefinition.SetProcDefinition(proc.Name, proc.Id);
-                return;
-            }
-
-            // Find the first override of the proc, we're replacing that one's super
-            while (proc.SuperProc?.SuperProc != null)
-                proc = proc.SuperProc;
-
-            proc.SuperProc = nativeProc;
-        }
+        proc.SuperProc = nativeProc;
     }
 }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
@@ -70,6 +70,19 @@ internal static class DreamProcNativeWorld {
         return new DreamValue(list);
     }
 
+    [DreamProc("Error")]
+    [DreamProcParameter("exception", Type = DreamValue.DreamValueTypeFlag.DreamObject)]
+    public static DreamValue NativeProc_Error(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
+        var exceptionArg = bundle.GetArgument(0, "exception");
+        if (!exceptionArg.TryGetValueAsDreamObject<DreamObjectException>(out var exception)) // Ignore anything not an /exception
+            return DreamValue.Null;
+        if (!exception.Desc.TryGetValueAsString(out var exceptionDesc))
+            return DreamValue.Null;
+
+        bundle.DreamManager.WriteWorldLog(exceptionDesc, LogLevel.Error);
+        return DreamValue.Null;
+    }
+
     [DreamProc("GetConfig")]
     [DreamProcParameter("config_set", Type = DreamValue.DreamValueTypeFlag.String)]
     [DreamProcParameter("param", Type = DreamValue.DreamValueTypeFlag.String)]

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeWorld.cs
@@ -7,226 +7,226 @@ using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Objects.Types;
 using Robust.Server;
 
-namespace OpenDreamRuntime.Procs.Native {
-    internal static class DreamProcNativeWorld {
-        [DreamProc("Export")]
-        [DreamProcParameter("Addr", Type = DreamValue.DreamValueTypeFlag.String)]
-        [DreamProcParameter("File", Type = DreamValue.DreamValueTypeFlag.DreamObject)]
-        [DreamProcParameter("Persist", Type = DreamValue.DreamValueTypeFlag.Float, DefaultValue = 0)]
-        [DreamProcParameter("Clients", Type = DreamValue.DreamValueTypeFlag.DreamObject)]
-        public static async Task<DreamValue> NativeProc_Export(AsyncNativeProc.State state) {
-            var addr = state.GetArgument(0, "Addr").Stringify();
+namespace OpenDreamRuntime.Procs.Native;
 
-            if (!Uri.TryCreate(addr, UriKind.RelativeOrAbsolute, out var uri))
-                throw new ArgumentException("Unable to parse URI.");
+internal static class DreamProcNativeWorld {
+    [DreamProc("Export")]
+    [DreamProcParameter("Addr", Type = DreamValue.DreamValueTypeFlag.String)]
+    [DreamProcParameter("File", Type = DreamValue.DreamValueTypeFlag.DreamObject)]
+    [DreamProcParameter("Persist", Type = DreamValue.DreamValueTypeFlag.Float, DefaultValue = 0)]
+    [DreamProcParameter("Clients", Type = DreamValue.DreamValueTypeFlag.DreamObject)]
+    public static async Task<DreamValue> NativeProc_Export(AsyncNativeProc.State state) {
+        var addr = state.GetArgument(0, "Addr").Stringify();
 
-            if (uri.Scheme is not ("http" or "https" or "byond"))
-                throw new NotSupportedException($"Unknown scheme for world.Export: '{uri.Scheme}'");
+        if (!Uri.TryCreate(addr, UriKind.RelativeOrAbsolute, out var uri))
+            throw new ArgumentException("Unable to parse URI.");
 
-            if (uri.Scheme is "byond") {
-                var tenSecondTimeout = TimeSpan.FromSeconds(10);
-                var topicClient = new TopicClient(new SocketParameters {
-                    ConnectTimeout = tenSecondTimeout,
-                    DisconnectTimeout = tenSecondTimeout,
-                    ReceiveTimeout = tenSecondTimeout,
-                    SendTimeout = tenSecondTimeout,
-                });
+        if (uri.Scheme is not ("http" or "https" or "byond"))
+            throw new NotSupportedException($"Unknown scheme for world.Export: '{uri.Scheme}'");
 
-                var topicResponse = await topicClient.SendTopic(uri.Host, uri.Query[1..], Convert.ToUInt16(uri.Port));
-                switch (topicResponse.ResponseType) {
-                    case TopicResponseType.FloatResponse:
-                        return new DreamValue(topicResponse.FloatData!.Value);
+        if (uri.Scheme is "byond") {
+            var tenSecondTimeout = TimeSpan.FromSeconds(10);
+            var topicClient = new TopicClient(new SocketParameters {
+                ConnectTimeout = tenSecondTimeout,
+                DisconnectTimeout = tenSecondTimeout,
+                ReceiveTimeout = tenSecondTimeout,
+                SendTimeout = tenSecondTimeout,
+            });
 
-                    case TopicResponseType.StringResponse:
-                        return new DreamValue(topicResponse.StringData!);
+            var topicResponse = await topicClient.SendTopic(uri.Host, uri.Query[1..], Convert.ToUInt16(uri.Port));
+            switch (topicResponse.ResponseType) {
+                case TopicResponseType.FloatResponse:
+                    return new DreamValue(topicResponse.FloatData!.Value);
 
-                    case TopicResponseType.UnknownResponse:
-                        var byteList = state.ObjectTree.CreateList();
-                        foreach (var @byte in topicResponse.RawData)
-                            byteList.AddValue(new DreamValue(@byte));
-                        return new DreamValue(byteList);
+                case TopicResponseType.StringResponse:
+                    return new DreamValue(topicResponse.StringData!);
 
-                    default:
-                        throw new IOException($"Topic returned an unknown response type: '{topicResponse.ResponseType}'");
+                case TopicResponseType.UnknownResponse:
+                    var byteList = state.ObjectTree.CreateList();
+                    foreach (var @byte in topicResponse.RawData)
+                        byteList.AddValue(new DreamValue(@byte));
+                    return new DreamValue(byteList);
+
+                default:
+                    throw new IOException($"Topic returned an unknown response type: '{topicResponse.ResponseType}'");
+            }
+        }
+
+        // TODO: Definitely cache HttpClient.
+        using var client = new HttpClient();
+        using var response = await client.GetAsync(uri);
+        var contentBytes = await response.Content.ReadAsByteArrayAsync();
+
+        var list = state.ObjectTree.CreateList();
+        foreach (var header in response.Headers) {
+            // TODO: How to handle headers with multiple values?
+            list.SetValue(new DreamValue(header.Key), new DreamValue(header.Value.First()));
+        }
+
+        var content = state.ResourceManager.CreateResource(contentBytes);
+        list.SetValue(new DreamValue("STATUS"), new DreamValue(((int) response.StatusCode).ToString()));
+        list.SetValue(new DreamValue("CONTENT"), new DreamValue(content));
+
+        return new DreamValue(list);
+    }
+
+    [DreamProc("GetConfig")]
+    [DreamProcParameter("config_set", Type = DreamValue.DreamValueTypeFlag.String)]
+    [DreamProcParameter("param", Type = DreamValue.DreamValueTypeFlag.String)]
+    public static DreamValue NativeProc_GetConfig(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
+        bundle.GetArgument(0, "config_set").TryGetValueAsString(out var configSetArg);
+        var param = bundle.GetArgument(1, "param");
+
+        ProcessConfigSet(configSetArg, out _, out var configSet);
+
+        switch (configSet) {
+            case "env":
+                if (param.IsNull) {
+                    // DM ref says: "If no parameter is specified, a list of the names of all available parameters is returned."
+                    // but apparently it's actually just null for "env".
+                    return DreamValue.Null;
+                } else if (param.TryGetValueAsString(out var paramString) && Environment.GetEnvironmentVariable(paramString) is string strValue) {
+                    return new DreamValue(strValue);
+                } else {
+                    return DreamValue.Null;
                 }
+            case "ban":
+            case "keyban":
+            case "ipban":
+            case "admin":
+                Logger.GetSawmill("opendream.world").Warning("Unsupported GetConfig config_set: " + configSet);
+                return new(bundle.ObjectTree.CreateList());
+            default:
+                throw new ArgumentException("Incorrect GetConfig config_set: " + configSet);
+        }
+    }
+
+    [DreamProc("Profile")]
+    [DreamProcParameter("command", Type = DreamValue.DreamValueTypeFlag.Float)]
+    [DreamProcParameter("type", Type = DreamValue.DreamValueTypeFlag.String)]
+    [DreamProcParameter("format", Type = DreamValue.DreamValueTypeFlag.String)]
+    public static DreamValue NativeProc_Profile(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
+        bundle.GetArgument(0, "command").TryGetValueAsInteger(out var command);
+
+        string? type, format;
+        switch (bundle.Arguments.Length) {
+            case 3:
+                bundle.GetArgument(1, "type").TryGetValueAsString(out type);
+                bundle.GetArgument(2, "format").TryGetValueAsString(out format);
+                break;
+            case 2:
+                type = null;
+                bundle.GetArgument(1, "type").TryGetValueAsString(out format);
+                break;
+            default:
+                type = null;
+                format = null;
+                break;
+        }
+
+        // TODO: Actually return profiling data
+
+        if (format == "json") {
+            return new("[]");
+        } else { // Anything else gives a /list
+            DreamList dataList = bundle.ObjectTree.CreateList();
+
+            if (type == "sendmaps") {
+                dataList.AddValue(new("name"));
+                dataList.AddValue(new("value"));
+                dataList.AddValue(new("calls"));
+            } else { // Anything else is a proc profile
+                dataList.AddValue(new("name"));
+                dataList.AddValue(new("self"));
+                dataList.AddValue(new("total"));
+                dataList.AddValue(new("real"));
+                dataList.AddValue(new("over"));
+                dataList.AddValue(new("calls"));
             }
 
-            // TODO: Definitely cache HttpClient.
-            using var client = new HttpClient();
-            using var response = await client.GetAsync(uri);
-            var contentBytes = await response.Content.ReadAsByteArrayAsync();
+            return new(dataList);
+        }
+    }
 
-            var list = state.ObjectTree.CreateList();
-            foreach (var header in response.Headers) {
-                // TODO: How to handle headers with multiple values?
-                list.SetValue(new DreamValue(header.Key), new DreamValue(header.Value.First()));
-            }
+    [DreamProc("Reboot")]
+    [DreamProcParameter("reason", Type = DreamValue.DreamValueTypeFlag.Float)]
+    public static DreamValue NativeProc_Reboot(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
+        var server = IoCManager.Resolve<IBaseServer>();
 
-            var content = state.ResourceManager.CreateResource(contentBytes);
-            list.SetValue(new DreamValue("STATUS"), new DreamValue(((int) response.StatusCode).ToString()));
-            list.SetValue(new DreamValue("CONTENT"), new DreamValue(content));
+        server.Shutdown("/world.Reboot() was called but restarting is very broken");
+        return DreamValue.Null;
+    }
 
-            return new DreamValue(list);
+    [DreamProc("SetConfig")]
+    [DreamProcParameter("config_set", Type = DreamValue.DreamValueTypeFlag.String)]
+    [DreamProcParameter("param", Type = DreamValue.DreamValueTypeFlag.String)]
+    [DreamProcParameter("value", Type = DreamValue.DreamValueTypeFlag.String)]
+    public static DreamValue NativeProc_SetConfig(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
+        bundle.GetArgument(0, "config_set").TryGetValueAsString(out var configSetArg);
+        bundle.GetArgument(1, "param").TryGetValueAsString(out var param);
+        var value = bundle.GetArgument(2, "value");
+
+        ProcessConfigSet(configSetArg, out _, out var configSet);
+
+        switch (configSet) {
+            case "env":
+                value.TryGetValueAsString(out var valueString);
+                Environment.SetEnvironmentVariable(param, valueString);
+                break;
+            case "ban":
+            case "keyban":
+            case "ipban":
+            case "admin":
+                Logger.GetSawmill("opendream.world").Warning("Unsupported SetConfig config_set: " + configSet);
+                break;
+            default:
+                throw new ArgumentException("Incorrect SetConfig config_set: " + configSet);
         }
 
-        [DreamProc("GetConfig")]
-        [DreamProcParameter("config_set", Type = DreamValue.DreamValueTypeFlag.String)]
-        [DreamProcParameter("param", Type = DreamValue.DreamValueTypeFlag.String)]
-        public static DreamValue NativeProc_GetConfig(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-            bundle.GetArgument(0, "config_set").TryGetValueAsString(out var configSetArg);
-            var param = bundle.GetArgument(1, "param");
+        return DreamValue.Null;
+    }
 
-            ProcessConfigSet(configSetArg, out _, out var configSet);
+    [DreamProc("ODHotReloadInterface")]
+    public static DreamValue NativeProc_ODHotReloadInterface(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
+        var dreamManager = IoCManager.Resolve<DreamManager>();
+        dreamManager.HotReloadInterface();
+        return DreamValue.Null;
+    }
 
-            switch (configSet) {
-                case "env":
-                    if (param.IsNull) {
-                        // DM ref says: "If no parameter is specified, a list of the names of all available parameters is returned."
-                        // but apparently it's actually just null for "env".
-                        return DreamValue.Null;
-                    } else if (param.TryGetValueAsString(out var paramString) && Environment.GetEnvironmentVariable(paramString) is string strValue) {
-                        return new DreamValue(strValue);
-                    } else {
-                        return DreamValue.Null;
-                    }
-                case "ban":
-                case "keyban":
-                case "ipban":
-                case "admin":
-                    Logger.GetSawmill("opendream.world").Warning("Unsupported GetConfig config_set: " + configSet);
-                    return new(bundle.ObjectTree.CreateList());
-                default:
-                    throw new ArgumentException("Incorrect GetConfig config_set: " + configSet);
-            }
+    [DreamProc("ODHotReloadResource")]
+    [DreamProcParameter("file_name", Type = DreamValue.DreamValueTypeFlag.String)]
+    public static DreamValue NativeProc_ODHotReloadResource(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
+        if(!bundle.GetArgument(0, "file_name").TryGetValueAsString(out var fileName))
+            throw new ArgumentException("file_name must be a string");
+        var dreamManager = IoCManager.Resolve<DreamManager>();
+        dreamManager.HotReloadResource(fileName);
+        return DreamValue.Null;
+    }
+
+    /// <summary>
+    /// Determines the specified configuration space and configuration set in a config_set argument
+    /// </summary>
+    private static void ProcessConfigSet(string value, out string? configSpace, out string configSet) {
+        int slash = value.IndexOf('/');
+
+        // No specified config space, default to USER
+        // TODO: Supposedly defaults to HOME in safe mode
+        if (slash == -1) {
+            configSpace = "USER";
+            configSet = value;
+            return;
         }
 
-        [DreamProc("Profile")]
-        [DreamProcParameter("command", Type = DreamValue.DreamValueTypeFlag.Float)]
-        [DreamProcParameter("type", Type = DreamValue.DreamValueTypeFlag.String)]
-        [DreamProcParameter("format", Type = DreamValue.DreamValueTypeFlag.String)]
-        public static DreamValue NativeProc_Profile(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-            bundle.GetArgument(0, "command").TryGetValueAsInteger(out var command);
-
-            string? type, format;
-            switch (bundle.Arguments.Length) {
-                case 3:
-                    bundle.GetArgument(1, "type").TryGetValueAsString(out type);
-                    bundle.GetArgument(2, "format").TryGetValueAsString(out format);
-                    break;
-                case 2:
-                    type = null;
-                    bundle.GetArgument(1, "type").TryGetValueAsString(out format);
-                    break;
-                default:
-                    type = null;
-                    format = null;
-                    break;
-            }
-
-            // TODO: Actually return profiling data
-
-            if (format == "json") {
-                return new("[]");
-            } else { // Anything else gives a /list
-                DreamList dataList = bundle.ObjectTree.CreateList();
-
-                if (type == "sendmaps") {
-                    dataList.AddValue(new("name"));
-                    dataList.AddValue(new("value"));
-                    dataList.AddValue(new("calls"));
-                } else { // Anything else is a proc profile
-                    dataList.AddValue(new("name"));
-                    dataList.AddValue(new("self"));
-                    dataList.AddValue(new("total"));
-                    dataList.AddValue(new("real"));
-                    dataList.AddValue(new("over"));
-                    dataList.AddValue(new("calls"));
-                }
-
-                return new(dataList);
-            }
-        }
-
-        [DreamProc("Reboot")]
-        [DreamProcParameter("reason", Type = DreamValue.DreamValueTypeFlag.Float)]
-        public static DreamValue NativeProc_Reboot(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-            var server = IoCManager.Resolve<IBaseServer>();
-
-            server.Shutdown("/world.Reboot() was called but restarting is very broken");
-            return DreamValue.Null;
-        }
-
-        [DreamProc("SetConfig")]
-        [DreamProcParameter("config_set", Type = DreamValue.DreamValueTypeFlag.String)]
-        [DreamProcParameter("param", Type = DreamValue.DreamValueTypeFlag.String)]
-        [DreamProcParameter("value", Type = DreamValue.DreamValueTypeFlag.String)]
-        public static DreamValue NativeProc_SetConfig(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-            bundle.GetArgument(0, "config_set").TryGetValueAsString(out var configSetArg);
-            bundle.GetArgument(1, "param").TryGetValueAsString(out var param);
-            var value = bundle.GetArgument(2, "value");
-
-            ProcessConfigSet(configSetArg, out _, out var configSet);
-
-            switch (configSet) {
-                case "env":
-                    value.TryGetValueAsString(out var valueString);
-                    Environment.SetEnvironmentVariable(param, valueString);
-                    break;
-                case "ban":
-                case "keyban":
-                case "ipban":
-                case "admin":
-                    Logger.GetSawmill("opendream.world").Warning("Unsupported SetConfig config_set: " + configSet);
-                    break;
-                default:
-                    throw new ArgumentException("Incorrect SetConfig config_set: " + configSet);
-            }
-
-            return DreamValue.Null;
-        }
-
-        [DreamProc("ODHotReloadInterface")]
-        public static DreamValue NativeProc_ODHotReloadInterface(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-            var dreamManager = IoCManager.Resolve<DreamManager>();
-            dreamManager.HotReloadInterface();
-            return DreamValue.Null;
-        }
-
-        [DreamProc("ODHotReloadResource")]
-        [DreamProcParameter("file_name", Type = DreamValue.DreamValueTypeFlag.String)]
-        public static DreamValue NativeProc_ODHotReloadResource(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-            if(!bundle.GetArgument(0, "file_name").TryGetValueAsString(out var fileName))
-                throw new ArgumentException("file_name must be a string");
-            var dreamManager = IoCManager.Resolve<DreamManager>();
-            dreamManager.HotReloadResource(fileName);
-            return DreamValue.Null;
-        }
-
-        /// <summary>
-        /// Determines the specified configuration space and configuration set in a config_set argument
-        /// </summary>
-        private static void ProcessConfigSet(string value, out string? configSpace, out string configSet) {
-            int slash = value.IndexOf('/');
-
-            // No specified config space, default to USER
-            // TODO: Supposedly defaults to HOME in safe mode
-            if (slash == -1) {
-                configSpace = "USER";
-                configSet = value;
+        configSpace = value.Substring(0, slash).ToUpperInvariant();
+        configSet = value.Substring(slash + 1);
+        switch (configSpace) {
+            case "SYSTEM":
+            case "USER":
+            case "HOME":
+            case "APP":
                 return;
-            }
-
-            configSpace = value.Substring(0, slash).ToUpperInvariant();
-            configSet = value.Substring(slash + 1);
-            switch (configSpace) {
-                case "SYSTEM":
-                case "USER":
-                case "HOME":
-                case "APP":
-                    return;
-                default:
-                    throw new ArgumentException($"There is no \"{configSpace}\" configuration space");
-            }
+            default:
+                throw new ArgumentException($"There is no \"{configSpace}\" configuration space");
         }
     }
 }


### PR DESCRIPTION
If you implement `/world/Error()` yourself then BYOND will only print the error to the log if you explicitly call `..()`. We copy that behavior now, allowing games to silence errors if they want to.