### PR TITLE
Fix `catch` in procs with arguments

### DIFF
--- a/Content.Tests/DMProject/Tests/Statements/Control Flow/try_catch5.dm
+++ b/Content.Tests/DMProject/Tests/Statements/Control Flow/try_catch5.dm
@@ -1,0 +1,17 @@
+/proc/RunTryCatch(var/arg1 = 1, var/arg2 = 2)
+	var/catchRan = FALSE
+	
+	try
+		throw "error"
+	catch(var/e)
+		catchRan = TRUE
+		ASSERT(e == "error")
+	
+	ASSERT(catchRan)
+	
+	// Ensure these were left unmodified
+	ASSERT(arg1 == 1)
+	ASSERT(arg2 == 2) 
+
+/proc/RunTest()
+	RunTryCatch()

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1641,7 +1641,12 @@ namespace OpenDreamRuntime.Procs {
         }
 
         public static ProcStatus Try(DMProcState state) {
-            state.StartTryBlock(state.ReadInt(), state.ReadReference().Value);
+            var exceptionVarRef = state.ReadReference();
+            if (exceptionVarRef.Type != DMReference.Type.Local)
+                throw new Exception(
+                    $"The reference to place a caught exception into must be a local. {exceptionVarRef} is not valid.");
+
+            state.StartTryBlock(state.ReadInt(), exceptionVarRef.Value);
             return ProcStatus.Continue;
         }
 

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -1641,12 +1641,13 @@ namespace OpenDreamRuntime.Procs {
         }
 
         public static ProcStatus Try(DMProcState state) {
+            var catchPosition = state.ReadInt();
             var exceptionVarRef = state.ReadReference();
             if (exceptionVarRef.Type != DMReference.Type.Local)
                 throw new Exception(
                     $"The reference to place a caught exception into must be a local. {exceptionVarRef} is not valid.");
 
-            state.StartTryBlock(state.ReadInt(), exceptionVarRef.Value);
+            state.StartTryBlock(catchPosition, exceptionVarRef.Value);
             return ProcStatus.Continue;
         }
 

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -497,7 +497,7 @@ namespace OpenDreamRuntime.Procs {
 
         public void StartTryBlock(int catchPosition, int catchVarIndex = NoTryCatchVar) {
             _catchPosition.Push(catchPosition);
-            _catchVarIndex.Push(catchVarIndex);
+            _catchVarIndex.Push(ArgumentCount + catchVarIndex);
         }
 
         public void EndTryBlock() {

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -496,8 +496,11 @@ namespace OpenDreamRuntime.Procs {
         }
 
         public void StartTryBlock(int catchPosition, int catchVarIndex = NoTryCatchVar) {
+            if (catchVarIndex != NoTryCatchVar)
+                catchVarIndex += ArgumentCount; // We're given a local var index so we need to account for our arguments
+
             _catchPosition.Push(catchPosition);
-            _catchVarIndex.Push(ArgumentCount + catchVarIndex);
+            _catchVarIndex.Push(catchVarIndex);
         }
 
         public void EndTryBlock() {


### PR DESCRIPTION
The catch var index wasn't accounting for arguments the proc had.