### PR TITLE
Implements `winget()` formatting 

### DIFF
--- a/OpenDreamClient/Interface/DMF/IDMFProperty.cs
+++ b/OpenDreamClient/Interface/DMF/IDMFProperty.cs
@@ -18,6 +18,7 @@ public interface IDMFProperty {
     public string AsJson();
     public string AsJsonDM();
     public string AsRaw();
+    /// winget() calls do not act the same as embedded winget calls, and the default behaviour is some whacky combination of AsEscaped() and AsRaw(). This proc handles that. Fucking BYOND.
     public string AsSnowflake();
 }
 
@@ -84,6 +85,7 @@ public struct DMFPropertyString(string value) : IDMFProperty {
     public string AsSnowflake() {
         return AsRaw();
     }
+    
     public override string ToString() {
         return AsRaw();
     }
@@ -137,6 +139,7 @@ public struct DMFPropertyNum(float value) : IDMFProperty {
     public string AsSnowflake() {
         return AsRaw();
     }
+    
     public override string ToString() {
         return AsRaw();
     }
@@ -475,6 +478,7 @@ public struct DMFPropertyBool(bool value) : IDMFProperty {
     public string AsSnowflake() {
         return Value ? "true" : "false";
     }
+    
     public override string ToString() {
         return AsRaw();
     }

--- a/OpenDreamClient/Interface/DMF/IDMFProperty.cs
+++ b/OpenDreamClient/Interface/DMF/IDMFProperty.cs
@@ -18,6 +18,7 @@ public interface IDMFProperty {
     public string AsJson();
     public string AsJsonDM();
     public string AsRaw();
+    public string AsSnowflake();
 }
 
 /*
@@ -80,6 +81,9 @@ public struct DMFPropertyString(string value) : IDMFProperty {
         return Value ?? "";
     }
 
+    public string AsSnowflake() {
+        return AsRaw();
+    }
     public override string ToString() {
         return AsRaw();
     }
@@ -130,6 +134,9 @@ public struct DMFPropertyNum(float value) : IDMFProperty {
         return Value.ToString(CultureInfo.InvariantCulture);
     }
 
+    public string AsSnowflake() {
+        return AsRaw();
+    }
     public override string ToString() {
         return AsRaw();
     }
@@ -203,6 +210,10 @@ public struct DMFPropertyVec2 : IDMFProperty {
         return AsEscaped();
     }
 
+    public string AsSnowflake() {
+        return AsEscaped();
+    }
+
     public override string ToString() {
         return AsRaw();
     }
@@ -272,6 +283,10 @@ public struct DMFPropertySize : IDMFProperty {
         return _value.AsString();
     }
 
+    public string AsSnowflake() {
+        return _value.AsSnowflake();
+    }
+
     public bool Equals(string comparison) {
         return _value.Equals(comparison);
     }
@@ -339,6 +354,10 @@ public struct DMFPropertyPos : IDMFProperty {
         return _value.AsString();
     }
 
+    public string AsSnowflake() {
+        return _value.AsSnowflake();
+    }
+
     public bool Equals(string comparison) {
         return _value.Equals(comparison);
     }
@@ -403,6 +422,12 @@ public struct DMFPropertyColor : IDMFProperty {
         return Value.ToHexNoAlpha();
     }
 
+    public string AsSnowflake() {
+        if(Value == Color.Transparent)
+            return "none";
+        return Value.ToHexNoAlpha();
+    }
+
     public override string ToString() {
         return AsRaw();
     }
@@ -447,6 +472,9 @@ public struct DMFPropertyBool(bool value) : IDMFProperty {
         return Value ? "1" : "0";
     }
 
+    public string AsSnowflake() {
+        return Value ? "true" : "false";
+    }
     public override string ToString() {
         return AsRaw();
     }

--- a/OpenDreamClient/Interface/DMF/IDMFProperty.cs
+++ b/OpenDreamClient/Interface/DMF/IDMFProperty.cs
@@ -18,6 +18,7 @@ public interface IDMFProperty {
     public string AsJson();
     public string AsJsonDM();
     public string AsRaw();
+    
     /// winget() calls do not act the same as embedded winget calls, and the default behaviour is some whacky combination of AsEscaped() and AsRaw(). This proc handles that. Fucking BYOND.
     public string AsSnowflake();
 }

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -241,7 +241,7 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
             MsgPromptResponse response = new() {
                 PromptId = message.PromptId,
                 Type = DreamValueType.Text,
-                Value = WinGet(message.ControlId, message.QueryValue)
+                Value = WinGet(message.ControlId, message.QueryValue, forceSnowflake:true)
             };
 
             _netManager.ClientSendMessage(response);
@@ -639,14 +639,14 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
         }
     }
 
-    public string WinGet(string controlId, string queryValue, bool forceJson = false) {
+    public string WinGet(string controlId, string queryValue, bool forceJson = false, bool forceSnowflake = false) {
         bool ParseAndTryGet(InterfaceElement element, string query, out string result) {
             //parse "as blah" from query if it's there
             string[] querySplit = query.Split(" as ");
             IDMFProperty propResult;
             if(querySplit.Length != 2) //must be "thing as blah" or "thing". Anything else is invalid.
                 if(element.TryGetProperty(query, out propResult!)){
-                    result = forceJson ? propResult.AsJson() : propResult.AsRaw();
+                    result = forceJson ? propResult.AsJson() : forceSnowflake ? propResult.AsSnowflake() : propResult.AsRaw();
                     return true;
                 } else {
                     result = "";
@@ -660,6 +660,9 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
 
                 if (forceJson) {
                     result = propResult.AsJson();
+                    return true;
+                } else if (forceSnowflake) {
+                    result = propResult.AsSnowflake();
                     return true;
                 }
 
@@ -932,5 +935,5 @@ public interface IDreamInterfaceManager {
     public void StartRepeatingCommand(string command);
     public void StopRepeatingCommand(string command);
     public void WinSet(string? controlId, string winsetParams);
-    public string WinGet(string controlId, string queryValue, bool forceJson = false);
+    public string WinGet(string controlId, string queryValue, bool forceJson = false, bool forceSnowflake = false);
 }

--- a/OpenDreamClient/Interface/DummyDreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DummyDreamInterfaceManager.cs
@@ -37,7 +37,7 @@ public sealed class DummyDreamInterfaceManager : IDreamInterfaceManager {
     public void WinSet(string? controlId, string winsetParams) {
     }
 
-    public string WinGet(string controlId, string queryValue, bool forceJson = false) {
+    public string WinGet(string controlId, string queryValue, bool forceJson = false, bool forceSnowflake = false) {
         return string.Empty;
     }
 


### PR DESCRIPTION
So apparently BYOND just loves being grossly inconsistent, and `winget()` calls act differently to embedded wingets.

This fixes that, and incidentally enables darkmode on goon as a side-effect
![image](https://github.com/user-attachments/assets/640bf441-abb4-4219-a1f6-6d51141ca7db)
