### PR TITLE
Fix default /world/Error()

### DIFF
--- a/OpenDreamRuntime/DreamThread.cs
+++ b/OpenDreamRuntime/DreamThread.cs
@@ -209,6 +209,11 @@ namespace OpenDreamRuntime {
 
         public static DreamValue Run(DreamProc proc, DreamObject src, DreamObject? usr, params DreamValue[] arguments) {
             var context = new DreamThread(proc.ToString());
+
+            if (proc is NativeProc nativeProc) {
+                return nativeProc.Call(context, src, usr, new(arguments));
+            }
+
             var state = proc.CreateState(context, src, usr, new DreamProcArguments(arguments));
             context.PushProcState(state);
             return context.Resume();

--- a/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
@@ -136,8 +136,8 @@ public sealed class DreamObjectDefinition {
         Variables[variableName] = value;
     }
 
-    public void SetProcDefinition(string procName, int procId) {
-        if (HasProc(procName)) {
+    public void SetProcDefinition(string procName, int procId, bool replace = false) {
+        if (HasProc(procName) && !replace) {
             var proc = ObjectTree.Procs[procId];
             proc.SuperProc = GetProc(procName);
             OverridingProcs[procName] = procId;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -163,7 +163,7 @@ internal static class DreamProcNative {
 
         var proc = objectTree.World.ObjectDefinition.GetProc(nativeProc.Name);
         if (proc.SuperProc == null) { // This proc was never overriden so just replace it
-            type.ObjectDefinition.SetProcDefinition(proc.Name, proc.Id);
+            type.ObjectDefinition.SetProcDefinition(proc.Name, nativeProc.Id, replace: true);
             return;
         }
 


### PR DESCRIPTION
The proc ID wasn't properly set if there was no `/world/Error()` override and `SpawnProc()` didn't work for synchronous native procs.