### PR TITLE
HtmlParser: Support named entities in body text

### DIFF
--- a/OpenDreamClient/Interface/Html/HtmlParser.cs
+++ b/OpenDreamClient/Interface/Html/HtmlParser.cs
@@ -88,6 +88,7 @@ public static class HtmlParser {
                         // browsers usually allow for some fallibility here
                         break;
                     }
+                    
                     string insideEntity = text.Substring(i + 1, end - (i + 1));
                     i = end;
 
@@ -114,6 +115,7 @@ public static class HtmlParser {
                                 break;
                         }
                     }
+                    
                     break;
                 default:
                     currentText.Append(c);

--- a/OpenDreamClient/Interface/Html/HtmlParser.cs
+++ b/OpenDreamClient/Interface/Html/HtmlParser.cs
@@ -81,6 +81,40 @@ public static class HtmlParser {
                 case '\n':
                     appendTo.PushNewline();
                     break;
+                case '&':
+                    // HTML named/numbered entity
+                    int end = text.IndexOf(';', i);
+                    if (end == -1) {
+                        // browsers usually allow for some fallibility here
+                        break;
+                    }
+                    string insideEntity = text.Substring(i + 1, end - (i + 1));
+                    i = end;
+
+                    if (insideEntity.StartsWith('#')) {
+                        if (int.TryParse(insideEntity.Substring(1), out int result)) {
+                            currentText.Append((char) result);
+                        }
+                    } else {
+                        switch (insideEntity) {
+                            case "nbsp": currentText.Append("\u00A0"); break;
+                            case "lt": currentText.Append("<"); break;
+                            case "gt": currentText.Append(">"); break;
+                            case "amp": currentText.Append("&"); break;
+                            case "quot": currentText.Append("\""); break;
+                            case "apos": currentText.Append("'"); break;
+                            case "cent": currentText.Append("¢"); break;
+                            case "pound": currentText.Append("£"); break;
+                            case "yen": currentText.Append("¥"); break;
+                            case "euro": currentText.Append("€"); break;
+                            case "copyright": currentText.Append("©"); break;
+                            case "trademark": currentText.Append("®"); break;
+                            default:
+                                currentText.Append("&" + insideEntity + ";");
+                                break;
+                        }
+                    }
+                    break;
                 default:
                     currentText.Append(c);
                     break;


### PR DESCRIPTION
This gives HtmlParser the ability to support HTML character entities in body text. This is primarily useful to clean up text such as "`&quot;`", "`&apos;`" ,and "`&#33;`".

This was tested with [Tomeno's OpenDream branch of Console](https://github.com/Tomeno/console/tree/opendream_cope) but with changes to interface/default.dmf reverted and then the computer_docked window deleted (it attempts to share ownership of controls). When operating a computer and "> "-commands are typed, the window no longer shows HTML entities with this patch.

...I'm sure there are simpler ways to test this, but that's where I found the issue.