### PR TITLE
Add a Tools build to GitHub releases

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -62,7 +62,9 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: build-${{ matrix.os }}
-        path: output_*/*.tar.gz
+        path: |
+          output_release/*.tar.gz
+          output_tools/*.tar.gz
         retention-days: 1
 
   release:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -45,21 +45,24 @@ jobs:
         dotnet test --no-build Content.IntegrationTests/Content.IntegrationTests.csproj -v n
     - name: Publish OpenDream
       if: github.event_name == 'push'
-      run: dotnet run --project OpenDreamPackageTool --no-build --configuration Release -- --server --hybrid-acz --platform ${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }} --output output/
+      run: |
+        dotnet run --project OpenDreamPackageTool --no-build --configuration Release -- --server --hybrid-acz --configuration Release --platform ${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }} --output output_release/
+        dotnet run --project OpenDreamPackageTool --no-build --configuration Release -- --server --hybrid-acz --configuration Tools --platform ${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }} --output output_tools/
     - name: Publish DMCompiler
       if: github.event_name == 'push'
-      run: dotnet publish DMCompiler -c Release -o output/DMCompiler_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}
+      run: dotnet publish DMCompiler -c Release -o output_release/DMCompiler_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}
     - name: Gzip releases
       if: github.event_name == 'push'
       run: |
-        tar -czvf output/DMCompiler_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}.tar.gz -C output DMCompiler_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}
-        tar -czvf output/OpenDreamServer_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}.tar.gz -C output OpenDreamServer_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}
+        tar -czvf output_release/DMCompiler_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}.tar.gz -C output DMCompiler_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}
+        tar -czvf output_release/OpenDreamServer_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}.tar.gz -C output OpenDreamServer_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}
+        tar -czvf output_tools/OpenDreamServer_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}.tar.gz -C output OpenDreamServer_TOOLS_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}
     - name: Upload artifact
       if: github.event_name == 'push'
       uses: actions/upload-artifact@v3
       with:
         name: build-${{ matrix.os }}
-        path: output/*.tar.gz
+        path: output_*/*.tar.gz
         retention-days: 1
 
   release:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         tar -czvf output_release/DMCompiler_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}.tar.gz -C output_release DMCompiler_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}
         tar -czvf output_release/OpenDreamServer_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}.tar.gz -C output_release OpenDreamServer_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}
-        tar -czvf output_tools/OpenDreamServer_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}.tar.gz -C output_tools OpenDreamServer_TOOLS_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}
+        tar -czvf output_tools/OpenDreamServer_TOOLS_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}.tar.gz -C output_tools OpenDreamServer_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}
     - name: Upload artifact
       if: github.event_name == 'push'
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -84,5 +84,5 @@ jobs:
         prerelease: true
         title: "Development Build"
         files: |
-          artifacts/*/*.tar.gz
+          artifacts/*/*/*.tar.gz
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -54,9 +54,9 @@ jobs:
     - name: Gzip releases
       if: github.event_name == 'push'
       run: |
-        tar -czvf output_release/DMCompiler_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}.tar.gz -C output DMCompiler_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}
-        tar -czvf output_release/OpenDreamServer_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}.tar.gz -C output OpenDreamServer_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}
-        tar -czvf output_tools/OpenDreamServer_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}.tar.gz -C output OpenDreamServer_TOOLS_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}
+        tar -czvf output_release/DMCompiler_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}.tar.gz -C output_release DMCompiler_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}
+        tar -czvf output_release/OpenDreamServer_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}.tar.gz -C output_release OpenDreamServer_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}
+        tar -czvf output_tools/OpenDreamServer_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}.tar.gz -C output_tools OpenDreamServer_TOOLS_${{ matrix.os == 'windows-latest' && 'win-x64' || 'linux-x64' }}
     - name: Upload artifact
       if: github.event_name == 'push'
       uses: actions/upload-artifact@v3

--- a/OpenDreamPackageTool/Program.cs
+++ b/OpenDreamPackageTool/Program.cs
@@ -200,9 +200,6 @@ public static class Program {
                         }
 
                         break;
-                    case "--tools":
-                        tgsOptions.BuildConfiguration = "Debug";
-                        break;
                     default:
                         Console.Error.WriteLine($"Invalid argument '{arg}'");
                         return false;

--- a/OpenDreamPackageTool/Program.cs
+++ b/OpenDreamPackageTool/Program.cs
@@ -16,18 +16,22 @@ public static class Program {
         public bool TgsEngineBuild;
     }
 
-    public class ClientOptions : Options {
-
-    }
+    public class ClientOptions : Options;
 
     public class TgsOptions : Options {
         // Avoid adding arguments for TGS, to give us more flexibility while keeping compatibility
     }
 
-    public static readonly string[] SharedIgnoredResources = {
+    public static readonly string[] SharedIgnoredResources = [
         ".gitignore",
         ".directory",
         ".DS_Store"
+    ];
+
+    private static readonly IReadOnlySet<string> ValidBuildConfigurations = new HashSet<string> {
+        "Release",
+        "Debug",
+        "Tools"
     };
 
     public static int Main(string[] args) {
@@ -56,7 +60,7 @@ public static class Program {
     }
 
     public static void CopyDirectory(string src, string dest, string[]? skip = null) {
-        skip ??= Array.Empty<string>();
+        skip ??= [];
 
         var srcDir = new DirectoryInfo(src);
         if (!srcDir.Exists)
@@ -97,8 +101,18 @@ public static class Program {
                     case "--skip-build":
                         serverOptions.SkipBuild = true;
                         break;
-                    case "--debug":
-                        serverOptions.BuildConfiguration = "Debug";
+                    case "--configuration":
+                        if (i + 1 >= args.Length) {
+                            Console.Error.WriteLine("No configuration given");
+                            return false;
+                        }
+
+                        serverOptions.BuildConfiguration = args[++i];
+                        if (!ValidBuildConfigurations.Contains(serverOptions.BuildConfiguration)) {
+                            Console.Error.WriteLine($"Invalid configuration '{serverOptions.BuildConfiguration}'");
+                            return false;
+                        }
+
                         break;
                     case "--platform":
                     case "-p":
@@ -136,8 +150,18 @@ public static class Program {
                     case "--skip-build":
                         clientOptions.SkipBuild = true;
                         break;
-                    case "--debug":
-                        clientOptions.BuildConfiguration = "Debug";
+                    case "--configuration":
+                        if (i + 1 >= args.Length) {
+                            Console.Error.WriteLine("No configuration given");
+                            return false;
+                        }
+
+                        clientOptions.BuildConfiguration = args[++i];
+                        if (!ValidBuildConfigurations.Contains(clientOptions.BuildConfiguration)) {
+                            Console.Error.WriteLine($"Invalid configuration '{clientOptions.BuildConfiguration}'");
+                            return false;
+                        }
+
                         break;
                     default:
                         Console.Error.WriteLine($"Invalid argument '{arg}'");
@@ -163,7 +187,20 @@ public static class Program {
                     case "--skip-build":
                         tgsOptions.SkipBuild = true;
                         break;
-                    case "--debug":
+                    case "--configuration":
+                        if (i + 1 >= args.Length) {
+                            Console.Error.WriteLine("No configuration given");
+                            return false;
+                        }
+
+                        tgsOptions.BuildConfiguration = args[++i];
+                        if (!ValidBuildConfigurations.Contains(tgsOptions.BuildConfiguration)) {
+                            Console.Error.WriteLine($"Invalid configuration '{tgsOptions.BuildConfiguration}'");
+                            return false;
+                        }
+
+                        break;
+                    case "--tools":
                         tgsOptions.BuildConfiguration = "Debug";
                         break;
                     default:


### PR DESCRIPTION
A version of the server build with `-c Tools` is helpful for our VSCode extension because it includes our DM debugger.