### PR TITLE
restores opendream_unimplemented warnings for procs with empty bodies in DMStandard

### DIFF
--- a/Content.Tests/DMProject/Tests/SetStatements/unimplemented_with_body.dm
+++ b/Content.Tests/DMProject/Tests/SetStatements/unimplemented_with_body.dm
@@ -1,4 +1,6 @@
-// COMPILE WARNING
+// COMPILE ERROR
+
+#pragma UnimplementedAccess error
 
 /proc/A()
 	set opendream_unimplemented = TRUE

--- a/Content.Tests/DMProject/Tests/SetStatements/unimplemented_with_body.dm
+++ b/Content.Tests/DMProject/Tests/SetStatements/unimplemented_with_body.dm
@@ -1,0 +1,8 @@
+// COMPILE WARNING
+
+/proc/A()
+	set opendream_unimplemented = TRUE
+	return
+
+/proc/RunTest()
+	A()

--- a/Content.Tests/DMProject/Tests/SetStatements/unimplemented_without_body.dm
+++ b/Content.Tests/DMProject/Tests/SetStatements/unimplemented_without_body.dm
@@ -1,4 +1,6 @@
-// COMPILE WARNING
+// COMPILE ERROR
+
+#pragma UnimplementedAccess error
 
 /proc/A()
 	set opendream_unimplemented = TRUE

--- a/Content.Tests/DMProject/Tests/SetStatements/unimplemented_without_body.dm
+++ b/Content.Tests/DMProject/Tests/SetStatements/unimplemented_without_body.dm
@@ -1,0 +1,7 @@
+// COMPILE WARNING
+
+/proc/A()
+	set opendream_unimplemented = TRUE
+
+/proc/RunTest()
+	A()

--- a/Content.Tests/DMTests.cs
+++ b/Content.Tests/DMTests.cs
@@ -26,10 +26,9 @@ public sealed class DMTests : ContentUnitTest {
         NoError = 0,        // Should run without errors
         Ignore = 1,         // Ignore entirely
         CompileError = 2,   // Should fail to compile
-        CompileWarning = 4, // Should throw a warning during compile
-        RuntimeError = 8,   // Should throw an exception at runtime
-        ReturnTrue = 16,     // Should return TRUE
-        NoReturn = 32,      // Shouldn't return (aka stopped by a stack-overflow or runtimes)
+        RuntimeError = 4,   // Should throw an exception at runtime
+        ReturnTrue = 8,     // Should return TRUE
+        NoReturn = 16,      // Shouldn't return (aka stopped by a stack-overflow or runtimes)
     }
 
     private void OnException(object? sender, Exception exception) => TestContext.WriteLine(exception);
@@ -69,16 +68,6 @@ public sealed class DMTests : ContentUnitTest {
                 Cleanup(compiledFile);
                 TestContext.WriteLine($"--- PASS {sourceFile}");
                 return;
-            }
-
-            #if DEBUG
-            const int minWarnings = 1;
-            #else
-            const int minWarnings = 0;
-            #endif
-
-            if (testFlags.HasFlag(DMTestFlags.CompileWarning)) {
-                Assert.That(DMCompiler.DMCompiler.WarningCount, Is.GreaterThan(minWarnings), "Expected a warning during DM compilation");
             }
 
             Assert.That(compiledFile is not null && File.Exists(compiledFile), "Failed to compile DM source file");
@@ -176,8 +165,6 @@ public sealed class DMTests : ContentUnitTest {
                 testFlags |= DMTestFlags.Ignore;
             if (firstLine.Contains("COMPILE ERROR", StringComparison.InvariantCulture))
                 testFlags |= DMTestFlags.CompileError;
-            if (firstLine.Contains("COMPILE WARNING", StringComparison.InvariantCulture))
-                testFlags |= DMTestFlags.CompileWarning;
             if (firstLine.Contains("RUNTIME ERROR", StringComparison.InvariantCulture))
                 testFlags |= DMTestFlags.RuntimeError;
             if (firstLine.Contains("RETURN TRUE", StringComparison.InvariantCulture))

--- a/DMCompiler/Compiler/CompilerError.cs
+++ b/DMCompiler/Compiler/CompilerError.cs
@@ -64,6 +64,7 @@ public enum WarningCode {
     InvalidVarType = 2702, // Var static typing
     ImplicitNullType = 2703, //  Raised when a null variable isn't explicitly statically typed as nullable
     LostTypeInfo = 2704, // An operation led to lost type information
+    UnimplementedAccess = 2800, // When accessing unimplemented procs and vars
 
     // 3000 - 3999 are reserved for stylistic configuration.
     EmptyBlock = 3100,

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -635,8 +635,7 @@ namespace DMCompiler.Compiler.DM {
             } while (Delimiter() || statement is DMASTProcStatementLabel);
             Whitespace();
 
-            if (procStatements.Count == 0) return (null,null);
-            return (procStatements, setStatements);
+            return (procStatements.Count > 0 ? procStatements : null, setStatements.Count > 0 ? setStatements : null);
         }
 
         private DMASTProcStatement? ProcStatement() {

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -233,7 +233,7 @@ public static class DMCompiler {
         if (Settings.SuppressUnimplementedWarnings)
             return;
 
-        ForcedWarning(loc, message);
+        Emit(WarningCode.UnimplementedAccess, loc, message);
     }
 
     public static void VerbosePrint(string message) {

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -41,6 +41,7 @@
 #pragma ImplicitNullType notice
 #pragma LostTypeInfo notice
 // END TYPEMAKER
+#pragma UnimplementedAccess warning
 
 //3000-3999
 #pragma EmptyBlock notice


### PR DESCRIPTION
currently some opendream_unimplemented warnings from dmstandard aren't being emitted, as we null both the Statement and SetStatement blocks if the Statement block is empty (due to having an empty proc body)