### PR TITLE
Implement `walk()` and `walk_rand()`

### DIFF
--- a/DMCompiler/DMStandard/UnsortedAdditions.dm
+++ b/DMCompiler/DMStandard/UnsortedAdditions.dm
@@ -40,8 +40,6 @@ proc/missile(Type, Start, End)
 	set opendream_unimplemented = TRUE
 /proc/splittext_char(Text,Start=1,End=0,Insert="")
 	set opendream_unimplemented = TRUE
-/proc/walk_rand(Ref,Lag=0,Speed=0)
-	set opendream_unimplemented = TRUE
 
 /database
 	parent_type = /datum

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -105,7 +105,7 @@ proc/viewers(Depth, Center = usr) as /list
 proc/walk(Ref, Dir, Lag = 0, Speed = 0)
 proc/walk_rand(Ref,Lag = 0,Speed = 0)
 proc/walk_to(Ref, Trg, Min = 0, Lag = 0, Speed = 0)
-	set opendream_unimplemented = TRUE
+	set opendream_unimplemented = 1
 proc/walk_towards(Ref,Trg,Lag=0,Speed=0)
 proc/winclone(player, window_name, clone_name)
 proc/winexists(player, control_id) as text

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -103,6 +103,7 @@ proc/url_encode(PlainText, format = 0) as text
 proc/view(Dist = 5, Center = usr) as /list
 proc/viewers(Depth, Center = usr) as /list
 proc/walk(Ref, Dir, Lag = 0, Speed = 0)
+proc/walk_rand(Ref,Lag = 0,Speed = 0)
 proc/walk_to(Ref, Trg, Min = 0, Lag = 0, Speed = 0)
 proc/walk_towards(Ref,Trg,Lag=0,Speed=0)
 proc/winclone(player, window_name, clone_name)

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -105,6 +105,7 @@ proc/viewers(Depth, Center = usr) as /list
 proc/walk(Ref, Dir, Lag = 0, Speed = 0)
 proc/walk_rand(Ref,Lag = 0,Speed = 0)
 proc/walk_to(Ref, Trg, Min = 0, Lag = 0, Speed = 0)
+	set opendream_unimplemented = TRUE
 proc/walk_towards(Ref,Trg,Lag=0,Speed=0)
 proc/winclone(player, window_name, clone_name)
 proc/winexists(player, control_id) as text

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -106,6 +106,7 @@ internal static class DreamProcNative {
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_view);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_viewers);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_walk);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_walk_rand);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_walk_to);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_walk_towards);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_winclone);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -107,7 +107,6 @@ internal static class DreamProcNative {
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_viewers);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_walk);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_walk_rand);
-        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_walk_to);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_walk_towards);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_winclone);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_winexists);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
@@ -445,13 +445,7 @@ internal static partial class DreamProcNativeHelpers {
     /// </summary>
     public static DreamObjectTurf? GetStep(AtomManager atomManager, IDreamMapManager mapManager, DreamObjectAtom loc,
         AtomDirection dir) {
-        return GetStep(atomManager, mapManager, loc, (int)dir);
-    }
-
-    /// <summary>
-    /// Gets the turf 1 step away from an atom in the given direction
-    /// </summary>
-    public static DreamObjectTurf? GetStep(AtomManager atomManager, IDreamMapManager mapManager, DreamObjectAtom loc, int dirInt) {
+        var dirInt = (int)dir;
         var locPos = atomManager.GetAtomPosition(loc);
 
         if ((dirInt & (int) AtomDirection.North) != 0)

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
@@ -438,8 +438,15 @@ internal static partial class DreamProcNativeHelpers {
     /// <summary>
     /// Gets the turf 1 step away from an atom in the given direction
     /// </summary>
-    public static DreamObjectTurf? GetStep(AtomManager atomManager, IDreamMapManager mapManager, DreamObjectAtom loc, AtomDirection dir) {
-        var dirInt = (int)dir;
+    public static DreamObjectTurf? GetStep(AtomManager atomManager, IDreamMapManager mapManager, DreamObjectAtom loc,
+        AtomDirection dir) {
+        return GetStep(atomManager, mapManager, loc, (int)dir);
+    }
+
+    /// <summary>
+    /// Gets the turf 1 step away from an atom in the given direction
+    /// </summary>
+    public static DreamObjectTurf? GetStep(AtomManager atomManager, IDreamMapManager mapManager, DreamObjectAtom loc, int dirInt) {
         var locPos = atomManager.GetAtomPosition(loc);
 
         if ((dirInt & (int) AtomDirection.North) != 0)
@@ -463,4 +470,18 @@ internal static partial class DreamProcNativeHelpers {
 
     [GeneratedRegex("[\\^]|[^a-z0-9@]")]
     private static partial Regex CkeyRegex();
+
+    /// <summary>
+    /// Returns one of NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, or SOUTHWEST
+    /// </summary>
+    public static AtomDirection GetRandomDirection(DreamManager dreamManager) {
+        AtomDirection[] dirs = [
+            AtomDirection.North, AtomDirection.South, AtomDirection.East, AtomDirection.West, AtomDirection.Northeast,
+            AtomDirection.Northwest, AtomDirection.Southeast, AtomDirection.Southwest
+        ];
+
+        var index = dreamManager.Random.Next(0, 8); // [0, 8). There's 8 options but arrays start at 0.
+
+        return dirs[index];
+    }
 }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeHelpers.cs
@@ -18,6 +18,11 @@ internal static partial class DreamProcNativeHelpers {
         'w', 'x', 'y', 'z'
     ];
 
+    private static readonly AtomDirection[] AtomDirs = [
+        AtomDirection.North, AtomDirection.South, AtomDirection.East, AtomDirection.West, AtomDirection.Northeast,
+        AtomDirection.Northwest, AtomDirection.Southeast, AtomDirection.Southwest
+    ];
+
     /// <summary>
     /// This is a helper proc for oview, view, orange, and range to do their strange iteration with.<br/>
     /// BYOND has a very strange, kinda-spiralling iteration pattern for the above procs, <br/>
@@ -475,13 +480,7 @@ internal static partial class DreamProcNativeHelpers {
     /// Returns one of NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, or SOUTHWEST
     /// </summary>
     public static AtomDirection GetRandomDirection(DreamManager dreamManager) {
-        AtomDirection[] dirs = [
-            AtomDirection.North, AtomDirection.South, AtomDirection.East, AtomDirection.West, AtomDirection.Northeast,
-            AtomDirection.Northwest, AtomDirection.Southeast, AtomDirection.Southwest
-        ];
-
         var index = dreamManager.Random.Next(0, 8); // [0, 8). There's 8 options but arrays start at 0.
-
-        return dirs[index];
+        return AtomDirs[index];
     }
 }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -3184,8 +3184,8 @@ namespace OpenDreamRuntime.Procs.Native {
             if (!bundle.GetArgument(0, "Ref").TryGetValueAsDreamObject<DreamObjectMovable>(out var refAtom))
                 return DreamValue.Null;
 
-            bundle.GetArgument(2, "Lag").TryGetValueAsInteger(out var lag);
-            bundle.GetArgument(3, "Speed").TryGetValueAsInteger(out var speed);
+            bundle.GetArgument(1, "Lag").TryGetValueAsInteger(out var lag);
+            bundle.GetArgument(2, "Speed").TryGetValueAsInteger(out var speed);
 
             bundle.WalkManager.StartWalkRand(refAtom, lag, speed);
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -3192,18 +3192,6 @@ namespace OpenDreamRuntime.Procs.Native {
             return DreamValue.Null;
         }
 
-        [DreamProc("walk_to")]
-        [DreamProcParameter("Ref", Type = DreamValueTypeFlag.DreamObject)]
-        [DreamProcParameter("Trg", Type = DreamValueTypeFlag.DreamObject)]
-        [DreamProcParameter("Min", Type = DreamValueTypeFlag.Float, DefaultValue = 0)]
-        [DreamProcParameter("Lag", Type = DreamValueTypeFlag.Float, DefaultValue = 0)]
-        [DreamProcParameter("Speed", Type = DreamValueTypeFlag.Float, DefaultValue = 0)]
-        public static DreamValue NativeProc_walk_to(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-            //TODO: Implement walk_to()
-
-            return DreamValue.Null;
-        }
-
         [DreamProc("walk_towards")]
         [DreamProcParameter("Ref", Type = DreamValueTypeFlag.DreamObject)]
         [DreamProcParameter("Trg", Type = DreamValueTypeFlag.DreamObject)]

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -3159,7 +3159,35 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("Lag", Type = DreamValueTypeFlag.Float, DefaultValue = 0)]
         [DreamProcParameter("Speed", Type = DreamValueTypeFlag.Float, DefaultValue = 0)]
         public static DreamValue NativeProc_walk(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-            //TODO: Implement walk()
+            if (!bundle.GetArgument(0, "Ref").TryGetValueAsDreamObject<DreamObjectMovable>(out var refAtom))
+                return DreamValue.Null;
+
+            // Per the ref, calling walk(Ref, 0) halts walking
+            if (bundle.GetArgument(1, "Dir").TryGetValueAsInteger(out var dir) && dir == 0) {
+                bundle.WalkManager.StopWalks(refAtom);
+                return DreamValue.Null;
+            }
+
+            bundle.GetArgument(2, "Lag").TryGetValueAsInteger(out var lag);
+            bundle.GetArgument(3, "Speed").TryGetValueAsInteger(out var speed);
+
+            bundle.WalkManager.StartWalk(refAtom, dir, lag, speed);
+
+            return DreamValue.Null;
+        }
+
+        [DreamProc("walk_rand")]
+        [DreamProcParameter("Ref", Type = DreamValueTypeFlag.DreamObject)]
+        [DreamProcParameter("Lag", Type = DreamValueTypeFlag.Float, DefaultValue = 0)]
+        [DreamProcParameter("Speed", Type = DreamValueTypeFlag.Float, DefaultValue = 0)]
+        public static DreamValue NativeProc_walk_rand(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
+            if (!bundle.GetArgument(0, "Ref").TryGetValueAsDreamObject<DreamObjectMovable>(out var refAtom))
+                return DreamValue.Null;
+
+            bundle.GetArgument(2, "Lag").TryGetValueAsInteger(out var lag);
+            bundle.GetArgument(3, "Speed").TryGetValueAsInteger(out var speed);
+
+            bundle.WalkManager.StartWalkRand(refAtom, lag, speed);
 
             return DreamValue.Null;
         }
@@ -3191,9 +3219,9 @@ namespace OpenDreamRuntime.Procs.Native {
             }
 
             bundle.GetArgument(2, "Lag").TryGetValueAsInteger(out var lag);
-            bundle.GetArgument(3, "Speed").TryGetValueAsInteger(out var speed); // TODO: Use this. Speed=0 uses Ref.step_size
+            bundle.GetArgument(3, "Speed").TryGetValueAsInteger(out var speed);
 
-            bundle.WalkManager.StartWalkTowards(refAtom, trgAtom, lag);
+            bundle.WalkManager.StartWalkTowards(refAtom, trgAtom, lag, speed);
             return DreamValue.Null;
         }
 

--- a/OpenDreamRuntime/WalkManager.cs
+++ b/OpenDreamRuntime/WalkManager.cs
@@ -64,7 +64,7 @@ public sealed class WalkManager {
         CancellationTokenSource cancelSource = new();
         _walkTasks[movable] = cancelSource;
 
-        DreamThread.Run($"walk_rand", async state => {
+        DreamThread.Run("walk_rand", async state => {
             var moveProc = movable.GetProc("Move");
 
             while (true) {

--- a/OpenDreamRuntime/WalkManager.cs
+++ b/OpenDreamRuntime/WalkManager.cs
@@ -45,7 +45,7 @@ public sealed class WalkManager {
                 if (cancelSource.IsCancellationRequested)
                     break;
 
-                DreamObjectTurf? newLoc = DreamProcNativeHelpers.GetStep(_atomManager, _dreamMapManager, movable, dir);
+                DreamObjectTurf? newLoc = DreamProcNativeHelpers.GetStep(_atomManager, _dreamMapManager, movable, (AtomDirection)dir);
                 await state.Call(moveProc, movable, null, new(newLoc), new(dir));
             }
 
@@ -71,9 +71,9 @@ public sealed class WalkManager {
                 await _scheduler.CreateDelayTicks(lag);
                 if (cancelSource.IsCancellationRequested)
                     break;
-                var dir = (int)DreamProcNativeHelpers.GetRandomDirection(_dreamManager);
+                var dir = DreamProcNativeHelpers.GetRandomDirection(_dreamManager);
                 DreamObjectTurf? newLoc = DreamProcNativeHelpers.GetStep(_atomManager, _dreamMapManager, movable, dir);
-                await state.Call(moveProc, movable, null, new(newLoc), new(dir));
+                await state.Call(moveProc, movable, null, new(newLoc), new((int)dir));
             }
 
             return DreamValue.Null;

--- a/OpenDreamRuntime/WalkManager.cs
+++ b/OpenDreamRuntime/WalkManager.cs
@@ -14,6 +14,7 @@ public sealed class WalkManager {
     [Dependency] private readonly AtomManager _atomManager = default!;
     [Dependency] private readonly IDreamMapManager _dreamMapManager = default!;
     [Dependency] private readonly ProcScheduler _scheduler = default!;
+    [Dependency] private readonly DreamManager _dreamManager = default!;
 
     private readonly Dictionary<DreamObjectMovable, CancellationTokenSource> _walkTasks = new();
 
@@ -26,9 +27,63 @@ public sealed class WalkManager {
     }
 
     /// <summary>
+    /// Walk in the specified direction Dir continuously.
+    /// </summary>
+    public void StartWalk(DreamObjectMovable movable, int dir, int lag, int speed) { // TODO: Implement speed. Speed=0 uses Ref.step_size
+        StopWalks(movable);
+
+        lag = Math.Max(lag, 1); // Minimum of 1 tick lag
+
+        CancellationTokenSource cancelSource = new();
+        _walkTasks[movable] = cancelSource;
+
+        DreamThread.Run($"walk {dir}", async state => {
+            var moveProc = movable.GetProc("Move");
+
+            while (true) {
+                await _scheduler.CreateDelayTicks(lag);
+                if (cancelSource.IsCancellationRequested)
+                    break;
+
+                DreamObjectTurf? newLoc = DreamProcNativeHelpers.GetStep(_atomManager, _dreamMapManager, movable, dir);
+                await state.Call(moveProc, movable, null, new(newLoc), new(dir));
+            }
+
+            return DreamValue.Null;
+        });
+    }
+
+    /// <summary>
+    /// Walk in a random direction continuously.
+    /// </summary>
+    public void StartWalkRand(DreamObjectMovable movable, int lag, int speed) { // TODO: Implement speed. Speed=0 uses Ref.step_size
+        StopWalks(movable);
+
+        lag = Math.Max(lag, 1); // Minimum of 1 tick lag
+
+        CancellationTokenSource cancelSource = new();
+        _walkTasks[movable] = cancelSource;
+
+        DreamThread.Run($"walk_rand", async state => {
+            var moveProc = movable.GetProc("Move");
+
+            while (true) {
+                await _scheduler.CreateDelayTicks(lag);
+                if (cancelSource.IsCancellationRequested)
+                    break;
+                var dir = (int)DreamProcNativeHelpers.GetRandomDirection(_dreamManager);
+                DreamObjectTurf? newLoc = DreamProcNativeHelpers.GetStep(_atomManager, _dreamMapManager, movable, dir);
+                await state.Call(moveProc, movable, null, new(newLoc), new(dir));
+            }
+
+            return DreamValue.Null;
+        });
+    }
+
+    /// <summary>
     /// Walk towards the target with no pathfinding taken into account
     /// </summary>
-    public void StartWalkTowards(DreamObjectMovable movable, DreamObjectAtom target, int lag) {
+    public void StartWalkTowards(DreamObjectMovable movable, DreamObjectAtom target, int lag, int speed) { // TODO: Implement speed. Speed=0 uses Ref.step_size
         StopWalks(movable);
 
         lag = Math.Max(lag, 1); // Minimum of 1 tick lag

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -103,9 +103,9 @@
 		walk(src, NORTH)
 		
 	verb/start_walk_rand()
-    	set name = "Walk Randomly"
-    	usr << "Walking randomly. Use the 'Walk Stop' verb to cease."
-    	walk_rand(src)
+		set name = "Walk Randomly"
+		usr << "Walking randomly. Use the 'Walk Stop' verb to cease."
+		walk_rand(src)
 	
 	verb/stop_walk()
 		set name = "Walk Stop"

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -96,6 +96,21 @@
 	verb/say_loud()
 		var/msg = input("Please put the message you want to say loudly.", "Say Loud", "Hello!")
 		world << "[ckey] says loudly: \"[msg]\""
+	
+	verb/start_walk()
+		set name = "Walk North"
+		usr << "Walking north. Use the 'Walk Stop' verb to cease."
+		walk(src, NORTH)
+		
+	verb/start_walk_rand()
+    	set name = "Walk Randomly"
+    	usr << "Walking randomly. Use the 'Walk Stop' verb to cease."
+    	walk_rand(src)
+	
+	verb/stop_walk()
+		set name = "Walk Stop"
+		usr << "Walking stopped."
+		walk(src, 0)
 
 	verb/move_up()
 		step(src, UP)


### PR DESCRIPTION
- Implemented `walk()`. Including `walk(Ref, 0)` to cease any walking.
- Implemented `walk_rand()`
- Added a helper for getting a random dir
- ~~Added a `GetStep()` overload that takes dir as an integer directly, to avoid redundant casting.~~
- `speed` is now ignored in WalkManager, rather than the native walk-related procs
- Properly flags `walk_to()` as unimplemented

https://github.com/user-attachments/assets/dd802c99-afa4-4720-950f-c68563211b53

