### PR TITLE
Slight optimisation in viewer() and oviewer()

### DIFF
--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1906,7 +1906,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 if (mob.X == centerPos.X && mob.Y == centerPos.Y)
                     continue;
 
-                if (Math.Abs(centerPos.X - mob.X) <= depth && Math.Abs(centerPos.Y - mob.Y) <= depth && centerPos.Z == mob.Z) {
+                if (centerPos.Z == mob.Z && Math.Abs(centerPos.X - mob.X) <= depth && Math.Abs(centerPos.Y - mob.Y) <= depth) {
                     (_, ViewRange range) = DreamProcNativeHelpers.ResolveViewArguments(bundle.DreamManager, mob, bundle.Arguments);
                     var eyePos = bundle.AtomManager.GetAtomPosition(mob);
                     var viewData = DreamProcNativeHelpers.CollectViewData(bundle.AtomManager, bundle.MapManager, eyePos, range);
@@ -3128,7 +3128,7 @@ namespace OpenDreamRuntime.Procs.Native {
             foreach (var atom in bundle.AtomManager.EnumerateAtoms(bundle.ObjectTree.Mob)) {
                 var mob = (DreamObjectMob)atom;
 
-                if (Math.Abs(centerPos.X - mob.X) <= depth && Math.Abs(centerPos.Y - mob.Y) <= depth && centerPos.Z == mob.Z) {
+                if (centerPos.Z == mob.Z && Math.Abs(centerPos.X - mob.X) <= depth && Math.Abs(centerPos.Y - mob.Y) <= depth) {
                     (_, ViewRange range) = DreamProcNativeHelpers.ResolveViewArguments(bundle.DreamManager, mob, bundle.Arguments);
                     var eyePos = bundle.AtomManager.GetAtomPosition(mob);
                     var viewData = DreamProcNativeHelpers.CollectViewData(bundle.AtomManager, bundle.MapManager, eyePos, range);


### PR DESCRIPTION
In `DreamProcNativeRoot.cs` there is a line used in `viewer()` and `oviewer()`:

```cs
if (Math.Abs(centerPos.X - mob.X) <= depth && Math.Abs(centerPos.Y - mob.Y) <= depth && centerPos.Z == mob.Z)
```

if you have more than one Z level, then more mobs will be outside of the Z level than in it. Therefore, you can slightly speed up the code by having the Z level check run first, and short circuit the rest of the `if` condition, evaluating it slightly faster:

```cs
if (centerPos.Z == mob.Z && Math.Abs(centerPos.X - mob.X) <= depth && Math.Abs(centerPos.Y - mob.Y) <= depth)
```