### PR TITLE
Implement replacetextEx_char, reimplement Splittext to match new 515 behavior

### DIFF
--- a/Content.Tests/DMProject/Tests/Text/Splittext.dm
+++ b/Content.Tests/DMProject/Tests/Text/Splittext.dm
@@ -5,19 +5,19 @@
 	ASSERT(test1 ~= test1_expected)
 
 	var/list/test2 = splittext(test_text, " ", 5)
-	var/test2_expected = list("average","of","1,","2,","3,","4,","5","is:","3")
+	var/test2_expected = list("The average","of","1,","2,","3,","4,","5","is:","3")
 	ASSERT(test2 ~= test2_expected)
 
 	var/list/test3 = splittext(test_text, " ", 5, 10)
-	var/test3_expected = list("avera")
+	var/test3_expected = list("The average of 1, 2, 3, 4, 5 is: 3")
 	ASSERT(test3 ~= test3_expected)
 
 	var/list/test4 = splittext(test_text, " ", 10, 20)
-	var/test4_expected = list("ge","of","1,","2")
+	var/test4_expected = list("The average","of","1,","2, 3, 4, 5 is: 3")
 	ASSERT(test4 ~= test4_expected)
 
 	var/list/test5 = splittext(test_text, " ", 10, 20, 1)
-	var/test5_expected = list("ge"," ","of"," ","1,"," ","2")
+	var/test5_expected = list("The average"," ","of"," ","1,"," ","2, 3, 4, 5 is: 3")
 	ASSERT(test5 ~= test5_expected)
 
 	//it's regex time
@@ -26,9 +26,9 @@
 	ASSERT(test6 ~= test6_expected)
 
 	var/test7 = splittext(test_text, regex(@"\d"), 5, 30)
-	var/test7_expected = list("average of ",", ",", ",", ",", "," ")
+	var/test7_expected = list("The average of ",", ",", ",", ",", "," is: 3")
 	ASSERT(test7 ~= test7_expected)
 
 	var/test8 = splittext(test_text, regex(@"\d"), 5, 30, 1)
-	var/test8_expected = list("average of ","1",", ","2",", ","3",", ","4",", ","5"," ")
+	var/test8_expected = list("The average of ","1",", ","2",", ","3",", ","4",", ","5"," is: 3")
 	ASSERT(test8 ~= test8_expected)

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -135,8 +135,7 @@ proc/winset(player, control_id, params)
 #include "UnsortedAdditions.dm"
 
 proc/replacetextEx_char(Haystack as text, Needle, Replacement, Start = 1, End = 0) as text
-	set opendream_unimplemented = TRUE
-	return Haystack
+	return jointext(splittext(Haystack, Needle, Start, End), Replacement)
 
 /proc/step(atom/movable/Ref as /atom/movable, var/Dir, var/Speed=0) as num
 	//TODO: Speed = step_size if Speed is 0

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2618,6 +2618,7 @@ namespace OpenDreamRuntime.Procs.Native {
             // save the start/end beforehand to staple back on at the end
             string startText = text[0..Math.Max(start,0)];
             string endText = text[Math.Min(end, text.Length)..];
+            // figure out if we should be adding the start/end in the first place
 
             if(start > 0 || end < text.Length)
                 text = text[Math.Max(start,0)..Math.Min(end, text.Length)];
@@ -2626,7 +2627,7 @@ namespace OpenDreamRuntime.Procs.Native {
 
             if (delim.TryGetValueAsDreamObject<DreamObjectRegex>(out var regexObject)) {
                 if(includeDelimiters) {
-                    var values = new List<string> {startText};
+                    var values = new List<string>();
                     int pos = 0;
                     foreach (Match m in regexObject.Regex.Matches(text)) {
                         values.Add(text.Substring(pos, m.Index - pos));
@@ -2634,13 +2635,15 @@ namespace OpenDreamRuntime.Procs.Native {
                         pos = m.Index + m.Length;
                     }
                     values.Add(text.Substring(pos));
-                    values.Add(endText);
-                    return new DreamValue(bundle.ObjectTree.CreateList(values.ToArray()));
+                    string[] arrayValues = values.ToArray();
+                    arrayValues[0] = startText + arrayValues[0];
+                    arrayValues[arrayValues.Length-1] = arrayValues[arrayValues.Length-1] + endText;
+                    return new DreamValue(bundle.ObjectTree.CreateList(arrayValues));
                 } else {
-                    List<string> values = new List<string> {startText};
-                    values.AddRange(regexObject.Regex.Split(text));
-                    values.Add(endText);
-                    return new DreamValue(bundle.ObjectTree.CreateList(values.ToArray()));
+                    string[] values = regexObject.Regex.Split(text);
+                    values[0] = startText + values[0];
+                    values[values.Length-1] = values[values.Length-1] + endText;
+                    return new DreamValue(bundle.ObjectTree.CreateList(values));
                 }
             } else if (delim.TryGetValueAsString(out var delimiter)) {
                 string[] splitText;
@@ -2657,10 +2660,9 @@ namespace OpenDreamRuntime.Procs.Native {
                 } else {
                     splitText = text.Split(delimiter);
                 }
-                List<string> finalList = new List<string> {startText};
-                finalList.AddRange(splitText);
-                finalList.Add(endText);
-                return new DreamValue(bundle.ObjectTree.CreateList(finalList.ToArray()));
+                splitText[0] = startText + splitText[0];
+                splitText[splitText.Length-1] = splitText[splitText.Length-1] + endText;
+                return new DreamValue(bundle.ObjectTree.CreateList(splitText));
             } else {
                 return new DreamValue(bundle.ObjectTree.CreateList());
             }


### PR DESCRIPTION
Very simple one-liner piggybacking off jointext and spltitext, with an update to Splittext so that it functions properly.

Basically, splittext has been updated in 515 to include the start and end of the string, so the current implementation of Splittext now remembers that and pre/appends those parts to the first/last elements.

The splittext unit tests were updated based off the output from DM for 515:
![image](https://github.com/user-attachments/assets/c0e68f01-b7dc-4f1f-8c9a-9f4c129262a8)

Originally this was just going to be a one-liner for replacetextEx_char, but after being informed of the changes needed to Splittext I decided to go ahead and do that too, so that this works.