### PR TITLE
Clean up lots of warnings in DreamProcNativeRoot.cs

### DIFF
--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -651,13 +651,13 @@ namespace OpenDreamRuntime.Procs.Native {
 
             string filePath;
             if (file.TryGetValueAsDreamResource(out var resource)) {
-                filePath = resource.ResourcePath;
-            } else if(!file.TryGetValueAsString(out filePath)) {
+                filePath = resource.ResourcePath!;
+            } else if(!file.TryGetValueAsString(out filePath!)) {
                 throw new Exception($"{file} is not a valid file");
             }
 
             bool successful;
-            if (filePath.EndsWith("/")) {
+            if (filePath!.EndsWith("/")) {
                 successful = bundle.ResourceManager.DeleteDirectory(filePath);
             } else {
                 successful = bundle.ResourceManager.DeleteFile(filePath);
@@ -673,12 +673,12 @@ namespace OpenDreamRuntime.Procs.Native {
 
             string filePath;
             if (file.TryGetValueAsDreamResource(out var rsc)) {
-                filePath = rsc.ResourcePath;
-            } else if (!file.TryGetValueAsString(out filePath)) {
+                filePath = rsc.ResourcePath!;
+            } else if (!file.TryGetValueAsString(out filePath!)) {
                 return DreamValue.Null;
             }
 
-            return new DreamValue(bundle.ResourceManager.DoesFileExist(filePath) ? 1 : 0);
+            return new DreamValue(bundle.ResourceManager.DoesFileExist(filePath!) ? 1 : 0);
         }
 
         [DreamProc("file")]
@@ -708,7 +708,7 @@ namespace OpenDreamRuntime.Procs.Native {
 
             if (file.TryGetValueAsString(out var rscPath)) {
                 resource = bundle.ResourceManager.LoadResource(rscPath);
-            } else if (!file.TryGetValueAsDreamResource(out resource)) {
+            } else if (!file.TryGetValueAsDreamResource(out resource!)) {
                 return DreamValue.Null;
             }
 
@@ -788,7 +788,7 @@ namespace OpenDreamRuntime.Procs.Native {
             int start = bundle.GetArgument(2, "Start").MustGetValueAsInteger(); //1-indexed
             int end = bundle.GetArgument(3, "End").MustGetValueAsInteger(); //1-indexed
 
-            if (start > text.Length || start == 0) return new DreamValue(0);
+            if (start > text!.Length || start == 0) return new DreamValue(0);
 
             if (start < 0) {
                 start = text.Length + start + 1; //1-indexed
@@ -808,7 +808,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 return match.Success ? new DreamValue(match.Index + 1) : new DreamValue(0);
             }
 
-            int needleIndex = text.IndexOf(needle, start - 1, end - start, StringComparison.OrdinalIgnoreCase);
+            int needleIndex = text.IndexOf(needle!, start - 1, end - start, StringComparison.OrdinalIgnoreCase);
             return new DreamValue(needleIndex + 1); //1-indexed
         }
 
@@ -839,7 +839,7 @@ namespace OpenDreamRuntime.Procs.Native {
             int start = bundle.GetArgument(2, "Start").MustGetValueAsInteger(); //1-indexed
             int end = bundle.GetArgument(3, "End").MustGetValueAsInteger(); //1-indexed
 
-            if (start <= 0 || start > text.Length || end < 0) return new DreamValue(0);
+            if (start <= 0 || start > text!.Length || end < 0) return new DreamValue(0);
 
             if (end == 0 || end > text.Length + 1) {
                 end = text.Length + 1;
@@ -851,7 +851,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 return match.Success ? new DreamValue(match.Index + 1) : new DreamValue(0);
             }
 
-            int needleIndex = text.IndexOf(needle, start - 1, end - start, StringComparison.InvariantCulture);
+            int needleIndex = text.IndexOf(needle!, start - 1, end - start, StringComparison.InvariantCulture);
             if (needleIndex != -1) {
                 return new DreamValue(needleIndex + 1); //1-indexed
             } else {
@@ -885,9 +885,9 @@ namespace OpenDreamRuntime.Procs.Native {
             if(start > 0)
                 actualstart = start-1;
             else
-                actualstart = (text.Length-1) + start;
-            actualstart += needle.Length-1;
-            actualstart = Math.Max(Math.Min(text.Length, actualstart),0);
+                actualstart = (text!.Length-1) + start;
+            actualstart += needle!.Length-1;
+            actualstart = Math.Max(Math.Min(text!.Length, actualstart),0);
 
             if(end > 0)
                 actualcount = actualstart - (end-1);
@@ -925,9 +925,9 @@ namespace OpenDreamRuntime.Procs.Native {
             if(start > 0)
                 actualstart = start-1;
             else
-                actualstart = (text.Length-1) + start;
-            actualstart += needle.Length-1;
-            actualstart = Math.Max(Math.Min(text.Length, actualstart),0);
+                actualstart = (text!.Length-1) + start;
+            actualstart += needle!.Length-1;
+            actualstart = Math.Max(Math.Min(text!.Length, actualstart),0);
 
             if(end > 0)
                 actualcount = actualstart - (end-1);
@@ -1011,7 +1011,7 @@ namespace OpenDreamRuntime.Procs.Native {
             if(!bundle.GetArgument(1, "ProcName").TryGetValueAsString(out var procName))
                 return new DreamValue(0);
 
-            return new DreamValue(obj.ObjectDefinition.HasProc(procName) ? 1 : 0);
+            return new DreamValue(obj!.ObjectDefinition.HasProc(procName) ? 1 : 0);
         }
 
         [DreamProc("html_decode")]
@@ -2047,7 +2047,7 @@ namespace OpenDreamRuntime.Procs.Native {
             if(center is not DreamObjectTurf) { // If it's not a /turf, we have to include its loc and the loc's contents
                 if(center.TryGetVariable("loc",out DreamValue centerLoc) && centerLoc.TryGetValueAsDreamObject(out var centerLocObject)) {
                     rangeList.AddValue(centerLoc);
-                    if(centerLocObject.GetVariable("contents").TryGetValueAsDreamList(out var locContentsList)) {
+                    if(centerLocObject!.GetVariable("contents").TryGetValueAsDreamList(out var locContentsList)) {
                         foreach (DreamValue content in locContentsList.GetValues()) {
                             rangeList.AddValue(content);
                         }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -775,7 +775,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 }
             }
 
-            if (failCount > 0 || String.IsNullOrEmpty(text) || String.IsNullOrEmpty(needle)) { // the second condition is to ensure the compiler knows text isn't null
+            if (failCount > 0 || String.IsNullOrEmpty(text) || String.IsNullOrEmpty(needle)) {
                 return new DreamValue(failCount == 2 ? 1 : 0);
             }
 
@@ -2039,7 +2039,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 }
             }
             if(center is not DreamObjectTurf) { // If it's not a /turf, we have to include its loc and the loc's contents
-                if(center.TryGetVariable("loc",out DreamValue centerLoc) && centerLoc.TryGetValueAsDreamObject(out var centerLocObject)) {
+                if(center.TryGetVariable("loc",out DreamValue centerLoc) && centerLoc.TryGetValueAsDreamObject<DreamObjectAtom>(out var centerLocObject)) {
                     rangeList.AddValue(centerLoc);
                     if(centerLocObject.GetVariable("contents").TryGetValueAsDreamList(out var locContentsList)) {
                         foreach (DreamValue content in locContentsList.GetValues()) {
@@ -3291,8 +3291,8 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("params", Type = DreamValueTypeFlag.String)]
         public static DreamValue NativeProc_winset(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
             DreamValue player = bundle.GetArgument(0, "player");
-            DreamValue? controlId = bundle.GetArgument(1, "control_id");
-            string winsetControlId = (!controlId.IsNull) ? controlId.GetValueAsString() : null;
+            DreamValue controlId = bundle.GetArgument(1, "control_id");
+            string? winsetControlId = (!controlId.IsNull) ? controlId.GetValueAsString() : null;
             string winsetParams = bundle.GetArgument(2, "params").GetValueAsString();
 
             DreamConnection? connection = null;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -667,7 +667,7 @@ namespace OpenDreamRuntime.Procs.Native {
 
             string? filePath;
             if (file.TryGetValueAsDreamResource(out var rsc)) {
-                filePath = rsc.ResourcePath!;
+                filePath = rsc.ResourcePath;
             } else if (!file.TryGetValueAsString(out filePath)) {
                 return DreamValue.Null;
             }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1445,7 +1445,7 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProc("list2params")]
         [DreamProcParameter("List")]
         public static DreamValue NativeProc_list2params(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-            if (!bundle.GetArgument(0, "List").TryGetValueAsDreamList(out DreamList list))
+            if (!bundle.GetArgument(0, "List").TryGetValueAsDreamList(out DreamList? list))
                 return new DreamValue(string.Empty);
             return new DreamValue(list2params(list));
         }
@@ -1687,7 +1687,7 @@ namespace OpenDreamRuntime.Procs.Native {
 
             byte[] bytes;
 
-            if (arg.TryGetValueAsDreamResource(out DreamResource resource)) {
+            if (arg.TryGetValueAsDreamResource(out DreamResource? resource)) {
                 byte[]? filebytes = resource.ResourceData;
 
                 if (filebytes == null) {
@@ -2224,7 +2224,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 return DreamValue.Null;
             }
 
-            if (!ColorHelpers.TryParseColor(color, out var c, defaultAlpha: null)) {
+            if (!ColorHelpers.TryParseColor(color, out var c, defaultAlpha: null!)) {
                 Rgb2NumBadColor();
                 return DreamValue.Null;
             }
@@ -3298,7 +3298,7 @@ namespace OpenDreamRuntime.Procs.Native {
         public static DreamValue NativeProc_winset(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
             DreamValue player = bundle.GetArgument(0, "player");
             DreamValue controlId = bundle.GetArgument(1, "control_id");
-            string winsetControlId = (!controlId.IsNull) ? controlId.GetValueAsString() : null;
+            string winsetControlId = (!controlId.IsNull) ? controlId.GetValueAsString() : null!;
             string winsetParams = bundle.GetArgument(2, "params").GetValueAsString();
 
             DreamConnection? connection = null;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1294,7 +1294,7 @@ namespace OpenDreamRuntime.Procs.Native {
                     return new DreamValue(list);
                 }
                 case JsonValueKind.String:
-                    return new DreamValue(jsonElement.GetString());
+                    return new DreamValue(jsonElement.GetString() ?? ""); // it shouldn't be null but it was throwing a warning
                 case JsonValueKind.Number:
                     if (!jsonElement.TryGetSingle(out float floatValue)) {
                         throw new Exception("Invalid number " + jsonElement);
@@ -2399,7 +2399,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 }
 
                 return new DreamValue(1);
-            } else if (!bundle.GetArgument(1, "T2").TryGetValueAsString(out t2)) {
+            } else if (!bundle.GetArgument(1, "T2").TryGetValueAsString(out t2!)) {
                 return new DreamValue(-1);
             }
 
@@ -2419,7 +2419,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 }
 
                 return new DreamValue(1);
-            } else if (!bundle.GetArgument(1, "T2").TryGetValueAsString(out t2)) {
+            } else if (!bundle.GetArgument(1, "T2").TryGetValueAsString(out t2!)) {
                 return new DreamValue(-1);
             }
 
@@ -2532,7 +2532,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 else
                     return new DreamValue(insertText);
             else if(text == "")
-                return new DreamValue(insertText);
+                return new DreamValue(insertText!);
 
             //runtime if start = 0 runtime error: bad text or out of bounds
 
@@ -2546,7 +2546,7 @@ namespace OpenDreamRuntime.Procs.Native {
             if(start == 0 || start > text.Length || start > end)
                 throw new Exception("bad text or out of bounds");
 
-            string result = text.Remove(start - 1, (end-start)).Insert(start - 1, insertText);
+            string result = text.Remove(start - 1, (end-start)).Insert(start - 1, insertText!);
 
             return new DreamValue(result);
         }
@@ -2568,7 +2568,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 else
                     return new DreamValue(insertText);
             else if(text == "")
-                return new DreamValue(insertText);
+                return new DreamValue(insertText!);
 
             //runtime if start = 0 runtime error: bad text or out of bounds
             StringInfo textElements = new StringInfo(text);
@@ -3288,7 +3288,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 return new("true");
             }
 
-            return await connection.WinGet(controlId, paramsValue);
+            return await connection.WinGet(controlId!, paramsValue);
         }
 
         [DreamProc("winset")]

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -652,7 +652,7 @@ namespace OpenDreamRuntime.Procs.Native {
             string? filePath;
             if (file.TryGetValueAsDreamResource(out var resource)) {
                 filePath = resource.ResourcePath;
-            } else if(file.TryGetValueAsString(out filePath)) {
+            } else if(!file.TryGetValueAsString(out filePath)) {
                 throw new Exception($"{file} is not a valid file");
             }
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -656,13 +656,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 throw new Exception($"{file} is not a valid file");
             }
 
-            bool successful;
-            if (filePath!.EndsWith("/")) {
-                successful = bundle.ResourceManager.DeleteDirectory(filePath);
-            } else {
-                successful = bundle.ResourceManager.DeleteFile(filePath);
-            }
-
+            bool successful = filePath.EndsWith("/") ? bundle.ResourceManager.DeleteDirectory(filePath) : bundle.ResourceManager.DeleteFile(filePath);
             return new DreamValue(successful ? 1 : 0);
         }
 
@@ -678,7 +672,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 return DreamValue.Null;
             }
 
-            return new DreamValue(bundle.ResourceManager.DoesFileExist(filePath!) ? 1 : 0);
+            return new DreamValue(bundle.ResourceManager.DoesFileExist(filePath) ? 1 : 0);
         }
 
         [DreamProc("file")]

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -656,7 +656,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 throw new Exception($"{file} is not a valid file");
             }
 
-            bool successful = filePath!.EndsWith("/") ? bundle.ResourceManager.DeleteDirectory(filePath) : bundle.ResourceManager.DeleteFile(filePath);
+            bool successful = filePath.EndsWith("/") ? bundle.ResourceManager.DeleteDirectory(filePath) : bundle.ResourceManager.DeleteFile(filePath);
             return new DreamValue(successful ? 1 : 0);
         }
 
@@ -665,10 +665,10 @@ namespace OpenDreamRuntime.Procs.Native {
         public static DreamValue NativeProc_fexists(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
             DreamValue file = bundle.GetArgument(0, "File");
 
-            string filePath;
+            string? filePath;
             if (file.TryGetValueAsDreamResource(out var rsc)) {
                 filePath = rsc.ResourcePath!;
-            } else if (!file.TryGetValueAsString(out filePath!)) {
+            } else if (!file.TryGetValueAsString(out filePath)) {
                 return DreamValue.Null;
             }
 
@@ -697,12 +697,12 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("File", Type = DreamValueTypeFlag.String | DreamValueTypeFlag.DreamResource)]
         public static DreamValue NativeProc_file2text(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
             DreamValue file = bundle.GetArgument(0, "File");
-            DreamResource resource;
+            DreamResource? resource;
 
 
             if (file.TryGetValueAsString(out var rscPath)) {
                 resource = bundle.ResourceManager.LoadResource(rscPath);
-            } else if (!file.TryGetValueAsDreamResource(out resource!)) {
+            } else if (!file.TryGetValueAsDreamResource(out resource)) {
                 return DreamValue.Null;
             }
 
@@ -2542,7 +2542,7 @@ namespace OpenDreamRuntime.Procs.Native {
             if(start == 0 || start > text.Length || start > end)
                 throw new Exception("bad text or out of bounds");
 
-            string result = text.Remove(start - 1, (end-start)).Insert(start - 1, insertText!);
+            string result = text.Remove(start - 1, (end-start)).Insert(start - 1, insertText);
 
             return new DreamValue(result);
         }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2218,7 +2218,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 return DreamValue.Null;
             }
 
-            if (!ColorHelpers.TryParseColor(color, out var c, defaultAlpha: null)) {
+            if (!ColorHelpers.TryParseColor(color, out var c, defaultAlpha: string.Empty)) {
                 Rgb2NumBadColor();
                 return DreamValue.Null;
             }
@@ -2386,14 +2386,14 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("T1", Type = DreamValueTypeFlag.String)]
         [DreamProcParameter("T2", Type = DreamValueTypeFlag.String)]
         public static DreamValue NativeProc_sorttext(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-            string t2;
+            string? t2;
             if (!bundle.GetArgument(0, "T1").TryGetValueAsString(out var t1)) {
                 if (!bundle.GetArgument(1, "T2").TryGetValueAsString(out _)) {
                     return new DreamValue(0);
                 }
 
                 return new DreamValue(1);
-            } else if (!bundle.GetArgument(1, "T2").TryGetValueAsString(out t2!)) {
+            } else if (!bundle.GetArgument(1, "T2").TryGetValueAsString(out t2)) {
                 return new DreamValue(-1);
             }
 
@@ -2406,14 +2406,14 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("T1", Type = DreamValueTypeFlag.String)]
         [DreamProcParameter("T2", Type = DreamValueTypeFlag.String)]
         public static DreamValue NativeProc_sorttextEx(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
-            string t2;
+            string? t2;
             if (!bundle.GetArgument(0, "T1").TryGetValueAsString(out var t1)) {
                 if (!bundle.GetArgument(1, "T2").TryGetValueAsString(out _)) {
                     return new DreamValue(0);
                 }
 
                 return new DreamValue(1);
-            } else if (!bundle.GetArgument(1, "T2").TryGetValueAsString(out t2!)) {
+            } else if (!bundle.GetArgument(1, "T2").TryGetValueAsString(out t2)) {
                 return new DreamValue(-1);
             }
 
@@ -2526,7 +2526,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 else
                     return new DreamValue(insertText);
             else if(text == "")
-                return new DreamValue(insertText!);
+                return new DreamValue(insertText);
 
             //runtime if start = 0 runtime error: bad text or out of bounds
 
@@ -2562,7 +2562,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 else
                     return new DreamValue(insertText);
             else if(text == "")
-                return new DreamValue(insertText!);
+                return new DreamValue(insertText);
 
             //runtime if start = 0 runtime error: bad text or out of bounds
             StringInfo textElements = new StringInfo(text);
@@ -3282,7 +3282,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 return new("true");
             }
 
-            return await connection.WinGet(controlId!, paramsValue);
+            return await connection.WinGet(controlId, paramsValue);
         }
 
         [DreamProc("winset")]
@@ -3291,8 +3291,8 @@ namespace OpenDreamRuntime.Procs.Native {
         [DreamProcParameter("params", Type = DreamValueTypeFlag.String)]
         public static DreamValue NativeProc_winset(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
             DreamValue player = bundle.GetArgument(0, "player");
-            DreamValue controlId = bundle.GetArgument(1, "control_id");
-            string winsetControlId = (!controlId.IsNull) ? controlId.GetValueAsString() : null!;
+            DreamValue? controlId = bundle.GetArgument(1, "control_id");
+            string winsetControlId = (!controlId.IsNull) ? controlId.GetValueAsString() : null;
             string winsetParams = bundle.GetArgument(2, "params").GetValueAsString();
 
             DreamConnection? connection = null;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -775,7 +775,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 }
             }
 
-            if (failCount > 0 || String.IsNullOrEmpty(text) || String.IsNullOrEmpty(needle)) {
+            if (failCount > 0 || string.IsNullOrEmpty(text) || string.IsNullOrEmpty(needle)) {
                 return new DreamValue(failCount == 2 ? 1 : 0);
             }
 
@@ -826,7 +826,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 }
             }
 
-            if (failCount > 0 || String.IsNullOrEmpty(text) || String.IsNullOrEmpty(needle)) {
+            if (failCount > 0 || string.IsNullOrEmpty(text) || string.IsNullOrEmpty(needle)) {
                 return new DreamValue(failCount == 2 ? 1 : 0);
             }
 
@@ -867,7 +867,8 @@ namespace OpenDreamRuntime.Procs.Native {
             if (!bundle.GetArgument(1, "Needle").TryGetValueAsString(out var needle)) {
                 failCount++;
             }
-            if (failCount > 0 || String.IsNullOrEmpty(text) || String.IsNullOrEmpty(needle)) {
+
+            if (failCount > 0 || string.IsNullOrEmpty(text) || string.IsNullOrEmpty(needle)) {
                 return new DreamValue(failCount == 2 ? 1 : 0);
             }
 
@@ -881,7 +882,7 @@ namespace OpenDreamRuntime.Procs.Native {
             else
                 actualstart = (text.Length-1) + start;
             actualstart += needle.Length-1;
-            actualstart = Math.Max(Math.Min(text!.Length, actualstart),0);
+            actualstart = Math.Max(Math.Min(text.Length, actualstart),0);
 
             if(end > 0)
                 actualcount = actualstart - (end-1);
@@ -907,7 +908,8 @@ namespace OpenDreamRuntime.Procs.Native {
             if (!bundle.GetArgument(1, "Needle").TryGetValueAsString(out var needle)) {
                 failCount++;
             }
-            if (failCount > 0 || String.IsNullOrEmpty(text) || String.IsNullOrEmpty(needle)) {
+
+            if (failCount > 0 || string.IsNullOrEmpty(text) || string.IsNullOrEmpty(needle)) {
                 return new DreamValue(failCount == 2 ? 1 : 0);
             }
 
@@ -921,7 +923,7 @@ namespace OpenDreamRuntime.Procs.Native {
             else
                 actualstart = (text.Length-1) + start;
             actualstart += needle.Length-1;
-            actualstart = Math.Max(Math.Min(text!.Length, actualstart),0);
+            actualstart = Math.Max(Math.Min(text.Length, actualstart),0);
 
             if(end > 0)
                 actualcount = actualstart - (end-1);


### PR DESCRIPTION
By adding `!` and `?` at strategic locations, as well as some other changes, the warnings about dereferencing/referencing of null/nullable types are removed. in (presumably) all the cases where the warning exists there are already circumstances that make it so that the errors being warned against can't happen anyway, so these shouldn't hurt. fingers crossed.

The file has gone from having 39 warnings to only 14.

Some of the warnings that are more legitimate in origin have been left in.