### PR TITLE
Strip colons from the server IPs in the cache directory

### DIFF
--- a/OpenDreamClient/Resources/DreamResourceManager.cs
+++ b/OpenDreamClient/Resources/DreamResourceManager.cs
@@ -59,7 +59,11 @@ namespace OpenDreamClient.Resources {
                 return;
             if(_netManager.ServerChannel is null)
                 throw new Exception("Server doesn't appear to be connected, can't use cache right now!");
-            _cacheDirectory = new ResPath($"/OpenDream/Cache/{_netManager.ServerChannel.RemoteEndPoint}");
+
+            var address = _netManager.ServerChannel.RemoteEndPoint.ToString();
+            address = address.Replace(':', '.'); // colons aren't legal on Windows
+
+            _cacheDirectory = new ResPath($"/OpenDream/Cache/{address}");
             _resourceManager.UserData.CreateDir(_cacheDirectory);
             if (!_resourceManager.UserData.Exists(_cacheDirectory))
                 throw new Exception($"Could not create cache directory at {_cacheDirectory}");


### PR DESCRIPTION
Fixes this exception:
`System.IO.IOException: The filename, directory name, or volume label syntax is incorrect. : 'C:\Users\Ike\AppData\Roaming\Space Station 14\data\OpenDream\Cache\127.0.0.1:1212\browse1774779223.html'`

`:` is not a legal filepath on Windows. See [this Microsoft doc](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file) if you don't believe me.

This fixes TGUI when connecting to a local server.