### PR TITLE
VSCode Extension Hot Reload Enable

### DIFF
--- a/OpenDreamRuntime/DreamManager.Connections.cs
+++ b/OpenDreamRuntime/DreamManager.Connections.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
@@ -298,7 +299,8 @@ namespace OpenDreamRuntime {
         }
 
         public void HotReloadResource(string fileName){
-            var resource = _dreamResourceManager.LoadResource(fileName, forceReload:true);
+            //ensure all paths are relative for consistency
+            var resource = _dreamResourceManager.LoadResource(Path.GetRelativePath(_dreamResourceManager.RootPath, fileName), forceReload:true);
             var msgBrowseResource = new MsgNotifyResourceUpdate() { //send a message that this resource id has been updated, let the clients handle re-requesting it
                 ResourceId = resource.Id
             };

--- a/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
@@ -844,7 +844,7 @@ internal sealed class DreamDebugManager : IDreamDebugManager {
 
     private void HandleRequestHotReloadResource(DebugAdapterClient client, RequestHotReloadResource requestHotReloadResource) {
         if (string.IsNullOrWhiteSpace(requestHotReloadResource.Arguments.FilePath)) {
-            _sawmill.Error($"Debug adapter requested a resource hot reload but didn't provide a file");
+            _sawmill.Error("Debug adapter requested a resource hot reload but didn't provide a file");
             requestHotReloadResource.RespondError(client, "No file provided for a hot reload");
             return;
         }

--- a/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
@@ -843,9 +843,9 @@ internal sealed class DreamDebugManager : IDreamDebugManager {
     }
 
     private void HandleRequestHotReloadResource(DebugAdapterClient client, RequestHotReloadResource requestHotReloadResource) {
-        _sawmill.Debug("Debug adapter triggered resource hot reload for "+requestHotReloadResource.Arguments.filePath!);
+        _sawmill.Debug("Debug adapter triggered resource hot reload for "+requestHotReloadResource.Arguments.FilePath!);
         try {
-            _dreamManager.HotReloadResource(requestHotReloadResource.Arguments.filePath!);
+            _dreamManager.HotReloadResource(requestHotReloadResource.Arguments.FilePath!);
             requestHotReloadResource.Respond(client);
         } catch (Exception e) {
             requestHotReloadResource.RespondError(client, e.Message);

--- a/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
@@ -843,9 +843,15 @@ internal sealed class DreamDebugManager : IDreamDebugManager {
     }
 
     private void HandleRequestHotReloadResource(DebugAdapterClient client, RequestHotReloadResource requestHotReloadResource) {
-        _sawmill.Debug("Debug adapter triggered resource hot reload for "+requestHotReloadResource.Arguments.FilePath!);
+        if (string.IsNullOrWhiteSpace(requestHotReloadResource.Arguments.FilePath)) {
+            _sawmill.Error($"Debug adapter requested a resource hot reload but didn't provide a file");
+            requestHotReloadResource.RespondError(client, "No file provided for a hot reload");
+            return;
+        }
+        
+        _sawmill.Debug("Debug adapter triggered resource hot reload for "+requestHotReloadResource.Arguments.FilePath);
         try {
-            _dreamManager.HotReloadResource(requestHotReloadResource.Arguments.FilePath!);
+            _dreamManager.HotReloadResource(requestHotReloadResource.Arguments.FilePath);
             requestHotReloadResource.Respond(client);
         } catch (Exception e) {
             requestHotReloadResource.RespondError(client, e.Message);

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/Request.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/Request.cs
@@ -35,6 +35,8 @@ public class Request : ProtocolMessage {
             "stepIn" => json.Deserialize<RequestStepIn>(),
             "stepOut" => json.Deserialize<RequestStepOut>(),
             "disassemble" => json.Deserialize<RequestDisassemble>(),
+            "hotreloadinterface" => json.Deserialize<RequestHotReloadInterface>(),
+            "hotreloadresource" => json.Deserialize<RequestHotReloadResource>(),
             // Caller will fail to recognize it and can respond with `success: false`.
             _ => request,
         };

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestHotReloadInterface.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestHotReloadInterface.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json.Serialization;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 
 namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
 

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestHotReloadInterface.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestHotReloadInterface.cs
@@ -1,0 +1,11 @@
+﻿using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+
+namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
+
+[UsedImplicitly]
+public sealed class RequestHotReloadInterface : Request {
+    public void Respond(DebugAdapterClient client) {
+        client.SendMessage(Response.NewSuccess(this));
+    }
+}

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestHotReloadResource.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestHotReloadResource.cs
@@ -9,7 +9,7 @@ public sealed class RequestHotReloadResource : Request {
 
     [UsedImplicitly]
     public sealed class RequestHotReloadResourceArguments {
-        [JsonPropertyName("file")] public string? filePath { get; set; }
+        [JsonPropertyName("file")] public string? FilePath { get; set; }
     }
 
     public void Respond(DebugAdapterClient client) {

--- a/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestHotReloadResource.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/Protocol/RequestHotReloadResource.cs
@@ -1,0 +1,18 @@
+﻿using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+
+namespace OpenDreamRuntime.Procs.DebugAdapter.Protocol;
+
+[UsedImplicitly]
+public sealed class RequestHotReloadResource : Request {
+    [JsonPropertyName("arguments")] public required RequestHotReloadResourceArguments Arguments { get; set; }
+
+    [UsedImplicitly]
+    public sealed class RequestHotReloadResourceArguments {
+        [JsonPropertyName("file")] public string? filePath { get; set; }
+    }
+
+    public void Respond(DebugAdapterClient client) {
+        client.SendMessage(Response.NewSuccess(this));
+    }
+}

--- a/OpenDreamRuntime/Resources/DreamResourceManager.cs
+++ b/OpenDreamRuntime/Resources/DreamResourceManager.cs
@@ -57,6 +57,7 @@ namespace OpenDreamRuntime.Resources {
         public DreamResource LoadResource(string resourcePath, bool forceReload = false) {
             DreamResource resource;
             int resourceId;
+            resourcePath = Path.GetRelativePath(RootPath, resourcePath); //ensure all paths are relative for consistency
 
             DreamResource GetResource() {
                 // Create a new type of resource based on its extension

--- a/OpenDreamRuntime/Resources/DreamResourceManager.cs
+++ b/OpenDreamRuntime/Resources/DreamResourceManager.cs
@@ -57,7 +57,6 @@ namespace OpenDreamRuntime.Resources {
         public DreamResource LoadResource(string resourcePath, bool forceReload = false) {
             DreamResource resource;
             int resourceId;
-            resourcePath = Path.GetRelativePath(RootPath, resourcePath); //ensure all paths are relative for consistency
 
             DreamResource GetResource() {
                 // Create a new type of resource based on its extension


### PR DESCRIPTION
Adds hot reload commands for resources and interface to the debug adapter so they can be called by the vscode extension