### PR TITLE
Implement `right-click` parameter

### DIFF
--- a/OpenDreamClient/Input/MouseInputSystem.cs
+++ b/OpenDreamClient/Input/MouseInputSystem.cs
@@ -1,6 +1,7 @@
 ﻿using OpenDreamClient.Input.ContextMenu;
 using OpenDreamClient.Interface;
 using OpenDreamClient.Interface.Controls.UI;
+using OpenDreamClient.Interface.Descriptors;
 using OpenDreamClient.Rendering;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Input;
@@ -62,9 +63,9 @@ internal sealed class MouseInputSystem : SharedMouseInputSystem {
         CommandBinds.Unregister<MouseInputSystem>();
     }
 
-    public bool HandleViewportEvent(ScalingViewport viewport, GUIBoundKeyEventArgs args) {
+    public bool HandleViewportEvent(ScalingViewport viewport, GUIBoundKeyEventArgs args, ControlDescriptor descriptor) {
         if (args.State == BoundKeyState.Down)
-            return OnPress(viewport, args);
+            return OnPress(viewport, args, descriptor);
         else
             return OnRelease(viewport, args);
     }
@@ -116,8 +117,9 @@ internal sealed class MouseInputSystem : SharedMouseInputSystem {
         }
     }
 
-    private bool OnPress(ScalingViewport viewport, GUIBoundKeyEventArgs args) {
-        if (args.Function == EngineKeyFunctions.UIRightClick && _dreamInterfaceManager.ShowPopupMenus) { //either turf or atom was clicked, and it was a right-click, and the popup menu is enabled
+    private bool OnPress(ScalingViewport viewport, GUIBoundKeyEventArgs args, ControlDescriptor descriptor) {
+        //either turf or atom was clicked, and it was a right-click, and the popup menu is enabled, and the right-click parameter is disabled
+        if (args.Function == EngineKeyFunctions.UIRightClick && _dreamInterfaceManager.ShowPopupMenus && !descriptor.RightClick.Value) {
             var mapCoords = viewport.ScreenToMap(args.PointerLocation.Position);
             var entities = _lookupSystem.GetEntitiesInRange(mapCoords, 0.01f, LookupFlags.Uncontained | LookupFlags.Approximate);
 

--- a/OpenDreamClient/Interface/Controls/ControlMap.cs
+++ b/OpenDreamClient/Interface/Controls/ControlMap.cs
@@ -76,7 +76,7 @@ public sealed class ControlMap(ControlDescriptor controlDescriptor, ControlWindo
             e.Function == EngineKeyFunctions.UIRightClick || e.Function == OpenDreamKeyFunctions.MouseMiddle) {
             _entitySystemManager.Resolve(ref _mouseInput);
 
-            if (_mouseInput.HandleViewportEvent(Viewport, e)) {
+            if (_mouseInput.HandleViewportEvent(Viewport, e, ControlDescriptor)) {
                 e.Handle();
             }
         }


### PR DESCRIPTION
Resolves #1928

This implements TG's right-clicking behavior. I tested it by right clicking on a fire extinguisher cabinet repeatedly, which toggles its opened/closed state.

Shift+RMB behavior is still unimplemented, see https://github.com/OpenDreamProject/OpenDream/issues/1936