### PR TITLE
Fix remaining click param issues

### DIFF
--- a/OpenDreamRuntime/Input/MouseInputSystem.cs
+++ b/OpenDreamRuntime/Input/MouseInputSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Specialized;
+using System.Text;
 using System.Web;
 using OpenDreamRuntime.Objects.Types;
 using OpenDreamShared.Input;
@@ -79,29 +80,36 @@ internal sealed class MouseInputSystem : SharedMouseInputSystem {
     }
 
     private string ConstructClickParams(ClickParams clickParams) {
-        NameValueCollection paramsBuilder = HttpUtility.ParseQueryString(string.Empty);
+        StringBuilder paramsBuilder = new StringBuilder(96); // Click param strings are typically ~86 chars with all modifiers held. 96 is 64*1.5
+
+        // All of these parameters have been ordered with BYOND parity
+
+        paramsBuilder.Append($"icon-x={clickParams.IconX.ToString()};");
+        paramsBuilder.Append($"icon-y={clickParams.IconY.ToString()};");
+
+        string button;
 
         // Handles setting left=1, right=1, or middle=1 mouse param
         if (clickParams.Right) {
-            paramsBuilder.Add("right", "1");
-            paramsBuilder.Add("button", "right");
+            paramsBuilder.Append("right=1;");
+            button = "right";
         } else if (clickParams.Middle) {
-             paramsBuilder.Add("middle", "1");
-             paramsBuilder.Add("button", "middle");
+             paramsBuilder.Append("middle=1;");
+             button = "middle";
         } else {
-            paramsBuilder.Add("left", "1");
-            paramsBuilder.Add("button", "left");
+            paramsBuilder.Append("left=1;");
+            button = "left";
         }
 
         // Modifier keys
-        if (clickParams.Shift) paramsBuilder.Add("shift", "1");
-        if (clickParams.Ctrl) paramsBuilder.Add("ctrl", "1");
-        if (clickParams.Alt) paramsBuilder.Add("alt", "1");
+        if (clickParams.Ctrl) paramsBuilder.Append("ctrl=1;");
+        if (clickParams.Shift) paramsBuilder.Append("shift=1;");
+        if (clickParams.Alt) paramsBuilder.Append("alt=1;");
 
-        // Other params
-        paramsBuilder.Add("screen-loc", clickParams.ScreenLoc.ToString());
-        paramsBuilder.Add("icon-x", clickParams.IconX.ToString());
-        paramsBuilder.Add("icon-y", clickParams.IconY.ToString());
+        paramsBuilder.Append($"button={button};");
+
+        // Screen loc
+        paramsBuilder.Append($"screen-loc={clickParams.ScreenLoc.ToCoordinates()}");
 
         return paramsBuilder.ToString();
     }

--- a/OpenDreamShared/Dream/ScreenLocation.cs
+++ b/OpenDreamShared/Dream/ScreenLocation.cs
@@ -93,6 +93,10 @@ public sealed class ScreenLocation {
         return $"{mapControl}{HorizontalAnchor}+{X+1}:{PixelOffsetX},{VerticalAnchor}+{Y+1}:{PixelOffsetY}{range}";
     }
 
+    public string ToCoordinates() {
+        return $"{X+1}:{PixelOffsetX},{Y+1}:{PixelOffsetY}";
+    }
+
     private void ParseScreenLoc(string screenLoc) {
         string[] rangeSplit = screenLoc.Split(" TO ");
         Range = rangeSplit.Length > 1 ? new ScreenLocation(rangeSplit[1]) : null;


### PR DESCRIPTION
Resolves #1926 

Test code:
```
/client/New()
    ..()
    show_popup_menus = FALSE

/client/Click(object,location,control,params)
	..()
	src << "[params]"
```

I clicked the left, middle, and right mouse button once each with all modifiers held. Slight differences in coordinates are due to me not clicking the exactly identical spot.

BYOND:
```
icon-x=29;icon-y=29;left=1;ctrl=1;shift=1;alt=1;button=left;screen-loc=7:29,3:29
icon-x=29;icon-y=29;middle=1;ctrl=1;shift=1;alt=1;button=middle;screen-loc=7:29,3:29
icon-x=29;icon-y=29;right=1;ctrl=1;shift=1;alt=1;button=right;screen-loc=7:29,3:29
```
OpenDream:
![image](https://github.com/user-attachments/assets/c5dcfd49-37f5-49b3-aa89-f8d230fe2e96)

Note that middle-mouse is still broken in OD, ref #1925 

I converted it to a `StringBuilder` because afaict all `NameValueCollection` was doing for us was escaping the colons in `screen-loc` and we weren't actually using it for anything since it just gets converted to a string at the end.