### PR TITLE
Fix nullable warnings when using token.Value

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -2262,11 +2262,11 @@ namespace DMCompiler.Compiler.DM {
             Token constantToken = Current();
 
             switch (constantToken.Type) {
-                case TokenType.DM_Integer: Advance(); return new DMASTConstantInteger(constantToken.Location, (int)constantToken.Value);
-                case TokenType.DM_Float: Advance(); return new DMASTConstantFloat(constantToken.Location, (float)constantToken.Value);
-                case TokenType.DM_Resource: Advance(); return new DMASTConstantResource(constantToken.Location, (string)constantToken.Value);
+                case TokenType.DM_Integer: Advance(); return new DMASTConstantInteger(constantToken.Location, constantToken.ValueAsInt());
+                case TokenType.DM_Float: Advance(); return new DMASTConstantFloat(constantToken.Location, constantToken.ValueAsFloat());
+                case TokenType.DM_Resource: Advance(); return new DMASTConstantResource(constantToken.Location, constantToken.ValueAsString());
                 case TokenType.DM_Null: Advance(); return new DMASTConstantNull(constantToken.Location);
-                case TokenType.DM_RawString: Advance(); return new DMASTConstantString(constantToken.Location, (string)constantToken.Value);
+                case TokenType.DM_RawString: Advance(); return new DMASTConstantString(constantToken.Location, constantToken.ValueAsString());
                 case TokenType.DM_ConstantString:
                 case TokenType.DM_StringBegin:
                     // Don't advance, ExpressionFromString() will handle it

--- a/DMCompiler/Compiler/DM/DMParserHelper.cs
+++ b/DMCompiler/Compiler/DM/DMParserHelper.cs
@@ -111,7 +111,7 @@ public partial class DMParser {
             Token currentToken = Current();
             Advance();
 
-            string tokenValue = (string)currentToken.Value;
+            string tokenValue = currentToken.ValueAsString();
 
             // If an interpolation comes after this, ignore the last character (always '[')
             int iterateLength = currentToken.Type is TokenType.DM_StringBegin or TokenType.DM_StringMiddle

--- a/DMCompiler/Compiler/DMM/DMMParser.cs
+++ b/DMCompiler/Compiler/DMM/DMMParser.cs
@@ -54,7 +54,7 @@ internal sealed class DMMParser(DMLexer lexer, int zOffset) : DMParser(lexer) {
             Consume(TokenType.DM_Equals, "Expected '='");
             Consume(TokenType.DM_LeftParenthesis, "Expected '('");
 
-            CellDefinitionJson cellDefinition = new CellDefinitionJson((string)currentToken.Value);
+            CellDefinitionJson cellDefinition = new CellDefinitionJson(currentToken.ValueAsString());
             DMASTPath? objectType = Path();
             while (objectType != null) {
                 bool skipType = !DMObjectTree.TryGetTypeId(objectType.Path, out int typeId);
@@ -122,11 +122,11 @@ internal sealed class DMMParser(DMLexer lexer, int zOffset) : DMParser(lexer) {
             Token blockStringToken = Current();
             Consume(TokenType.DM_ConstantString, "Expected a constant string");
 
-            string blockString = (string)blockStringToken.Value;
-            List<string> lines = new(blockString.Split("\n", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries));
+            string blockString = blockStringToken.ValueAsString();
+            string[] lines = blockString.Split("\n", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
 
-            mapBlock.Height = lines.Count;
-            for (int y = 1; y <= lines.Count; y++) {
+            mapBlock.Height = lines.Length;
+            for (int y = 1; y <= lines.Length; y++) {
                 string line = lines[y - 1];
                 int width = (line.Length / _cellNameLength);
 

--- a/DMCompiler/Compiler/DMPreprocessor/DMMacro.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMMacro.cs
@@ -69,7 +69,7 @@ internal class DMMacro {
         foreach (Token token in _tokens) {
             string parameterName =
                 token.Type is TokenType.DM_Preproc_TokenConcat or TokenType.DM_Preproc_ParameterStringify
-                    ? (string) token.Value!
+                    ? token.ValueAsString()
                     : token.Text;
             int parameterIndex = _parameters!.IndexOf(parameterName);
 

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -160,7 +160,7 @@ public sealed class DMPreprocessor(bool enableDirectives) : IEnumerable<Token> {
                 }
 
                 case TokenType.Error:
-                    DMCompiler.Emit(WarningCode.ErrorDirective, token.Location, (string)token.Value);
+                    DMCompiler.Emit(WarningCode.ErrorDirective, token.Location, token.ValueAsString());
                     break;
 
                 default:
@@ -267,7 +267,7 @@ public sealed class DMPreprocessor(bool enableDirectives) : IEnumerable<Token> {
         }
 
         DMPreprocessorLexer currentLexer = _lexerStack.Peek();
-        string file = Path.Combine(Path.GetDirectoryName(currentLexer.File.Replace('\\', Path.DirectorySeparatorChar)), (string)includedFileToken.Value);
+        string file = Path.Combine(Path.GetDirectoryName(currentLexer.File.Replace('\\', Path.DirectorySeparatorChar)), includedFileToken.ValueAsString());
         string directory = currentLexer.IncludeDirectory;
 
         IncludeFile(directory, file, includedFrom: includeToken.Location);
@@ -289,7 +289,7 @@ public sealed class DMPreprocessor(bool enableDirectives) : IEnumerable<Token> {
         if (defineIdentifier.Text == "FILE_DIR") {
             Token dirToken = GetNextToken(true);
             string? dirTokenValue = dirToken.Type switch {
-                TokenType.DM_Preproc_ConstantString => (string?)dirToken.Value,
+                TokenType.DM_Preproc_ConstantString => dirToken.ValueAsString(),
                 TokenType.DM_Preproc_Punctuator_Period => ".",
                 _ => null
             };

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorParser.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorParser.cs
@@ -334,7 +334,7 @@ internal static class DMPreprocessorParser {
                             "Expected ')' to end fexists() expression");
                     }
 
-                    var filePath = Path.GetRelativePath(".", fExistsInner.Value!.ToString()!.Replace('\\', '/'));
+                    var filePath = Path.GetRelativePath(".", fExistsInner.ValueAsString().Replace('\\', '/'));
 
                     var outputDir = Path.Combine(Path.GetDirectoryName(DMCompiler.Settings.Files?[0]) ?? "/", Path.GetDirectoryName(fExistsInner.Location.SourceFile) ?? "/");
                     if (string.IsNullOrEmpty(outputDir))
@@ -358,10 +358,10 @@ internal static class DMPreprocessorParser {
         switch (constantToken.Type) {
             case TokenType.DM_Integer:
                 Advance();
-                return (float)((int)constantToken.Value);
+                return (float)(constantToken.ValueAsInt());
             case TokenType.DM_Float:
                 Advance();
-                return (float)constantToken.Value;
+                return constantToken.ValueAsFloat();
             case TokenType.DM_ConstantString: {
                 Advance();
                 Error("Strings are not valid in preprocessor expressions. Did you mean to use a define() here?");

--- a/DMCompiler/Compiler/Parser.cs
+++ b/DMCompiler/Compiler/Parser.cs
@@ -28,10 +28,10 @@ public class Parser<SourceType> {
             _currentToken = _lexer.GetNextToken();
 
             if (_currentToken.Type == TokenType.Error) {
-                Emit(WarningCode.BadToken, (string)_currentToken.Value!);
+                Emit(WarningCode.BadToken, _currentToken.ValueAsString());
                 Advance();
             } else if (_currentToken.Type == TokenType.Warning) {
-                Warning((string)_currentToken.Value!);
+                Warning(_currentToken.ValueAsString());
                 Advance();
             }
         }

--- a/DMCompiler/Compiler/Token.cs
+++ b/DMCompiler/Compiler/Token.cs
@@ -1,5 +1,8 @@
 ﻿// ReSharper disable InconsistentNaming
 
+using System;
+using System.Runtime.CompilerServices;
+
 namespace DMCompiler.Compiler;
 
 // Must be : byte for ReadOnlySpan<TokenType> x = new TokenType[] { } to be intrinsic'd by the compiler.
@@ -151,11 +154,36 @@ public enum TokenType : byte {
 public struct Token(TokenType type, string text, Location location, object? value) {
     public readonly TokenType Type = type;
     public Location Location = location;
-    /// <remarks> Use <see cref="PrintableText"/> if you intend to show this to the user.</remarks>
-    public readonly string Text = text;
     public readonly object? Value = value;
 
+    /// <remarks> Use <see cref="PrintableText"/> if you intend to show this to the user.</remarks>
+    public readonly string Text = text;
+
     public string PrintableText => Text.Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int ValueAsInt() {
+        if (Value is not int intValue)
+            throw new Exception("Token value was not an int");
+
+        return intValue;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public float ValueAsFloat() {
+        if (Value is not float floatValue)
+            throw new Exception("Token value was not a float");
+
+        return floatValue;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public string ValueAsString() {
+        if (Value is not string strValue)
+            throw new Exception("Token value was not a string");
+
+        return strValue;
+    }
 
     public override string ToString() {
         return $"{Type}({Location.ToString()}, {PrintableText})";


### PR DESCRIPTION
Fixes 19 warnings in the compiler (132 -> 113).

Also remove an unnecessary list copy I noticed in the DMM parser.