### PR TITLE
Fix nullability warnings in JSON definitions

### DIFF
--- a/DMCompiler/DM/DMObjectTree.cs
+++ b/DMCompiler/DM/DMObjectTree.cs
@@ -21,7 +21,7 @@ internal static class DMObjectTree {
     /// </summary>
     public static readonly HashSet<string> SeenGlobalProcDefinition = new();
     public static readonly List<string> StringTable = new();
-    public static DMProc GlobalInitProc;
+    public static DMProc GlobalInitProc = default!; // Initialized by Reset() (called in the static initializer)
     public static readonly HashSet<string> Resources = new();
 
     public static DMObject Root => GetDMObject(DreamPath.Root)!;

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -169,41 +169,14 @@ namespace DMCompiler.DM {
         }
 
         public ProcDefinitionJson GetJsonRepresentation() {
-            ProcDefinitionJson procDefinition = new ProcDefinitionJson();
+            var optimizer = new BytecodeOptimizer();
+            var serializer = new AnnotatedBytecodeSerializer();
 
-            procDefinition.OwningTypeId = _dmObject.Id;
-            procDefinition.Name = Name;
-            procDefinition.IsVerb = IsVerb;
+            optimizer.Optimize(AnnotatedBytecode.GetAnnotatedBytecode());
 
-            if ((Attributes & ProcAttributes.None) != ProcAttributes.None) {
-                procDefinition.Attributes = Attributes;
-            }
-
-            procDefinition.VerbSrc = VerbSrc;
-            procDefinition.VerbName = VerbName;
-            // Normally VerbCategory is "" by default and null to hide it, but we invert those during (de)serialization to reduce JSON size
-            VerbCategory = VerbCategory switch {
-                "" => null,
-                null => string.Empty,
-                _ => VerbCategory
-            };
-            procDefinition.VerbCategory = VerbCategory;
-            procDefinition.VerbDesc = VerbDesc;
-            procDefinition.Invisibility = Invisibility;
-
-            BytecodeOptimizer optimizer = new();
-
-            var bytecodelist = optimizer.Optimize(AnnotatedBytecode.GetAnnotatedBytecode());
-
-            procDefinition.MaxStackSize = AnnotatedBytecode.GetMaxStackSize();
-            AnnotatedBytecodeSerializer serializer = new();
-
-            if (bytecodelist.Count > 0)
-                procDefinition.Bytecode =
-                    serializer.Serialize(AnnotatedBytecode.GetAnnotatedBytecode());
-
+            List<ProcArgumentJson>? arguments = null;
             if (_parameters.Count > 0) {
-                procDefinition.Arguments = new List<ProcArgumentJson>();
+                arguments = new List<ProcArgumentJson>();
 
                 foreach (var parameter in _parameters.Values) {
                     if (parameter.ExplicitValueType is not { } argumentType) {
@@ -217,20 +190,36 @@ namespace DMCompiler.DM {
                         }
                     }
 
-                    procDefinition.Arguments.Add(new ProcArgumentJson {
+                    arguments.Add(new ProcArgumentJson {
                         Name = parameter.Name,
                         Type = argumentType.Type
                     });
                 }
             }
 
-            if (_localVariableNames.Count > 0) {
-                procDefinition.Locals = serializer.GetLocalVariablesJson();
-            }
+            return new ProcDefinitionJson {
+                OwningTypeId = _dmObject.Id,
+                Name = Name,
+                Attributes = Attributes,
+                MaxStackSize = AnnotatedBytecode.GetMaxStackSize(),
+                Bytecode = serializer.Serialize(AnnotatedBytecode.GetAnnotatedBytecode()),
+                Arguments = arguments,
+                SourceInfo = serializer.SourceInfo,
+                Locals = (_localVariableNames.Count > 0) ? serializer.GetLocalVariablesJson() : null,
 
-            procDefinition.SourceInfo = serializer.SourceInfo;
+                IsVerb = IsVerb,
+                VerbSrc = VerbSrc,
+                VerbName = VerbName,
+                VerbDesc = VerbDesc,
+                Invisibility = Invisibility,
 
-            return procDefinition;
+                // Normally VerbCategory is "" by default and null to hide it, but we invert those during (de)serialization to reduce JSON size
+                VerbCategory = VerbCategory switch {
+                    "" => null,
+                    null => string.Empty,
+                    _ => VerbCategory
+                }
+            };
         }
 
         public void WaitFor(bool waitFor) {

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -282,12 +282,16 @@ public static class DMCompiler {
             compiledDream.GlobalInitProc = DMObjectTree.GlobalInitProc.GetJsonRepresentation();
 
         if (DMObjectTree.Globals.Count > 0) {
-            GlobalListJson globalListJson = new GlobalListJson();
-            globalListJson.GlobalCount = DMObjectTree.Globals.Count;
-            globalListJson.Names = new List<string>(globalListJson.GlobalCount);
+            GlobalListJson globalListJson = new GlobalListJson {
+                GlobalCount = DMObjectTree.Globals.Count,
+                Names = new(),
+                Globals = new()
+            };
+
+            globalListJson.Names.EnsureCapacity(globalListJson.GlobalCount);
 
             // Approximate capacity (4/285 in tgstation, ~3%)
-            globalListJson.Globals = new Dictionary<int, object>((int) (DMObjectTree.Globals.Count * 0.03));
+            globalListJson.Globals.EnsureCapacity((int)(DMObjectTree.Globals.Count * 0.03));
 
             for (int i = 0; i < DMObjectTree.Globals.Count; i++) {
                 DMVariable global = DMObjectTree.Globals[i];
@@ -300,7 +304,7 @@ public static class DMCompiler {
                     globalListJson.Globals.Add(i, globalJson);
                 }
             }
-            
+
             compiledDream.Globals = globalListJson;
         }
 

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -266,7 +266,7 @@ public static class DMCompiler {
 
     private static string SaveJson(List<DreamMapJson> maps, string interfaceFile, string outputFile) {
         var jsonRep = DMObjectTree.CreateJsonRepresentation();
-        DreamCompiledJson compiledDream = new DreamCompiledJson {
+        var compiledDream = new DreamCompiledJson {
             Metadata = new DreamCompiledJsonMetadata { Version = OpcodeVerifier.GetOpcodesHash() },
             Strings = DMObjectTree.StringTable,
             Resources = DMObjectTree.Resources.ToArray(),
@@ -300,6 +300,7 @@ public static class DMCompiler {
                     globalListJson.Globals.Add(i, globalJson);
                 }
             }
+            
             compiledDream.Globals = globalListJson;
         }
 

--- a/DMCompiler/Json/DreamCompiledJson.cs
+++ b/DMCompiler/Json/DreamCompiledJson.cs
@@ -4,15 +4,15 @@ namespace DMCompiler.Json;
 
 public sealed class DreamCompiledJson {
     public required DreamCompiledJsonMetadata Metadata { get; set; }
-    public required List<string>? Strings { get; set; }
-    public required string[]? Resources { get; set; }
+    public List<string>? Strings { get; set; }
+    public string[]? Resources { get; set; }
     public int[]? GlobalProcs { get; set; }
     public GlobalListJson? Globals { get; set; }
     public ProcDefinitionJson? GlobalInitProc { get; set; }
-    public required List<DreamMapJson>? Maps { get; set; }
-    public required string? Interface { get; set; }
-    public required DreamTypeJson[]? Types { get; set; }
-    public required ProcDefinitionJson[]? Procs { get; set; }
+    public List<DreamMapJson>? Maps { get; set; }
+    public string? Interface { get; set; }
+    public DreamTypeJson[]? Types { get; set; }
+    public ProcDefinitionJson[]? Procs { get; set; }
 }
 
 public sealed class DreamCompiledJsonMetadata {

--- a/DMCompiler/Json/DreamCompiledJson.cs
+++ b/DMCompiler/Json/DreamCompiledJson.cs
@@ -3,16 +3,16 @@
 namespace DMCompiler.Json;
 
 public sealed class DreamCompiledJson {
-    public DreamCompiledJsonMetadata Metadata { get; set; }
-    public List<string>? Strings { get; set; }
-    public string[]? Resources { get; set; }
+    public required DreamCompiledJsonMetadata Metadata { get; set; }
+    public required List<string>? Strings { get; set; }
+    public required string[]? Resources { get; set; }
     public int[]? GlobalProcs { get; set; }
     public GlobalListJson? Globals { get; set; }
     public ProcDefinitionJson? GlobalInitProc { get; set; }
-    public List<DreamMapJson>? Maps { get; set; }
-    public string? Interface { get; set; }
-    public DreamTypeJson[]? Types { get; set; }
-    public ProcDefinitionJson[]? Procs { get; set; }
+    public required List<DreamMapJson>? Maps { get; set; }
+    public required string? Interface { get; set; }
+    public required DreamTypeJson[]? Types { get; set; }
+    public required ProcDefinitionJson[]? Procs { get; set; }
 }
 
 public sealed class DreamCompiledJsonMetadata {

--- a/DMCompiler/Json/DreamMapJson.cs
+++ b/DMCompiler/Json/DreamMapJson.cs
@@ -11,15 +11,11 @@ public sealed class DreamMapJson {
     public List<MapBlockJson> Blocks { get; set; } = new();
 }
 
-public sealed class CellDefinitionJson {
-    public string Name { get; set; }
+public sealed class CellDefinitionJson(string name) {
+    public string Name { get; set; } = name;
     public MapObjectJson Turf { get; set; }
-    public MapObjectJson Area { get; set; }
+    public MapObjectJson? Area { get; set; }
     public List<MapObjectJson> Objects { get; set; } = new();
-
-    public CellDefinitionJson(string name) {
-        Name = name;
-    }
 }
 
 public sealed class MapObjectJson(int type) {

--- a/DMCompiler/Json/DreamObjectJson.cs
+++ b/DMCompiler/Json/DreamObjectJson.cs
@@ -13,7 +13,7 @@ public enum JsonVariableType {
 
 public sealed class DreamTypeJson {
     public required string Path { get; set; }
-    public required int? Parent { get; set; }
+    public int? Parent { get; set; }
     public int? InitProc { get; set; }
     public List<List<int>>? Procs { get; set; }
     public List<int>? Verbs { get; set; }

--- a/DMCompiler/Json/DreamObjectJson.cs
+++ b/DMCompiler/Json/DreamObjectJson.cs
@@ -25,6 +25,6 @@ public sealed class DreamTypeJson {
 
 public sealed class GlobalListJson {
     public int GlobalCount { get; set; }
-    public List<string> Names { get; set; }
-    public Dictionary<int, object> Globals { get; set; }
+    public required List<string> Names { get; set; }
+    public required Dictionary<int, object> Globals { get; set; }
 }

--- a/DMCompiler/Json/DreamObjectJson.cs
+++ b/DMCompiler/Json/DreamObjectJson.cs
@@ -12,13 +12,13 @@ public enum JsonVariableType {
 }
 
 public sealed class DreamTypeJson {
-    public string Path { get; set; }
-    public int? Parent { get; set; }
+    public required string Path { get; set; }
+    public required int? Parent { get; set; }
     public int? InitProc { get; set; }
-    public List<List<int>> Procs { get; set; }
-    public List<int> Verbs { get; set; }
-    public Dictionary<string, object> Variables { get; set; }
-    public Dictionary<string, int> GlobalVariables { get; set; }
+    public List<List<int>>? Procs { get; set; }
+    public List<int>? Verbs { get; set; }
+    public Dictionary<string, object>? Variables { get; set; }
+    public Dictionary<string, int>? GlobalVariables { get; set; }
     public HashSet<string>? ConstVariables { get; set; }
     public HashSet<string>? TmpVariables { get; set; }
 }

--- a/DMCompiler/Json/DreamProcJson.cs
+++ b/DMCompiler/Json/DreamProcJson.cs
@@ -4,16 +4,17 @@ using DMCompiler.DM;
 namespace DMCompiler.Json;
 
 public sealed class ProcDefinitionJson {
-    public int OwningTypeId { get; set; }
-    public string Name { get; set; }
-    public bool IsVerb { get; set; }
-    public int MaxStackSize { get; set; }
-    public List<ProcArgumentJson>? Arguments { get; set; }
-    public List<LocalVariableJson> Locals { get; set; }
-    public ProcAttributes Attributes { get; set; } = ProcAttributes.None;
-    public List<SourceInfoJson> SourceInfo { get; set; }
-    public byte[]? Bytecode { get; set; }
+    public required int OwningTypeId { get; set; }
+    public required string Name { get; set; }
+    public required ProcAttributes Attributes { get; set; }
 
+    public required int MaxStackSize { get; set; }
+    public required List<ProcArgumentJson>? Arguments { get; set; }
+    public required List<LocalVariableJson>? Locals { get; set; }
+    public required List<SourceInfoJson> SourceInfo { get; set; }
+    public required byte[]? Bytecode { get; set; }
+
+    public required bool IsVerb { get; set; }
     public VerbSrc? VerbSrc { get; set; }
     public string? VerbName { get; set; }
     public string? VerbCategory { get; set; }
@@ -22,14 +23,14 @@ public sealed class ProcDefinitionJson {
 }
 
 public sealed class ProcArgumentJson {
-    public string Name { get; set; }
-    public DMValueType Type { get; set; }
+    public required string Name { get; set; }
+    public required DMValueType Type { get; set; }
 }
 
 public sealed class LocalVariableJson {
-    public int Offset { get; set; }
+    public required int Offset { get; set; }
     public int? Remove { get; set; }
-    public string Add { get; set; }
+    public string? Add { get; set; }
 }
 
 public sealed class SourceInfoJson {

--- a/DMCompiler/Json/DreamProcJson.cs
+++ b/DMCompiler/Json/DreamProcJson.cs
@@ -4,17 +4,17 @@ using DMCompiler.DM;
 namespace DMCompiler.Json;
 
 public sealed class ProcDefinitionJson {
-    public required int OwningTypeId { get; set; }
+    public int OwningTypeId { get; set; }
     public required string Name { get; set; }
-    public required ProcAttributes Attributes { get; set; }
+    public ProcAttributes Attributes { get; set; }
 
-    public required int MaxStackSize { get; set; }
-    public required List<ProcArgumentJson>? Arguments { get; set; }
-    public required List<LocalVariableJson>? Locals { get; set; }
+    public int MaxStackSize { get; set; }
+    public List<ProcArgumentJson>? Arguments { get; set; }
+    public List<LocalVariableJson>? Locals { get; set; }
     public required List<SourceInfoJson> SourceInfo { get; set; }
-    public required byte[]? Bytecode { get; set; }
+    public byte[]? Bytecode { get; set; }
 
-    public required bool IsVerb { get; set; }
+    public bool IsVerb { get; set; }
     public VerbSrc? VerbSrc { get; set; }
     public string? VerbName { get; set; }
     public string? VerbCategory { get; set; }
@@ -24,11 +24,11 @@ public sealed class ProcDefinitionJson {
 
 public sealed class ProcArgumentJson {
     public required string Name { get; set; }
-    public required DMValueType Type { get; set; }
+    public DMValueType Type { get; set; }
 }
 
 public sealed class LocalVariableJson {
-    public required int Offset { get; set; }
+    public int Offset { get; set; }
     public int? Remove { get; set; }
     public string? Add { get; set; }
 }

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -33,8 +33,8 @@ namespace OpenDreamRuntime.Procs {
 
         public DMProc(int id, TreeEntry owningType, ProcDefinitionJson json, string? name, DreamManager dreamManager, AtomManager atomManager, IDreamMapManager dreamMapManager, IDreamDebugManager dreamDebugManager, DreamResourceManager dreamResourceManager, DreamObjectTree objectTree, ProcScheduler procScheduler, ServerVerbSystem verbSystem)
             : base(id, owningType, name ?? json.Name, null, json.Attributes, GetArgumentNames(json), GetArgumentTypes(json), json.VerbSrc, json.VerbName, json.VerbCategory, json.VerbDesc, json.Invisibility, json.IsVerb) {
-            Bytecode = json.Bytecode ?? Array.Empty<byte>();
-            LocalNames = json.Locals;
+            Bytecode = json.Bytecode ?? [];
+            LocalNames = json.Locals ?? [];
             SourceInfo = json.SourceInfo;
             _maxStackSize = json.MaxStackSize;
             IsNullProc = CheckIfNullProc();
@@ -977,10 +977,12 @@ namespace OpenDreamRuntime.Procs {
                 if (info.Offset > _pc) {
                     break;
                 }
-                if (info.Remove is int remove) {
+
+                if (info.Remove is { } remove) {
                     count -= remove;
                 }
-                if (info.Add is string add) {
+
+                if (info.Add is { } add) {
                     names[count++] = add;
                 }
             }


### PR DESCRIPTION
Applies nullable flags or `required` where they make sense.

Fixes 16 warnings in the compiler (down to 97 with #1944).