### PR TITLE
Fix modifiers as keybinds, add ".winset :type" support

### DIFF
--- a/OpenDreamClient/Interface/DMF/DMFLexer.cs
+++ b/OpenDreamClient/Interface/DMF/DMFLexer.cs
@@ -82,6 +82,7 @@ public sealed class DMFLexer(string source) {
                         textBuilder.Append(GetCurrent());
                     }
                 }
+
                 if (GetCurrent() != c) throw new Exception($"Expected '{c}' got '{GetCurrent()}'");
                 textBuilder.Append(c);
                 Advance();
@@ -95,7 +96,8 @@ public sealed class DMFLexer(string source) {
                 Advance();
                 return new(TokenType.Ternary, c);
             }
-            case ':':{
+            // If _parsingAttributeName is true, we're parsing ":[type].whatever"
+            case ':' when _parsingAttributeName == false: {
                 Advance();
                 return new(TokenType.Colon, c);
             }
@@ -109,6 +111,7 @@ public sealed class DMFLexer(string source) {
                 while (Advance() != ']' && !AtEndOfSource) {
                     textBuilder.Append(GetCurrent());
                 }
+
                 if (GetCurrent() != ']') throw new Exception("Expected ']'");
                 Advance();
                 textBuilder.Append("]]");

--- a/OpenDreamClient/Interface/DMF/DMFParser.cs
+++ b/OpenDreamClient/Interface/DMF/DMFParser.cs
@@ -189,8 +189,6 @@ public sealed class DMFParser(DMFLexer lexer, ISerializationManager serializatio
         string? element = null;
         winSet = null;
 
-        bool selectDefault = Check(TokenType.Colon); // Handling for ":[type]"
-
         Token attributeToken = Current();
 
         if (Check(_attributeTokenTypes)) {
@@ -240,12 +238,12 @@ public sealed class DMFParser(DMFLexer lexer, ISerializationManager serializatio
                     }
                 }
 
-                winSet = new DMFWinSet(element, attributeToken.Text, valueText, selectDefault, trueStatements, falseStatements);
+                winSet = new DMFWinSet(element, attributeToken.Text, valueText, trueStatements, falseStatements);
                 return true;
             }
 
             Newline();
-            winSet = new DMFWinSet(element, attributeToken.Text, valueText, selectDefault);
+            winSet = new DMFWinSet(element, attributeToken.Text, valueText);
             return true;
         }
 

--- a/OpenDreamClient/Interface/DMF/DMFParser.cs
+++ b/OpenDreamClient/Interface/DMF/DMFParser.cs
@@ -233,11 +233,13 @@ public sealed class DMFParser(DMFLexer lexer, ISerializationManager serializatio
                 while(TryGetAttribute(out var statement)){
                     trueStatements.Add(statement);
                 }
+
                 if(Check(TokenType.Colon)){ //not all ternarys have an else
                     while(TryGetAttribute(out var statement)){
                         falseStatements.Add(statement);
                     }
                 }
+
                 winSet = new DMFWinSet(element, attributeToken.Text, valueText, selectDefault, trueStatements, falseStatements);
                 return true;
             }

--- a/OpenDreamClient/Interface/DMF/DMFParser.cs
+++ b/OpenDreamClient/Interface/DMF/DMFParser.cs
@@ -188,6 +188,9 @@ public sealed class DMFParser(DMFLexer lexer, ISerializationManager serializatio
     private bool TryGetAttribute([NotNullWhen(true)] out DMFWinSet? winSet) {
         string? element = null;
         winSet = null;
+
+        bool selectDefault = Check(TokenType.Colon); // Handling for ":[type]"
+
         Token attributeToken = Current();
 
         if (Check(_attributeTokenTypes)) {
@@ -235,12 +238,12 @@ public sealed class DMFParser(DMFLexer lexer, ISerializationManager serializatio
                         falseStatements.Add(statement);
                     }
                 }
-                winSet = new DMFWinSet(element, attributeToken.Text, valueText, trueStatements, falseStatements);
+                winSet = new DMFWinSet(element, attributeToken.Text, valueText, selectDefault, trueStatements, falseStatements);
                 return true;
             }
 
             Newline();
-            winSet = new DMFWinSet(element, attributeToken.Text, valueText);
+            winSet = new DMFWinSet(element, attributeToken.Text, valueText, selectDefault);
             return true;
         }
 

--- a/OpenDreamClient/Interface/DMF/DMFWinSet.cs
+++ b/OpenDreamClient/Interface/DMF/DMFWinSet.cs
@@ -4,15 +4,11 @@ public sealed class DMFWinSet(
     string? element,
     string attribute,
     string value,
-    bool selectDefault,
     List<DMFWinSet>? trueStatements = null,
     List<DMFWinSet>? falseStatements = null) {
     public readonly string? Element = element;
     public readonly string Attribute = attribute;
     public readonly string Value = value;
-
-    // ":[type]" selects the default control of that type
-    public readonly bool SelectDefault = selectDefault;
 
     /// Winsets that are evaluated if Element.Attribute == Value
     public List<DMFWinSet>? TrueStatements = trueStatements;

--- a/OpenDreamClient/Interface/DMF/DMFWinSet.cs
+++ b/OpenDreamClient/Interface/DMF/DMFWinSet.cs
@@ -1,25 +1,22 @@
 ﻿namespace OpenDreamClient.Interface.DMF;
 
-public sealed class DMFWinSet {
-    public readonly string? Element;
-    public readonly string Attribute;
-    public readonly string Value;
+public sealed class DMFWinSet(
+    string? element,
+    string attribute,
+    string value,
+    bool selectDefault,
+    List<DMFWinSet>? trueStatements = null,
+    List<DMFWinSet>? falseStatements = null) {
+    public readonly string? Element = element;
+    public readonly string Attribute = attribute;
+    public readonly string Value = value;
 
     // ":[type]" selects the default control of that type
-    public readonly bool SelectDefault;
+    public readonly bool SelectDefault = selectDefault;
 
     /// Winsets that are evaluated if Element.Attribute == Value
-    public List<DMFWinSet>? TrueStatements;
+    public List<DMFWinSet>? TrueStatements = trueStatements;
 
     /// Winsets that are evaluated if Element.Attribute != Value
-    public List<DMFWinSet>? FalseStatements;
-
-    public DMFWinSet(string? element, string attribute, string value, bool selectDefault, List<DMFWinSet>? trueStatements = null, List<DMFWinSet>? falseStatements = null) {
-        Element = element;
-        Attribute = attribute;
-        Value = value;
-        SelectDefault = selectDefault;
-        TrueStatements = trueStatements;
-        FalseStatements = falseStatements;
-    }
+    public List<DMFWinSet>? FalseStatements = falseStatements;
 }

--- a/OpenDreamClient/Interface/DMF/DMFWinSet.cs
+++ b/OpenDreamClient/Interface/DMF/DMFWinSet.cs
@@ -4,15 +4,21 @@ public sealed class DMFWinSet {
     public readonly string? Element;
     public readonly string Attribute;
     public readonly string Value;
+
+    // ":[type]" selects the default control of that type
+    public readonly bool SelectDefault;
+
     /// Winsets that are evaluated if Element.Attribute == Value
     public List<DMFWinSet>? TrueStatements;
+
     /// Winsets that are evaluated if Element.Attribute != Value
     public List<DMFWinSet>? FalseStatements;
 
-    public DMFWinSet(string? element, string attribute, string value, List<DMFWinSet>? trueStatements = null, List<DMFWinSet>? falseStatements = null) {
+    public DMFWinSet(string? element, string attribute, string value, bool selectDefault, List<DMFWinSet>? trueStatements = null, List<DMFWinSet>? falseStatements = null) {
         Element = element;
         Attribute = attribute;
         Value = value;
+        SelectDefault = selectDefault;
         TrueStatements = trueStatements;
         FalseStatements = falseStatements;
     }

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -331,17 +331,15 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
             string elementId = split[0];
 
             // ":[element]" returns the default element of that type
-            if (elementId[0] == ':') {
-                switch (elementId[1..]) {
-                    case "map":
-                        return DefaultMap;
-                    case "info":
-                        return DefaultInfo;
-                    case "window":
-                        return DefaultWindow;
-                    case "output":
-                        return DefaultOutput;
-                }
+            switch (elementId) {
+                case ":map":
+                    return DefaultMap;
+                case ":info":
+                    return DefaultInfo;
+                case ":window":
+                    return DefaultWindow;
+                case ":output":
+                    return DefaultOutput;
             }
 
             foreach (ControlWindow window in Windows.Values) {

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -302,7 +302,7 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
             DefaultMap.Viewport.Eye = _eyeManager.CurrentEye;
     }
 
-    public InterfaceElement? FindElementWithId(string id) {
+    public InterfaceElement? FindElementWithId(string id, bool selectDefault = false) {
         string[] split = id.Split(".");
 
         if (split.Length == 2) {
@@ -329,6 +329,19 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
             }
         } else {
             string elementId = split[0];
+
+            if (selectDefault) {
+                switch (elementId) {
+                    case "map":
+                        return DefaultMap;
+                    case "info":
+                        return DefaultInfo;
+                    case "window":
+                        return DefaultWindow;
+                    case "output":
+                        return DefaultOutput;
+                }
+            }
 
             foreach (ControlWindow window in Windows.Values) {
                 if (window.Id.Value == elementId)
@@ -602,7 +615,7 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
                                 }
                             }
                     } else {
-                        InterfaceElement? element = FindElementWithId(elementId);
+                        InterfaceElement? element = FindElementWithId(elementId, winSet.SelectDefault);
 
                         if (element != null) {
                             element.SetProperty(winSet.Attribute, HandleEmbeddedWinget(elementId, winSet.Value), manualWinset: true);
@@ -929,7 +942,7 @@ public interface IDreamInterfaceManager {
 
     void Initialize();
     void FrameUpdate(FrameEventArgs frameEventArgs);
-    InterfaceElement? FindElementWithId(string id);
+    InterfaceElement? FindElementWithId(string id, bool selectDefault = false);
     void SaveScreenshot(bool openDialog);
     void LoadInterfaceFromSource(string source);
 

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -302,7 +302,7 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
             DefaultMap.Viewport.Eye = _eyeManager.CurrentEye;
     }
 
-    public InterfaceElement? FindElementWithId(string id, bool selectDefault = false) {
+    public InterfaceElement? FindElementWithId(string id) {
         string[] split = id.Split(".");
 
         if (split.Length == 2) {
@@ -330,8 +330,9 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
         } else {
             string elementId = split[0];
 
-            if (selectDefault) {
-                switch (elementId) {
+            // ":[element]" returns the default element of that type
+            if (elementId[0] == ':') {
+                switch (elementId[1..]) {
                     case "map":
                         return DefaultMap;
                     case "info":
@@ -615,7 +616,7 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
                                 }
                             }
                     } else {
-                        InterfaceElement? element = FindElementWithId(elementId, winSet.SelectDefault);
+                        InterfaceElement? element = FindElementWithId(elementId);
 
                         if (element != null) {
                             element.SetProperty(winSet.Attribute, HandleEmbeddedWinget(elementId, winSet.Value), manualWinset: true);
@@ -942,7 +943,7 @@ public interface IDreamInterfaceManager {
 
     void Initialize();
     void FrameUpdate(FrameEventArgs frameEventArgs);
-    InterfaceElement? FindElementWithId(string id, bool selectDefault = false);
+    InterfaceElement? FindElementWithId(string id);
     void SaveScreenshot(bool openDialog);
     void LoadInterfaceFromSource(string source);
 

--- a/OpenDreamClient/Interface/DummyDreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DummyDreamInterfaceManager.cs
@@ -25,7 +25,7 @@ public sealed class DummyDreamInterfaceManager : IDreamInterfaceManager {
     public void FrameUpdate(FrameEventArgs frameEventArgs) {
     }
 
-    public InterfaceElement? FindElementWithId(string id) {
+    public InterfaceElement? FindElementWithId(string id, bool selectDefault = false) {
         return null;
     }
 

--- a/OpenDreamClient/Interface/DummyDreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DummyDreamInterfaceManager.cs
@@ -25,7 +25,7 @@ public sealed class DummyDreamInterfaceManager : IDreamInterfaceManager {
     public void FrameUpdate(FrameEventArgs frameEventArgs) {
     }
 
-    public InterfaceElement? FindElementWithId(string id, bool selectDefault = false) {
+    public InterfaceElement? FindElementWithId(string id) {
         return null;
     }
 

--- a/OpenDreamClient/Interface/InterfaceMacro.cs
+++ b/OpenDreamClient/Interface/InterfaceMacro.cs
@@ -204,8 +204,23 @@ internal struct ParsedKeybind {
                     if (foundKey) {
                         throw new Exception($"Duplicate key in keybind: {part}");
                     }
+
                     foundKey = true;
                     break;
+            }
+        }
+
+        // If we haven't found a key and the first part is a modifier, treat it as the keybind instead of a modifier
+        if (!foundKey) {
+            if (parts[0] == "SHIFT") {
+                parsed.Key = KeyNameToKey(parts[0]);
+                parsed.Shift = false;
+            } else if (parts[0] == "CTRL") {
+                parsed.Key = KeyNameToKey(parts[0]);
+                parsed.Ctrl = false;
+            } else if (parts[0] == "ALT") {
+                parsed.Key = KeyNameToKey(parts[0]);
+                parsed.Alt = false;
             }
         }
 


### PR DESCRIPTION
Resolves #1936 

- In the DMF, modifier keys are now treated as keys when no other key is present. This appears to be more in line with the behavior described in the ref.
- `.winset :[type].whatever` is now implemented, where `:[type]` is the default control of that type

This makes TG shift+RMB behavior functional.

RMB toggles the cabinet's open/closed state. Shift+RMB opens ye olde context menu.

https://github.com/user-attachments/assets/c4a3949a-c088-4f12-9aeb-764bb8b5227c

