### PR TITLE
Fix missing `EnsureCache()` calls

### DIFF
--- a/OpenDreamClient/EntryPoint.cs
+++ b/OpenDreamClient/EntryPoint.cs
@@ -94,10 +94,6 @@ public sealed class EntryPoint : GameClient {
                 "Ok", null, null, null);
     }
 
-    protected override void Dispose(bool disposing) {
-        _dreamResource.Shutdown();
-    }
-
     public override void Update(ModUpdateLevel level, FrameEventArgs frameEventArgs) {
         switch (level) {
             case ModUpdateLevel.FramePostEngine:

--- a/OpenDreamClient/Resources/DreamResourceManager.cs
+++ b/OpenDreamClient/Resources/DreamResourceManager.cs
@@ -9,7 +9,6 @@ using Robust.Shared.Utility;
 namespace OpenDreamClient.Resources {
     public interface IDreamResourceManager {
         void Initialize();
-        void Shutdown();
         ResPath CreateCacheFile(string filename, string data);
         ResPath CreateCacheFile(string filename, byte[] data);
 

--- a/OpenDreamClient/Resources/DreamResourceManager.cs
+++ b/OpenDreamClient/Resources/DreamResourceManager.cs
@@ -50,10 +50,6 @@ namespace OpenDreamClient.Resources {
             _netManager.RegisterNetMessage<MsgNotifyResourceUpdate>(RxResourceUpdateNotification);
         }
 
-        public void Shutdown() {
-            _resourceManager.UserData.Delete(_cacheDirectory);
-        }
-
         private void EnsureCacheDirectory() {
             if(_cacheDirectory != default)
                 return;
@@ -186,21 +182,24 @@ namespace OpenDreamClient.Resources {
             return resource;
         }
 
-        public ResPath GetCacheFilePath(string filename)
-        {
+        public ResPath GetCacheFilePath(string filename) {
+            EnsureCacheDirectory();
+
             return _cacheDirectory / new ResPath(filename).ToRelativePath();
         }
 
-        public ResPath CreateCacheFile(string filename, string data)
-        {
+        public ResPath CreateCacheFile(string filename, string data) {
+            EnsureCacheDirectory();
+
             // in BYOND when filename is a path everything except the filename at the end gets ignored - meaning all resource files end up directly in the cache folder
             var path = _cacheDirectory / new ResPath(filename).Filename;
             _resourceManager.UserData.WriteAllText(path, data);
             return new ResPath(filename);
         }
 
-        public ResPath CreateCacheFile(string filename, byte[] data)
-        {
+        public ResPath CreateCacheFile(string filename, byte[] data) {
+            EnsureCacheDirectory();
+
             // in BYOND when filename is a path everything except the filename at the end gets ignored - meaning all resource files end up directly in the cache folder
             var path = _cacheDirectory / new ResPath(filename).Filename;
             _resourceManager.UserData.WriteAllBytes(path, data);


### PR DESCRIPTION
`EnsureCache()` wasn't being called before using `_cacheDirectory` in some cases.

Also no longer delete the cache folder on shutdown. We want to keep those files, and it didn't work in a few situations anyways.