### PR TITLE
Add `name` to `IconAppearance`, fix placeholder turf names

### DIFF
--- a/OpenDreamClient/Input/ContextMenu/ContextMenuPopup.xaml.cs
+++ b/OpenDreamClient/Input/ContextMenu/ContextMenuPopup.xaml.cs
@@ -68,7 +68,9 @@ internal sealed partial class ContextMenuPopup : Popup {
                 ContextMenu.AddChild(new ContextMenuItem(this, objectReference, metadata.EntityName, sprite.Icon));
             } else if (objectReference.Type == ClientObjectReference.RefType.Turf && turfId is not null && _appearanceSystem is not null) {
                 var icon = _appearanceSystem.GetTurfIcon(turfId.Value);
-                ContextMenu.AddChild(new ContextMenuItem(this, objectReference, "turf (OD WIP)", icon));
+                if(icon.Appearance is null) continue;
+
+                ContextMenu.AddChild(new ContextMenuItem(this, objectReference, icon.Appearance.Name, icon));
             }
         }
     }

--- a/OpenDreamClient/Interface/DebugWindows/IconDebugWindow.xaml.cs
+++ b/OpenDreamClient/Interface/DebugWindows/IconDebugWindow.xaml.cs
@@ -43,6 +43,7 @@ internal sealed partial class IconDebugWindow : OSWindow {
 
         // Would be nice if we could use ViewVariables instead, but I couldn't find a nice way to do that
         // Would be especially nice if we could use VV to make these editable
+        AddPropertyIfNotDefault("Name", appearance.Name, IconAppearance.Default.Name);
         AddPropertyIfNotDefault("Icon State", appearance.IconState, IconAppearance.Default.IconState);
         AddPropertyIfNotDefault("Direction", appearance.Direction, IconAppearance.Default.Direction);
         AddPropertyIfNotDefault("Inherits Direction", appearance.InheritsDirection, IconAppearance.Default.InheritsDirection);

--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -243,7 +243,8 @@ public sealed class AtomManager {
     public void SetAppearanceVar(IconAppearance appearance, string varName, DreamValue value) {
         switch (varName) {
             case "name":
-                value.TryGetValueAsString(out appearance.Name);
+                value.TryGetValueAsString(out var name);
+                appearance.Name = name ?? string.Empty;
                 break;
             case "icon":
                 if (_resourceManager.TryLoadIcon(value, out var icon)) {

--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -208,6 +208,7 @@ public sealed class AtomManager {
 
     public bool IsValidAppearanceVar(string name) {
         switch (name) {
+            case "name":
             case "icon":
             case "icon_state":
             case "dir":
@@ -241,6 +242,9 @@ public sealed class AtomManager {
 
     public void SetAppearanceVar(IconAppearance appearance, string varName, DreamValue value) {
         switch (varName) {
+            case "name":
+                value.TryGetValueAsString(out appearance.Name);
+                break;
             case "icon":
                 if (_resourceManager.TryLoadIcon(value, out var icon)) {
                     appearance.Icon = icon.Id;
@@ -366,6 +370,8 @@ public sealed class AtomManager {
 
     public DreamValue GetAppearanceVar(IconAppearance appearance, string varName) {
         switch (varName) {
+            case "name":
+                return new(appearance.Name);
             case "icon":
                 if (appearance.Icon == null)
                     return DreamValue.Null;
@@ -545,6 +551,7 @@ public sealed class AtomManager {
         if (_definitionAppearanceCache.TryGetValue(def, out var appearance))
             return appearance;
 
+        def.TryGetVariable("name", out var nameVar);
         def.TryGetVariable("icon", out var iconVar);
         def.TryGetVariable("icon_state", out var stateVar);
         def.TryGetVariable("color", out var colorVar);
@@ -564,6 +571,7 @@ public sealed class AtomManager {
         def.TryGetVariable("appearance_flags", out var appearanceFlagsVar);
 
         appearance = new IconAppearance();
+        SetAppearanceVar(appearance, "name", nameVar);
         SetAppearanceVar(appearance, "icon", iconVar);
         SetAppearanceVar(appearance, "icon_state", stateVar);
         SetAppearanceVar(appearance, "color", colorVar);

--- a/OpenDreamShared/Dream/IconAppearance.cs
+++ b/OpenDreamShared/Dream/IconAppearance.cs
@@ -23,7 +23,7 @@ namespace OpenDreamShared.Dream;
 public sealed class IconAppearance : IEquatable<IconAppearance> {
     public static readonly IconAppearance Default = new();
 
-    [ViewVariables] public string Name;
+    [ViewVariables] public string Name = string.Empty;
     [ViewVariables] public int? Icon;
     [ViewVariables] public string? IconState;
     [ViewVariables] public AtomDirection Direction = AtomDirection.South;
@@ -69,7 +69,6 @@ public sealed class IconAppearance : IEquatable<IconAppearance> {
     ];
 
     public IconAppearance() {
-        Name = string.Empty;
         Overlays = new();
         Underlays = new();
         VisContents = new();

--- a/OpenDreamShared/Dream/IconAppearance.cs
+++ b/OpenDreamShared/Dream/IconAppearance.cs
@@ -8,11 +8,22 @@ using Robust.Shared.GameObjects;
 
 namespace OpenDreamShared.Dream;
 
+/*
+ * Woe, weary traveler, modifying this class is not for the faint of heart.
+ * If you modify IconAppearance, be sure to update the following places:
+ * - All of the methods on IconAppearance itself
+ * - IconAppearance methods in AtomManager
+ * - MsgAllAppearances
+ * - IconDebugWindow
+ * - There may be others
+ */
+
 // TODO: Wow this is huge! Probably look into splitting this by most used/least used to reduce the size of these
 [Serializable, NetSerializable]
 public sealed class IconAppearance : IEquatable<IconAppearance> {
     public static readonly IconAppearance Default = new();
 
+    [ViewVariables] public string Name;
     [ViewVariables] public int? Icon;
     [ViewVariables] public string? IconState;
     [ViewVariables] public AtomDirection Direction = AtomDirection.South;
@@ -58,6 +69,7 @@ public sealed class IconAppearance : IEquatable<IconAppearance> {
     ];
 
     public IconAppearance() {
+        Name = string.Empty;
         Overlays = new();
         Underlays = new();
         VisContents = new();
@@ -66,6 +78,7 @@ public sealed class IconAppearance : IEquatable<IconAppearance> {
     }
 
     public IconAppearance(IconAppearance appearance) {
+        Name = appearance.Name;
         Icon = appearance.Icon;
         IconState = appearance.IconState;
         Direction = appearance.Direction;
@@ -101,6 +114,7 @@ public sealed class IconAppearance : IEquatable<IconAppearance> {
     public bool Equals(IconAppearance? appearance) {
         if (appearance == null) return false;
 
+        if (appearance.Name != Name) return false;
         if (appearance.Icon != Icon) return false;
         if (appearance.IconState != IconState) return false;
         if (appearance.Direction != Direction) return false;
@@ -187,6 +201,7 @@ public sealed class IconAppearance : IEquatable<IconAppearance> {
     public override int GetHashCode() {
         HashCode hashCode = new HashCode();
 
+        hashCode.Add(Name);
         hashCode.Add(Icon);
         hashCode.Add(IconState);
         hashCode.Add(Direction);

--- a/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
+++ b/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
@@ -221,8 +221,10 @@ public sealed class MsgAllAppearances(Dictionary<int, IconAppearance> allAppeara
 
             lastId = pair.Key;
 
-            buffer.Write((byte)Property.Name);
-            buffer.Write(appearance.Name);
+            if (appearance.Name != IconAppearance.Default.Name) {
+                buffer.Write((byte)Property.Name);
+                buffer.Write(appearance.Name);
+            }
 
             if (appearance.Icon != null) {
                 buffer.Write((byte)Property.Icon);

--- a/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
+++ b/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
@@ -13,6 +13,7 @@ public sealed class MsgAllAppearances(Dictionary<int, IconAppearance> allAppeara
     public override MsgGroups MsgGroup => MsgGroups.EntityEvent;
 
     private enum Property : byte {
+        Name,
         Icon,
         IconState,
         Direction,
@@ -61,6 +62,9 @@ public sealed class MsgAllAppearances(Dictionary<int, IconAppearance> allAppeara
 
             while (property != Property.End) {
                 switch (property) {
+                    case Property.Name:
+                        appearance.Name = buffer.ReadString();
+                        break;
                     case Property.Id:
                         appearanceId = buffer.ReadVariableInt32();
                         break;
@@ -216,6 +220,9 @@ public sealed class MsgAllAppearances(Dictionary<int, IconAppearance> allAppeara
             }
 
             lastId = pair.Key;
+
+            buffer.Write((byte)Property.Name);
+            buffer.Write(appearance.Name);
 
             if (appearance.Icon != null) {
                 buffer.Write((byte)Property.Icon);


### PR DESCRIPTION
Resolves #1960 

As far as I can tell it seems to work?

![image](https://github.com/user-attachments/assets/df6a741f-2b2f-43d0-8ce8-8d0fa52ecd31)
