### PR TITLE
Remove all `OpenDreamShared` and `Content.Tests` warnings

### DIFF
--- a/Content.IntegrationTests/Content.IntegrationTests.csproj
+++ b/Content.IntegrationTests/Content.IntegrationTests.csproj
@@ -6,6 +6,8 @@
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <LangVersion>12</LangVersion>
+    <NoWarn>NU1507</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" />

--- a/Content.Tests/Content.Tests.csproj
+++ b/Content.Tests/Content.Tests.csproj
@@ -9,6 +9,8 @@
     <Configurations>Debug;Release;Tools</Configurations>
     <Platforms>AnyCPU</Platforms>
     <Nullable>enable</Nullable>
+    <NoWarn>NU1507</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" />

--- a/Content.Tests/DMTests.cs
+++ b/Content.Tests/DMTests.cs
@@ -111,7 +111,7 @@ public sealed class DMTests : ContentUnitTest {
 
         DreamThread.Run("RunTest", async (state) => {
             if (_objectTree.TryGetGlobalProc("RunTest", out DreamProc? proc)) {
-                callTask = state.Call(proc, null, null);
+                callTask = state.Call(proc, _dreamMan.WorldInstance, null);
                 retValue = await callTask;
                 return DreamValue.Null;
             } else {

--- a/Content.Tests/DMTests.cs
+++ b/Content.Tests/DMTests.cs
@@ -111,7 +111,7 @@ public sealed class DMTests : ContentUnitTest {
 
         DreamThread.Run("RunTest", async (state) => {
             if (_objectTree.TryGetGlobalProc("RunTest", out DreamProc? proc)) {
-                callTask = state.Call(proc, _dreamMan.WorldInstance, null);
+                callTask = state.Call(proc, null, null);
                 retValue = await callTask;
                 return DreamValue.Null;
             } else {

--- a/Content.Tests/DummyDreamMapManager.cs
+++ b/Content.Tests/DummyDreamMapManager.cs
@@ -35,16 +35,12 @@ namespace Content.Tests {
             return false;
         }
 
-        public IDreamMapManager.Cell GetCellFromTurf(DreamObjectTurf turf) {
-            throw null;
-        }
-
-        public bool TryGetCellAt(Vector2i pos, int z, out IDreamMapManager.Cell? cell) {
+        public bool TryGetCellAt(Vector2i pos, int z, [NotNullWhen(true)] out IDreamMapManager.Cell? cell) {
             cell = null;
             return false;
         }
 
-        public bool TryGetTurfAt(Vector2i pos, int z, out DreamObjectTurf turf) {
+        public bool TryGetTurfAt(Vector2i pos, int z, [NotNullWhen(true)] out DreamObjectTurf? turf) {
             turf = null;
             return false;
         }

--- a/DMDisassembler/DMDisassembler.csproj
+++ b/DMDisassembler/DMDisassembler.csproj
@@ -6,6 +6,8 @@
     <Platforms>AnyCPU</Platforms>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>..\bin\DMDisassembler\</OutputPath>
+    <NoWarn>NU1507</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OpenDreamPackageTool/OpenDreamPackageTool.csproj
+++ b/OpenDreamPackageTool/OpenDreamPackageTool.csproj
@@ -4,6 +4,8 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <NoWarn>NU1507</NoWarn>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/OpenDreamPackaging/OpenDreamPackaging.csproj
+++ b/OpenDreamPackaging/OpenDreamPackaging.csproj
@@ -4,6 +4,8 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <NoWarn>NU1507</NoWarn>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/OpenDreamRuntime/Objects/DreamIcon.cs
+++ b/OpenDreamRuntime/Objects/DreamIcon.cs
@@ -111,7 +111,9 @@ public sealed class DreamIcon(DreamResourceManager resourceManager) {
             frameHeight = 32;
         }
 
-        Dictionary<string, ParsedDMIState> dmiStates = new(States.Count);
+        ParsedDMIDescription newDescription = new() {Width = frameWidth, Height = frameHeight};
+        newDescription.States.EnsureCapacity(States.Count);
+
         int span = frameWidth * Math.Max(frameCount, 1);
         Rgba32[] pixels = PixelArrayPool.Rent(span * frameHeight);
 
@@ -120,7 +122,7 @@ public sealed class DreamIcon(DreamResourceManager resourceManager) {
             var iconState = iconStatePair.Value;
             ParsedDMIState newState = new() { Name = iconStatePair.Key, Loop = false, Rewind = false };
 
-            dmiStates.Add(newState.Name, newState);
+            newDescription.States.Add(newState.Name, newState);
 
             int exportedDirectionCount = DMIParser.GetExportedDirectionCount(iconState.Directions);
             for (int directionIndex = 0; directionIndex < exportedDirectionCount; directionIndex++) {
@@ -137,7 +139,6 @@ public sealed class DreamIcon(DreamResourceManager resourceManager) {
         }
 
         Image<Rgba32> dmiImage = Image.LoadPixelData<Rgba32>(pixels, span, frameHeight);
-        ParsedDMIDescription newDescription = new() {Width = frameWidth, Height = frameHeight, States = dmiStates};
 
         PixelArrayPool.Return(pixels, clearArray: true);
 

--- a/OpenDreamRuntime/Procs/AsyncNativeProc.cs
+++ b/OpenDreamRuntime/Procs/AsyncNativeProc.cs
@@ -59,7 +59,7 @@ namespace OpenDreamRuntime.Procs {
                 Thread.Resume();
             }
 
-            public Task<DreamValue> Call(DreamProc proc, DreamObject src, DreamObject? usr, params DreamValue[] arguments) {
+            public Task<DreamValue> Call(DreamProc proc, DreamObject? src, DreamObject? usr, params DreamValue[] arguments) {
                 _callTcs = new();
                 _callProcNotify = proc.CreateState(Thread, src, usr, new DreamProcArguments(arguments));
 

--- a/OpenDreamServer/OpenDreamServer.csproj
+++ b/OpenDreamServer/OpenDreamServer.csproj
@@ -10,6 +10,8 @@
     <OutputType Condition="'$(FullRelease)' != 'True'">Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <NoWarn>NU1507</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenDreamRuntime\OpenDreamRuntime.csproj" />

--- a/OpenDreamShared/OpenDreamShared.csproj
+++ b/OpenDreamShared/OpenDreamShared.csproj
@@ -8,6 +8,8 @@
     <OutputPath>../bin/Content.Shared</OutputPath>
     <AssemblyName>OpenDreamShared</AssemblyName>
     <Nullable>enable</Nullable>
+    <NoWarn>NU1507</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" />

--- a/OpenDreamShared/Resources/DMIParser.cs
+++ b/OpenDreamShared/Resources/DMIParser.cs
@@ -26,7 +26,7 @@ public static class DMIParser {
 
     public sealed class ParsedDMIDescription {
         public int Width, Height;
-        public Dictionary<string, ParsedDMIState> States;
+        public Dictionary<string, ParsedDMIState> States = new();
 
         /// <summary>
         /// Gets the requested state, or the default if it doesn't exist
@@ -73,7 +73,7 @@ public static class DMIParser {
     }
 
     public sealed class ParsedDMIState {
-        public string Name;
+        public string Name = string.Empty;
         public bool Loop = true;
         public bool Rewind = false;
 
@@ -273,13 +273,10 @@ public static class DMIParser {
 
             var desc = new ParsedDMIDescription() {
                 Width = (int)imageSize.Value.X,
-                Height = (int)imageSize.Value.Y,
-                States = new()
+                Height = (int)imageSize.Value.Y
             };
 
-            var state = new ParsedDMIState() {
-                Name = string.Empty
-            };
+            var state = new ParsedDMIState();
 
             var frame = new ParsedDMIFrame() {
                 X = 0,
@@ -297,14 +294,12 @@ public static class DMIParser {
 
     private static ParsedDMIDescription ParseDMIDescription(string dmiDescription, uint imageWidth) {
         ParsedDMIDescription description = new ParsedDMIDescription();
-        ParsedDMIState currentState = null;
+        ParsedDMIState? currentState = null;
         int currentFrameX = 0;
         int currentFrameY = 0;
         int currentStateDirectionCount = 1;
         int currentStateFrameCount = 1;
-        float[] currentStateFrameDelays = null;
-
-        description.States = new Dictionary<string, ParsedDMIState>();
+        float[]? currentStateFrameDelays = null;
 
         string[] lines = dmiDescription.Split("\n");
         foreach (string line in lines) {
@@ -385,9 +380,11 @@ public static class DMIParser {
 
                         break;
                     case "loop":
+                        if (currentState is null) break;
                         currentState.Loop = (int.Parse(value) == 0);
                         break;
                     case "rewind":
+                        if (currentState is null) break;
                         currentState.Rewind = (int.Parse(value) == 1);
                         break;
                     case "movement":
@@ -403,6 +400,8 @@ public static class DMIParser {
                 throw new Exception($"Invalid line in DMI description: \"{line}\"");
             }
         }
+
+        if (currentState is null) return description;
 
         for (int i = 0; i < currentStateDirectionCount; i++) {
             ParsedDMIFrame[] frames = new ParsedDMIFrame[currentStateFrameCount];


### PR DESCRIPTION
See title. Also elevates warnings to errors in all of the projects that don't currently have warnings.