### PR TITLE
Fix setting a static var to a const var

### DIFF
--- a/Content.Tests/DMProject/Tests/Const/StaticEqualsConstVar.dm
+++ b/Content.Tests/DMProject/Tests/Const/StaticEqualsConstVar.dm
@@ -1,0 +1,8 @@
+
+/atom/movable/foo
+	var/const/tick_limit_default = 80
+	var/static/current_ticklimit = tick_limit_default
+	
+/proc/RunTest()
+	var/atom/movable/foo/F = new
+	ASSERT(F.current_ticklimit == 80)

--- a/DMCompiler/DM/Builders/DMExpressionBuilder.cs
+++ b/DMCompiler/DM/Builders/DMExpressionBuilder.cs
@@ -404,7 +404,11 @@ internal static class DMExpressionBuilder {
 
                     var field = dmObject?.GetVariable(name);
                     if (field != null) {
-                        return new Field(identifier.Location, field, field.ValType);
+                        if (field.IsConst)
+                            return new Field(identifier.Location, field, field.ValType);
+
+                        return BadExpression(WarningCode.BadExpression, identifier.Location,
+                            "Var \"{name}\" cannot be used in this context");
                     }
                 }
 

--- a/DMCompiler/DM/Builders/DMExpressionBuilder.cs
+++ b/DMCompiler/DM/Builders/DMExpressionBuilder.cs
@@ -401,6 +401,11 @@ internal static class DMExpressionBuilder {
                         var global = new GlobalField(identifier.Location, globalVar.Type, globalId.Value, globalVar.ValType);
                         return global;
                     }
+
+                    var field = dmObject?.GetVariable(name);
+                    if (field != null) {
+                        return new Field(identifier.Location, field, field.ValType);
+                    }
                 }
 
                 throw new UnknownIdentifierException(identifier.Location, name);


### PR DESCRIPTION
See title. Brings Baystation from 211 errors down to 15.

I'm not entirely confident that this doesn't break things, as var parsing is a bit of a convoluted mess. I did confirm that this didn't generate any *new* errors for Baystation, and I tested that Paradise still seems to be playable.