### PR TITLE
Reduce `DuplicateVariable` to a warning by default

### DIFF
--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -14,7 +14,7 @@
 
 //2000-2999
 #pragma SoftReservedKeyword error
-#pragma DuplicateVariable error
+#pragma DuplicateVariable warning
 #pragma DuplicateProcDefinition error
 #pragma PointlessParentCall warning
 #pragma PointlessBuiltinCall warning


### PR DESCRIPTION
Baystation emits this and we shouldn't error by default on code BYOND compiles.