### PR TITLE
Fix an issue with deref operations

### DIFF
--- a/DMCompiler/DM/Builders/DMExpressionBuilder.cs
+++ b/DMCompiler/DM/Builders/DMExpressionBuilder.cs
@@ -717,8 +717,7 @@ internal static class DMExpressionBuilder {
                             }
 
                             operations = new Dereference.Operation[newOperationCount];
-                            astOperationOffset = i + iteration + 1;
-                            iteration++;
+                            astOperationOffset += i + 1;
                             i = -1;
                             prevPath = property.Type;
                             pathIsFuzzy = prevPath == null;

--- a/DMCompiler/DM/Builders/DMExpressionBuilder.cs
+++ b/DMCompiler/DM/Builders/DMExpressionBuilder.cs
@@ -669,7 +669,6 @@ internal static class DMExpressionBuilder {
             }
         }
 
-        var iteration = 0; // Since we do cursed stuff to `i` for reasons(TM), we need to track the for loop's iterations elsewhere
         for (int i = 0; i < operations.Length; i++) {
             DMASTDereference.Operation astOperation = astOperations[i + astOperationOffset];
             Dereference.Operation operation;

--- a/DMCompiler/DM/Builders/DMExpressionBuilder.cs
+++ b/DMCompiler/DM/Builders/DMExpressionBuilder.cs
@@ -669,6 +669,7 @@ internal static class DMExpressionBuilder {
             }
         }
 
+        var iteration = 0; // Since we do cursed stuff to `i` for reasons(TM), we need to track the for loop's iterations elsewhere
         for (int i = 0; i < operations.Length; i++) {
             DMASTDereference.Operation astOperation = astOperations[i + astOperationOffset];
             Dereference.Operation operation;
@@ -716,7 +717,8 @@ internal static class DMExpressionBuilder {
                             }
 
                             operations = new Dereference.Operation[newOperationCount];
-                            astOperationOffset = i + 1;
+                            astOperationOffset = i + iteration + 1;
+                            iteration++;
                             i = -1;
                             prevPath = property.Type;
                             pathIsFuzzy = prevPath == null;


### PR DESCRIPTION
Resolves #1977 

`astOperationOffset` never reached `2`, which is the index of the `IndexOperation`. Instead it was trying to repeat the previous `FieldOperation` again.