### PR TITLE
Fix `findtext()` with /regex

### DIFF
--- a/Content.Tests/DMProject/Tests/Regex/regex_start.dm
+++ b/Content.Tests/DMProject/Tests/Regex/regex_start.dm
@@ -25,11 +25,16 @@
 	ASSERT(result == "foo foo")
 
 	ASSERT(R.Find("foo foo", start=1) == 1)
+	ASSERT(findtext("foo foo", R, Start=1) == 1)
 
 	ASSERT(R.Find("foo foo", start=2) == 5)
+	ASSERT(findtext("foo foo", R, Start=2) == 5)
 
 	ASSERT(R.Find("foo foo", start=5) == 5)
+	ASSERT(findtext("foo foo", R, Start=5) == 5)
 
 	ASSERT(R.Find("foo foo", start=6) == 0)
+	ASSERT(findtext("foo foo", R, Start=6) == 0)
 
 	ASSERT(R.Find("foo foo", start=69) == 0)
+	ASSERT(findtext("foo foo", R, Start=69) == 0)

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -775,7 +775,7 @@ internal static class DreamProcNativeRoot {
             }
         }
 
-        if (failCount > 0 || string.IsNullOrEmpty(text) || string.IsNullOrEmpty(needle)) {
+        if (failCount > 0 || string.IsNullOrEmpty(text) || (string.IsNullOrEmpty(needle) && regex == null)) {
             return new DreamValue(failCount == 2 ? 1 : 0);
         }
 
@@ -826,7 +826,7 @@ internal static class DreamProcNativeRoot {
             }
         }
 
-        if (failCount > 0 || string.IsNullOrEmpty(text) || string.IsNullOrEmpty(needle)) {
+        if (failCount > 0 || string.IsNullOrEmpty(text) || (string.IsNullOrEmpty(needle) && regex == null)) {
             return new DreamValue(failCount == 2 ? 1 : 0);
         }
 


### PR DESCRIPTION
A change had made `findtext()` always return 0 when used with a /regex. Now it should properly run the regex.

This fixes the map loader on TG, which was improperly treating TGM-formatted maps as BYOND-formatted DMM maps due to this:
```dm
if(findtext(tfile, matches_tgm))
	map_format = MAP_TGM
else
	map_format = MAP_DMM
```