### PR TITLE
Fix issues found via Nebula testing

### DIFF
--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -123,7 +123,6 @@ namespace DMCompiler.DM {
 
         private void DeallocLocalVariables(int amount) {
             if (amount > 0) {
-                _localVariableNames.RemoveRange(_localVariableNames.Count - amount, amount);
                 WriteLocalVariableDealloc(amount);
                 _localVariableIdCounter -= amount;
             }

--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -326,7 +326,7 @@ public sealed class AtomManager {
                 break;
             case "alpha":
                 value.TryGetValueAsFloat(out float floatAlpha);
-                appearance.Alpha = (byte) floatAlpha;
+                appearance.Alpha = (byte) Math.Clamp(floatAlpha, 0, 255);
                 break;
             case "glide_size":
                 value.TryGetValueAsFloat(out float glideSize);

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -827,9 +827,9 @@ namespace OpenDreamRuntime.Procs {
                 case DMReference.Type.ListIndex: {
                     GetIndexReferenceValues(reference, out var index, out var indexing, peek);
 
-                    ProcStatus subState = GetIndex(indexing, index, this, out Result);
+                    ProcStatus subState = GetIndex(indexing, index, this, out var indexResult);
                     if (subState == ProcStatus.Continue)
-                        return Result;
+                        return indexResult;
                     else
                         throw new Exception("fuck this is gonna be so hard to implement");
                 }


### PR DESCRIPTION
Local proc variables that fall out of scope during the proc were not serialized due to an overeager optimization. This reverses that.

Due to using `out Result` instead of `out var result`, indexing a list set the proc return value. This changes the variable used to avoid that. ~~i see why some codebases require explicit `this`/`src` now~~

Due to setting alpha casting a `float` to a `byte`, the new alpha value was just truncated to the least significant byte of its integer conversion, meaning setting the alpha to `256` would set it to `0`, setting it to `355` would set it to `99`, etc. Now, it's clamped between 0 and 255 before the conversion.