### PR TITLE
Fix initial() with mismatched variable and value types

### DIFF
--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -607,7 +607,7 @@ namespace OpenDreamRuntime.Procs {
                         ? DreamValue.Null
                         : new DreamValue(objectDefinition.Parent.TreeEntry),
                 "type" => new DreamValue(objectDefinition.TreeEntry),
-                _ => objectDefinition.Variables[property]
+                _ => objectDefinition.Variables.ContainsKey(property) ? objectDefinition.Variables[property] : DreamValue.Null
             };
 
             state.Push(result);

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -607,7 +607,7 @@ namespace OpenDreamRuntime.Procs {
                         ? DreamValue.Null
                         : new DreamValue(objectDefinition.Parent.TreeEntry),
                 "type" => new DreamValue(objectDefinition.TreeEntry),
-                _ => objectDefinition.Variables.ContainsKey(property) ? objectDefinition.Variables[property] : DreamValue.Null
+                _ => objectDefinition.Variables.TryGetValue(property, out var val) ? val : DreamValue.Null
             };
 
             state.Push(result);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ef0b8004-ae3a-4f73-b780-ea295750946b)
When a variable is typed as `var/whatever/` at compiletime, the compiler allows `initial()` usage for any variable on that type. If the value in that variable is of a different type, BYOND returns null, while we currently throw a `KeyNotFoundException`. This PR makes us return null as well. This could maybe be made a config thing somehow, but... eh.