### PR TITLE
Fix lexing of long raw string values

### DIFF
--- a/Content.Tests/DMProject/Tests/Text/rawstr_parsing2.dm
+++ b/Content.Tests/DMProject/Tests/Text/rawstr_parsing2.dm
@@ -1,0 +1,21 @@
+var/static/test_string1=@{"
+foo"}
+var/static/test_string2=@{"
+foo
+bar"}
+var/static/test_string3=@{"
+foo
+bar
+"}
+var/static/test_string4=@{"
+
+foo
+bar
+
+"}
+
+/proc/RunTest()
+	ASSERT(length(test_string1) == 3)
+	ASSERT(length(test_string2) == 7)
+	ASSERT(length(test_string3) == 7)
+	ASSERT(length(test_string4) == 9)

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessorLexer.cs
@@ -307,15 +307,18 @@ internal sealed class DMPreprocessorLexer {
 
                 if (isLong) {
                     bool nextCharCanTerm = false;
-                    do {
-                        c = Advance();
 
-                        if(nextCharCanTerm && c == '}')
+                    Advance();
+                    do {
+                        c = GetCurrent();
+
+                        if (nextCharCanTerm && c == '}')
                             break;
 
                         if (HandleLineEnd()) {
                             TokenTextBuilder.Append('\n');
                         } else {
+                            Advance();
                             TokenTextBuilder.Append(c);
                             nextCharCanTerm = false;
                         }
@@ -335,7 +338,20 @@ internal sealed class DMPreprocessorLexer {
                     Advance();
 
                 string text = TokenTextBuilder.ToString();
-                string value = isLong ? text.Substring(3, text.Length - 5) : text.Substring(2, text.Length - 3);
+                string value;
+
+                if (isLong) {
+                    // Long strings ignore a newline immediately after the @{" and before the "}
+                    if (TokenTextBuilder[3] == '\n')
+                        TokenTextBuilder.Remove(3, 1);
+                    if (TokenTextBuilder[^3] == '\n')
+                        TokenTextBuilder.Remove(TokenTextBuilder.Length - 3, 1);
+
+                    value = TokenTextBuilder.ToString(3, TokenTextBuilder.Length - 5);
+                } else {
+                    value = TokenTextBuilder.ToString(2, TokenTextBuilder.Length - 3);
+                }
+
                 return CreateToken(TokenType.DM_Preproc_ConstantString, text, value);
             }
             case '\'':


### PR DESCRIPTION
The first character after every newline was being thrown out.

The newline immediately after `@{"` and before `"}` was being included in the value. Those are now removed.