### PR TITLE
Leave an image's `InheritsDirection` on when the provided `dir` is invalid

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamObjectImage.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectImage.cs
@@ -62,7 +62,7 @@ public sealed class DreamObjectImage : DreamObject {
                 continue;
 
             AtomManager.SetAppearanceVar(Appearance, argName, arg);
-            if (argName == "dir") {
+            if (argName == "dir" && arg.TryGetValueAsInteger(out var argDir) && argDir > 0) {
                 // If a dir is explicitly given in the constructor then overlays using this won't use their owner's dir
                 // Setting dir after construction does not affect this
                 // This is undocumented and I hate it


### PR DESCRIPTION
Body part overlays in TG are created with a `dir` of `NONE`, or 0. This is an ignored value in BYOND which apparently leaves the inherits-direction flag on. Fixing this causes body parts to correctly rotate with you.
![image](https://github.com/user-attachments/assets/fe03961d-7726-4bb5-876c-c7dcb0c9b2a6)
