### PR TITLE
Remove `DreamPath.IsDescendantOf()`

### DIFF
--- a/DMCompiler/DM/DMObject.cs
+++ b/DMCompiler/DM/DMObject.cs
@@ -213,9 +213,8 @@ internal sealed class DMObject {
     }
 
     public bool IsSubtypeOf(DreamPath path) {
-        if (Path.IsDescendantOf(path)) return true;
-        if (Parent != null) return Parent.IsSubtypeOf(path);
-        return false;
+        if (path.Equals(Path)) return true;
+        return Parent != null && Parent.IsSubtypeOf(path);
     }
 
     public DMValueType GetDMValueType() {

--- a/DMCompiler/DreamPath.cs
+++ b/DMCompiler/DreamPath.cs
@@ -152,20 +152,6 @@ public struct DreamPath {
         Normalize(false);
     }
 
-    /// <summary>
-    /// Checks if the DreamPath is a descendant of another. NOTE: For type inheritance, use IsSubtypeOf()
-    /// </summary>
-    /// <param name="path">Path to compare to.</param>
-    public bool IsDescendantOf(DreamPath path) {
-        if (path.Elements.Length > Elements.Length) return false;
-
-        for (int i = 0; i < path.Elements.Length; i++) {
-            if (Elements[i] != path.Elements[i]) return false;
-        }
-
-        return true;
-    }
-
     public DreamPath AddToPath(string path) {
         string rawPath = PathString;
 


### PR DESCRIPTION
Causes too much confusion between the difference of path-descendants and inheritance-descendants