### PR TITLE
`COMPILE ERROR` unit tests now require a specific error code

### DIFF
--- a/Content.Tests/DMProject/Broken Tests/Typemaker/proc_path_error.dm
+++ b/Content.Tests/DMProject/Broken Tests/Typemaker/proc_path_error.dm
@@ -1,6 +1,8 @@
 // COMPILE ERROR OD2701
 #pragma InvalidReturnType error
 
+/datum/foo
+
 /datum/proc/meep() as /atom
 	return /atom
 

--- a/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixLint.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/Matrix/MatrixLint.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD2207
 #pragma SuspiciousMatrixCall error
 
 /proc/RunTest()

--- a/Content.Tests/DMProject/Tests/Call/PointlessParentCall.dm
+++ b/Content.Tests/DMProject/Tests/Call/PointlessParentCall.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD2205
 #pragma PointlessParentCall error
 
 /datum/proc/foo()

--- a/Content.Tests/DMProject/Tests/Call/RedundantPositionalKey.dm
+++ b/Content.Tests/DMProject/Tests/Call/RedundantPositionalKey.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD2210
 
 #pragma PointlessPositionalArgument error
 

--- a/Content.Tests/DMProject/Tests/Const/Const_CycleRefences.dm
+++ b/Content.Tests/DMProject/Tests/Const/Const_CycleRefences.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0404
 
 var/const/A = B
 var/const/B = C

--- a/Content.Tests/DMProject/Tests/Dereference/DatumIndex.dm
+++ b/Content.Tests/DMProject/Tests/Dereference/DatumIndex.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD2304
 #pragma InvalidIndexOperation error
 
 // Indexing a datum (e.g. datum["foo"]) is not valid in BYOND 515.1641+

--- a/Content.Tests/DMProject/Tests/Expression/Constants/resource_not_exists.dm
+++ b/Content.Tests/DMProject/Tests/Expression/Constants/resource_not_exists.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0404
 
 /proc/RunTest()
 	var/resource = 'file_doesnt_exist.txt'

--- a/Content.Tests/DMProject/Tests/Expression/Derefs/untyped/ident.dm
+++ b/Content.Tests/DMProject/Tests/Expression/Derefs/untyped/ident.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0404
 
 /obj
     var/ele = 2

--- a/Content.Tests/DMProject/Tests/Expression/Derefs/untyped/proccall.dm
+++ b/Content.Tests/DMProject/Tests/Expression/Derefs/untyped/proccall.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0011
 
 /obj
     proc/elefn()

--- a/Content.Tests/DMProject/Tests/Indent/inconsistent.dm
+++ b/Content.Tests/DMProject/Tests/Indent/inconsistent.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0001
 
 /proc/RunTest()
 	var/test1 = 1

--- a/Content.Tests/DMProject/Tests/Indent/inner_root_in_proc.dm
+++ b/Content.Tests/DMProject/Tests/Indent/inner_root_in_proc.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0001
 
 /obj/proc/p()
     return 5 + 3

--- a/Content.Tests/DMProject/Tests/List/readonly1.dm
+++ b/Content.Tests/DMProject/Tests/List/readonly1.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0501
 
 //# issue 702
 

--- a/Content.Tests/DMProject/Tests/List/readonly2.dm
+++ b/Content.Tests/DMProject/Tests/List/readonly2.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0501
 
 //# issue 702
 

--- a/Content.Tests/DMProject/Tests/List/readonly3.dm
+++ b/Content.Tests/DMProject/Tests/List/readonly3.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0501
 
 //# issue 702
 

--- a/Content.Tests/DMProject/Tests/List/readonly4.dm
+++ b/Content.Tests/DMProject/Tests/List/readonly4.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0501
 
 //# issue 702
 

--- a/Content.Tests/DMProject/Tests/Operators/In_OrderOfOperationsWarning.dm
+++ b/Content.Tests/DMProject/Tests/Operators/In_OrderOfOperationsWarning.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD3204
 
 #pragma AmbiguousInOrder error
 

--- a/Content.Tests/DMProject/Tests/Operators/is_assign_lvalue.dm
+++ b/Content.Tests/DMProject/Tests/Operators/is_assign_lvalue.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0011
 
 /proc/RunTest()
     var/a = 0

--- a/Content.Tests/DMProject/Tests/Operators/is_decl_lvalue.dm
+++ b/Content.Tests/DMProject/Tests/Operators/is_decl_lvalue.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0011
 
 /proc/RunTest()
     (var/a = 1) = 2

--- a/Content.Tests/DMProject/Tests/Operators/scope_proc_pointless.dm
+++ b/Content.Tests/DMProject/Tests/Operators/scope_proc_pointless.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD2209
 #pragma PointlessScopeOperator error
 
 /datum/proc/foo()

--- a/Content.Tests/DMProject/Tests/Preprocessor/Pragma/pragma_warning.dm
+++ b/Content.Tests/DMProject/Tests/Preprocessor/Pragma/pragma_warning.dm
@@ -1,4 +1,4 @@
-//COMPILE ERROR
+//COMPILE ERROR OD1201
 
 #pragma WarningDirective error
 

--- a/Content.Tests/DMProject/Tests/Preprocessor/Variadic/variadic_must_be_last.dm
+++ b/Content.Tests/DMProject/Tests/Preprocessor/Variadic/variadic_must_be_last.dm
@@ -1,4 +1,4 @@
-//COMPILE ERROR
+//COMPILE ERROR OD0010
 
 #define DAMN(what...,the...,hockeysticks...) world << list(##what)
 

--- a/Content.Tests/DMProject/Tests/Preprocessor/define_var_clash2.dm
+++ b/Content.Tests/DMProject/Tests/Preprocessor/define_var_clash2.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0001
 
 #define A 1
 #define B 1

--- a/Content.Tests/DMProject/Tests/Preprocessor/directive_linebreaks1.dm
+++ b/Content.Tests/DMProject/Tests/Preprocessor/directive_linebreaks1.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0404
 
 #define A 5\
 #define B 6

--- a/Content.Tests/DMProject/Tests/Preprocessor/macro_newline_compileerror.dm
+++ b/Content.Tests/DMProject/Tests/Preprocessor/macro_newline_compileerror.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0012
 #define TEST(a,b) a+b
 
 /proc/main()

--- a/Content.Tests/DMProject/Tests/Preprocessor/macro_var_clash.dm
+++ b/Content.Tests/DMProject/Tests/Preprocessor/macro_var_clash.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0014
 
 //# issue 389
 

--- a/Content.Tests/DMProject/Tests/Preprocessor/multi_arg.dm
+++ b/Content.Tests/DMProject/Tests/Preprocessor/multi_arg.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0001
 
 //# issue 14
 

--- a/Content.Tests/DMProject/Tests/Preprocessor/nested_comment1.dm
+++ b/Content.Tests/DMProject/Tests/Preprocessor/nested_comment1.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD1200
 
 /proc/RunTest()
     /*

--- a/Content.Tests/DMProject/Tests/Preprocessor/nested_comment3.dm
+++ b/Content.Tests/DMProject/Tests/Preprocessor/nested_comment3.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD1200
 
 //# issue 465
 

--- a/Content.Tests/DMProject/Tests/Preprocessor/whitespace_with_macro_functor.dm
+++ b/Content.Tests/DMProject/Tests/Preprocessor/whitespace_with_macro_functor.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0404
 // issue OD#846
 
 #define TEST(x) x

--- a/Content.Tests/DMProject/Tests/Procs/Arglist/input.dm
+++ b/Content.Tests/DMProject/Tests/Procs/Arglist/input.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0011
 
 /proc/_input(...)
     return input(arglist(args))

--- a/Content.Tests/DMProject/Tests/Procs/Arglist/istype.dm
+++ b/Content.Tests/DMProject/Tests/Procs/Arglist/istype.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0011
 
 /proc/_istype(...)
     return istype(arglist(args))

--- a/Content.Tests/DMProject/Tests/Procs/Arglist/locate.dm
+++ b/Content.Tests/DMProject/Tests/Procs/Arglist/locate.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0011
 
 /proc/_locate(...)
     return locate(arglist(args))

--- a/Content.Tests/DMProject/Tests/Procs/Arglist/newlist.dm
+++ b/Content.Tests/DMProject/Tests/Procs/Arglist/newlist.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0011
 
 /proc/_newlist(...)
     return newlist(arglist(args))

--- a/Content.Tests/DMProject/Tests/Procs/var_decl_param.dm
+++ b/Content.Tests/DMProject/Tests/Procs/var_decl_param.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0001
 
 /proc/novar(a, b)
     return a + b

--- a/Content.Tests/DMProject/Tests/SetStatements/unimplemented_with_body.dm
+++ b/Content.Tests/DMProject/Tests/SetStatements/unimplemented_with_body.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD2800
 
 #pragma UnimplementedAccess error
 

--- a/Content.Tests/DMProject/Tests/SetStatements/unimplemented_without_body.dm
+++ b/Content.Tests/DMProject/Tests/SetStatements/unimplemented_without_body.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD2800
 
 #pragma UnimplementedAccess error
 

--- a/Content.Tests/DMProject/Tests/Special Procs/nameof/nameof_error.dm
+++ b/Content.Tests/DMProject/Tests/Special Procs/nameof/nameof_error.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0100
 /proc/RunTest()
 	var/list/L = list(1,2,3)
 	nameof(L[2]) // nameof() isn't valid on a list index

--- a/Content.Tests/DMProject/Tests/Statements/Control Flow/empty_blocks.dm
+++ b/Content.Tests/DMProject/Tests/Statements/Control Flow/empty_blocks.dm
@@ -1,4 +1,4 @@
-//COMPILE ERROR
+//COMPILE ERROR OD3100
 //Test that our pragma for this is working.
 #pragma EmptyBlock error
 /proc/RunTest()

--- a/Content.Tests/DMProject/Tests/Statements/Control Flow/empty_proc.dm
+++ b/Content.Tests/DMProject/Tests/Statements/Control Flow/empty_proc.dm
@@ -1,4 +1,4 @@
-//COMPILE ERROR
+//COMPILE ERROR OD3101
 //Test that our pragma for this is working.
 #pragma EmptyProc error
 

--- a/Content.Tests/DMProject/Tests/Statements/Control Flow/labels_bad_jump.dm
+++ b/Content.Tests/DMProject/Tests/Statements/Control Flow/labels_bad_jump.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0404
 //# issue 360
 
 bad:

--- a/Content.Tests/DMProject/Tests/Statements/Control Flow/labels_bad_link.dm
+++ b/Content.Tests/DMProject/Tests/Statements/Control Flow/labels_bad_link.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0404
 //# issue 360
 
 /proc/RunTest()

--- a/Content.Tests/DMProject/Tests/Statements/Control Flow/labels_order_bad.dm
+++ b/Content.Tests/DMProject/Tests/Statements/Control Flow/labels_order_bad.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0404
 //# issue 360
 
 /proc/RunTest()

--- a/Content.Tests/DMProject/Tests/Statements/EmptyBlock.dm
+++ b/Content.Tests/DMProject/Tests/Statements/EmptyBlock.dm
@@ -1,4 +1,4 @@
-﻿// COMPILE ERROR
+﻿// COMPILE ERROR OD3100
 #pragma EmptyBlock error
 
 /proc/RunTest()

--- a/Content.Tests/DMProject/Tests/Statements/For/nest_in.dm
+++ b/Content.Tests/DMProject/Tests/Statements/For/nest_in.dm
@@ -1,8 +1,8 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0011
 
 /proc/RunTest()
 	var/list/l1 = list(1,2,3)
 	var/list/l2 = list(4,5,6)
 	var/out = 0
 	for (var/i in l1 in l2)
-		logi += i
+		out += i

--- a/Content.Tests/DMProject/Tests/Statements/For/undeclared_iter_var.dm
+++ b/Content.Tests/DMProject/Tests/Statements/For/undeclared_iter_var.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0011
 
 /proc/RunTest()
 	var/c = 0

--- a/Content.Tests/DMProject/Tests/Statements/For/var_only_not_decl.dm
+++ b/Content.Tests/DMProject/Tests/Statements/For/var_only_not_decl.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0011
 
 /proc/RunTest()
 	var/i

--- a/Content.Tests/DMProject/Tests/Statements/Switch/weird_when_clause_pragma.dm
+++ b/Content.Tests/DMProject/Tests/Statements/Switch/weird_when_clause_pragma.dm
@@ -1,4 +1,4 @@
-//COMPILE ERROR
+//COMPILE ERROR OD3201
 //test to make sure SuspiciousSwitchCase is working
 
 #pragma SuspiciousSwitchCase error

--- a/Content.Tests/DMProject/Tests/Statements/Var Decl/var_decl_expr.dm
+++ b/Content.Tests/DMProject/Tests/Statements/Var Decl/var_decl_expr.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0012
 
 /proc/RunTest()
 	var/a = 0 && var/b = 1

--- a/Content.Tests/DMProject/Tests/Stdlib/addtext1.dm
+++ b/Content.Tests/DMProject/Tests/Stdlib/addtext1.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0013
 
 //# issue 663
 

--- a/Content.Tests/DMProject/Tests/Text/EmbeddedExpressionPassesErrors.dm
+++ b/Content.Tests/DMProject/Tests/Text/EmbeddedExpressionPassesErrors.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0011
 
 /proc/RunTest()
 	var/test1 = "["["a""b"]"]" // 'expected end of embedded statement' from inner interpolation

--- a/Content.Tests/DMProject/Tests/Text/EndOfEmbeddedExpression.dm
+++ b/Content.Tests/DMProject/Tests/Text/EndOfEmbeddedExpression.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0011
 
 /proc/RunTest()
 	var/test1 = "["a""b"]" // expected end of embedded expression

--- a/Content.Tests/DMProject/Tests/Text/ExpectedEmbeddedExpression.dm
+++ b/Content.Tests/DMProject/Tests/Text/ExpectedEmbeddedExpression.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0012
 
 /proc/RunTest()
 	var/test1 = "[;]" // expected an expression

--- a/Content.Tests/DMProject/Tests/Text/ProperImproper.dm
+++ b/Content.Tests/DMProject/Tests/Text/ProperImproper.dm
@@ -1,4 +1,4 @@
-﻿// COMPILE ERROR
+﻿// COMPILE ERROR OD0001
 
 /proc/RunTest()
 	var/InvalidProper = "Example \proper"

--- a/Content.Tests/DMProject/Tests/Tree/Const/Assign/const_assign1.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Const/Assign/const_assign1.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0501
 
 //# issue 535
 

--- a/Content.Tests/DMProject/Tests/Tree/Const/Assign/const_assign2.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Const/Assign/const_assign2.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0501
 
 /obj
 	/var/const/a = 5

--- a/Content.Tests/DMProject/Tests/Tree/Const/Assign/const_assign3.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Const/Assign/const_assign3.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0501
 
 /proc/RunTest()
 	var/const/a = 7

--- a/Content.Tests/DMProject/Tests/Tree/Const/const_fn_badarg1.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Const/const_fn_badarg1.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0500
 
 /proc/somered()
 	return 127

--- a/Content.Tests/DMProject/Tests/Tree/Const/const_fn_badarg2.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Const/const_fn_badarg2.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0500
 
 /proc/somered()
 	return 127

--- a/Content.Tests/DMProject/Tests/Tree/Override/override_const.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Override/override_const.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0011
 
 /atom/var/a = 5
 /atom/const/a = 4

--- a/Content.Tests/DMProject/Tests/Tree/Override/override_global.dm
+++ b/Content.Tests/DMProject/Tests/Tree/Override/override_global.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0406
 
 /turf/C = 4
 /datum/var/const/C = 5

--- a/Content.Tests/DMProject/Tests/Tree/duplicate_proc.dm
+++ b/Content.Tests/DMProject/Tests/Tree/duplicate_proc.dm
@@ -1,4 +1,5 @@
-// COMPILE ERROR
+// COMPILE ERROR OD2101
+#pragma DuplicateProcDefinition error
 
 //# issue 172
 

--- a/Content.Tests/DMProject/Tests/Tree/type_duplicate_proc.dm
+++ b/Content.Tests/DMProject/Tests/Tree/type_duplicate_proc.dm
@@ -1,4 +1,5 @@
-//COMPILE ERROR
+//COMPILE ERROR OD2101
+#pragma DuplicateProcDefinition error
 
 //Issue OD#933: https://github.com/OpenDreamProject/OpenDream/issues/933
 

--- a/Content.Tests/DMProject/Tests/Type Inference/unknown_type.dm
+++ b/Content.Tests/DMProject/Tests/Type Inference/unknown_type.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0404
 
 /datum/later
 	var/datum/laterrr/aa = new(0)

--- a/Content.Tests/DMProject/Tests/Typemaker/arg_fail.dm
+++ b/Content.Tests/DMProject/Tests/Typemaker/arg_fail.dm
@@ -1,4 +1,4 @@
-//COMPILE ERROR
+//COMPILE ERROR OD2701
 #pragma InvalidReturnType error
 /proc/meep(var/foo = "bar" as text) as num
 	return foo

--- a/Content.Tests/DMProject/Tests/Typemaker/global_proccall_error.dm
+++ b/Content.Tests/DMProject/Tests/Typemaker/global_proccall_error.dm
@@ -1,4 +1,4 @@
-//COMPILE ERROR
+//COMPILE ERROR OD2701
 #pragma InvalidReturnType error
 /proc/foo()
 	return "bar"

--- a/Content.Tests/DMProject/Tests/Typemaker/newpath_fail.dm
+++ b/Content.Tests/DMProject/Tests/Typemaker/newpath_fail.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD2701
 #pragma InvalidVarType error
 /proc/foo(turf/bar as turf)
 	bar = new /obj(null)

--- a/Content.Tests/DMProject/Tests/Typemaker/newpath_fail.dm
+++ b/Content.Tests/DMProject/Tests/Typemaker/newpath_fail.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR OD2701
+// COMPILE ERROR OD2702
 #pragma InvalidVarType error
 /proc/foo(turf/bar as turf)
 	bar = new /obj(null)

--- a/Content.Tests/DMProject/Tests/Typemaker/proc_early_override.dm
+++ b/Content.Tests/DMProject/Tests/Typemaker/proc_early_override.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD2701
 #pragma InvalidReturnType error
 
 /datum/do/re/mi/fa/so/f()

--- a/Content.Tests/DMProject/Tests/Typemaker/proc_local_error.dm
+++ b/Content.Tests/DMProject/Tests/Typemaker/proc_local_error.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD2701
 #pragma InvalidReturnType error
 /datum/proc/foo() as num
 	var/const/meep = "foo"

--- a/Content.Tests/DMProject/Tests/Typemaker/proc_local_error2.dm
+++ b/Content.Tests/DMProject/Tests/Typemaker/proc_local_error2.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD2701
 #pragma InvalidReturnType error
 /datum/proc/foo() as num
 	var/meep = 5 // Not const

--- a/Content.Tests/DMProject/Tests/Typemaker/proc_override_error.dm
+++ b/Content.Tests/DMProject/Tests/Typemaker/proc_override_error.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD2701
 #pragma InvalidReturnType error
 /datum/proc/foo() as num
 	return 5

--- a/Content.Tests/DMProject/Tests/Typemaker/proc_path_error.dm
+++ b/Content.Tests/DMProject/Tests/Typemaker/proc_path_error.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD2701
 #pragma InvalidReturnType error
 
 /datum/proc/meep() as /atom

--- a/Content.Tests/DMProject/Tests/Typemaker/proc_return_override.dm
+++ b/Content.Tests/DMProject/Tests/Typemaker/proc_return_override.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD2701
 #pragma InvalidReturnType error
 /datum/proc/foo() as num
 	return 5

--- a/Content.Tests/DMProject/Tests/Typemaker/proccall_error.dm
+++ b/Content.Tests/DMProject/Tests/Typemaker/proccall_error.dm
@@ -1,4 +1,4 @@
-//COMPILE ERROR
+//COMPILE ERROR OD2701
 #pragma InvalidReturnType error
 /datum/proc/foo()
 	return "bar"

--- a/Content.Tests/DMProject/Tests/Typemaker/return_objvar_fail.dm
+++ b/Content.Tests/DMProject/Tests/Typemaker/return_objvar_fail.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD2701
 #pragma InvalidReturnType error
 /datum/var/bar = 5 as num
 

--- a/Content.Tests/DMProject/Tests/Typemaker/var_implicit_null.dm
+++ b/Content.Tests/DMProject/Tests/Typemaker/var_implicit_null.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD2703
 #pragma ImplicitNullType error
 
 /datum/do

--- a/Content.Tests/DMProject/Tests/Typemaker/var_override_error.dm
+++ b/Content.Tests/DMProject/Tests/Typemaker/var_override_error.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD2702
 #pragma InvalidVarType error
 /datum/do/re/mi/fa/so
 	meep = "foo"

--- a/Content.Tests/DMTests.cs
+++ b/Content.Tests/DMTests.cs
@@ -179,7 +179,7 @@ public sealed partial class DMTests : ContentUnitTest {
                 testFlags |= DMTestFlags.Ignore;
             if (firstLine.Contains("COMPILE ERROR", StringComparison.InvariantCulture)) {
                 testFlags |= DMTestFlags.CompileError;
-                Match match = ErrorCodeRegex().Match(firstLine);  // "OD" followed by exactly 4 characters
+                Match match = ErrorCodeRegex().Match(firstLine);  // "OD" followed by exactly 4 numbers
                 if (!match.Success) {
                     Console.WriteLine($"\"COMPILE ERROR\" test \"{sourceFile}\" does not specify an error code");
                 } else {

--- a/Content.Tests/DMTests.cs
+++ b/Content.Tests/DMTests.cs
@@ -64,19 +64,16 @@ public sealed partial class DMTests : ContentUnitTest {
         string initialDirectory = Directory.GetCurrentDirectory();
         TestContext.WriteLine($"--- TEST {sourceFile} | Flags: {testFlags}");
         try {
+            string? compiledFile = Compile(Path.Join(initialDirectory, TestsDirectory, sourceFile));
             if (testFlags.HasFlag(DMTestFlags.CompileError)) {
                 Assert.That(errorCode == -1, Is.False, "Expected an error code");
-                string? compileErrorFile = Compile(Path.Join(initialDirectory, TestsDirectory, sourceFile));
-
                 Assert.That(DMCompiler.DMCompiler.UniqueEmissions.Contains((WarningCode)errorCode), Is.True, $"Expected error code \"{errorCode}\" was not found");
-                Assert.That(compileErrorFile, Is.Null, "Expected an error during DM compilation");
+                Assert.That(compiledFile, Is.Null, "Expected an error during DM compilation");
 
-                Cleanup(compileErrorFile);
+                Cleanup(compiledFile);
                 TestContext.WriteLine($"--- PASS {sourceFile}");
                 return;
             }
-
-            string? compiledFile = Compile(Path.Join(initialDirectory, TestsDirectory, sourceFile));
 
             Assert.That(compiledFile is not null && File.Exists(compiledFile), "Failed to compile DM source file");
             Assert.That(_dreamMan.LoadJson(compiledFile), $"Failed to load {compiledFile}");

--- a/Content.Tests/DMTests.cs
+++ b/Content.Tests/DMTests.cs
@@ -198,7 +198,7 @@ public sealed partial class DMTests : ContentUnitTest {
         return testFlags;
     }
 
-    [GeneratedRegex(@"OD.{4}")]
+    [GeneratedRegex(@"OD[0-9]{4}")]
     private static partial Regex ErrorCodeRegex();
 
     // TODO Convert the below async tests

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -21,6 +21,7 @@ namespace DMCompiler;
 public static class DMCompiler {
     public static int ErrorCount;
     public static int WarningCount;
+    public static HashSet<WarningCode> UniqueEmissions = new();
     public static DMCompilerSettings Settings;
     public static IReadOnlyList<string> ResourceDirectories => _resourceDirectories;
 
@@ -187,6 +188,7 @@ public static class DMCompiler {
                 break;
         }
 
+        UniqueEmissions.Add(emission.Code);
         Console.WriteLine(emission);
     }
 

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -32,6 +32,7 @@ public static class DMCompiler {
     public static bool Compile(DMCompilerSettings settings) {
         ErrorCount = 0;
         WarningCount = 0;
+        UniqueEmissions.Clear();
         Settings = settings;
         if (Settings.Files == null) return false;
         Config.Reset();


### PR DESCRIPTION
Unit tests that check for a compiler error must now specify the error code that they want. 

Example: `// COMPILE ERROR OD0404`

For the tests that do not explicitly elevate a pragma, I got the error code by running the test in the OD compiler bot (while renaming `RunTest()` to `main()`) and seeing what got emitted. This means that if any test is wildly broken currently, this PR doesn't really fix that.

I recommend reviewing it by commit, they're split up pretty nicely.
