### PR TITLE
Add a `dump-all` command to the disassembler

### DIFF
--- a/DMDisassembler/DMProc.cs
+++ b/DMDisassembler/DMProc.cs
@@ -2,7 +2,9 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using DMCompiler.DM;
 using DMCompiler.Json;
+using JetBrains.Annotations;
 
 namespace DMDisassembler;
 
@@ -13,10 +15,13 @@ internal class DMProc(ProcDefinitionJson json) {
     }
 
     public string Name = json.Name;
+    public int OwningTypeId = json.OwningTypeId;
     public byte[] Bytecode = json.Bytecode ?? Array.Empty<byte>();
+    public bool IsOverride = (json.Attributes & ProcAttributes.IsOverride) != 0;
     public Exception exception;
 
     public string Decompile() {
+        var foo = json.Arguments;
         List<DecompiledOpcode> decompiled = new();
         HashSet<int> labeledPositions = new();
 
@@ -35,7 +40,9 @@ internal class DMProc(ProcDefinitionJson json) {
         foreach (DecompiledOpcode decompiledOpcode in decompiled) {
             if (labeledPositions.Contains(decompiledOpcode.Position)) {
                 result.AppendFormat("0x{0:x}", decompiledOpcode.Position);
+                result.AppendLine();
             }
+
             result.Append('\t');
             result.AppendLine(decompiledOpcode.Text);
         }
@@ -51,5 +58,17 @@ internal class DMProc(ProcDefinitionJson json) {
         }
 
         return result.ToString();
+    }
+
+    [CanBeNull]
+    public string[] GetArguments() {
+        if (json.Arguments is null || json.Arguments.Count == 0) return null;
+
+        string[] argNames = new string[json.Arguments.Count];
+        for (var index = 0; index < json.Arguments.Count; index++) {
+            argNames[index] = json.Arguments[index].Name;
+        }
+
+        return argNames;
     }
 }

--- a/DMDisassembler/DMProc.cs
+++ b/DMDisassembler/DMProc.cs
@@ -21,7 +21,6 @@ internal class DMProc(ProcDefinitionJson json) {
     public Exception exception;
 
     public string Decompile() {
-        var foo = json.Arguments;
         List<DecompiledOpcode> decompiled = new();
         HashSet<int> labeledPositions = new();
 

--- a/DMDisassembler/Program.cs
+++ b/DMDisassembler/Program.cs
@@ -262,8 +262,7 @@ internal class Program {
         var outputFile = Path.ChangeExtension(JsonFile, ".dmd")!;
         using StreamWriter writer = new StreamWriter(outputFile, append: false, encoding: Encoding.UTF8, bufferSize: 65536);
 
-        foreach (DMProc proc in Procs)
-        {
+        foreach (DMProc proc in Procs) {
             string value = proc.Decompile();
             if (proc.exception != null) {
                 Console.WriteLine("Error disassembling " + PrettyPrintPath(proc));

--- a/DMDisassembler/Program.cs
+++ b/DMDisassembler/Program.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Text;
 using System.Text.Json;
 using DMCompiler.Json;
-using JetBrains.Annotations;
 
 namespace DMDisassembler;
 

--- a/DMDisassembler/Program.cs
+++ b/DMDisassembler/Program.cs
@@ -277,7 +277,8 @@ internal class Program {
             ++all;
         }
 
-        Console.WriteLine($"Successfully dumped {all - errored}/{all} procs to {outputFile}");
+        var procCount = errored > 0 ? $"{all - errored}/{all} ({errored} failed procs)" : $"all {all}";
+        Console.WriteLine($"Successfully dumped {procCount} procs to {outputFile}");
     }
 
     private static string PrettyPrintPath(DMProc proc) {

--- a/DMDisassembler/Program.cs
+++ b/DMDisassembler/Program.cs
@@ -1,12 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Text.Json;
 using DMCompiler.Json;
+using JetBrains.Annotations;
 
 namespace DMDisassembler;
 
 internal class Program {
+    public static string JsonFile = string.Empty;
     public static DreamCompiledJson CompiledJson;
     public static DMProc GlobalInitProc = null;
     public static List<DMProc> Procs = null;
@@ -22,6 +25,8 @@ internal class Program {
             Environment.Exit(1);
         }
 
+        JsonFile = args[0];
+
         string compiledJsonText = File.ReadAllText(args[0]);
 
         CompiledJson = JsonSerializer.Deserialize<DreamCompiledJson>(compiledJsonText);
@@ -29,16 +34,21 @@ internal class Program {
         LoadAllProcs();
         LoadAllTypes();
 
-        if (args.Length == 2 && args[1] == "crash-on-test") {
-            // crash-on-test is a special mode used by CI to
-            // verify that an entire codebase can be disassembled without errors
-            int errors = TestAll();
+        if (args.Length == 2) {
+            if (args[1] == "crash-on-test") {
+                // crash-on-test is a special mode used by CI to
+                // verify that an entire codebase can be disassembled without errors
+                int errors = TestAll();
 
-            if (errors > 0) {
-                Console.WriteLine($"Detected {errors} errors. Exiting.");
-                Environment.Exit(1);
-            } else {
-                Console.WriteLine("No errors detected. Exiting cleanly.");
+                if (errors > 0) {
+                    Console.WriteLine($"Detected {errors} errors. Exiting.");
+                    Environment.Exit(1);
+                } else {
+                    Console.WriteLine("No errors detected. Exiting cleanly.");
+                    Environment.Exit(0);
+                }
+            } else if (args[1] == "dump-all") {
+                DumpAll();
                 Environment.Exit(0);
             }
         }
@@ -70,6 +80,7 @@ internal class Program {
                 case "d":
                 case "decompile": Decompile(split); break;
                 case "test-all": TestAll(); break;
+                case "dump-all": DumpAll(); break;
                 case "help": PrintHelp(); break;
                 default: Console.WriteLine("Invalid command \"" + command + "\""); break;
             }
@@ -85,6 +96,7 @@ internal class Program {
         Console.WriteLine("select|sel                : Select a typepath to run further commands on");
         Console.WriteLine("list procs|globals        : List all globals, or all procs on a selected type");
         Console.WriteLine("decompile|d [name]        : Decompiles the proc on the selected type");
+        Console.WriteLine("dump-all                  : Decompiles every proc and writes the output to a file");
         Console.WriteLine("test-all                  : Tries to decompile every single proc to check for issues with this disassembler; not for production use");
     }
 
@@ -232,7 +244,7 @@ internal class Program {
         foreach (DMProc proc in Procs) {
             string value = proc.Decompile();
             if (proc.exception != null) {
-                Console.WriteLine("Error disassembling " + proc.Name);
+                Console.WriteLine("Error disassembling " + PrettyPrintPath(proc));
                 Console.WriteLine(value);
                 ++errored;
             }
@@ -242,5 +254,38 @@ internal class Program {
 
         Console.WriteLine($"Errors in {errored}/{all} procs");
         return errored;
+    }
+
+    private static void DumpAll() {
+        Console.WriteLine("Dumping all procs. This may take a moment.");
+        int errored = 0, all = 0;
+        // ".dmd" for "dm disassembly"
+        var outputFile = Path.ChangeExtension(JsonFile, ".dmd")!;
+        using StreamWriter writer = new StreamWriter(outputFile, append: false, encoding: Encoding.UTF8, bufferSize: 65536);
+
+        foreach (DMProc proc in Procs)
+        {
+            string value = proc.Decompile();
+            if (proc.exception != null) {
+                Console.WriteLine("Error disassembling " + PrettyPrintPath(proc));
+                ++errored;
+            } else {
+                writer.WriteLine(PrettyPrintPath(proc) + ":");
+                writer.WriteLine(value);
+            }
+
+            ++all;
+        }
+
+        Console.WriteLine($"Successfully dumped {all - errored}/{all} procs to {outputFile}");
+    }
+
+    private static string PrettyPrintPath(DMProc proc) {
+        var path = CompiledJson.Types![proc.OwningTypeId].Path;
+        var args = proc.GetArguments();
+
+        if(args is null)
+            return path + (path[^1] == '/' ? "" : "/") + (proc.IsOverride ? "" : "proc/") + proc.Name + "()";
+        return path + (path[^1] == '/' ? "" : "/") + (proc.IsOverride ? "" : "proc/") + proc.Name + $"({string.Join(", ", args)})";
     }
 }


### PR DESCRIPTION
Passing `dump-all` to the disassembler will write the disassembly of all procs to a file named `[CompiledJsonFile].dmd`.

Useful for bytecode analysis since I can no longer be bothered to maintain my annotated bytecode writer branch.