### PR TITLE
Implement `world.sleep_offline`

### DIFF
--- a/OpenDreamRuntime/EntryPoint.cs
+++ b/OpenDreamRuntime/EntryPoint.cs
@@ -42,7 +42,7 @@ namespace OpenDreamRuntime {
             componentFactory.GenerateNetIds();
 
             _configManager.OverrideDefault(CVars.NetLogLateMsg, false); // Disable since disabling prediction causes timing errors otherwise.
-            _configManager.OverrideDefault(CVars.GameAutoPauseEmpty, false); // TODO: world.sleep_offline can control this
+
             _configManager.OverrideDefault(CVars.DiscordRichPresenceSecondIconId, "opendream");
             _configManager.SetCVar(CVars.GridSplitting, false); // Grid splitting should never be used
             if(String.IsNullOrEmpty(_configManager.GetCVar<string>(OpenDreamCVars.JsonPath))) //if you haven't set the jsonpath cvar, set it to the first valid file path passed as an arg


### PR DESCRIPTION
Also handles `world.tick_lag` being set on the object definition.

`world.sleep_offline` works slightly differently from BYOND. According to the ref, if `sleep_offline = 0` then the server pauses *if there are no sleeping procs*. Setting `sleep_offline = 1` causes it to still pause even if there *are* sleeping procs.

This PR just makes `world.sleep_offline = 1` set `CVars.GameAutoPauseEmpty` to `true`. Probably good enough for now.

Resolves #194 