### PR TITLE
Freeze some collections for faster accessing

### DIFF
--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -149,11 +149,12 @@ namespace OpenDreamRuntime.Objects {
         }
 
         #region Variables
+
         public virtual bool IsSaved(string name) {
             return ObjectDefinition.Variables.ContainsKey(name)
                 && !ObjectDefinition.GlobalVariables.ContainsKey(name)
-                && !(ObjectDefinition.ConstVariables is not null && ObjectDefinition.ConstVariables.Contains(name))
-                && !(ObjectDefinition.TmpVariables is not null && ObjectDefinition.TmpVariables.Contains(name));
+                && !(ObjectDefinition.ConstVariables.Contains(name))
+                && !(ObjectDefinition.TmpVariables.Contains(name));
         }
 
         public bool HasVariable(string name) {

--- a/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Frozen;
+using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using OpenDreamRuntime.Procs;
@@ -54,10 +54,10 @@ public sealed class DreamObjectDefinition {
     public readonly Dictionary<string, DreamValue> Variables = new();
 
     // Maps /static variables from name to their index in the global variable table.
-    public FrozenDictionary<string, int> GlobalVariables;
+    public FrozenDictionary<string, int> GlobalVariables = FrozenDictionary<string, int>.Empty;
 
     // Contains hashes of variables that are tagged /const.
-    public HashSet<string>? ConstVariables = null;
+    public FrozenSet<string> ConstVariables = FrozenSet<string>.Empty;
 
     // Contains hashes of variables that are tagged /tmp.
     public HashSet<string>? TmpVariables = null;

--- a/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
@@ -1,4 +1,4 @@
-using System.Collections.Frozen;
+﻿using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using OpenDreamRuntime.Procs;
@@ -84,7 +84,7 @@ public sealed class DreamObjectDefinition {
 
         Variables = new Dictionary<string, DreamValue>(copyFrom.Variables);
         GlobalVariables = copyFrom.GlobalVariables;
-        ConstVariables = copyFrom.ConstVariables is not null ? new HashSet<string>(copyFrom.ConstVariables) : null;
+        ConstVariables = copyFrom.ConstVariables;
         TmpVariables = copyFrom.TmpVariables is not null ? new HashSet<string>(copyFrom.TmpVariables) : null;
         Procs = new Dictionary<string, int>(copyFrom.Procs);
         OverridingProcs = new Dictionary<string, int>(copyFrom.OverridingProcs);
@@ -118,8 +118,7 @@ public sealed class DreamObjectDefinition {
                 Verbs = new List<int>(Parent.Verbs);
             if (Parent != ObjectTree.Root.ObjectDefinition) // Don't include root-level globals
                 GlobalVariables = Parent.GlobalVariables;
-            if (Parent.ConstVariables != null)
-                ConstVariables = new HashSet<string>(Parent.ConstVariables);
+            ConstVariables = Parent.ConstVariables;
             if (Parent.TmpVariables != null)
                 TmpVariables = new HashSet<string>(Parent.TmpVariables);
         }

--- a/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Frozen;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using OpenDreamRuntime.Procs;
 using OpenDreamRuntime.Rendering;
@@ -51,10 +52,13 @@ public sealed class DreamObjectDefinition {
 
     // Maps variables from their name to their initial value.
     public readonly Dictionary<string, DreamValue> Variables = new();
+
     // Maps /static variables from name to their index in the global variable table.
-    public readonly Dictionary<string, int> GlobalVariables = new();
+    public FrozenDictionary<string, int> GlobalVariables;
+
     // Contains hashes of variables that are tagged /const.
     public HashSet<string>? ConstVariables = null;
+
     // Contains hashes of variables that are tagged /tmp.
     public HashSet<string>? TmpVariables = null;
 
@@ -79,7 +83,7 @@ public sealed class DreamObjectDefinition {
         InitializationProc = copyFrom.InitializationProc;
 
         Variables = new Dictionary<string, DreamValue>(copyFrom.Variables);
-        GlobalVariables = new Dictionary<string, int>(copyFrom.GlobalVariables);
+        GlobalVariables = copyFrom.GlobalVariables;
         ConstVariables = copyFrom.ConstVariables is not null ? new HashSet<string>(copyFrom.ConstVariables) : null;
         TmpVariables = copyFrom.TmpVariables is not null ? new HashSet<string>(copyFrom.TmpVariables) : null;
         Procs = new Dictionary<string, int>(copyFrom.Procs);
@@ -113,7 +117,7 @@ public sealed class DreamObjectDefinition {
             if (Parent.Verbs != null)
                 Verbs = new List<int>(Parent.Verbs);
             if (Parent != ObjectTree.Root.ObjectDefinition) // Don't include root-level globals
-                GlobalVariables = new Dictionary<string, int>(Parent.GlobalVariables);
+                GlobalVariables = Parent.GlobalVariables;
             if (Parent.ConstVariables != null)
                 ConstVariables = new HashSet<string>(Parent.ConstVariables);
             if (Parent.TmpVariables != null)

--- a/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectDefinition.cs
@@ -60,7 +60,7 @@ public sealed class DreamObjectDefinition {
     public FrozenSet<string> ConstVariables = FrozenSet<string>.Empty;
 
     // Contains hashes of variables that are tagged /tmp.
-    public HashSet<string>? TmpVariables = null;
+    public FrozenSet<string> TmpVariables = FrozenSet<string>.Empty;
 
     public DreamObjectDefinition(DreamObjectDefinition copyFrom) {
         DreamManager = copyFrom.DreamManager;
@@ -85,7 +85,7 @@ public sealed class DreamObjectDefinition {
         Variables = new Dictionary<string, DreamValue>(copyFrom.Variables);
         GlobalVariables = copyFrom.GlobalVariables;
         ConstVariables = copyFrom.ConstVariables;
-        TmpVariables = copyFrom.TmpVariables is not null ? new HashSet<string>(copyFrom.TmpVariables) : null;
+        TmpVariables = copyFrom.TmpVariables;
         Procs = new Dictionary<string, int>(copyFrom.Procs);
         OverridingProcs = new Dictionary<string, int>(copyFrom.OverridingProcs);
         if (copyFrom.Verbs != null)
@@ -119,8 +119,7 @@ public sealed class DreamObjectDefinition {
             if (Parent != ObjectTree.Root.ObjectDefinition) // Don't include root-level globals
                 GlobalVariables = Parent.GlobalVariables;
             ConstVariables = Parent.ConstVariables;
-            if (Parent.TmpVariables != null)
-                TmpVariables = new HashSet<string>(Parent.TmpVariables);
+            TmpVariables = Parent.TmpVariables;
         }
     }
 

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -398,8 +398,6 @@ public sealed class DreamObjectTree {
             }
 
             objectDefinition.GlobalVariables = globalVars.ToFrozenDictionary();
-        } else {
-            objectDefinition.GlobalVariables = FrozenDictionary<string, int>.Empty;
         }
 
         if (jsonObject.ConstVariables != null) {
@@ -445,8 +443,6 @@ public sealed class DreamObjectTree {
             }
 
             _globalProcIds = globalProcIds.ToFrozenDictionary();
-        } else {
-            _globalProcIds = FrozenDictionary<string, int>.Empty;
         }
     }
 

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -401,10 +401,12 @@ public sealed class DreamObjectTree {
         }
 
         if (jsonObject.ConstVariables != null) {
-            objectDefinition.ConstVariables ??= new();
+            HashSet<string> constVars = new HashSet<string>(jsonObject.ConstVariables.Count);
             foreach (string jsonConstVariable in jsonObject.ConstVariables) {
-                objectDefinition.ConstVariables.Add(jsonConstVariable);
+                constVars.Add(jsonConstVariable);
             }
+
+            objectDefinition.ConstVariables = constVars.ToFrozenSet();
         }
 
         if(jsonObject.TmpVariables != null) {

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -392,9 +392,14 @@ public sealed class DreamObjectTree {
         }
 
         if (jsonObject.GlobalVariables != null) {
+            Dictionary<string, int> globalVars = new Dictionary<string, int>(jsonObject.GlobalVariables.Count);
             foreach (KeyValuePair<string, int> jsonGlobalVariable in jsonObject.GlobalVariables) {
-                objectDefinition.GlobalVariables.Add(jsonGlobalVariable.Key, jsonGlobalVariable.Value);
+                globalVars.Add(jsonGlobalVariable.Key, jsonGlobalVariable.Value);
             }
+
+            objectDefinition.GlobalVariables = globalVars.ToFrozenDictionary();
+        } else {
+            objectDefinition.GlobalVariables = FrozenDictionary<string, int>.Empty;
         }
 
         if (jsonObject.ConstVariables != null) {

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -410,10 +410,12 @@ public sealed class DreamObjectTree {
         }
 
         if(jsonObject.TmpVariables != null) {
-            objectDefinition.TmpVariables ??= new();
+            HashSet<string> tmpVars = new HashSet<string>(jsonObject.TmpVariables.Count);
             foreach (string jsonTmpVariable in jsonObject.TmpVariables) {
-                objectDefinition.TmpVariables.Add(jsonTmpVariable);
+                tmpVars.Add(jsonTmpVariable);
             }
+
+            objectDefinition.TmpVariables = tmpVars.ToFrozenSet();
         }
     }
 

--- a/OpenDreamRuntime/Objects/DreamObjectTree.cs
+++ b/OpenDreamRuntime/Objects/DreamObjectTree.cs
@@ -48,8 +48,8 @@ public sealed class DreamObjectTree {
     public TreeEntry Obj { get; private set; }
     public TreeEntry Mob { get; private set; }
 
-    private FrozenDictionary<string, TreeEntry>? _pathToType;
-    private FrozenDictionary<string, int>? _globalProcIds;
+    private FrozenDictionary<string, TreeEntry> _pathToType = FrozenDictionary<string, TreeEntry>.Empty;
+    private FrozenDictionary<string, int> _globalProcIds = FrozenDictionary<string, int>.Empty;
 
     [Dependency] private readonly AtomManager _atomManager = default!;
     [Dependency] private readonly DreamManager _dreamManager = default!;
@@ -97,7 +97,7 @@ public sealed class DreamObjectTree {
     }
 
     public TreeEntry GetTreeEntry(string path) {
-        if (!_pathToType!.TryGetValue(path, out TreeEntry? type)) {
+        if (!_pathToType.TryGetValue(path, out TreeEntry? type)) {
             throw new Exception($"Object '{path}' does not exist");
         }
 
@@ -109,7 +109,7 @@ public sealed class DreamObjectTree {
     }
 
     public bool TryGetTreeEntry(string path, [NotNullWhen(true)] out TreeEntry? treeEntry) {
-        return _pathToType!.TryGetValue(path, out treeEntry);
+        return _pathToType.TryGetValue(path, out treeEntry);
     }
 
     public DreamObjectDefinition GetObjectDefinition(int typeId) {
@@ -117,7 +117,7 @@ public sealed class DreamObjectTree {
     }
 
     public bool TryGetGlobalProc(string name, [NotNullWhen(true)] out DreamProc? globalProc) {
-        globalProc = _globalProcIds!.TryGetValue(name, out int procId) ? Procs[procId] : null;
+        globalProc = _globalProcIds.TryGetValue(name, out int procId) ? Procs[procId] : null;
 
         return (globalProc != null);
     }

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -453,7 +453,7 @@ sealed class DreamGlobalVars : DreamList {
 
     public override List<DreamValue> GetValues() {
         var root = _objectTree.Root.ObjectDefinition;
-        List<DreamValue> values = new List<DreamValue>(root.GlobalVariables.Keys.Count - 1);
+        List<DreamValue> values = new List<DreamValue>(root.GlobalVariables.Keys.Length - 1);
         // Skip world
         foreach (var key in root.GlobalVariables.Keys.Skip(1)) {
             values.Add(new DreamValue(key));

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -2227,8 +2227,8 @@ namespace OpenDreamRuntime.Procs {
             }
 
             if (objectDefinition.GlobalVariables.ContainsKey(property)
-            || (objectDefinition.ConstVariables is not null && objectDefinition.ConstVariables.Contains(property))
-            || (objectDefinition.TmpVariables is not null && objectDefinition.TmpVariables.Contains(property))) {
+            || (objectDefinition.ConstVariables.Contains(property))
+            || (objectDefinition.TmpVariables.Contains(property))) {
                 state.Push(new DreamValue(0));
             } else {
                 state.Push(new DreamValue(1));


### PR DESCRIPTION
Converts some collections on `DreamObjectTree` and `DreamObjectDefinition` to their frozen variants. On my machine this consistently reduced Paradise round init by roughly ~2 seconds. I only compared third and fourth runs for both before & after so PGO wouldn't impact the results.

Since these collections never change after JSON parsing, it's a free performance boost on any accesses for the remainder of the round.

I'll try to tackle Procs & Variables in a subsequent PR since they need a bit more wrangling.