### PR TITLE
Handle `/icon.Blend()`-ing a small icon onto a bigger one

### DIFF
--- a/OpenDreamRuntime/Objects/DreamIcon.cs
+++ b/OpenDreamRuntime/Objects/DreamIcon.cs
@@ -428,6 +428,11 @@ public sealed class DreamIconOperationBlendImage : DreamIconOperationBlend {
 
         var blendingFrame = blendingDirFrames[frame];
 
+        // Use the smaller of the two sizes if they're different
+        // TODO: 1,1 should be bottom left, not top left
+        bounds = UIBox2i.FromDimensions(bounds.Left, bounds.Top, Math.Min(_blending.Width, bounds.Width),
+            Math.Min(_blending.Height, bounds.Height));
+
         _blending.ProcessPixelRows(accessor => {
             // TODO: x & y offsets
 


### PR DESCRIPTION
In /tg/, blending a 32x32 icon onto a 115x115 icon was causing an out of bounds error. This was because it was assumed that for every pixel in the first icon, there was also one in the second icon. Now we shrink the bounds to the smaller of the two, resulting in byond's behavior.