### PR TITLE
Fix a few bugs in `browse()`

### DIFF
--- a/OpenDreamClient/Interface/Controls/ControlBrowser.cs
+++ b/OpenDreamClient/Interface/Controls/ControlBrowser.cs
@@ -90,8 +90,13 @@ internal sealed class ControlBrowser : InterfaceControl {
         _webView.ExecuteJavaScript($"{jsFunction}({string.Join(",", parts)})");
     }
 
-    public void SetFileSource(ResPath filepath) {
-        _webView.Url = "http://127.0.0.1/" + filepath; // hostname must be the localhost IP for TGUI to work properly
+    public void SetFileSource(ResPath? filepath) {
+        if (filepath != null) {
+            // hostname must be the localhost IP for TGUI to work properly
+            _webView.Url = "http://127.0.0.1/" + filepath;
+        } else {
+            _webView.Url = "about:blank";
+        }
     }
 
     private void BeforeBrowseHandler(IBeforeBrowseContext context) {
@@ -157,6 +162,7 @@ internal sealed class ControlBrowser : InterfaceControl {
             }
         } catch (Exception e) {
             _sawmill.Error($"Exception in RequestHandler: {e}");
+            context.DoCancel();
         }
     }
 


### PR DESCRIPTION
The window argument of `browse()` can reference either a browser control directly, or a window that contains a browser control.

A `browse()` referencing a window was creating a new popup because it didn't recognize the window as a valid target. I removed the difference between popups and other windows, they are held in the same dictionary now.

This gets one step closer to tgui_say working. It no longer creates a useless popup when joining, and the only thing keeping it from fully working is that RT does not initialize the browser control until it is visible for the first time.