### PR TITLE
`world.sleep_offline` fixes

### DIFF
--- a/DMCompiler/DMStandard/Types/World.dm
+++ b/DMCompiler/DMStandard/Types/World.dm
@@ -40,7 +40,7 @@
 	var/process
 	var/list/params = null
 
-	var/sleep_offline = 0 as opendream_unimplemented
+	var/sleep_offline = 0
 
 	var/system_type
 

--- a/OpenDreamRuntime/EntryPoint.cs
+++ b/OpenDreamRuntime/EntryPoint.cs
@@ -42,6 +42,7 @@ namespace OpenDreamRuntime {
             componentFactory.GenerateNetIds();
 
             _configManager.OverrideDefault(CVars.NetLogLateMsg, false); // Disable since disabling prediction causes timing errors otherwise.
+            _configManager.OverrideDefault(CVars.GameAutoPauseEmpty, false); // DreamObjectWorld sets this appropriately but we need to keep it disabled til then or it won't be reached
             _configManager.OverrideDefault(CVars.DiscordRichPresenceSecondIconId, "opendream");
             _configManager.SetCVar(CVars.GridSplitting, false); // Grid splitting should never be used
             if(String.IsNullOrEmpty(_configManager.GetCVar<string>(OpenDreamCVars.JsonPath))) //if you haven't set the jsonpath cvar, set it to the first valid file path passed as an arg


### PR DESCRIPTION
- Mark it as implemented
- Disable the cvar in pre-init so we actually reach `DreamObjectWorld` handling