### PR TITLE
Halves `OpenDreamClient` warnings

### DIFF
--- a/OpenDreamClient/EntryPoint.cs
+++ b/OpenDreamClient/EntryPoint.cs
@@ -22,7 +22,6 @@ namespace OpenDreamClient;
 public sealed class EntryPoint : GameClient {
     [Dependency] private readonly IDreamInterfaceManager _dreamInterface = default!;
     [Dependency] private readonly IDreamResourceManager _dreamResource = default!;
-    [Dependency] private readonly IDreamSoundEngine _soundEngine = default!;
     [Dependency] private readonly IOverlayManager _overlayManager = default!;
     [Dependency] private readonly ILightManager _lightManager = default!;
     [Dependency] private readonly IConfigurationManager _configurationManager = default!;

--- a/OpenDreamClient/Input/ContextMenu/ContextMenuPopup.xaml.cs
+++ b/OpenDreamClient/Input/ContextMenu/ContextMenuPopup.xaml.cs
@@ -52,7 +52,7 @@ internal sealed partial class ContextMenuPopup : Popup {
         foreach (var objectReference in entities) {
             if (objectReference.Type == ClientObjectReference.RefType.Entity) {
                 var entity = _entityManager.GetEntity(objectReference.Entity);
-                if (_xformQuery.TryGetComponent(entity, out TransformComponent? transform) && !_mapManager.IsGrid(_transformSystem.GetParent(transform)!.Owner)) // Not a child of another entity
+                if (_xformQuery.TryGetComponent(entity, out TransformComponent? transform) && !_mapManager.IsGrid(_transformSystem.GetParentUid(entity))) // Not a child of another entity
                     continue;
                 if (!_spriteQuery.TryGetComponent(entity, out DMISpriteComponent? sprite)) // Has a sprite
                     continue;

--- a/OpenDreamClient/Interface/BrowsePopup.cs
+++ b/OpenDreamClient/Interface/BrowsePopup.cs
@@ -7,12 +7,12 @@ using Robust.Client.UserInterface.Controls;
 namespace OpenDreamClient.Interface;
 
 internal sealed class BrowsePopup {
-    public event Action Closed;
+    public event Action? Closed;
 
-    public ControlBrowser Browser;
-    public ControlWindow WindowElement;
+    public readonly ControlBrowser Browser;
+    public readonly ControlWindow WindowElement;
 
-    private OSWindow _window;
+    private readonly OSWindow _window;
 
     public BrowsePopup(
         string name,

--- a/OpenDreamClient/Interface/Controls/ControlChild.cs
+++ b/OpenDreamClient/Interface/Controls/ControlChild.cs
@@ -21,10 +21,10 @@ internal sealed class ControlChild(ControlDescriptor controlDescriptor, ControlW
     protected override void UpdateElementDescriptor() {
         base.UpdateElementDescriptor();
 
-        var newLeftElement = ChildDescriptor.Left.Value != null && _interfaceManager.Windows.TryGetValue(ChildDescriptor.Left.Value, out var leftWindow)
+        var newLeftElement = _interfaceManager.Windows.TryGetValue(ChildDescriptor.Left.Value, out var leftWindow)
             ? leftWindow.UIElement
             : null;
-        var newRightElement = ChildDescriptor.Right.Value != null && _interfaceManager.Windows.TryGetValue(ChildDescriptor.Right.Value, out var rightWindow)
+        var newRightElement = _interfaceManager.Windows.TryGetValue(ChildDescriptor.Right.Value, out var rightWindow)
             ? rightWindow.UIElement
             : null;
 
@@ -45,9 +45,9 @@ internal sealed class ControlChild(ControlDescriptor controlDescriptor, ControlW
     }
 
     public override void Shutdown() {
-        if (ChildDescriptor.Left.Value != null && _interfaceManager.Windows.TryGetValue(ChildDescriptor.Left.Value, out var left))
+        if (_interfaceManager.Windows.TryGetValue(ChildDescriptor.Left.Value, out var left))
             left.Shutdown();
-        if (ChildDescriptor.Right.Value != null && _interfaceManager.Windows.TryGetValue(ChildDescriptor.Right.Value, out var right))
+        if (_interfaceManager.Windows.TryGetValue(ChildDescriptor.Right.Value, out var right))
             right.Shutdown();
     }
 

--- a/OpenDreamClient/Interface/Controls/ControlTab.cs
+++ b/OpenDreamClient/Interface/Controls/ControlTab.cs
@@ -25,20 +25,19 @@ internal sealed class ControlTab(ControlDescriptor controlDescriptor, ControlWin
 
         _tabs.Clear();
         _tab.RemoveAllChildren();
-        if (TabDescriptor.Tabs.Value != null) {
-            var tabIds = TabDescriptor.Tabs.Value.Split(',',
-                StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
 
-            foreach (var tabId in tabIds) {
-                if (!_interfaceManager.Windows.TryGetValue(tabId, out var pane))
-                    continue;
+        var tabIds = TabDescriptor.Tabs.Value.Split(',',
+            StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
 
-                TabContainer.SetTabTitle(pane.UIElement, pane.Title);
-                _tab.AddChild(pane.UIElement);
-                _tabs.Add(pane);
-                if (TabDescriptor.CurrentTab.Value == pane.Title)
-                    _tab.CurrentTab = pane.UIElement.GetPositionInParent();
-            }
+        foreach (var tabId in tabIds) {
+            if (!_interfaceManager.Windows.TryGetValue(tabId, out var pane))
+                continue;
+
+            TabContainer.SetTabTitle(pane.UIElement, pane.Title);
+            _tab.AddChild(pane.UIElement);
+            _tabs.Add(pane);
+            if (TabDescriptor.CurrentTab.Value == pane.Title)
+                _tab.CurrentTab = pane.UIElement.GetPositionInParent();
         }
     }
 

--- a/OpenDreamClient/Interface/Controls/ControlWindow.cs
+++ b/OpenDreamClient/Interface/Controls/ControlWindow.cs
@@ -19,7 +19,7 @@ public sealed class ControlWindow : InterfaceControl {
 
     public readonly List<InterfaceControl> ChildControls = new();
 
-    public string Title => WindowDescriptor.Title.Value ?? (WindowDescriptor.IsDefault.Value ? "OpenDream World" : WindowDescriptor.Id.AsRaw());
+    public string Title => WindowDescriptor.Title.Value;
     public InterfaceMacroSet Macro => _interfaceManager.MacroSets[WindowDescriptor.Macro.AsRaw()];
 
     private WindowDescriptor WindowDescriptor => (WindowDescriptor)ElementDescriptor;
@@ -37,7 +37,7 @@ public sealed class ControlWindow : InterfaceControl {
         // Don't call base.UpdateElementDescriptor();
 
         _menuContainer.RemoveAllChildren();
-        if (WindowDescriptor.Menu.Value != null && _interfaceManager.Menus.TryGetValue(WindowDescriptor.Menu.Value, out var menu)) {
+        if (_interfaceManager.Menus.TryGetValue(WindowDescriptor.Menu.Value, out var menu)) {
             _menuContainer.AddChild(menu.MenuBar);
             _menuContainer.Visible = true;
         } else {

--- a/OpenDreamClient/Interface/DMF/IDMFProperty.cs
+++ b/OpenDreamClient/Interface/DMF/IDMFProperty.cs
@@ -222,38 +222,20 @@ public struct DMFPropertyVec2 : IDMFProperty, IEquatable<DMFPropertyVec2> {
         return comparisonVec.X == X && comparisonVec.Y == Y;
     }
 
-    public bool Equals(DMFPropertyVec2 other)
-    {
+    public bool Equals(DMFPropertyVec2 other) {
         return X == other.X && Y == other.Y && Delim == other.Delim;
     }
 
-    public override bool Equals(object? obj)
-    {
+    public override bool Equals(object? obj) {
         return obj is DMFPropertyVec2 other && Equals(other);
     }
 
-    public override int GetHashCode()
-    {
+    public override int GetHashCode() {
         return HashCode.Combine(X, Y, Delim);
     }
 }
 
 public struct DMFPropertySize : IDMFProperty, IEquatable<DMFPropertySize> {
-    public bool Equals(DMFPropertySize other)
-    {
-        return _value.Equals(other._value);
-    }
-
-    public override bool Equals(object? obj)
-    {
-        return obj is DMFPropertySize other && Equals(other);
-    }
-
-    public override int GetHashCode()
-    {
-        return _value.GetHashCode();
-    }
-
     private DMFPropertyVec2 _value;
     public int X {get => _value.X; set => _value.X = value;}
     public int Y {get => _value.Y; set => _value.Y = value;}
@@ -320,26 +302,23 @@ public struct DMFPropertySize : IDMFProperty, IEquatable<DMFPropertySize> {
         return _value.Equals(comparison);
     }
 
+    public bool Equals(DMFPropertySize other) {
+        return _value.Equals(other._value);
+    }
+
+    public override bool Equals(object? obj) {
+        return obj is DMFPropertySize other && Equals(other);
+    }
+
+    public override int GetHashCode() {
+        return _value.GetHashCode();
+    }
+
     public static bool operator ==(DMFPropertySize a, DMFPropertySize b) => a.Vector == b.Vector;
     public static bool operator !=(DMFPropertySize a, DMFPropertySize b) => a.Vector != b.Vector;
 }
 
 public struct DMFPropertyPos : IDMFProperty, IEquatable<DMFPropertyPos> {
-    public bool Equals(DMFPropertyPos other)
-    {
-        return _value.Equals(other._value);
-    }
-
-    public override bool Equals(object? obj)
-    {
-        return obj is DMFPropertyPos other && Equals(other);
-    }
-
-    public override int GetHashCode()
-    {
-        return _value.GetHashCode();
-    }
-
     private DMFPropertyVec2 _value;
     public int X => _value.X;
     public int Y => _value.Y;
@@ -404,6 +383,18 @@ public struct DMFPropertyPos : IDMFProperty, IEquatable<DMFPropertyPos> {
 
     public bool Equals(string comparison) {
         return _value.Equals(comparison);
+    }
+
+    public bool Equals(DMFPropertyPos other) {
+        return _value.Equals(other._value);
+    }
+
+    public override bool Equals(object? obj) {
+        return obj is DMFPropertyPos other && Equals(other);
+    }
+
+    public override int GetHashCode() {
+        return _value.GetHashCode();
     }
 
     public static bool operator ==(DMFPropertyPos a, DMFPropertyPos b) => a.Vector == b.Vector;

--- a/OpenDreamClient/Interface/DMF/IDMFProperty.cs
+++ b/OpenDreamClient/Interface/DMF/IDMFProperty.cs
@@ -41,15 +41,13 @@ raw
 */
 
 public struct DMFPropertyString(string value) : IDMFProperty {
-    public string? Value = value;
+    public string Value = value;
 
     public string AsArg() {
-        return Value != null ? "\""+AsEscaped()+"\"" : "\"\"";
+        return "\""+AsEscaped()+"\"";
     }
 
     public string AsEscaped() {
-        if(Value == null)
-            return "";
         return Value
             .Replace("\\", "\\\\")
             .Replace("\"", "\\\"");
@@ -60,10 +58,7 @@ public struct DMFPropertyString(string value) : IDMFProperty {
     }
 
     public string AsParams() {
-        if(Value == null)
-            return "";
-        else
-            return System.Web.HttpUtility.UrlEncode(Value);
+        return System.Web.HttpUtility.UrlEncode(Value);
     }
 
     public string AsJson() {
@@ -80,7 +75,7 @@ public struct DMFPropertyString(string value) : IDMFProperty {
     }
 
     public string AsRaw() {
-        return Value ?? "";
+        return Value;
     }
 
     public string AsSnowflake() {

--- a/OpenDreamClient/Interface/DMF/IDMFProperty.cs
+++ b/OpenDreamClient/Interface/DMF/IDMFProperty.cs
@@ -18,7 +18,7 @@ public interface IDMFProperty {
     public string AsJson();
     public string AsJsonDM();
     public string AsRaw();
-    
+
     /// winget() calls do not act the same as embedded winget calls, and the default behaviour is some whacky combination of AsEscaped() and AsRaw(). This proc handles that. Fucking BYOND.
     public string AsSnowflake();
 }
@@ -86,7 +86,7 @@ public struct DMFPropertyString(string value) : IDMFProperty {
     public string AsSnowflake() {
         return AsRaw();
     }
-    
+
     public override string ToString() {
         return AsRaw();
     }
@@ -140,7 +140,7 @@ public struct DMFPropertyNum(float value) : IDMFProperty {
     public string AsSnowflake() {
         return AsRaw();
     }
-    
+
     public override string ToString() {
         return AsRaw();
     }
@@ -151,7 +151,7 @@ public struct DMFPropertyNum(float value) : IDMFProperty {
     }
 }
 
-public struct DMFPropertyVec2 : IDMFProperty {
+public struct DMFPropertyVec2 : IDMFProperty, IEquatable<DMFPropertyVec2> {
     public int X;
     public int Y;
     public char Delim = ',';
@@ -226,9 +226,39 @@ public struct DMFPropertyVec2 : IDMFProperty {
         DMFPropertyVec2 comparisonVec = new(comparison);
         return comparisonVec.X == X && comparisonVec.Y == Y;
     }
+
+    public bool Equals(DMFPropertyVec2 other)
+    {
+        return X == other.X && Y == other.Y && Delim == other.Delim;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is DMFPropertyVec2 other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(X, Y, Delim);
+    }
 }
 
-public struct DMFPropertySize : IDMFProperty {
+public struct DMFPropertySize : IDMFProperty, IEquatable<DMFPropertySize> {
+    public bool Equals(DMFPropertySize other)
+    {
+        return _value.Equals(other._value);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is DMFPropertySize other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return _value.GetHashCode();
+    }
+
     private DMFPropertyVec2 _value;
     public int X {get => _value.X; set => _value.X = value;}
     public int Y {get => _value.Y; set => _value.Y = value;}
@@ -299,7 +329,22 @@ public struct DMFPropertySize : IDMFProperty {
     public static bool operator !=(DMFPropertySize a, DMFPropertySize b) => a.Vector != b.Vector;
 }
 
-public struct DMFPropertyPos : IDMFProperty {
+public struct DMFPropertyPos : IDMFProperty, IEquatable<DMFPropertyPos> {
+    public bool Equals(DMFPropertyPos other)
+    {
+        return _value.Equals(other._value);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is DMFPropertyPos other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return _value.GetHashCode();
+    }
+
     private DMFPropertyVec2 _value;
     public int X => _value.X;
     public int Y => _value.Y;
@@ -479,7 +524,7 @@ public struct DMFPropertyBool(bool value) : IDMFProperty {
     public string AsSnowflake() {
         return Value ? "true" : "false";
     }
-    
+
     public override string ToString() {
         return AsRaw();
     }

--- a/OpenDreamClient/Interface/Descriptors/InterfaceDescriptor.cs
+++ b/OpenDreamClient/Interface/Descriptors/InterfaceDescriptor.cs
@@ -38,7 +38,7 @@ public partial class ElementDescriptor {
         init => _id = value;
     }
 
-    public DMFPropertyString Name => new(_name.Value ?? Id.AsRaw());
+    public DMFPropertyString Name => new(_name.Value);
 
     public DMFPropertyString Type {
         get => _type;

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -891,22 +891,21 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
     }
 
     private void LoadDescriptor(ElementDescriptor descriptor) {
-        // Note: Id has a getter to ensure Id.Value is never null
         switch (descriptor) {
             case MacroSetDescriptor macroSetDescriptor:
                 InterfaceMacroSet macroSet = new(macroSetDescriptor, _entitySystemManager, _inputManager, _uiManager);
 
-                MacroSets[macroSet.Id.Value!] = macroSet;
+                MacroSets[macroSet.Id.Value] = macroSet;
                 break;
             case MenuDescriptor menuDescriptor:
                 InterfaceMenu menu = new(menuDescriptor);
 
-                Menus.Add(menu.Id.Value!, menu);
+                Menus.Add(menu.Id.Value, menu);
                 break;
             case WindowDescriptor windowDescriptor:
                 ControlWindow window = new ControlWindow(windowDescriptor);
 
-                Windows.Add(windowDescriptor.Id.Value!, window);
+                Windows.Add(windowDescriptor.Id.Value, window);
                 if (window.IsDefault) {
                     DefaultWindow = window;
                 }

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -444,7 +444,7 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
             }
 
             default: {
-                string[] argsRaw = fullCommand.Split(' ', 2, StringSplitOptions.TrimEntries);
+                string[] argsRaw = fullCommand!.Split(' ', 2, StringSplitOptions.TrimEntries);
                 string command = argsRaw[0].ToLowerInvariant(); // Case-insensitive
 
                 if (!_entitySystemManager.TryGetEntitySystem(out ClientVerbSystem? verbSystem))
@@ -891,21 +891,22 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
     }
 
     private void LoadDescriptor(ElementDescriptor descriptor) {
+        // Note: Id has a getter to ensure Id.Value is never null
         switch (descriptor) {
             case MacroSetDescriptor macroSetDescriptor:
                 InterfaceMacroSet macroSet = new(macroSetDescriptor, _entitySystemManager, _inputManager, _uiManager);
 
-                MacroSets[macroSet.Id.Value] = macroSet;
+                MacroSets[macroSet.Id.Value!] = macroSet;
                 break;
             case MenuDescriptor menuDescriptor:
                 InterfaceMenu menu = new(menuDescriptor);
 
-                Menus.Add(menu.Id.Value, menu);
+                Menus.Add(menu.Id.Value!, menu);
                 break;
             case WindowDescriptor windowDescriptor:
                 ControlWindow window = new ControlWindow(windowDescriptor);
 
-                Windows.Add(windowDescriptor.Id.Value, window);
+                Windows.Add(windowDescriptor.Id.Value!, window);
                 if (window.IsDefault) {
                     DefaultWindow = window;
                 }

--- a/OpenDreamClient/Interface/Html/HtmlParser.cs
+++ b/OpenDreamClient/Interface/Html/HtmlParser.cs
@@ -7,6 +7,12 @@ namespace OpenDreamClient.Interface.Html;
 public static class HtmlParser {
     private const string TagNotClosedError = "HTML tag was not closed";
 
+    private static readonly ISawmill Sawmill;
+
+    static HtmlParser() {
+        Sawmill = IoCManager.Resolve<ILogManager>().GetSawmill("opendream.html_parser");
+    }
+
     public static void Parse(string text, FormattedMessage appendTo) {
         StringBuilder currentText = new();
         Stack<string> tags = new();
@@ -32,7 +38,7 @@ public static class HtmlParser {
                     i++;
                     SkipWhitespace();
                     if (i >= text.Length) {
-                        Logger.Error(TagNotClosedError);
+                        Sawmill.Error(TagNotClosedError);
                         return;
                     }
 
@@ -51,7 +57,7 @@ public static class HtmlParser {
                     } while (i < text.Length);
 
                     if (c != '>') {
-                        Logger.Error(TagNotClosedError);
+                        Sawmill.Error(TagNotClosedError);
                         return;
                     }
 
@@ -62,10 +68,10 @@ public static class HtmlParser {
                     currentText.Clear();
                     if (closingTag) {
                         if (tags.Count == 0) {
-                            Logger.Error("Unexpected closing tag");
+                            Sawmill.Error("Unexpected closing tag");
                             return;
                         } else if (tags.Peek() != tagType) {
-                            Logger.Error($"Invalid closing tag </{tagType}>, expected </{tags.Peek()}>");
+                            Sawmill.Error($"Invalid closing tag </{tagType}>, expected </{tags.Peek()}>");
                             return;
                         }
 
@@ -88,7 +94,7 @@ public static class HtmlParser {
                         // browsers usually allow for some fallibility here
                         break;
                     }
-                    
+
                     string insideEntity = text.Substring(i + 1, end - (i + 1));
                     i = end;
 
@@ -115,7 +121,7 @@ public static class HtmlParser {
                                 break;
                         }
                     }
-                    
+
                     break;
                 default:
                     currentText.Append(c);
@@ -159,7 +165,7 @@ public static class HtmlParser {
                     parameter = new(color);
                     break;
                 default:
-                    Logger.Debug($"Unimplemented HTML attribute \"{attributeName}\"");
+                    Sawmill.Debug($"Unimplemented HTML attribute \"{attributeName}\"");
                     continue;
             }
 

--- a/OpenDreamClient/Interface/InterfaceElement.cs
+++ b/OpenDreamClient/Interface/InterfaceElement.cs
@@ -42,7 +42,9 @@ public class InterfaceElement {
 
             MappingDataNode newNode = original.Merge(node);
 
-            ElementDescriptor = (ElementDescriptor)serializationManager.Read(ElementDescriptor.GetType(), newNode);
+            var descriptor = serializationManager.Read(ElementDescriptor.GetType(), newNode);
+            if(descriptor is null) throw new NullReferenceException(); // We're in a try/catch anyway, just play it safe
+            ElementDescriptor = (ElementDescriptor)descriptor;
             UpdateElementDescriptor();
         } catch (Exception e) {
             Logger.GetSawmill("opendream.interface").Error($"Error while populating values of \"{Id}\": {e}");

--- a/OpenDreamClient/OpenDreamClient.csproj
+++ b/OpenDreamClient/OpenDreamClient.csproj
@@ -8,6 +8,7 @@
     <OutputPath>..\bin\Content.Client\</OutputPath>
     <OutputType Condition="'$(FullRelease)' != 'True'">Exe</OutputType>
     <Nullable>enable</Nullable>
+    <NoWarn>NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenDreamShared\OpenDreamShared.csproj" />

--- a/OpenDreamClient/Rendering/AtomGlideSystem.cs
+++ b/OpenDreamClient/Rendering/AtomGlideSystem.cs
@@ -8,7 +8,8 @@ namespace OpenDreamClient.Rendering;
 /// Disables RobustToolbox's transform lerping and replaces it with our own gliding
 /// </summary>
 public sealed class AtomGlideSystem : EntitySystem {
-    private sealed class Glide(TransformComponent transform, DMISpriteComponent sprite) {
+    private sealed class Glide(EntityUid uid, TransformComponent transform, DMISpriteComponent sprite) {
+        public readonly EntityUid Uid = uid;
         public readonly TransformComponent Transform = transform;
         public readonly DMISpriteComponent Sprite = sprite;
         public Vector2 EndPos;
@@ -82,7 +83,7 @@ public sealed class AtomGlideSystem : EntitySystem {
             }
 
             _ignoreMoveEvent = true;
-            _transformSystem.SetLocalPositionNoLerp(glide.Transform, newPos);
+            _transformSystem.SetLocalPositionNoLerp(glide.Uid, newPos, glide.Transform);
             _ignoreMoveEvent = false;
         }
     }
@@ -123,7 +124,7 @@ public sealed class AtomGlideSystem : EntitySystem {
         }
 
         if (glide == null) {
-            glide = new(e.Component, sprite);
+            glide = new(e.Sender, e.Component, sprite);
             _currentGlides.Add(glide);
         }
 

--- a/OpenDreamClient/Rendering/ClientImagesSystem.cs
+++ b/OpenDreamClient/Rendering/ClientImagesSystem.cs
@@ -6,8 +6,6 @@ using Vector3 = Robust.Shared.Maths.Vector3;
 namespace OpenDreamClient.Rendering;
 internal sealed class ClientImagesSystem : SharedClientImagesSystem {
     [Dependency] private readonly IEntityManager _entityManager = default!;
-    [Dependency] private readonly IGameTiming _gameTiming = default!;
-    [Dependency] private readonly ClientAppearanceSystem _appearanceSystem = default!;
 
     private readonly Dictionary<Vector3, List<NetEntity>> _turfClientImages = new();
     private readonly Dictionary<EntityUid, List<NetEntity>> _amClientImages = new();


### PR DESCRIPTION
Takes `OpenDreamClient` from 40 to 20 warnings.

I confirmed that the changes to gliding and the context menu didn't break them.