### PR TITLE
Run UI controls in the background

### DIFF
--- a/OpenDreamClient/Interface/Controls/ControlMap.cs
+++ b/OpenDreamClient/Interface/Controls/ControlMap.cs
@@ -20,6 +20,9 @@ public sealed class ControlMap(ControlDescriptor controlDescriptor, ControlWindo
     protected override void UpdateElementDescriptor() {
         base.UpdateElementDescriptor();
 
+        // Don't attempt to render any non-main viewports
+        Viewport.Visible = MapDescriptor.IsDefault.Value;
+
         Viewport.StretchMode = MapDescriptor.ZoomMode.Value switch {
             "blur" => ScalingViewportStretchMode.Bilinear,
             "distort" => ScalingViewportStretchMode.Nearest,

--- a/OpenDreamClient/Interface/Controls/ControlWindow.cs
+++ b/OpenDreamClient/Interface/Controls/ControlWindow.cs
@@ -90,6 +90,7 @@ public sealed class ControlWindow : InterfaceControl {
         window.Owner = _clyde.MainWindow;
 
         _myWindow = (window, _myWindow.clydeWindow);
+        window.Create();
         UpdateWindowAttributes(_myWindow);
         return window;
     }
@@ -178,16 +179,8 @@ public sealed class ControlWindow : InterfaceControl {
 
         //if our window is null or closed, and we are visible, we need to create a new one. Otherwise we need to update the existing one.
         if(osWindow == null && clydeWindow == null) {
-            if (WindowDescriptor.IsVisible.Value) {
-                CreateWindow();
-                return; //we return because CreateWindow() calls UpdateWindowAttributes() again.
-            }
-        }
-
-        if(osWindow != null && !osWindow.IsOpen) {
-            if (WindowDescriptor.IsVisible.Value) {
-                osWindow.Show();
-            }
+            CreateWindow();
+            return; //we return because CreateWindow() calls UpdateWindowAttributes() again.
         }
 
         if (osWindow != null) osWindow.Title = Title;
@@ -340,8 +333,16 @@ public sealed class ControlWindow : InterfaceControl {
     }
 
     public override void SetProperty(string property, string value, bool manualWinset = false) {
-        if (property is "size" or "pos")
-            return; // TODO: RT offers no ability to resize or position windows
+        if (_myWindow.osWindow is {ClydeWindow: not null}) {
+            switch (property) {
+                case "size":
+                    _myWindow.osWindow.ClydeWindow.Size = new DMFPropertySize(value).Vector;
+                    return;
+                case "pos":
+                    // TODO: RT offers no ability to position windows
+                    return;
+            }
+        }
 
         base.SetProperty(property, value, manualWinset);
     }

--- a/OpenDreamClient/Interface/Controls/ControlWindow.cs
+++ b/OpenDreamClient/Interface/Controls/ControlWindow.cs
@@ -177,7 +177,7 @@ public sealed class ControlWindow : InterfaceControl {
         // TODO: this would probably be cleaner if an OSWindow for MainWindow was available.
         var (osWindow, clydeWindow) = windowRoot;
 
-        //if our window is null or closed, and we are visible, we need to create a new one. Otherwise we need to update the existing one.
+        //if our window is null or closed, we need to create a new one. Otherwise we need to update the existing one.
         if(osWindow == null && clydeWindow == null) {
             CreateWindow();
             return; //we return because CreateWindow() calls UpdateWindowAttributes() again.

--- a/OpenDreamClient/Interface/Controls/ControlWindow.cs
+++ b/OpenDreamClient/Interface/Controls/ControlWindow.cs
@@ -333,15 +333,16 @@ public sealed class ControlWindow : InterfaceControl {
     }
 
     public override void SetProperty(string property, string value, bool manualWinset = false) {
-        if (_myWindow.osWindow is {ClydeWindow: not null}) {
-            switch (property) {
-                case "size":
+        switch (property) {
+            case "size":
+                if (_myWindow.osWindow is {ClydeWindow: not null}) {
                     _myWindow.osWindow.ClydeWindow.Size = new DMFPropertySize(value).Vector;
-                    return;
-                case "pos":
-                    // TODO: RT offers no ability to position windows
-                    return;
-            }
+                }
+
+                return;
+            case "pos":
+                // TODO: RT offers no ability to position windows
+                return;
         }
 
         base.SetProperty(property, value, manualWinset);


### PR DESCRIPTION
In BYOND non-visible browser controls on secondary windows still run & execute javascript in the background. We would only start running browser controls from the first time their window was shown.

Fixing this gets tg's say window working.
![image](https://github.com/user-attachments/assets/2e4de7ff-b9f7-44e4-a400-c7b85248695b)

Depends on https://github.com/space-wizards/RobustToolbox/pull/5489