### PR TITLE
`ReturnFloat` peephole optimization

### DIFF
--- a/DMCompiler/Bytecode/DreamProcOpcode.cs
+++ b/DMCompiler/Bytecode/DreamProcOpcode.cs
@@ -293,6 +293,8 @@ public enum DreamProcOpcode : byte {
     NullRef = 0x96,
     [OpcodeMetadata(0, OpcodeArgType.Reference)]
     ReturnReferenceValue = 0x97,
+    [OpcodeMetadata(0, OpcodeArgType.Float)]
+    ReturnFloat = 0x98,
 }
 // ReSharper restore MissingBlankLines
 

--- a/DMCompiler/Optimizer/PeepholeOptimizations.cs
+++ b/DMCompiler/Optimizer/PeepholeOptimizations.cs
@@ -101,6 +101,24 @@ internal class ReturnReferenceValue : IPeepholeOptimization {
     }
 }
 
+// PushFloat [float]
+// Return
+// -> ReturnFloat [float]
+internal class ReturnFloat : IPeepholeOptimization {
+    public ReadOnlySpan<DreamProcOpcode> GetOpcodes() {
+        return [
+            DreamProcOpcode.PushFloat,
+            DreamProcOpcode.Return
+        ];
+    }
+
+    public void Apply(List<IAnnotatedBytecode> input, int index) {
+        var firstInstruction = IPeepholeOptimization.GetInstructionAndValue(input[index], out var pushVal);
+        IPeepholeOptimization.ReplaceInstructions(input, index, 2,
+            new AnnotatedBytecodeInstruction(DreamProcOpcode.ReturnFloat, [new AnnotatedBytecodeFloat(pushVal, firstInstruction.Location)]));
+    }
+}
+
 // PushReferenceValue [ref]
 // JumpIfFalse [label]
 // -> JumpIfReferenceFalse [ref] [label]

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -3110,6 +3110,11 @@ namespace OpenDreamRuntime.Procs {
             return ProcStatus.Continue;
         }
 
+        public static ProcStatus ReturnFloat(DMProcState state) {
+            state.SetReturn(new DreamValue(state.ReadFloat()));
+            return ProcStatus.Returned;
+        }
+
         #endregion
     }
 }

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -321,7 +321,8 @@ namespace OpenDreamRuntime.Procs {
             {DreamProcOpcode.CreateListNResources, DMOpcodeHandlers.CreateListNResources},
             {DreamProcOpcode.JumpIfNotNull, DMOpcodeHandlers.JumpIfNotNull},
             {DreamProcOpcode.IsTypeDirect, DMOpcodeHandlers.IsTypeDirect},
-            {DreamProcOpcode.ReturnReferenceValue, DMOpcodeHandlers.ReturnReferenceValue}
+            {DreamProcOpcode.ReturnReferenceValue, DMOpcodeHandlers.ReturnReferenceValue},
+            {DreamProcOpcode.ReturnFloat, DMOpcodeHandlers.ReturnFloat}
         };
 
         public static readonly unsafe delegate*<DMProcState, ProcStatus>[] OpcodeHandlers;

--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -83,6 +83,7 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
                 return (opcode, ReadValueType());
 
             case DreamProcOpcode.PushFloat:
+            case DreamProcOpcode.ReturnFloat:
                 return (opcode, ReadFloat());
 
             case DreamProcOpcode.SwitchOnFloat:


### PR DESCRIPTION
`PushFloat -> Return` is a common pattern in TG with 21,601 occurrences. This is mainly due to procs returning `TRUE` or `FALSE`.

This PR replaces that pattern with a new `ReturnFloat` opcode to avoid pushing to and immediately popping from the stack on all of those proc returns.