### PR TITLE
Fix self-targeting verbs

### DIFF
--- a/OpenDreamClient/Input/ContextMenu/VerbMenuPopup.xaml.cs
+++ b/OpenDreamClient/Input/ContextMenu/VerbMenuPopup.xaml.cs
@@ -66,7 +66,7 @@ internal sealed partial class VerbMenuPopup : Popup {
 
     private void AddVerb(int verbId, ClientObjectReference verbSrc, VerbSystem.VerbInfo verbInfo) {
         var button = AddButton(verbInfo.Name);
-        var takesTargetArg = verbInfo.GetTargetType() != null && !verbSrc.Equals(_target);
+        var takesTargetArg = verbInfo.GetTargetType() != null;
 
         button.OnPressed += _ => {
             _verbSystem?.ExecuteVerb(verbSrc, verbId, takesTargetArg ? [_target] : []);


### PR DESCRIPTION
Redundant check that makes it impossible to _ever_ apply a verb to the mob it came from. Unless there's multiple arguments I guess?

Just the target type check is fine. I think.