### PR TITLE
Peephole optimizer & proc decoder fixes

### DIFF
--- a/DMCompiler/Optimizer/PeepholeOptimizations.cs
+++ b/DMCompiler/Optimizer/PeepholeOptimizations.cs
@@ -273,7 +273,6 @@ internal sealed class PushStringFloat : IPeepholeOptimization {
 
         int stackDelta = 0;
         List<IAnnotatedBytecode> args = new List<IAnnotatedBytecode>(2 * count + 1) { new AnnotatedBytecodeInteger(count, input[index].GetLocation()) };
-        args.Add(new AnnotatedBytecodeInteger(count, input[index].GetLocation()));
 
         for (int i = 0; i < count; i++) {
             AnnotatedBytecodeInstruction stringInstruction = (AnnotatedBytecodeInstruction)(input[index + i*2]);

--- a/DMCompiler/Optimizer/PeepholeOptimizations.cs
+++ b/DMCompiler/Optimizer/PeepholeOptimizations.cs
@@ -272,7 +272,7 @@ internal sealed class PushStringFloat : IPeepholeOptimization {
         // Otherwise, replace with PushNOfStringFloat
 
         int stackDelta = 0;
-        List<IAnnotatedBytecode> args = new List<IAnnotatedBytecode>(2 * count + 1);
+        List<IAnnotatedBytecode> args = new List<IAnnotatedBytecode>(2 * count + 1) { new AnnotatedBytecodeInteger(count, input[index].GetLocation()) };
         args.Add(new AnnotatedBytecodeInteger(count, input[index].GetLocation()));
 
         for (int i = 0; i < count; i++) {

--- a/DMCompiler/Optimizer/PeepholeOptimizer.cs
+++ b/DMCompiler/Optimizer/PeepholeOptimizer.cs
@@ -93,7 +93,7 @@ internal sealed class PeepholeOptimizer {
 
             if (currentOpt.Optimization?.CheckPreconditions(input, i - optSize) is true) {
                 currentOpt.Optimization.Apply(input, i - optSize);
-                offset = (optSize + 1); // Run over the new opcodes for potential further optimization
+                offset = (optSize + 2); // Run over the new opcodes for potential further optimization
             } else {
                 // This chain of opcodes did not lead to a valid optimization.
                 // Start again from the opcode after the first.
@@ -108,6 +108,7 @@ internal sealed class PeepholeOptimizer {
             var bytecode = input[i];
             if (bytecode is not AnnotatedBytecodeInstruction instruction) {
                 i -= AttemptCurrentOpt(i);
+                i = Math.Max(i, 0);
                 continue;
             }
 
@@ -126,6 +127,7 @@ internal sealed class PeepholeOptimizer {
             }
 
             i -= AttemptCurrentOpt(i);
+            i = Math.Max(i, 0);
         }
 
         AttemptCurrentOpt(input.Count);

--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -107,6 +107,7 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
             case DreamProcOpcode.OutputReference:
             case DreamProcOpcode.PushReferenceValue:
             case DreamProcOpcode.PopReference:
+            case DreamProcOpcode.NullRef:
             case DreamProcOpcode.AssignPop:
             case DreamProcOpcode.ReturnReferenceValue:
                 return (opcode, ReadReference());
@@ -199,6 +200,19 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
                 }
 
                 return (opcode, values);
+            }
+
+            case DreamProcOpcode.PushNOfStringFloats: {
+                var count = ReadInt();
+                var strings = new string[count];
+                var floats = new float[count];
+
+                for (int i = 0; i < count; i++) {
+                    strings[i] = ReadString();
+                    floats[i] = ReadFloat();
+                }
+
+                return (opcode, strings, floats);
             }
 
             case DreamProcOpcode.CreateListNResources:
@@ -326,6 +340,19 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
                     text.Append('\'');
                     text.Append(value);
                     text.Append("' ");
+                }
+
+                break;
+            }
+
+            case (DreamProcOpcode.PushNOfStringFloats, string[] strings, float[] floats): {
+                // The length of both arrays are equal
+                for (var index = 0; index < strings.Length; index++) {
+                    text.Append($"\"{strings[index]}\"");
+                    text.Append(' ');
+                    text.Append(floats[index]);
+                    if(index + 1 < strings.Length) // Don't leave a trailing space
+                        text.Append(' ');
                 }
 
                 break;


### PR DESCRIPTION
This PR does a few things:

1. Fixes peephole optimizations not being applied to opcodes created by peephole optimizations. E.g.:
`PushNull -> Assign -> Pop` was being optimized to `PushNull -> AssignPop`, but the optimizer offset wasn't rolled back far enough to consider optimizing `PushNull -> AssignPop` to `NullRef`. It would only be rolled back to the new `AssignPop` opcode. This meant that the `NullRef` opcode was never used, which is now fixed.

2. Fixes a few opcodes not being implemented in `ProcDecoder`. Because a few opcodes were specific to optimizations that were never applied, they never triggered any errors in the disassembler. `DreamProcOpcode.NullRef` and `DreamProcOpcode.PushNOfStringFloats` can now be decoded.

3. Fixes `PushNOfStringFloats` only being applied to pairs of `StringFloat`s. Because of how the peephole optimizer works, it would (now that it actually runs) try to run the `PushNOfStringFloats` optimization before every `PushString` and `PushFloat` in the sequence had been converted to `StringFloat`s. The `PushNOfStringFloat`s optimization has been folded into the `StringFloat` optimization, and it'll just use the relevant opcode depending on how many pairs of `PushString` and `PushFloat` opcodes there are. This has the added benefit of reducing the amount of optimizations that need to be applied.

We really need to implement a system for unit testing the peephole optimizer on input bytecode, but that is out of scope for this PR.

I made sure that TG doesn't explode, the `NullRef` opcode is now used, and that the `PushNOfStringFormat` optimization actually works correctly & disassembles with sane formatting:
```
	PushFloat 0 
	PushNOfStringFloats "y" 0 "size" 1 "repeat" 2 "radius" 0 "falloff" 1 "flags" 0
	CreateAssociativeList 7 
```
