### PR TITLE
Removes 2 unused opcodes

### DIFF
--- a/DMCompiler/Bytecode/DreamProcOpcode.cs
+++ b/DMCompiler/Bytecode/DreamProcOpcode.cs
@@ -253,8 +253,7 @@ public enum DreamProcOpcode : byte {
     [OpcodeMetadata]
     Abs = 0x83,
     // Peephole optimization opcodes
-    [OpcodeMetadata(0, OpcodeArgType.Reference, OpcodeArgType.Label)]
-    PushRefandJumpIfNotNull = 0x84,
+    //0x84
     [OpcodeMetadata(-1, OpcodeArgType.Reference)]
     AssignPop = 0x85,
     [OpcodeMetadata(1, OpcodeArgType.Reference, OpcodeArgType.String)]
@@ -285,8 +284,7 @@ public enum DreamProcOpcode : byte {
     CreateListNResources = 0x92,
     [OpcodeMetadata(0, OpcodeArgType.String, OpcodeArgType.Label)]
     SwitchOnString = 0x93,
-    [OpcodeMetadata(1, OpcodeArgType.Label)]
-    JumpIfNotNull = 0x94,
+    //0x94
     [OpcodeMetadata(0, OpcodeArgType.TypeId)]
     IsTypeDirect = 0x95,
     [OpcodeMetadata(0, OpcodeArgType.Reference)]

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -2867,25 +2867,10 @@ namespace OpenDreamRuntime.Procs {
             DreamProcNativeIcon.Blend(iconObj.Icon, blend, DreamIconOperationBlend.BlendType.Add, 0, 0);
             return new DreamValue(iconObj);
         }
+
         #endregion Helpers
 
         #region Peephole Optimizations
-
-        public static ProcStatus PushReferenceAndJumpIfNotNull(DMProcState state) {
-            DreamReference reference = state.ReadReference();
-            int jumpTo = state.ReadInt();
-
-            DreamValue value = state.GetReferenceValue(reference);
-
-            if (!value.IsNull) {
-                state.Push(value);
-                state.Jump(jumpTo);
-            } else {
-                state.Push(DreamValue.Null);
-            }
-
-            return ProcStatus.Continue;
-        }
 
         public static ProcStatus NullRef(DMProcState state) {
             state.AssignReference(state.ReadReference(), DreamValue.Null);
@@ -3082,17 +3067,6 @@ namespace OpenDreamRuntime.Procs {
             }
 
             state.Push(new DreamValue(list));
-            return ProcStatus.Continue;
-        }
-
-        public static ProcStatus JumpIfNotNull(DMProcState state) {
-            int position = state.ReadInt();
-
-            if (!state.Peek().IsNull) {
-                state.PopDrop();
-                state.Jump(position);
-            }
-
             return ProcStatus.Continue;
         }
 

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -180,6 +180,7 @@ namespace OpenDreamRuntime.Procs {
         private static readonly ArrayPool<DreamValue> _dreamValuePool = ArrayPool<DreamValue>.Create();
 
         #region Opcode Handlers
+
         //Human readable friendly version, which will be converted to a more efficient lookup at runtime.
         private static readonly Dictionary<DreamProcOpcode, OpcodeHandler> _opcodeHandlers = new() {
             {DreamProcOpcode.BitShiftLeft, DMOpcodeHandlers.BitShiftLeft},
@@ -302,7 +303,6 @@ namespace OpenDreamRuntime.Procs {
             {DreamProcOpcode.DebuggerBreakpoint, DMOpcodeHandlers.DebuggerBreakpoint},
             {DreamProcOpcode.Rgb, DMOpcodeHandlers.Rgb},
             // Peephole optimizer opcode handlers
-            {DreamProcOpcode.PushRefandJumpIfNotNull, DMOpcodeHandlers.PushReferenceAndJumpIfNotNull},
             {DreamProcOpcode.NullRef, DMOpcodeHandlers.NullRef},
             {DreamProcOpcode.AssignPop, DMOpcodeHandlers.AssignPop},
             {DreamProcOpcode.PushRefAndDereferenceField, DMOpcodeHandlers.PushReferenceAndDereferenceField},
@@ -319,12 +319,12 @@ namespace OpenDreamRuntime.Procs {
             {DreamProcOpcode.CreateListNStrings, DMOpcodeHandlers.CreateListNStrings},
             {DreamProcOpcode.CreateListNRefs, DMOpcodeHandlers.CreateListNRefs},
             {DreamProcOpcode.CreateListNResources, DMOpcodeHandlers.CreateListNResources},
-            {DreamProcOpcode.JumpIfNotNull, DMOpcodeHandlers.JumpIfNotNull},
             {DreamProcOpcode.IsTypeDirect, DMOpcodeHandlers.IsTypeDirect},
             {DreamProcOpcode.ReturnReferenceValue, DMOpcodeHandlers.ReturnReferenceValue}
         };
 
         public static readonly unsafe delegate*<DMProcState, ProcStatus>[] OpcodeHandlers;
+
         #endregion
 
         public DreamManager DreamManager => _proc.DreamManager;


### PR DESCRIPTION
These opcodes had `DMOpcodeHandler` implementations but nothing ever actually wrote the opcodes to the compiled bytecode.