### PR TITLE
Add an `AppendNoPush` optimization

### DIFF
--- a/DMCompiler/Bytecode/DreamProcOpcode.cs
+++ b/DMCompiler/Bytecode/DreamProcOpcode.cs
@@ -253,7 +253,8 @@ public enum DreamProcOpcode : byte {
     [OpcodeMetadata]
     Abs = 0x83,
     // Peephole optimization opcodes
-    //0x84
+    [OpcodeMetadata(-1, OpcodeArgType.Reference)]
+    AppendNoPush = 0x84,
     [OpcodeMetadata(-1, OpcodeArgType.Reference)]
     AssignPop = 0x85,
     [OpcodeMetadata(1, OpcodeArgType.Reference, OpcodeArgType.String)]

--- a/DMCompiler/Optimizer/PeepholeOptimizations.cs
+++ b/DMCompiler/Optimizer/PeepholeOptimizations.cs
@@ -2,6 +2,30 @@ using DMCompiler.Bytecode;
 
 namespace DMCompiler.Optimizer;
 
+// Append [ref]
+// Pop
+// -> AppendNoPush [ref]
+internal sealed class AppendNoPush : IPeepholeOptimization {
+    public ReadOnlySpan<DreamProcOpcode> GetOpcodes() {
+        return [
+            DreamProcOpcode.Append,
+            DreamProcOpcode.Pop
+        ];
+    }
+
+    public void Apply(List<IAnnotatedBytecode> input, int index) {
+        if (index + 1 >= input.Count) {
+            throw new ArgumentOutOfRangeException(nameof(index), "Bytecode index is outside the bounds of the input list.");
+        }
+
+        AnnotatedBytecodeInstruction firstInstruction = (AnnotatedBytecodeInstruction)(input[index]);
+        AnnotatedBytecodeReference assignTarget = firstInstruction.GetArg<AnnotatedBytecodeReference>(0);
+
+        input.RemoveRange(index, 2);
+        input.Insert(index, new AnnotatedBytecodeInstruction(DreamProcOpcode.AppendNoPush, [assignTarget]));
+    }
+}
+
 // Assign [ref]
 // Pop
 // -> AssignPop [ref]

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -207,6 +207,7 @@ namespace OpenDreamRuntime.Procs {
             {DreamProcOpcode.Negate, DMOpcodeHandlers.Negate},
             {DreamProcOpcode.Modulus, DMOpcodeHandlers.Modulus},
             {DreamProcOpcode.Append, DMOpcodeHandlers.Append},
+            {DreamProcOpcode.AppendNoPush, DMOpcodeHandlers.AppendNoPush},
             {DreamProcOpcode.CreateRangeEnumerator, DMOpcodeHandlers.CreateRangeEnumerator},
             {DreamProcOpcode.Input, DMOpcodeHandlers.Input},
             {DreamProcOpcode.CompareLessThanOrEqual, DMOpcodeHandlers.CompareLessThanOrEqual},

--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -107,6 +107,7 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
             case DreamProcOpcode.OutputReference:
             case DreamProcOpcode.PushReferenceValue:
             case DreamProcOpcode.PopReference:
+            case DreamProcOpcode.AppendNoPush:
             case DreamProcOpcode.AssignPop:
             case DreamProcOpcode.ReturnReferenceValue:
                 return (opcode, ReadReference());


### PR DESCRIPTION
There are ~10.5k usages of `Append` in Paradise bytecode. Of these, all but ~160 immediately pop the value that `Append` pushes to the stack.

This adds a simple `AppendNoPush` peephole opt and opcode, with identical behavior except the opcode handler does not push the result to the stack.