### PR TITLE
Rename `AssignPop` to `AssignNoPush`

### DIFF
--- a/DMCompiler/Bytecode/DreamProcOpcode.cs
+++ b/DMCompiler/Bytecode/DreamProcOpcode.cs
@@ -255,7 +255,7 @@ public enum DreamProcOpcode : byte {
     // Peephole optimization opcodes
     //0x84
     [OpcodeMetadata(-1, OpcodeArgType.Reference)]
-    AssignPop = 0x85,
+    AssignNoPush = 0x85,
     [OpcodeMetadata(1, OpcodeArgType.Reference, OpcodeArgType.String)]
     PushRefAndDereferenceField = 0x86,
     [OpcodeMetadata(true, 0, OpcodeArgType.Int)]

--- a/DMCompiler/Optimizer/PeepholeOptimizations.cs
+++ b/DMCompiler/Optimizer/PeepholeOptimizations.cs
@@ -4,8 +4,8 @@ namespace DMCompiler.Optimizer;
 
 // Assign [ref]
 // Pop
-// -> AssignPop [ref]
-internal sealed class AssignPop : IPeepholeOptimization {
+// -> AssignNoPush [ref]
+internal sealed class AssignNoPush : IPeepholeOptimization {
     public ReadOnlySpan<DreamProcOpcode> GetOpcodes() {
         return [
             DreamProcOpcode.Assign,
@@ -22,18 +22,18 @@ internal sealed class AssignPop : IPeepholeOptimization {
         AnnotatedBytecodeReference assignTarget = firstInstruction.GetArg<AnnotatedBytecodeReference>(0);
 
         input.RemoveRange(index, 2);
-        input.Insert(index, new AnnotatedBytecodeInstruction(DreamProcOpcode.AssignPop, [assignTarget]));
+        input.Insert(index, new AnnotatedBytecodeInstruction(DreamProcOpcode.AssignNoPush, [assignTarget]));
     }
 }
 
 // PushNull
-// AssignPop [ref]
+// AssignNoPush [ref]
 // -> AssignNull [ref]
 internal sealed class AssignNull : IPeepholeOptimization {
     public ReadOnlySpan<DreamProcOpcode> GetOpcodes() {
         return [
             DreamProcOpcode.PushNull,
-            DreamProcOpcode.AssignPop
+            DreamProcOpcode.AssignNoPush
         ];
     }
 

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -2877,7 +2877,7 @@ namespace OpenDreamRuntime.Procs {
             return ProcStatus.Continue;
         }
 
-        public static ProcStatus AssignPop(DMProcState state) {
+        public static ProcStatus AssignNoPush(DMProcState state) {
             DreamReference reference = state.ReadReference();
             DreamValue value = state.Pop();
 

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -304,7 +304,7 @@ namespace OpenDreamRuntime.Procs {
             {DreamProcOpcode.Rgb, DMOpcodeHandlers.Rgb},
             // Peephole optimizer opcode handlers
             {DreamProcOpcode.NullRef, DMOpcodeHandlers.NullRef},
-            {DreamProcOpcode.AssignPop, DMOpcodeHandlers.AssignPop},
+            {DreamProcOpcode.AssignNoPush, DMOpcodeHandlers.AssignNoPush},
             {DreamProcOpcode.PushRefAndDereferenceField, DMOpcodeHandlers.PushReferenceAndDereferenceField},
             {DreamProcOpcode.PushNRefs, DMOpcodeHandlers.PushNRefs},
             {DreamProcOpcode.PushNFloats, DMOpcodeHandlers.PushNFloats},

--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -108,7 +108,7 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
             case DreamProcOpcode.OutputReference:
             case DreamProcOpcode.PushReferenceValue:
             case DreamProcOpcode.PopReference:
-            case DreamProcOpcode.AssignPop:
+            case DreamProcOpcode.AssignNoPush:
             case DreamProcOpcode.ReturnReferenceValue:
                 return (opcode, ReadReference());
 


### PR DESCRIPTION
`AssignPop` made it sound like it was popping from the stack, when in reality it wasn't pushing to the stack in the first place.