### PR TITLE
Fix upward path search operator without lefthand side

### DIFF
--- a/Content.Tests/DMProject/Tests/Tree/upward_search_path3.dm
+++ b/Content.Tests/DMProject/Tests/Tree/upward_search_path3.dm
@@ -1,0 +1,8 @@
+
+//# issue 617
+
+/datum/foo
+/datum/bar/var/meep = .foo
+/proc/RunTest()
+    var/datum/bar/D = new
+    ASSERT(D.meep == /datum/foo)

--- a/DMCompiler/DM/DMObjectTree.cs
+++ b/DMCompiler/DM/DMObjectTree.cs
@@ -159,7 +159,10 @@ internal static class DMObjectTree {
 
         DreamPath currentPath = path;
         while (true) {
-            bool foundType = _pathToTypeId.TryGetValue(currentPath.Combine(search), out var foundTypeId);
+            // If the search path has nothing lefthand of '.', we need to strip the operator before combining
+            DreamPath combinedPath = (!string.IsNullOrEmpty(search.PathString) && search.PathString[0] == '.') ? currentPath.Combine(search.PathString[1..]) : currentPath.Combine(search);
+
+            bool foundType = _pathToTypeId.TryGetValue(combinedPath, out var foundTypeId);
 
             // We're searching for a proc
             if (searchingProcName != null && foundType) {
@@ -171,7 +174,7 @@ internal static class DMObjectTree {
                     return new DreamPath("/proc/" + searchingProcName);
                 }
             } else if (foundType) { // We're searching for a type
-                return currentPath.Combine(search);
+                return combinedPath;
             }
 
             if (currentPath == DreamPath.Root) {

--- a/DMCompiler/DM/Expressions/Constant.cs
+++ b/DMCompiler/DM/Expressions/Constant.cs
@@ -361,7 +361,7 @@ internal sealed class ConstantPath(Location location, DMObject dmObject, DreamPa
         }
 
         // Any other path
-        if (DMObjectTree.TryGetTypeId(Value, out var typeId)) {
+        if (DMObjectTree.TryGetTypeId(path, out var typeId)) {
             pathInfo = (PathType.TypeReference, typeId);
             return true;
         } else {

--- a/DMCompiler/DreamPath.cs
+++ b/DMCompiler/DreamPath.cs
@@ -206,6 +206,10 @@ public struct DreamPath {
         }
     }
 
+    public DreamPath Combine(string pathString) {
+        return new DreamPath(PathString + "/" + pathString);
+    }
+
     public override string ToString() {
         return PathString;
     }


### PR DESCRIPTION
The upward path search operator didn't resolve paths correctly specifically when there was nothing on the lefthand side of the operator. 

This is because:
```
/obj/foo
/obj/bar
    var/meep = .foo
```
would resolve to `/obj/.foo` instead of `/obj/foo`

Now we strip the search operator out of the path string if there's nothing on the lefthand side, so it can be combined into the correct path. 

The other upward search unit tests confirm that this doesn't break anything when there _is_ a lefthand side. I also confirmed TG didn't explode.

Fixes #617 
