### PR TITLE
Lint for `/var/` in proc args

### DIFF
--- a/Content.Tests/DMProject/Tests/Arg/ProcArgumentGlobal_lint.dm
+++ b/Content.Tests/DMProject/Tests/Arg/ProcArgumentGlobal_lint.dm
@@ -1,0 +1,8 @@
+// COMPILE ERROR OD2211
+#pragma ProcArgumentGlobal error
+
+/proc/foo(/var/bar)
+	return
+
+/proc/RunTest()
+	return

--- a/DMCompiler/Compiler/CompilerError.cs
+++ b/DMCompiler/Compiler/CompilerError.cs
@@ -49,7 +49,7 @@ public enum WarningCode {
     FallbackBuiltinArgument = 2208, // A builtin (sin(), cos(), etc) with an invalid/fallback argument
     PointlessScopeOperator = 2209,
     PointlessPositionalArgument = 2210,
-    ProcArgumentGlobal = 2211, // Prepending "/" on a proc arg (e.g. "/proc(/var/foo)" makes the arg a global var. Ref https://www.byond.com/forum/post/2830750
+    ProcArgumentGlobal = 2211, // Prepending "/" on a proc arg (e.g. "/proc/example(/var/foo)" makes the arg a global var. Ref https://www.byond.com/forum/post/2830750
     MalformedRange = 2300,
     InvalidRange = 2301,
     InvalidSetStatement = 2302,

--- a/DMCompiler/Compiler/CompilerError.cs
+++ b/DMCompiler/Compiler/CompilerError.cs
@@ -49,6 +49,7 @@ public enum WarningCode {
     FallbackBuiltinArgument = 2208, // A builtin (sin(), cos(), etc) with an invalid/fallback argument
     PointlessScopeOperator = 2209,
     PointlessPositionalArgument = 2210,
+    ProcArgumentGlobal = 2211, // Prepending "/" on a proc arg (e.g. "/proc(/var/foo)" makes the arg a global var. Ref https://www.byond.com/forum/post/2830750
     MalformedRange = 2300,
     InvalidRange = 2301,
     InvalidSetStatement = 2302,

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -1723,6 +1723,10 @@ namespace DMCompiler.Compiler.DM {
             DMASTPath? path = Path();
 
             if (path != null) {
+                if (path.Path.PathString.StartsWith("/var")) {
+                    Emit(WarningCode.ProcArgumentGlobal, $"Proc argument \"{path.Path.PathString}\" starting with \"/var/\" will create a global variable. Replace with \"{path.Path.PathString[1..]}\"");
+                }
+
                 var loc = Current().Location;
                 Whitespace();
 

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -1723,7 +1723,7 @@ namespace DMCompiler.Compiler.DM {
             DMASTPath? path = Path();
 
             if (path != null) {
-                if (path.Path.PathString.StartsWith("/var")) {
+                if (path.Path.PathString.StartsWith("/var/")) {
                     Emit(WarningCode.ProcArgumentGlobal, $"Proc argument \"{path.Path.PathString}\" starting with \"/var/\" will create a global variable. Replace with \"{path.Path.PathString[1..]}\"");
                 }
 

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -31,6 +31,7 @@
 #pragma AmbiguousResourcePath warning
 #pragma SuspiciousSwitchCase warning
 #pragma PointlessPositionalArgument warning
+#pragma ProcArgumentGlobal warning // Ref BYOND issue https://www.byond.com/forum/post/2830750
 // NOTE: The next few pragmas are for OpenDream's experimental type checker
 // This feature is still in development, elevating these pragmas outside of local testing is discouraged
 // An RFC to finalize this feature is coming soon(TM)


### PR DESCRIPTION
Lints for this BYOND bug: https://www.byond.com/forum/post/2830750

The following code prints `5` in BYOND but errors with `Unknown identifier "global.bar"` in OpenDream.
```
/datum/proc/foo(/var/bar = 5)
    return

/proc/main()
    world.log << global.bar // This prints 5 in BYOND
```

This PR doesn't replicate BYOND behavior, it just adds a lint. Ref https://github.com/OpenDreamProject/OpenDream/issues/2065 for tracking the status of replicating BYOND behavior.

Credit to @out-of-phaze for reminding me of this BYOND bug's existence.

I tested about half a dozen codebases and only found a single hit in goonstation.