### PR TITLE
Adds a system for printing stats to the disassembler

### DIFF
--- a/DMDisassembler/Program.cs
+++ b/DMDisassembler/Program.cs
@@ -131,7 +131,7 @@ internal class Program {
             Console.WriteLine("DM Disassembler for OpenDream");
             Console.WriteLine("Commands and arguments:");
             Console.WriteLine("help [command]            : Show additional help for [command] if applicable");
-            Console.WriteLine("quit|q                    : Exits the disassembler");
+            Console.WriteLine("exit|quit|q               : Exits the disassembler");
             Console.WriteLine("search type|proc [name]   : Search for a particular typepath or a proc on a selected type");
             Console.WriteLine("select|sel                : Select a typepath to run further commands on");
             Console.WriteLine("list procs|globals        : List all globals, or all procs on a selected type");

--- a/DMDisassembler/Program.cs
+++ b/DMDisassembler/Program.cs
@@ -172,10 +172,8 @@ internal class Program {
                 }
             }
 
-            var sorted = typeIdToProcCount.OrderByDescending(kvp => kvp.Value).ToList();
             Console.WriteLine("Type: Proc Declarations");
-            for (int i = 0; i < sorted.Count; i++) {
-                var pair = sorted[i];
+            foreach (var pair in typeIdToProcCount.OrderByDescending(kvp => kvp.Value)) {
 
                 var type = TypesById[pair.Key];
                 if (pair.Key == 0) {

--- a/DMDisassembler/Program.cs
+++ b/DMDisassembler/Program.cs
@@ -127,8 +127,7 @@ internal class Program {
             }
         }
 
-        void AllCommands()
-        {
+        void AllCommands() {
             Console.WriteLine("DM Disassembler for OpenDream");
             Console.WriteLine("Commands and arguments:");
             Console.WriteLine("help [command]            : Show additional help for [command] if applicable");

--- a/DMDisassembler/Program.cs
+++ b/DMDisassembler/Program.cs
@@ -163,17 +163,17 @@ internal class Program {
 
         void ProcsByType() {
             Console.WriteLine("Counting all proc declarations (no overrides) by type. This may take a moment.");
-            Dictionary<int, int> TypeIdToProcCount = new Dictionary<int, int>();
+            Dictionary<int, int> typeIdToProcCount = new Dictionary<int, int>();
             foreach (DMProc proc in Procs) {
                 if(proc.IsOverride || proc.Name == "<init>") continue; // Don't count overrides or <init> procs
-                if (TypeIdToProcCount.TryGetValue(proc.OwningTypeId, out var count)) {
-                    TypeIdToProcCount[proc.OwningTypeId] = count + 1;
+                if (typeIdToProcCount.TryGetValue(proc.OwningTypeId, out var count)) {
+                    typeIdToProcCount[proc.OwningTypeId] = count + 1;
                 } else {
-                    TypeIdToProcCount[proc.OwningTypeId] = 1;
+                    typeIdToProcCount[proc.OwningTypeId] = 1;
                 }
             }
 
-            var sorted = TypeIdToProcCount.OrderByDescending(kvp => kvp.Value).ToList();
+            var sorted = typeIdToProcCount.OrderByDescending(kvp => kvp.Value).ToList();
             Console.WriteLine("Type: Proc Declarations");
             for (int i = 0; i < sorted.Count; i++) {
                 var pair = sorted[i];


### PR DESCRIPTION
This adds a `stats` command to the disassembler which can be extended to provide various info about the bytecode. For now I've added a `procs-by-type` argument which prints the number of proc declarations on each type in descending order.

I've also spruced up the `help` command with the ability to take a `command` argument to learn more about a specific command.

Here's an excerpt from TG:
```
Counting all proc declarations by type. This may take a moment.
Type: Proc Declarations
<global>: 1595
/datum/controller/global_vars: 979
/client: 504
/mob/living: 441
/atom: 359
/mob: 328
/mob/living/carbon: 184
/atom/movable: 131
/obj/item: 128
/mob/living/carbon/human: 101
```