### PR TITLE
Typemaker 1.1 - fixes and improvements

### DIFF
--- a/DMCompiler/Compiler/DM/AST/DMAST.ObjectStatements.cs
+++ b/DMCompiler/Compiler/DM/AST/DMAST.ObjectStatements.cs
@@ -52,7 +52,7 @@ public sealed class DMASTObjectVarDefinition(
     Location location,
     DreamPath path,
     DMASTExpression value,
-    DMComplexValueType valType,
+    DMComplexValueType? valType,
     DreamPath? valPath = null) : DMASTStatement(location) {
     /// <summary>The path of the object that we are a property of.</summary>
     public DreamPath ObjectPath => _varDecl.ObjectPath;
@@ -73,7 +73,7 @@ public sealed class DMASTObjectVarDefinition(
     public bool IsConst => _varDecl.IsConst;
     public bool IsTmp => _varDecl.IsTmp;
 
-    public readonly DMComplexValueType ValType = valType;
+    public readonly DMComplexValueType? ValType = valType;
 }
 
 public sealed class DMASTMultipleObjectVarDefinitions(Location location, DMASTObjectVarDefinition[] varDefinitions)

--- a/DMCompiler/Compiler/DM/AST/DMAST.ProcStatements.cs
+++ b/DMCompiler/Compiler/DM/AST/DMAST.ProcStatements.cs
@@ -29,13 +29,14 @@ public sealed class DMASTProcStatementExpression(Location location, DMASTExpress
     public DMASTExpression Expression = expression;
 }
 
-public sealed class DMASTProcStatementVarDeclaration(Location location, DMASTPath path, DMASTExpression? value, DMComplexValueType valType)
+public sealed class DMASTProcStatementVarDeclaration(Location location, DMASTPath path, DMASTExpression? value, DMComplexValueType? valType)
     : DMASTProcStatement(location) {
     public DMASTExpression? Value = value;
 
     public DreamPath? Type => _varDecl.IsList ? DreamPath.List : _varDecl.TypePath;
+    public DMComplexValueType? ExplicitValType => valType;
 
-    public DMComplexValueType ValType => valType;
+    public DMComplexValueType ValType => ExplicitValType ?? DMValueType.Anything;
 
     public string Name => _varDecl.VarName;
     public bool IsGlobal => _varDecl.IsStatic;

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -886,7 +886,7 @@ namespace DMCompiler.Compiler.DM {
 
                 var valType = AsComplexTypes(procParameters);
                 // the != DMValueType.Null check is a hacky workaround for Anything|Null being equal to just Null
-                if (valType is null && value.GetUnwrapped() is DMASTInput input && input.Types != DMValueType.Null) {
+                if (valType is null && value?.GetUnwrapped() is DMASTInput input && input.Types != DMValueType.Null) {
                     valType = input.Types;
                 }
 

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -237,9 +237,9 @@ namespace DMCompiler.Compiler.DM {
                 Whitespace();
 
                 // Proc return type
-                var types = AsComplexTypes();
+                var types = AsComplexTypes(parameters);
 
-                DMASTProcBlockInner? procBlock = ProcBlock();
+                DMASTProcBlockInner? procBlock = ProcBlock(parameters);
                 if (procBlock is null) {
                     DMASTProcStatement? procStatement = ProcStatement();
 
@@ -539,12 +539,12 @@ namespace DMCompiler.Compiler.DM {
             return null;
         }
 
-        private DMASTProcBlockInner? ProcBlock() {
+        private DMASTProcBlockInner? ProcBlock(List<DMASTDefinitionParameter>? procParameters = null) {
             Token beforeBlockToken = Current();
             bool hasNewline = Newline();
 
-            DMASTProcBlockInner? procBlock = BracedProcBlock();
-            procBlock ??= IndentedProcBlock();
+            DMASTProcBlockInner? procBlock = BracedProcBlock(procParameters);
+            procBlock ??= IndentedProcBlock(procParameters);
 
             if (procBlock == null && hasNewline) {
                 ReuseToken(beforeBlockToken);
@@ -553,7 +553,7 @@ namespace DMCompiler.Compiler.DM {
             return procBlock;
         }
 
-        private DMASTProcBlockInner? BracedProcBlock() {
+        private DMASTProcBlockInner? BracedProcBlock(List<DMASTDefinitionParameter>? procParameters = null) {
             var loc = Current().Location;
             if (Check(TokenType.DM_LeftCurlyBracket)) {
                 DMASTProcBlockInner? block;
@@ -561,7 +561,7 @@ namespace DMCompiler.Compiler.DM {
                 Whitespace();
                 Newline();
                 if (Current().Type == TokenType.DM_Indent) {
-                    block = IndentedProcBlock();
+                    block = IndentedProcBlock(procParameters);
                     Newline();
                     Consume(TokenType.DM_RightCurlyBracket, "Expected '}'");
                 } else {
@@ -593,14 +593,14 @@ namespace DMCompiler.Compiler.DM {
             return null;
         }
 
-        private DMASTProcBlockInner? IndentedProcBlock() {
+        private DMASTProcBlockInner? IndentedProcBlock(List<DMASTDefinitionParameter>? procParameters = null) {
             var loc = Current().Location;
             if (Check(TokenType.DM_Indent)) {
                 List<DMASTProcStatement> statements = new();
                 List<DMASTProcStatement> setStatements = new(); // set statements are weird and must be held separately.
 
                 do {
-                    (List<DMASTProcStatement>? statements, List<DMASTProcStatement>? setStatements) blockInner = ProcBlockInner();
+                    (List<DMASTProcStatement>? statements, List<DMASTProcStatement>? setStatements) blockInner = ProcBlockInner(procParameters);
                     if (blockInner.statements is not null)
                         statements.AddRange(blockInner.statements);
                     if (blockInner.setStatements is not null)
@@ -621,14 +621,14 @@ namespace DMCompiler.Compiler.DM {
             return null;
         }
 
-        private (List<DMASTProcStatement>?, List<DMASTProcStatement>?) ProcBlockInner() {
+        private (List<DMASTProcStatement>?, List<DMASTProcStatement>?) ProcBlockInner(List<DMASTDefinitionParameter>? procParameters = null) {
             List<DMASTProcStatement> procStatements = new();
             List<DMASTProcStatement> setStatements = new(); // We have to store them separately because they're evaluated first
 
             DMASTProcStatement? statement;
             do {
                 Whitespace();
-                statement = ProcStatement();
+                statement = ProcStatement(procParameters);
 
                 if (statement is not null) {
                     Whitespace();
@@ -643,7 +643,7 @@ namespace DMCompiler.Compiler.DM {
             return (procStatements.Count > 0 ? procStatements : null, setStatements.Count > 0 ? setStatements : null);
         }
 
-        private DMASTProcStatement? ProcStatement() {
+        private DMASTProcStatement? ProcStatement(List<DMASTDefinitionParameter>? procParameters = null) {
             var loc = Current().Location;
 
             if (Current().Type == TokenType.DM_Semicolon) { // A lone semicolon creates a "null statement" (like C)
@@ -748,20 +748,20 @@ namespace DMCompiler.Compiler.DM {
                 return new DMASTProcStatementExpression(loc, expression);
             } else {
                 // These are sorted by frequency
-                DMASTProcStatement? procStatement = If();
+                DMASTProcStatement? procStatement = If(procParameters);
                 procStatement ??= Return();
-                procStatement ??= ProcVarDeclaration();
-                procStatement ??= For();
+                procStatement ??= ProcVarDeclaration(procParameters);
+                procStatement ??= For(procParameters);
                 procStatement ??= Set();
-                procStatement ??= Switch();
+                procStatement ??= Switch(procParameters);
                 procStatement ??= Continue();
                 procStatement ??= Break();
-                procStatement ??= Spawn();
-                procStatement ??= While();
-                procStatement ??= DoWhile();
+                procStatement ??= Spawn(procParameters);
+                procStatement ??= While(procParameters);
+                procStatement ??= DoWhile(procParameters);
                 procStatement ??= Throw();
                 procStatement ??= Del();
-                procStatement ??= TryCatch();
+                procStatement ??= TryCatch(procParameters);
                 procStatement ??= Goto();
 
                 if (procStatement != null) {
@@ -772,7 +772,7 @@ namespace DMCompiler.Compiler.DM {
             }
         }
 
-        private DMASTProcStatement? ProcVarDeclaration(bool allowMultiple = true) {
+        private DMASTProcStatement? ProcVarDeclaration(List<DMASTDefinitionParameter>? procParameters = null, bool allowMultiple = true) {
             Token firstToken = Current();
             bool wasSlash = Check(TokenType.DM_Slash);
 
@@ -783,7 +783,7 @@ namespace DMCompiler.Compiler.DM {
                 }
 
                 Whitespace(); // We have to consume whitespace here since "var foo = 1" (for example) is valid DM code.
-                DMASTProcStatementVarDeclaration[]? vars = ProcVarEnd(allowMultiple);
+                DMASTProcStatementVarDeclaration[]? vars = ProcVarEnd(procParameters, allowMultiple);
                 if (vars == null) {
                     Emit(WarningCode.InvalidVarDefinition, "Expected a var declaration");
                     return new DMASTInvalidProcStatement(firstToken.Location);
@@ -802,7 +802,7 @@ namespace DMCompiler.Compiler.DM {
         /// <summary>
         /// <see langword="WARNING:"/> This proc calls itself recursively.
         /// </summary>
-        private DMASTProcStatementVarDeclaration[]? ProcVarBlock(DMASTPath? varPath) {
+        private DMASTProcStatementVarDeclaration[]? ProcVarBlock(List<DMASTDefinitionParameter>? procParameters, DMASTPath? varPath) {
             Token newlineToken = Current();
             bool hasNewline = Newline();
 
@@ -810,7 +810,7 @@ namespace DMCompiler.Compiler.DM {
                 List<DMASTProcStatementVarDeclaration> varDeclarations = new();
 
                 while (!Check(TokenType.DM_Dedent)) {
-                    DMASTProcStatementVarDeclaration[]? varDecl = ProcVarEnd(true, path: varPath);
+                    DMASTProcStatementVarDeclaration[]? varDecl = ProcVarEnd(procParameters, true, path: varPath);
                     if (varDecl != null) {
                         varDeclarations.AddRange(varDecl);
                     } else {
@@ -831,7 +831,7 @@ namespace DMCompiler.Compiler.DM {
                 List<DMASTProcStatementVarDeclaration> varDeclarations = new();
                 TokenType type = isIndented ? TokenType.DM_Dedent : TokenType.DM_RightCurlyBracket;
                 while (!Check(type)) {
-                    DMASTProcStatementVarDeclaration[]? varDecl = ProcVarEnd(true, path: varPath);
+                    DMASTProcStatementVarDeclaration[]? varDecl = ProcVarEnd(procParameters, true, path: varPath);
                     Delimiter();
                     Whitespace();
                     if (varDecl == null) {
@@ -857,12 +857,12 @@ namespace DMCompiler.Compiler.DM {
             return null;
         }
 
-        private DMASTProcStatementVarDeclaration[]? ProcVarEnd(bool allowMultiple, DMASTPath? path = null) {
+        private DMASTProcStatementVarDeclaration[]? ProcVarEnd(List<DMASTDefinitionParameter>? procParameters, bool allowMultiple, DMASTPath? path = null) {
             var loc = Current().Location;
             DMASTPath? varPath = Path();
 
             if (allowMultiple) {
-                DMASTProcStatementVarDeclaration[]? block = ProcVarBlock(varPath);
+                DMASTProcStatementVarDeclaration[]? block = ProcVarBlock(procParameters, varPath);
                 if (block != null) return block;
             }
 
@@ -884,7 +884,7 @@ namespace DMCompiler.Compiler.DM {
                     RequireExpression(ref value);
                 }
 
-                var valType = AsComplexTypes() ?? DMValueType.Anything;
+                var valType = AsComplexTypes(procParameters);
 
                 varDeclarations.Add(new DMASTProcStatementVarDeclaration(loc, varPath, value, valType));
                 if (allowMultiple && Check(TokenType.DM_Comma)) {
@@ -1087,7 +1087,7 @@ namespace DMCompiler.Compiler.DM {
             return null;
         }
 
-        private DMASTProcStatementSpawn? Spawn() {
+        private DMASTProcStatementSpawn? Spawn(List<DMASTDefinitionParameter>? procParameters = null) {
             var loc = Current().Location;
 
             if (Check(TokenType.DM_Spawn)) {
@@ -1110,9 +1110,9 @@ namespace DMCompiler.Compiler.DM {
 
                 Newline();
 
-                DMASTProcBlockInner? body = ProcBlock();
+                DMASTProcBlockInner? body = ProcBlock(procParameters);
                 if (body == null) {
-                    DMASTProcStatement? statement = ProcStatement();
+                    DMASTProcStatement? statement = ProcStatement(procParameters);
 
                     if (statement != null) {
                         body = new DMASTProcBlockInner(loc, statement);
@@ -1128,7 +1128,7 @@ namespace DMCompiler.Compiler.DM {
             }
         }
 
-        private DMASTProcStatementIf? If() {
+        private DMASTProcStatementIf? If(List<DMASTDefinitionParameter>? procParameters = null) {
             var loc = Current().Location;
 
             if (Check(TokenType.DM_If)) {
@@ -1148,11 +1148,11 @@ namespace DMCompiler.Compiler.DM {
                 Check(TokenType.DM_Colon);
                 Whitespace();
 
-                DMASTProcStatement? procStatement = ProcStatement();
+                DMASTProcStatement? procStatement = ProcStatement(procParameters);
                 DMASTProcBlockInner? elseBody = null;
                 DMASTProcBlockInner? body = (procStatement != null)
                     ? new DMASTProcBlockInner(loc, procStatement)
-                    : ProcBlock();
+                    : ProcBlock(procParameters);
                 body ??= new DMASTProcBlockInner(loc);
 
                 Token afterIfBody = Current();
@@ -1162,11 +1162,11 @@ namespace DMCompiler.Compiler.DM {
                     Whitespace();
                     Check(TokenType.DM_Colon);
                     Whitespace();
-                    procStatement = ProcStatement();
+                    procStatement = ProcStatement(procParameters);
 
                     elseBody = (procStatement != null)
                         ? new DMASTProcBlockInner(loc, procStatement)
-                        : ProcBlock();
+                        : ProcBlock(procParameters);
                     elseBody ??= new DMASTProcBlockInner(loc);
                 } else if (newLineAfterIf) {
                     ReuseToken(afterIfBody);
@@ -1178,7 +1178,7 @@ namespace DMCompiler.Compiler.DM {
             }
         }
 
-        private DMASTProcStatement? For() {
+        private DMASTProcStatement? For(List<DMASTDefinitionParameter>? procParameters = null) {
             var loc = Current().Location;
 
             if (Check(TokenType.DM_For)) {
@@ -1187,7 +1187,7 @@ namespace DMCompiler.Compiler.DM {
                 Whitespace();
 
                 if (Check(TokenType.DM_RightParenthesis)) {
-                    return new DMASTProcStatementInfLoop(loc, GetForBody(loc));
+                    return new DMASTProcStatementInfLoop(loc, GetForBody(loc, procParameters));
                 }
 
                 _allowVarDeclExpression = true;
@@ -1207,7 +1207,7 @@ namespace DMCompiler.Compiler.DM {
                     if (expr1 is DMASTAssign assign) {
                         ExpressionTo(out var endRange, out var step);
                         Consume(TokenType.DM_RightParenthesis, "Expected ')' in for after to expression");
-                        return new DMASTProcStatementFor(loc, new DMASTExpressionInRange(loc, assign.LHS, assign.RHS, endRange, step), null, null, dmTypes, GetForBody(loc));
+                        return new DMASTProcStatementFor(loc, new DMASTExpressionInRange(loc, assign.LHS, assign.RHS, endRange, step), null, null, dmTypes, GetForBody(loc, procParameters));
                     } else {
                         Emit(WarningCode.BadExpression, "Expected = before to in for");
                         return new DMASTInvalidProcStatement(loc);
@@ -1219,16 +1219,16 @@ namespace DMCompiler.Compiler.DM {
                     DMASTExpression? listExpr = Expression();
                     Whitespace();
                     Consume(TokenType.DM_RightParenthesis, "Expected ')' in for after expression 2");
-                    return new DMASTProcStatementFor(loc, new DMASTExpressionIn(loc, expr1, listExpr), null, null, dmTypes, GetForBody(loc));
+                    return new DMASTProcStatementFor(loc, new DMASTExpressionIn(loc, expr1, listExpr), null, null, dmTypes, GetForBody(loc, procParameters));
                 }
 
                 if (!Check(ForSeparatorTypes)) {
                     Consume(TokenType.DM_RightParenthesis, "Expected ')' in for after expression 1");
-                    return new DMASTProcStatementFor(loc, expr1, null, null, dmTypes, GetForBody(loc));
+                    return new DMASTProcStatementFor(loc, expr1, null, null, dmTypes, GetForBody(loc, procParameters));
                 }
 
                 if (Check(TokenType.DM_RightParenthesis)) {
-                    return new DMASTProcStatementFor(loc, expr1, null, null, dmTypes, GetForBody(loc));
+                    return new DMASTProcStatementFor(loc, expr1, null, null, dmTypes, GetForBody(loc, procParameters));
                 }
 
                 Whitespace();
@@ -1243,11 +1243,11 @@ namespace DMCompiler.Compiler.DM {
 
                 if (!Check(ForSeparatorTypes)) {
                     Consume(TokenType.DM_RightParenthesis, "Expected ')' in for after expression 2");
-                    return new DMASTProcStatementFor(loc, expr1, expr2, null, dmTypes, GetForBody(loc));
+                    return new DMASTProcStatementFor(loc, expr1, expr2, null, dmTypes, GetForBody(loc, procParameters));
                 }
 
                 if (Check(TokenType.DM_RightParenthesis)) {
-                    return new DMASTProcStatementFor(loc, expr1, expr2, null, dmTypes, GetForBody(loc));
+                    return new DMASTProcStatementFor(loc, expr1, expr2, null, dmTypes, GetForBody(loc, procParameters));
                 }
 
                 Whitespace();
@@ -1261,23 +1261,23 @@ namespace DMCompiler.Compiler.DM {
                 }
 
                 Consume(TokenType.DM_RightParenthesis, "Expected ')' in for after expression 3");
-                return new DMASTProcStatementFor(loc, expr1, expr2, expr3, dmTypes, GetForBody(loc));
+                return new DMASTProcStatementFor(loc, expr1, expr2, expr3, dmTypes, GetForBody(loc, procParameters));
             }
 
             return null;
 
-            DMASTProcBlockInner GetForBody(Location forLocation) {
+            DMASTProcBlockInner GetForBody(Location forLocation, List<DMASTDefinitionParameter>? procParameters = null) {
                 Whitespace();
                 Newline();
 
-                DMASTProcBlockInner? body = ProcBlock();
+                DMASTProcBlockInner? body = ProcBlock(procParameters);
                 if (body == null) {
                     var loc = Current().Location;
                     DMASTProcStatement? statement;
                     if (Check(TokenType.DM_Semicolon)) {
                         statement = new DMASTProcStatementExpression(loc, new DMASTConstantNull(loc));
                     } else {
-                        statement = ProcStatement();
+                        statement = ProcStatement(procParameters);
                         if (statement == null) {
                             DMCompiler.Emit(WarningCode.MissingBody, forLocation, "Expected body or statement");
                             statement = new DMASTInvalidProcStatement(loc);
@@ -1291,7 +1291,7 @@ namespace DMCompiler.Compiler.DM {
             }
         }
 
-        private DMASTProcStatement? While() {
+        private DMASTProcStatement? While(List<DMASTDefinitionParameter>? procParameters = null) {
             var loc = Current().Location;
 
             if (Check(TokenType.DM_While)) {
@@ -1303,10 +1303,10 @@ namespace DMCompiler.Compiler.DM {
                 ConsumeRightParenthesis();
                 Check(TokenType.DM_Semicolon);
                 Whitespace();
-                DMASTProcBlockInner? body = ProcBlock();
+                DMASTProcBlockInner? body = ProcBlock(procParameters);
 
                 if (body == null) {
-                    DMASTProcStatement? statement = ProcStatement();
+                    DMASTProcStatement? statement = ProcStatement(procParameters);
 
                     //Loops without a body are valid DM
                     statement ??= new DMASTProcStatementContinue(loc);
@@ -1324,7 +1324,7 @@ namespace DMCompiler.Compiler.DM {
             return null;
         }
 
-        private DMASTProcStatementDoWhile? DoWhile() {
+        private DMASTProcStatementDoWhile? DoWhile(List<DMASTDefinitionParameter>? procParameters = null) {
             var loc = Current().Location;
 
             if (Check(TokenType.DM_Do)) {
@@ -1359,7 +1359,7 @@ namespace DMCompiler.Compiler.DM {
             return null;
         }
 
-        private DMASTProcStatementSwitch? Switch() {
+        private DMASTProcStatementSwitch? Switch(List<DMASTDefinitionParameter>? procParameters = null) {
             var loc = Current().Location;
 
             if (Check(TokenType.DM_Switch)) {
@@ -1371,7 +1371,7 @@ namespace DMCompiler.Compiler.DM {
                 ConsumeRightParenthesis();
                 Whitespace();
 
-                DMASTProcStatementSwitch.SwitchCase[]? switchCases = SwitchCases();
+                DMASTProcStatementSwitch.SwitchCase[]? switchCases = SwitchCases(procParameters);
                 if (switchCases == null) {
                     switchCases = [];
                     Emit(WarningCode.MissingBody, "Expected switch cases");
@@ -1383,11 +1383,11 @@ namespace DMCompiler.Compiler.DM {
             return null;
         }
 
-        private DMASTProcStatementSwitch.SwitchCase[]? SwitchCases() {
+        private DMASTProcStatementSwitch.SwitchCase[]? SwitchCases(List<DMASTDefinitionParameter>? procParameters = null) {
             Token beforeSwitchBlock = Current();
             bool hasNewline = Newline();
 
-            DMASTProcStatementSwitch.SwitchCase[]? switchCases = BracedSwitchInner() ?? IndentedSwitchInner();
+            DMASTProcStatementSwitch.SwitchCase[]? switchCases = BracedSwitchInner(procParameters) ?? IndentedSwitchInner(procParameters);
 
             if (switchCases == null && hasNewline) {
                 ReuseToken(beforeSwitchBlock);
@@ -1396,12 +1396,12 @@ namespace DMCompiler.Compiler.DM {
             return switchCases;
         }
 
-        private DMASTProcStatementSwitch.SwitchCase[]? BracedSwitchInner() {
+        private DMASTProcStatementSwitch.SwitchCase[]? BracedSwitchInner(List<DMASTDefinitionParameter>? procParameters = null) {
             if (Check(TokenType.DM_LeftCurlyBracket)) {
                 Whitespace();
                 Newline();
                 bool isIndented = Check(TokenType.DM_Indent);
-                DMASTProcStatementSwitch.SwitchCase[] switchInner = SwitchInner();
+                DMASTProcStatementSwitch.SwitchCase[] switchInner = SwitchInner(procParameters);
                 if (isIndented) Check(TokenType.DM_Dedent);
                 Newline();
                 Consume(TokenType.DM_RightCurlyBracket, "Expected '}'");
@@ -1412,9 +1412,9 @@ namespace DMCompiler.Compiler.DM {
             return null;
         }
 
-        private DMASTProcStatementSwitch.SwitchCase[]? IndentedSwitchInner() {
+        private DMASTProcStatementSwitch.SwitchCase[]? IndentedSwitchInner(List<DMASTDefinitionParameter>? procParameters = null) {
             if (Check(TokenType.DM_Indent)) {
-                DMASTProcStatementSwitch.SwitchCase[] switchInner = SwitchInner();
+                DMASTProcStatementSwitch.SwitchCase[] switchInner = SwitchInner(procParameters);
                 Consume(TokenType.DM_Dedent, "Expected \"if\" or \"else\"");
 
                 return switchInner;
@@ -1423,21 +1423,21 @@ namespace DMCompiler.Compiler.DM {
             return null;
         }
 
-        private DMASTProcStatementSwitch.SwitchCase[] SwitchInner() {
+        private DMASTProcStatementSwitch.SwitchCase[] SwitchInner(List<DMASTDefinitionParameter> procParameters = null) {
             List<DMASTProcStatementSwitch.SwitchCase> switchCases = new();
-            DMASTProcStatementSwitch.SwitchCase? switchCase = SwitchCase();
+            DMASTProcStatementSwitch.SwitchCase? switchCase = SwitchCase(procParameters);
 
             while (switchCase is not null) {
                 switchCases.Add(switchCase);
                 Newline();
                 Whitespace();
-                switchCase = SwitchCase();
+                switchCase = SwitchCase(procParameters);
             }
 
             return switchCases.ToArray();
         }
 
-        private DMASTProcStatementSwitch.SwitchCase? SwitchCase() {
+        private DMASTProcStatementSwitch.SwitchCase? SwitchCase(List<DMASTDefinitionParameter> procParameters = null) {
             if (Check(TokenType.DM_If)) {
                 List<DMASTExpression> expressions = new();
 
@@ -1474,10 +1474,10 @@ namespace DMCompiler.Compiler.DM {
                 Whitespace();
                 ConsumeRightParenthesis();
                 Whitespace();
-                DMASTProcBlockInner? body = ProcBlock();
+                DMASTProcBlockInner? body = ProcBlock(procParameters);
 
                 if (body == null) {
-                    DMASTProcStatement? statement = ProcStatement();
+                    DMASTProcStatement? statement = ProcStatement(procParameters);
 
                     body = (statement != null)
                         ? new DMASTProcBlockInner(statement.Location, statement)
@@ -1495,10 +1495,10 @@ namespace DMCompiler.Compiler.DM {
                         "Expected \"if\" or \"else\" - \"else if\" is ambiguous as a switch case and may cause unintended flow");
                 }
 
-                DMASTProcBlockInner? body = ProcBlock();
+                DMASTProcBlockInner? body = ProcBlock(procParameters);
 
                 if (body == null) {
-                    DMASTProcStatement? statement = ProcStatement();
+                    DMASTProcStatement? statement = ProcStatement(procParameters);
 
                     body = (statement != null)
                         ? new DMASTProcBlockInner(loc, statement)
@@ -1511,15 +1511,15 @@ namespace DMCompiler.Compiler.DM {
             return null;
         }
 
-        private DMASTProcStatementTryCatch? TryCatch() {
+        private DMASTProcStatementTryCatch? TryCatch(List<DMASTDefinitionParameter>? procParameters = null) {
             var loc = Current().Location;
 
             if (Check(TokenType.DM_Try)) {
                 Whitespace();
 
-                DMASTProcBlockInner? tryBody = ProcBlock();
+                DMASTProcBlockInner? tryBody = ProcBlock(procParameters);
                 if (tryBody == null) {
-                    DMASTProcStatement? statement = ProcStatement();
+                    DMASTProcStatement? statement = ProcStatement(procParameters);
                     if (statement == null) {
                         statement = new DMASTInvalidProcStatement(loc);
                         Emit(WarningCode.MissingBody, "Expected body or statement");
@@ -1537,15 +1537,15 @@ namespace DMCompiler.Compiler.DM {
                 DMASTProcStatement? parameter = null;
                 if (Check(TokenType.DM_LeftParenthesis)) {
                     BracketWhitespace();
-                    parameter = ProcVarDeclaration(allowMultiple: false);
+                    parameter = ProcVarDeclaration(procParameters, allowMultiple: false);
                     BracketWhitespace();
                     ConsumeRightParenthesis();
                     Whitespace();
                 }
 
-                DMASTProcBlockInner? catchBody = ProcBlock();
+                DMASTProcBlockInner? catchBody = ProcBlock(procParameters);
                 if (catchBody == null) {
-                    DMASTProcStatement? statement = ProcStatement();
+                    DMASTProcStatement? statement = ProcStatement(procParameters);
 
                     if (statement != null) catchBody = new DMASTProcBlockInner(loc, statement);
                 }
@@ -2703,7 +2703,7 @@ namespace DMCompiler.Compiler.DM {
 
             do {
                 Whitespace();
-                type |= SingleAsType(out _, out _);
+                type |= SingleAsType(out _, out _, out _);
                 Whitespace();
             } while (Check(TokenType.DM_Bar));
 
@@ -2716,14 +2716,15 @@ namespace DMCompiler.Compiler.DM {
 
         /// <summary>
         /// AsTypes(), but can handle more complex types such as type paths
+        /// If procParameters is non-null, allow as params[1] and as params[foo] syntax
         /// </summary>
-        private DMComplexValueType? AsComplexTypes() {
+        private DMComplexValueType? AsComplexTypes(List<DMASTDefinitionParameter>? procParameters = null) {
             if (!AsTypesStart(out var parenthetical))
                 return null;
             if (parenthetical && Check(TokenType.DM_RightParenthesis)) // as ()
                 return DMValueType.Anything; // TODO: BYOND doesn't allow this for proc return types
 
-            var outType = UnionComplexTypes();
+            var outType = UnionComplexTypes(procParameters);
 
             if (parenthetical) {
                 ConsumeRightParenthesis();
@@ -2732,16 +2733,20 @@ namespace DMCompiler.Compiler.DM {
             return outType;
         }
 
-        private DMComplexValueType? UnionComplexTypes() {
+        private DMComplexValueType? UnionComplexTypes(List<DMASTDefinitionParameter>? procParameters = null) {
             DMValueType type = DMValueType.Anything;
             DreamPath? path = null;
+            List<(int, bool)> paramIndices = new List<(int, bool)>();
             DMListValueTypes? outListTypes = null;
 
             do {
                 Whitespace();
-                type |= SingleAsType(out var pathType, out var listTypes, allowPath: true);
+                type |= SingleAsType(out var pathType, out var param, out var listTypes, allowPath: true, procParameters: procParameters);
                 Whitespace();
 
+                if (param.paramIndex is not null) {
+                    paramIndices.Add((param.paramIndex.Value, param.upcasted));
+                }
                 if (pathType is not null) {
                     if (path is null)
                         path = pathType;
@@ -2763,7 +2768,7 @@ namespace DMCompiler.Compiler.DM {
                 }
 
             } while (Check(TokenType.DM_Bar));
-            return new(type, path, outListTypes);
+            return new(type, path, paramIndices.Count > 0 ? paramIndices.ToArray() : null, outListTypes);
         }
 
         private bool AsTypesStart(out bool parenthetical) {
@@ -2777,9 +2782,10 @@ namespace DMCompiler.Compiler.DM {
             return false;
         }
 
-        private DMValueType SingleAsType(out DreamPath? path, out DMListValueTypes? listTypes, bool allowPath = false) {
+        private DMValueType SingleAsType(out DreamPath? path, out (int? paramIndex, bool upcasted) outParam, out DMListValueTypes? listTypes, bool allowPath = false, List<DMASTDefinitionParameter>? procParameters = null) {
             Token typeToken = Current();
 
+            outParam = (null, false);
             listTypes = null;
 
             var inPath = false;
@@ -2805,12 +2811,12 @@ namespace DMCompiler.Compiler.DM {
                     } else if (path == DreamPath.List) {
                         // check for list types
                         if (Check(TokenType.DM_LeftParenthesis)) {
-                            DMComplexValueType? nestedKeyType = UnionComplexTypes();
+                            DMComplexValueType? nestedKeyType = UnionComplexTypes(procParameters);
                             if (nestedKeyType is null)
                                 DMCompiler.Emit(WarningCode.BadToken, CurrentLoc, "Expected value type or path");
                             DMComplexValueType? nestedValType = null;
                             if (Check(TokenType.DM_Comma)) { // Value
-                                nestedValType = UnionComplexTypes();
+                                nestedValType = UnionComplexTypes(procParameters);
                             }
                             ConsumeRightParenthesis();
                             listTypes = new(nestedKeyType!.Value, nestedValType);
@@ -2841,7 +2847,49 @@ namespace DMCompiler.Compiler.DM {
                 case "command_text": return DMValueType.CommandText;
                 case "sound": return DMValueType.Sound;
                 case "icon": return DMValueType.Icon;
-                case "path": return DMValueType.Path;
+                case "params":
+                    if (procParameters is null) {
+                        DMCompiler.Emit(WarningCode.BadToken, typeToken.Location, "Cannot use 'as params' outside of a proc or its return type");
+                    }
+                    if (Check(TokenType.DM_LeftBracket)) {
+                        Whitespace();
+                        // Check for an identifier first
+                        Token paramToken = Current();
+                        switch (paramToken.Type) {
+                            case TokenType.DM_Identifier:
+                                outParam.paramIndex = procParameters?.FindIndex(x => x.Name == paramToken.Text);
+                                if (outParam.paramIndex < 0) {
+                                    outParam.paramIndex = null;
+                                }
+                                break;
+                            case TokenType.DM_Integer:
+                                outParam.paramIndex = paramToken.ValueAsInt();
+                                if (procParameters is null || (outParam.paramIndex is not null && outParam.paramIndex >= procParameters.Count)) {
+                                    DMCompiler.Emit(WarningCode.BadToken, paramToken.Location, $"Parameter index out of range ({outParam.paramIndex} >= {procParameters?.Count ?? 0})");
+                                    outParam.paramIndex = null;
+                                }
+                                break;
+                            default:
+                                DMCompiler.Emit(WarningCode.BadToken, paramToken.Location, $"Unrecognized parameter {paramToken.PrintableText}, expected parameter identifier or index");
+                                break;
+                        }
+                        Advance();
+                        Whitespace();
+                        // Allow recasting a path to an instance with the instance keyword, here and only here
+                        if(AsTypesStart(out var parenthetical)) {
+                            Token nextToken = Current();
+                            if (nextToken.Type is not TokenType.DM_Identifier || nextToken.Text != "instance")
+                                DMCompiler.Emit(WarningCode.BadToken, nextToken.Location, $"Expected 'as instance', got 'as {nextToken.PrintableText}'");
+                            else
+                                outParam.upcasted = true;
+                            Advance();
+                            if (parenthetical)
+                                ConsumeRightParenthesis();
+                        }
+                        ConsumeRightBracket();
+                    }
+                    path = null;
+                    return DMValueType.Anything;
                 case "opendream_unimplemented": return DMValueType.Unimplemented;
                 case "opendream_compiletimereadonly": return DMValueType.CompiletimeReadonly;
                 default:

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -300,7 +300,7 @@ namespace DMCompiler.Compiler.DM {
                         value = new DMASTConstantNull(loc);
                     }
 
-                    var valType = AsComplexTypes() ?? DMValueType.Anything;
+                    var valType = AsComplexTypes();
                     var varDef = new DMASTObjectVarDefinition(loc, varPath, value, valType);
 
                     varDefinitions.Add(varDef);
@@ -2735,7 +2735,7 @@ namespace DMCompiler.Compiler.DM {
                     if (path == null)
                         path = pathType;
                     else
-                        DMCompiler.Emit(WarningCode.BadToken, CurrentLoc,
+                        DMCompiler.Emit(WarningCode.LostTypeInfo, CurrentLoc,
                             $"Only one type path can be used, ignoring {pathType}");
                 }
 

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -2731,12 +2731,18 @@ namespace DMCompiler.Compiler.DM {
                 type |= SingleAsType(out var pathType, allowPath: true);
                 Whitespace();
 
-                if (pathType != null) {
-                    if (path == null)
+                if (pathType is not null) {
+                    if (path is null)
                         path = pathType;
-                    else
-                        DMCompiler.Emit(WarningCode.LostTypeInfo, CurrentLoc,
-                            $"Only one type path can be used, ignoring {pathType}");
+                    else {
+                        var newPath = path.Value.GetLastCommonAncestor(pathType.Value);
+                        if (newPath != path) {
+                            DMCompiler.Emit(WarningCode.LostTypeInfo, CurrentLoc,
+                                $"Only one type path can be used, using last common ancestor {newPath}");
+                            path = newPath;
+                        }
+                    }
+                }
                 }
 
             } while (Check(TokenType.DM_Bar));

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -885,6 +885,10 @@ namespace DMCompiler.Compiler.DM {
                 }
 
                 var valType = AsComplexTypes(procParameters);
+                // the != DMValueType.Null check is a hacky workaround for Anything|Null being equal to just Null
+                if (valType is null && value.GetUnwrapped() is DMASTInput input && input.Types != DMValueType.Null) {
+                    valType = input.Types;
+                }
 
                 varDeclarations.Add(new DMASTProcStatementVarDeclaration(loc, varPath, value, valType));
                 if (allowMultiple && Check(TokenType.DM_Comma)) {

--- a/DMCompiler/DM/Builders/DMExpressionBuilder.cs
+++ b/DMCompiler/DM/Builders/DMExpressionBuilder.cs
@@ -385,7 +385,7 @@ internal static class DMExpressionBuilder {
                 if (CurrentScopeMode == ScopeMode.Normal) {
                     var localVar = proc?.GetLocalVariable(name);
                     if (localVar != null)
-                        return new Local(identifier.Location, localVar);
+                        return new Local(identifier.Location, localVar, localVar.ExplicitValueType);
 
                     var field = dmObject?.GetVariable(name);
                     if (field != null) {

--- a/DMCompiler/DM/Builders/DMExpressionBuilder.cs
+++ b/DMCompiler/DM/Builders/DMExpressionBuilder.cs
@@ -779,7 +779,7 @@ internal static class DMExpressionBuilder {
                             return BadExpression(WarningCode.ItemDoesntExist, callOperation.Location,
                                 $"Type {prevPath.Value} does not have a proc named \"{field}\"");
 
-                        var returnTypes = fromObject.GetProcReturnTypes(field) ?? DMValueType.Anything;
+                        var returnTypes = fromObject.GetProcReturnTypes(field, argumentList) ?? DMValueType.Anything;
                         nextPath = returnTypes.HasPath ? returnTypes.TypePath : returnTypes.AsPath();
                         if (!returnTypes.HasPath & nextPath.HasValue) {
                             var thePath = nextPath!.Value;

--- a/DMCompiler/DM/Builders/DMExpressionBuilder.cs
+++ b/DMCompiler/DM/Builders/DMExpressionBuilder.cs
@@ -763,6 +763,7 @@ internal static class DMExpressionBuilder {
                 case DMASTDereference.CallOperation callOperation: {
                     var field = callOperation.Identifier;
                     ArgumentList argumentList = new(deref.Expression.Location, dmObject, proc, callOperation.Parameters);
+                    DreamPath? nextPath = null;
 
                     if (!callOperation.NoSearch && !pathIsFuzzy) {
                         if (prevPath == null) {
@@ -777,6 +778,9 @@ internal static class DMExpressionBuilder {
                         if (!fromObject.HasProc(field))
                             return BadExpression(WarningCode.ItemDoesntExist, callOperation.Location,
                                 $"Type {prevPath.Value} does not have a proc named \"{field}\"");
+
+                        var returnTypes = fromObject.GetProcReturnTypes(field) ?? DMValueType.Anything;
+                        nextPath = returnTypes.IsPath ? returnTypes.TypePath : returnTypes.AsPath();
                     }
 
                     operation = new Dereference.CallOperation {
@@ -785,8 +789,9 @@ internal static class DMExpressionBuilder {
                         Identifier = field,
                         Path = prevPath
                     };
-                    prevPath = null;
-                    pathIsFuzzy = true;
+                    prevPath = nextPath;
+                    if(prevPath is null)
+                        pathIsFuzzy = true;
                     break;
                 }
 

--- a/DMCompiler/DM/Builders/DMExpressionBuilder.cs
+++ b/DMCompiler/DM/Builders/DMExpressionBuilder.cs
@@ -783,7 +783,7 @@ internal static class DMExpressionBuilder {
                         Parameters = argumentList,
                         Safe = callOperation.Safe,
                         Identifier = field,
-                        Path = null
+                        Path = prevPath
                     };
                     prevPath = null;
                     pathIsFuzzy = true;

--- a/DMCompiler/DM/Builders/DMExpressionBuilder.cs
+++ b/DMCompiler/DM/Builders/DMExpressionBuilder.cs
@@ -780,7 +780,7 @@ internal static class DMExpressionBuilder {
                                 $"Type {prevPath.Value} does not have a proc named \"{field}\"");
 
                         var returnTypes = fromObject.GetProcReturnTypes(field) ?? DMValueType.Anything;
-                        nextPath = returnTypes.IsPath ? returnTypes.TypePath : returnTypes.AsPath();
+                        nextPath = returnTypes.HasPath ? returnTypes.TypePath : returnTypes.AsPath();
                     }
 
                     operation = new Dereference.CallOperation {

--- a/DMCompiler/DM/DMExpression.cs
+++ b/DMCompiler/DM/DMExpression.cs
@@ -181,7 +181,6 @@ internal sealed class ArgumentList {
         // TODO: Make a separate "UnsetStaticType" pragma for whether we should care if it's Anything
         // TODO: We currently silently avoid typechecking "call()()" and "new" args (NewPath is handled)
         // TODO: We currently don't handle variadic args (e.g. min())
-        // TODO: Dereference.CallOperation does not pass targetProc
 
         DMProc.LocalVariable? param;
         if (name != null) {
@@ -202,7 +201,7 @@ internal sealed class ArgumentList {
 
         DMComplexValueType paramType = param.ExplicitValueType ?? DMValueType.Anything;
 
-        if (!expr.ValType.IsAnything && !paramType.MatchesType(expr.ValType)) {
+        if (!(DMCompiler.Settings.SkipAnythingTypecheck && expr.ValType.IsAnything) && !paramType.MatchesType(expr.ValType)) {
             DMCompiler.Emit(WarningCode.InvalidVarType, expr.Location,
                 $"{targetProc.Name}(...) argument \"{param.Name}\": Invalid var value type {expr.ValType}, expected {paramType}");
         }

--- a/DMCompiler/DM/DMObject.cs
+++ b/DMCompiler/DM/DMObject.cs
@@ -1,4 +1,4 @@
-using DMCompiler.Bytecode;
+﻿using DMCompiler.Bytecode;
 using DMCompiler.Compiler;
 using DMCompiler.Json;
 
@@ -95,16 +95,21 @@ internal sealed class DMObject {
     }
 
     public DMComplexValueType? GetProcReturnTypes(string name) {
+
+        return GetProcReturnTypes(name, null);
+    }
+
+    public DMComplexValueType? GetProcReturnTypes(string name, ArgumentList? arguments) {
         if (this == DMObjectTree.Root && DMObjectTree.TryGetGlobalProc(name, out var globalProc))
-            return globalProc.RawReturnTypes;
+            return globalProc.GetParameterValueTypes(arguments);
         if (GetProcs(name) is not { } procs)
-            return Parent?.GetProcReturnTypes(name);
+            return Parent?.GetProcReturnTypes(name, arguments);
 
         var proc = DMObjectTree.AllProcs[procs[0]];
         if ((proc.Attributes & ProcAttributes.IsOverride) != 0)
-            return Parent?.GetProcReturnTypes(name) ?? DMValueType.Anything;
+            return Parent?.GetProcReturnTypes(name, arguments) ?? DMValueType.Anything;
 
-        return proc.RawReturnTypes;
+        return proc.GetParameterValueTypes(arguments);
     }
 
     public void AddVerb(DMProc verb) {

--- a/DMCompiler/DM/DMObject.cs
+++ b/DMCompiler/DM/DMObject.cs
@@ -113,7 +113,7 @@ internal sealed class DMObject {
     }
 
     public DMVariable CreateGlobalVariable(DreamPath? type, string name, bool isConst, DMComplexValueType? valType = null) {
-        int id = DMObjectTree.CreateGlobal(out DMVariable global, type, name, isConst, valType ?? DMValueType.Anything);
+        int id = DMObjectTree.CreateGlobal(out DMVariable global, type, name, isConst, valType);
 
         GlobalVariables[name] = id;
         return global;

--- a/DMCompiler/DM/DMObject.cs
+++ b/DMCompiler/DM/DMObject.cs
@@ -1,4 +1,4 @@
-﻿using DMCompiler.Bytecode;
+using DMCompiler.Bytecode;
 using DMCompiler.Compiler;
 using DMCompiler.Json;
 
@@ -217,14 +217,12 @@ internal sealed class DMObject {
         return Parent != null && Parent.IsSubtypeOf(path);
     }
 
-    public DMValueType GetDMValueType() {
-        if (IsSubtypeOf(DreamPath.Mob))
-            return DMValueType.Mob;
-        if (IsSubtypeOf(DreamPath.Obj))
-            return DMValueType.Obj;
-        if (IsSubtypeOf(DreamPath.Area))
-            return DMValueType.Area;
-
-        return DMValueType.Anything;
+    public DreamPath GetLastCommonAncestor(DMObject other) {
+        if(other.IsSubtypeOf(Path)) {
+            return Path;
+        } else if(IsSubtypeOf(other.Path)) {
+            return other.Path;
+        }
+        return Parent?.GetLastCommonAncestor(other) ?? DreamPath.Root;
     }
 }

--- a/DMCompiler/DM/DMObjectTree.cs
+++ b/DMCompiler/DM/DMObjectTree.cs
@@ -184,7 +184,7 @@ internal static class DMObjectTree {
         return null;
     }
 
-    public static int CreateGlobal(out DMVariable global, DreamPath? type, string name, bool isConst, DMComplexValueType valType) {
+    public static int CreateGlobal(out DMVariable global, DreamPath? type, string name, bool isConst, DMComplexValueType? valType) {
         int id = Globals.Count;
 
         global = new DMVariable(type, name, true, isConst, false, valType);

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -184,13 +184,13 @@ namespace DMCompiler.DM {
                         } else {
                             var type = DMObjectTree.GetDMObject(typePath, false);
 
-                            argumentType = type?.GetDMValueType() ?? DMValueType.Anything;
+                            argumentType = type?.Path.GetAtomType() ?? DMValueType.Anything;
                         }
                     }
 
                     arguments.Add(new ProcArgumentJson {
                         Name = parameter.Name,
-                        Type = argumentType.Type
+                        Type = argumentType.Type & ~(DMValueType.Instance|DMValueType.Path)
                     });
                 }
             }

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -230,7 +230,7 @@ namespace DMCompiler.DM {
         }
 
         public DMVariable CreateGlobalVariable(DreamPath? type, string name, bool isConst, out int id) {
-            id = DMObjectTree.CreateGlobal(out DMVariable global, type, name, isConst, DMValueType.Anything);
+            id = DMObjectTree.CreateGlobal(out DMVariable global, type, name, isConst, null);
 
             GlobalVariables[name] = id;
             return global;

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -280,7 +280,7 @@ namespace DMCompiler.DM {
             return label;
         }
 
-        public bool TryAddLocalVariable(string name, DreamPath? type, DMComplexValueType valType) {
+        public bool TryAddLocalVariable(string name, DreamPath? type, DMComplexValueType? valType) {
             if (_parameters.ContainsKey(name)) //Parameters and local vars cannot share a name
                 return false;
 

--- a/DMCompiler/DM/DMValueType.cs
+++ b/DMCompiler/DM/DMValueType.cs
@@ -78,7 +78,10 @@ public readonly struct DMComplexValueType {
     public DMComplexValueType(DMValueType type, DreamPath? typePath, DMListValueTypes? listValueTypes) : this(type, typePath, null, listValueTypes) { }
 
     public bool MatchesType(DMValueType type) {
-        return IsAnything || (Type & type) != 0;
+        if (IsAnything || (Type & type) != 0) return true;
+        if ((type & (DMValueType.Text | DMValueType.Message)) != 0 && (Type & (DMValueType.Text | DMValueType.Message)) != 0) return true;
+        if ((type & (DMValueType.Text | DMValueType.Color)) != 0 && (Type & (DMValueType.Text | DMValueType.Color)) != 0) return true;
+        return false;
     }
 
     public bool MatchesType(DMComplexValueType type) {
@@ -98,6 +101,12 @@ public readonly struct DMComplexValueType {
                 }
             }
         }
+        // special case for color and lists:
+        if (type.Type.HasFlag(DMValueType.Color) && IsList && ListValueTypes?.NestedListKeyType.Type == DMValueType.Num && ListValueTypes.NestedListValType is null)
+            return true;
+        // probably only one of these is correct but i can't be assed to figure out which
+        if (Type.HasFlag(DMValueType.Color) && type.IsList && type.ListValueTypes?.NestedListKeyType.Type == DMValueType.Num && type.ListValueTypes.NestedListValType is null)
+            return true;
         if (type.IsInstance && MatchesType(type.TypePath!.Value.GetAtomType())) {
             return true;
         }

--- a/DMCompiler/DM/DMValueType.cs
+++ b/DMCompiler/DM/DMValueType.cs
@@ -102,6 +102,17 @@ public readonly struct DMComplexValueType {
 
     public static DMComplexValueType operator |(DMComplexValueType type1, DMValueType type2) =>
         new(type1.Type | type2, type1.TypePath);
+
+    public static DMComplexValueType operator |(DMComplexValueType type1, DMComplexValueType type2) {
+        if (type2.TypePath is null) {
+            return type1 | type2.Type;
+        } else if (type1.TypePath is null) {
+            return type2 | type1.Type;
+        }
+        // Take the common ancestor of both types
+        return new(type1.Type | type2.Type, type1.TypePath.Value.GetLastCommonAncestor(type2.TypePath.Value));
+    }
+
     public DreamPath? AsPath() {
         return (HasPath ? TypePath : null) ?? (Type & ~DMValueType.Null) switch {
             DMValueType.Mob => DreamPath.Mob,

--- a/DMCompiler/DM/DMValueType.cs
+++ b/DMCompiler/DM/DMValueType.cs
@@ -94,7 +94,7 @@ public readonly struct DMComplexValueType {
                 return true;
             }
             var theirPath = type.AsPath();
-            if (theirPath is not null) {
+            if (type.ListValueTypes is null && theirPath is not null) {
                 var theirObject = DMObjectTree.GetDMObject(theirPath!.Value, false);
                 if (theirObject?.IsSubtypeOf(TypePath!.Value) is true) {
                     return true;
@@ -119,9 +119,10 @@ public readonly struct DMComplexValueType {
                 return ourObject?.IsSubtypeOf(type.TypePath!.Value) ?? false;
             }
             // If ListValueTypes is non-null, we do more advanced checks.
-            if (TypePath!.Value == DreamPath.List && ListValueTypes is not null && type.ListValueTypes is not null) {
+            // The other type's must also be non-null, because we consider empty lists as matching.
+            if (ListValueTypes is not null && type.ListValueTypes is not null) {
                 // Have to do an actual match check here. This can get expensive, but thankfully it's pretty rare.
-                if (!ListValueTypes.NestedListKeyType.MatchesType(type.ListValueTypes!.NestedListKeyType))
+                if (!ListValueTypes.NestedListKeyType.MatchesType(type.ListValueTypes.NestedListKeyType))
                     return false;
                 // If we're assoc (have value types rather than just keys), then the other list must match as well.
                 if (ListValueTypes?.NestedListValType is not null) {

--- a/DMCompiler/DM/DMValueType.cs
+++ b/DMCompiler/DM/DMValueType.cs
@@ -1,4 +1,4 @@
-namespace DMCompiler.DM;
+﻿namespace DMCompiler.DM;
 
 // If you are modifying this, you must also modify OpenDreamShared.Dream.DreamValueType !!
 // Unfortunately the client needs this and it can't reference DMCompiler due to the sandbox
@@ -37,6 +37,12 @@ public enum DMValueType {
 public readonly struct DMComplexValueType {
     public readonly DMValueType Type;
     public readonly DreamPath? TypePath;
+    /// <summary>
+    /// The indices of the proc parameters used to infer proc return types.
+    /// The resulting type is the union of all the parameter types with `this.Type`.
+    /// If two or more of those types have paths, their common ancestor is used.
+    /// </summary>
+    public readonly (int, bool)[]? ParameterIndices;
 
     public bool IsAnything => Type == DMValueType.Anything;
     public bool IsInstance => Type.HasFlag(DMValueType.Instance);
@@ -61,9 +67,16 @@ public readonly struct DMComplexValueType {
             throw new Exception("A Path or Instance value type must have a type-path");
     }
 
-    public DMComplexValueType(DMValueType type, DreamPath? typePath, DMListValueTypes? listValueTypes) : this(type, typePath) {
+    public DMComplexValueType(DMValueType type, DreamPath? typePath, (int, bool)[]? parameterIndices) : this(type, typePath) {
+        ParameterIndices = parameterIndices;
+    }
+
+    public DMComplexValueType(DMValueType type, DreamPath? typePath, (int, bool)[]? parameterIndices, DMListValueTypes? listValueTypes) : this(type, typePath, parameterIndices) {
         ListValueTypes = listValueTypes;
     }
+
+    public DMComplexValueType(DMValueType type, DreamPath? typePath, DMListValueTypes? listValueTypes) : this(type, typePath, null, listValueTypes) { }
+
     public bool MatchesType(DMValueType type) {
         return IsAnything || (Type & type) != 0;
     }

--- a/DMCompiler/DM/DMVariable.cs
+++ b/DMCompiler/DM/DMVariable.cs
@@ -21,8 +21,8 @@ internal sealed class DMVariable {
         IsConst = isConst;
         IsTmp = isTmp;
         Value = null;
-        DMComplexValueType atomType = Type?.GetAtomType() ?? DMValueType.Anything;
-        ValType = valType ?? (!atomType.IsAnything ? atomType | DMValueType.Null : (Type is null ? DMValueType.Anything : new DMComplexValueType(DMValueType.Path | DMValueType.Null, Type)));
+        DMComplexValueType atomType = Type is not null ? new DMComplexValueType(DMValueType.Instance | DMValueType.Path, Type) : DMValueType.Anything;
+        ValType = valType ?? (!atomType.IsAnything ? atomType | DMValueType.Null : (Type is null ? DMValueType.Anything : new DMComplexValueType(DMValueType.Instance | DMValueType.Path | DMValueType.Null, Type)));
     }
 
     /// <summary>

--- a/DMCompiler/DM/DMVariable.cs
+++ b/DMCompiler/DM/DMVariable.cs
@@ -21,7 +21,8 @@ internal sealed class DMVariable {
         IsConst = isConst;
         IsTmp = isTmp;
         Value = null;
-        ValType = valType ?? DMValueType.Anything;
+        DMComplexValueType atomType = Type?.GetAtomType() ?? DMValueType.Anything;
+        ValType = valType ?? (!atomType.IsAnything ? atomType | DMValueType.Null : (Type is null ? DMValueType.Anything : new DMComplexValueType(DMValueType.Path | DMValueType.Null, Type)));
     }
 
     /// <summary>

--- a/DMCompiler/DM/Expressions/Binary.cs
+++ b/DMCompiler/DM/Expressions/Binary.cs
@@ -322,6 +322,7 @@ internal sealed class BinaryOr(Location location, DMExpression lhs, DMExpression
 
 // x == y
 internal sealed class Equal(Location location, DMExpression lhs, DMExpression rhs) : BinaryOp(location, lhs, rhs) {
+    public override DMComplexValueType ValType => DMValueType.Num; // todo: DMValueType.Bool
     public override void EmitPushValue(DMObject dmObject, DMProc proc) {
         LHS.EmitPushValue(dmObject, proc);
         RHS.EmitPushValue(dmObject, proc);
@@ -331,6 +332,7 @@ internal sealed class Equal(Location location, DMExpression lhs, DMExpression rh
 
 // x != y
 internal sealed class NotEqual(Location location, DMExpression lhs, DMExpression rhs) : BinaryOp(location, lhs, rhs) {
+    public override DMComplexValueType ValType => DMValueType.Num; // todo: DMValueType.Bool
     public override void EmitPushValue(DMObject dmObject, DMProc proc) {
         LHS.EmitPushValue(dmObject, proc);
         RHS.EmitPushValue(dmObject, proc);
@@ -340,6 +342,7 @@ internal sealed class NotEqual(Location location, DMExpression lhs, DMExpression
 
 // x ~= y
 internal sealed class Equivalent(Location location, DMExpression lhs, DMExpression rhs) : BinaryOp(location, lhs, rhs) {
+    public override DMComplexValueType ValType => DMValueType.Num; // todo: DMValueType.Bool
     public override void EmitPushValue(DMObject dmObject, DMProc proc) {
         LHS.EmitPushValue(dmObject, proc);
         RHS.EmitPushValue(dmObject, proc);
@@ -349,6 +352,7 @@ internal sealed class Equivalent(Location location, DMExpression lhs, DMExpressi
 
 // x ~! y
 internal sealed class NotEquivalent(Location location, DMExpression lhs, DMExpression rhs) : BinaryOp(location, lhs, rhs) {
+    public override DMComplexValueType ValType => DMValueType.Num; // todo: DMValueType.Bool
     public override void EmitPushValue(DMObject dmObject, DMProc proc) {
         LHS.EmitPushValue(dmObject, proc);
         RHS.EmitPushValue(dmObject, proc);
@@ -358,6 +362,7 @@ internal sealed class NotEquivalent(Location location, DMExpression lhs, DMExpre
 
 // x > y
 internal sealed class GreaterThan(Location location, DMExpression lhs, DMExpression rhs) : BinaryOp(location, lhs, rhs) {
+    public override DMComplexValueType ValType => DMValueType.Num; // todo: DMValueType.Bool
     public override bool TryAsConstant([NotNullWhen(true)] out Constant? constant) {
         if (!LHS.TryAsConstant(out var lhs) || !RHS.TryAsConstant(out var rhs)) {
             constant = null;
@@ -385,6 +390,7 @@ internal sealed class GreaterThan(Location location, DMExpression lhs, DMExpress
 
 // x >= y
 internal sealed class GreaterThanOrEqual(Location location, DMExpression lhs, DMExpression rhs) : BinaryOp(location, lhs, rhs) {
+    public override DMComplexValueType ValType => DMValueType.Num; // todo: DMValueType.Bool
     public override void EmitPushValue(DMObject dmObject, DMProc proc) {
         LHS.EmitPushValue(dmObject, proc);
         RHS.EmitPushValue(dmObject, proc);
@@ -413,6 +419,7 @@ internal sealed class GreaterThanOrEqual(Location location, DMExpression lhs, DM
 
 // x < y
 internal sealed class LessThan(Location location, DMExpression lhs, DMExpression rhs) : BinaryOp(location, lhs, rhs) {
+    public override DMComplexValueType ValType => DMValueType.Num; // todo: DMValueType.Bool
     public override void EmitPushValue(DMObject dmObject, DMProc proc) {
         LHS.EmitPushValue(dmObject, proc);
         RHS.EmitPushValue(dmObject, proc);
@@ -440,6 +447,7 @@ internal sealed class LessThan(Location location, DMExpression lhs, DMExpression
 
 // x <= y
 internal sealed class LessThanOrEqual(Location location, DMExpression lhs, DMExpression rhs) : BinaryOp(location, lhs, rhs) {
+    public override DMComplexValueType ValType => DMValueType.Num; // todo: DMValueType.Bool
     public override void EmitPushValue(DMObject dmObject, DMProc proc) {
         LHS.EmitPushValue(dmObject, proc);
         RHS.EmitPushValue(dmObject, proc);
@@ -496,6 +504,7 @@ internal sealed class Or(Location location, DMExpression lhs, DMExpression rhs) 
 
 // x && y
 internal sealed class And(Location location, DMExpression lhs, DMExpression rhs) : BinaryOp(location, lhs, rhs) {
+    public override DMComplexValueType ValType => RHS.ValType;
     public override bool TryAsConstant([NotNullWhen(true)] out Constant? constant) {
         if (LHS.TryAsConstant(out var lhs) && !lhs.IsTruthy()) {
             constant = lhs;
@@ -523,6 +532,7 @@ internal sealed class And(Location location, DMExpression lhs, DMExpression rhs)
 
 // x in y
 internal sealed class In(Location location, DMExpression expr, DMExpression container) : BinaryOp(location, expr, container) {
+    public override DMComplexValueType ValType => DMValueType.Num; // todo: DMValueType.Bool
     public override void EmitPushValue(DMObject dmObject, DMProc proc) {
         LHS.EmitPushValue(dmObject, proc);
         RHS.EmitPushValue(dmObject, proc);

--- a/DMCompiler/DM/Expressions/Binary.cs
+++ b/DMCompiler/DM/Expressions/Binary.cs
@@ -564,6 +564,7 @@ internal abstract class AssignmentBinaryOp(Location location, DMExpression lhs, 
 // x = y
 internal sealed class Assignment(Location location, DMExpression lhs, DMExpression rhs) : AssignmentBinaryOp(location, lhs, rhs) {
     public override DreamPath? Path => LHS.Path;
+    public override DMComplexValueType ValType => RHS.ValType;
 
     protected override void EmitOp(DMObject dmObject, DMProc proc, DMReference reference, string endLabel) {
         RHS.EmitPushValue(dmObject, proc);
@@ -591,6 +592,7 @@ internal sealed class AssignmentInto(Location location, DMExpression lhs, DMExpr
 
 // x += y
 internal sealed class Append(Location location, DMExpression lhs, DMExpression rhs) : AssignmentBinaryOp(location, lhs, rhs) {
+    public override DMComplexValueType ValType => LHS.ValType.Type == DMValueType.Null ? RHS.ValType : RHS.ValType;
     protected override void EmitOp(DMObject dmObject, DMProc proc, DMReference reference, string endLabel) {
         RHS.EmitPushValue(dmObject, proc);
         proc.Append(reference);

--- a/DMCompiler/DM/Expressions/Builtins.cs
+++ b/DMCompiler/DM/Expressions/Builtins.cs
@@ -72,6 +72,7 @@ internal sealed class NewPath(Location location, ConstantPath targetPath, Argume
 
     public override void EmitPushValue(DMObject dmObject, DMProc proc) {
         if (!targetPath.TryResolvePath(out var pathInfo)) {
+            DMCompiler.Emit(WarningCode.BadExpression, Location, "Invalid path to new /datum()");
             proc.PushNull();
             return;
         }
@@ -188,6 +189,7 @@ internal sealed class Gradient(Location location, ArgumentList arguments) : DMEx
 /// rgb(x, y, z, space)
 /// rgb(x, y, z, a, space)
 internal sealed class Rgb(Location location, ArgumentList arguments) : DMExpression(location) {
+    public override DMComplexValueType ValType => DMValueType.Color;
     public override void EmitPushValue(DMObject dmObject, DMProc proc) {
         DMObjectTree.TryGetGlobalProc("rgb", out var dmProc);
         var argInfo = arguments.EmitArguments(dmObject, proc, dmProc);

--- a/DMCompiler/DM/Expressions/Constant.cs
+++ b/DMCompiler/DM/Expressions/Constant.cs
@@ -101,6 +101,7 @@ internal sealed class Resource : Constant {
 
     private readonly string _filePath;
     private bool _isAmbiguous;
+    public override DMComplexValueType ValType { get; }
 
     public Resource(Location location, string filePath) : base(location) {
         // Treat backslashes as forward slashes on Linux
@@ -155,6 +156,15 @@ internal sealed class Resource : Constant {
         _filePath = _filePath.Replace('\\', '/');
 
         DMObjectTree.Resources.Add(_filePath);
+
+        ValType = System.IO.Path.GetExtension(fileName) switch {
+            ".dmi" => DMValueType.Icon,
+            ".png" => DMValueType.Icon,
+            ".bmp" => DMValueType.Icon,
+            ".gif" => DMValueType.Icon,
+            ".ogg" => DMValueType.Sound,
+            _ => DMValueType.File
+        };
     }
 
     public override void EmitPushValue(DMObject dmObject, DMProc proc) {

--- a/DMCompiler/DM/Expressions/Constant.cs
+++ b/DMCompiler/DM/Expressions/Constant.cs
@@ -240,7 +240,7 @@ internal sealed class ConstantPath(Location location, DMObject dmObject, DreamPa
     private readonly DMObject _dmObject = dmObject;
 
     public override DreamPath? Path => Value;
-    public override DMComplexValueType ValType => Value;
+    public override DMComplexValueType ValType => new DMComplexValueType(DMValueType.Path, Value);
 
     public enum PathType {
         TypeReference,

--- a/DMCompiler/DM/Expressions/Constant.cs
+++ b/DMCompiler/DM/Expressions/Constant.cs
@@ -163,6 +163,8 @@ internal sealed class Resource : Constant {
             ".bmp" => DMValueType.Icon,
             ".gif" => DMValueType.Icon,
             ".ogg" => DMValueType.Sound,
+            ".wav" => DMValueType.Sound,
+            ".mid" => DMValueType.Sound,
             _ => DMValueType.File
         };
     }

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -83,7 +83,7 @@ internal class Dereference : LValue {
             type = operation switch {
                 FieldOperation fieldOperation => dmObject.GetVariable(fieldOperation.Identifier)?.ValType ?? DMValueType.Anything,
                 IndexOperation indexOperation => type.ListValueTypes is null ? DMValueType.Anything : (indexOperation.Index.ValType.Type.HasFlag(DMValueType.Num) ? type.ListValueTypes.NestedListKeyType : type.ListValueTypes.NestedListValType ?? type.ListValueTypes.NestedListKeyType) | DMValueType.Null, // TODO: Keys of assoc lists
-                CallOperation callOperation => dmObject.GetProcReturnTypes(callOperation.Identifier) ?? DMValueType.Anything,
+                CallOperation callOperation => dmObject.GetProcReturnTypes(callOperation.Identifier, callOperation.Parameters) ?? DMValueType.Anything,
                 _ => throw new InvalidOperationException("Unimplemented dereference operation")
             };
         }

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -73,7 +73,8 @@ internal class Dereference : LValue {
         while (!type.IsAnything && i < _operations.Length) {
             var operation = _operations[i++];
 
-            if (type.TypePath is null || DMObjectTree.GetDMObject(type.TypePath.Value, false) is not { } dmObject) {
+            var typePath = type.TypePath ?? type.AsPath();
+            if (typePath is null || DMObjectTree.GetDMObject(typePath.Value, false) is not { } dmObject) {
                 // We're dereferencing something without a type-path, this could be anything
                 type = DMValueType.Anything;
                 break;

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -126,7 +126,15 @@ internal class Dereference : LValue {
                 break;
 
             case CallOperation callOperation:
-                var (argumentsType, argumentStackSize) = callOperation.Parameters.EmitArguments(dmObject, proc, null);
+                DMProc? targetProc = null;
+                if (callOperation.Path is not null) {
+                    var obj = DMObjectTree.GetDMObject(callOperation.Path.Value, false);
+                    var procs = obj?.GetProcs(callOperation.Identifier);
+                    if (procs is not null && procs.Count > 0) {
+                        targetProc = DMObjectTree.AllProcs[procs[0]];
+                    }
+                }
+                var (argumentsType, argumentStackSize) = callOperation.Parameters.EmitArguments(dmObject, proc, targetProc);
                 proc.DereferenceCall(callOperation.Identifier, argumentsType, argumentStackSize);
                 break;
 

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -82,7 +82,7 @@ internal class Dereference : LValue {
 
             type = operation switch {
                 FieldOperation fieldOperation => dmObject.GetVariable(fieldOperation.Identifier)?.ValType ?? DMValueType.Anything,
-                IndexOperation => DMValueType.Anything, // Lists currently can't be typed, this could be anything
+                IndexOperation indexOperation => type.ListValueTypes is null ? DMValueType.Anything : (indexOperation.Index.ValType.Type.HasFlag(DMValueType.Num) ? type.ListValueTypes.NestedListKeyType : type.ListValueTypes.NestedListValType ?? type.ListValueTypes.NestedListKeyType) | DMValueType.Null, // TODO: Keys of assoc lists
                 CallOperation callOperation => dmObject.GetProcReturnTypes(callOperation.Identifier) ?? DMValueType.Anything,
                 _ => throw new InvalidOperationException("Unimplemented dereference operation")
             };

--- a/DMCompiler/DM/Expressions/Dereference.cs
+++ b/DMCompiler/DM/Expressions/Dereference.cs
@@ -338,6 +338,12 @@ internal sealed class ScopeReference(Location location, DMExpression expression,
         ])
     ) {
     public override DreamPath? Path => Expression.Path;
+    public override DMComplexValueType ValType {
+        get {
+            TryAsConstant(out var constant);
+            return constant is not null ? constant.ValType : dmVar.ValType;
+        }
+    }
 
     public override string GetNameof(DMObject dmObject) => dmVar.Name;
 

--- a/DMCompiler/DM/Expressions/LValue.cs
+++ b/DMCompiler/DM/Expressions/LValue.cs
@@ -72,7 +72,7 @@ internal sealed class Args(Location location) : LValue(location, DreamPath.List)
 }
 
 // Identifier of local variable
-internal sealed class Local(Location location, DMProc.LocalVariable localVar, DMComplexValueType? valType) : LValue(location, localVar.Type) {
+internal sealed class Local(Location location, DMProc.LocalVariable localVar, DMProc proc, DMComplexValueType? valType) : LValue(location, localVar.Type) {
     public DMProc.LocalVariable LocalVar { get; } = localVar;
     public override DMComplexValueType ValType {
         get {

--- a/DMCompiler/DM/Expressions/LValue.cs
+++ b/DMCompiler/DM/Expressions/LValue.cs
@@ -76,9 +76,11 @@ internal sealed class Local(Location location, DMProc.LocalVariable localVar, DM
     public DMProc.LocalVariable LocalVar { get; } = localVar;
     public override DMComplexValueType ValType {
         get {
+            //todo: allow local variables to be param-typed again
+            // WITHOUT having to pass procParameters through the whole parser chain
+            //if (valType is not null) return proc.GetBaseProc().GetParameterValueTypes(valType.Value, null);
             if (valType is not null) return valType.Value;
-            DMComplexValueType atomType = LocalVar.Type?.GetAtomType() ?? DMValueType.Anything;
-            return !atomType.IsAnything ? atomType | DMValueType.Null : (localVar.Type is null ? DMValueType.Anything : new DMComplexValueType(DMValueType.Path | DMValueType.Null, localVar.Type));
+            return LocalVar.Type is not null ? new DMComplexValueType(DMValueType.Instance | DMValueType.Path | DMValueType.Null, LocalVar.Type) : DMValueType.Anything;
         }
     }
 

--- a/DMCompiler/DM/Expressions/Procs.cs
+++ b/DMCompiler/DM/Expressions/Procs.cs
@@ -72,7 +72,7 @@ internal sealed class GlobalProc(Location location, string name) : DMExpression(
 /// This is an LValue _and_ a proc!
 /// </summary>
 internal sealed class ProcSelf(Location location, DreamPath? path, DMProc proc) : LValue(location, path) {
-    public override DMComplexValueType ValType => proc.RawReturnTypes;
+    public override DMComplexValueType ValType => proc.GetParameterValueTypes(null);
 
     public override DMReference EmitReference(DMObject dmObject, DMProc proc, string endLabel, ShortCircuitMode shortCircuitMode = ShortCircuitMode.KeepNull) {
         return DMReference.Self;
@@ -110,10 +110,10 @@ internal sealed class ProcCall(Location location, DMExpression target, ArgumentL
                 return valType;
             switch (target) {
                 case Proc procTarget:
-                    return procTarget.dmObject.GetProcReturnTypes(procTarget.Identifier) ?? DMValueType.Anything;
+                    return procTarget.dmObject.GetProcReturnTypes(procTarget.Identifier, arguments) ?? DMValueType.Anything;
                 case GlobalProc procTarget:
                     if(DMObjectTree.TryGetGlobalProc(procTarget.Identifier, out var globalProc))
-                        return globalProc.RawReturnTypes ?? DMValueType.Anything;
+                        return globalProc.GetParameterValueTypes(arguments);
                     return DMValueType.Anything;
             }
             return target.ValType;

--- a/DMCompiler/DM/Expressions/Ternary.cs
+++ b/DMCompiler/DM/Expressions/Ternary.cs
@@ -17,13 +17,13 @@ internal sealed class Ternary : DMExpression {
 
         if (b.ValType.TypePath != null && c.ValType.TypePath != null && b.ValType.TypePath != c.ValType.TypePath) {
             DMCompiler.Emit(WarningCode.LostTypeInfo, Location,
-                $"Ternary has type paths {b.ValType.TypePath} and {c.ValType.TypePath} but a value can only have one type path. Using {b.ValType.TypePath}.");
+                $"Ternary has type paths {b.ValType.TypePath} and {c.ValType.TypePath} but a value can only have one type path. Using their common ancestor, {b.ValType.TypePath.Value.GetLastCommonAncestor(c.ValType.TypePath.Value)}.");
         }
 
         if (b.ValType.IsAnything || c.ValType.IsAnything)
             ValType = DMValueType.Anything;
         else
-            ValType = new(b.ValType.Type | c.ValType.Type, b.ValType.TypePath ?? c.ValType.TypePath);
+            ValType = b.ValType | c.ValType;
     }
 
     public override bool TryAsConstant([NotNullWhen(true)] out Constant? constant) {

--- a/DMCompiler/DM/Expressions/Ternary.cs
+++ b/DMCompiler/DM/Expressions/Ternary.cs
@@ -20,7 +20,10 @@ internal sealed class Ternary : DMExpression {
                 $"Ternary has type paths {b.ValType.TypePath} and {c.ValType.TypePath} but a value can only have one type path. Using {b.ValType.TypePath}.");
         }
 
-        ValType = new(b.ValType.Type | c.ValType.Type, b.ValType.TypePath ?? c.ValType.TypePath);
+        if (b.ValType.IsAnything || c.ValType.IsAnything)
+            ValType = DMValueType.Anything;
+        else
+            ValType = new(b.ValType.Type | c.ValType.Type, b.ValType.TypePath ?? c.ValType.TypePath);
     }
 
     public override bool TryAsConstant([NotNullWhen(true)] out Constant? constant) {

--- a/DMCompiler/DM/Expressions/Unary.cs
+++ b/DMCompiler/DM/Expressions/Unary.cs
@@ -9,6 +9,7 @@ internal abstract class UnaryOp(Location location, DMExpression expr) : DMExpres
 
 // -x
 internal sealed class Negate(Location location, DMExpression expr) : UnaryOp(location, expr) {
+    public override DMComplexValueType ValType => Expr.ValType; // could be a num, could be a matrix, you never know
     public override bool TryAsConstant([NotNullWhen(true)] out Constant? constant) {
         if (!Expr.TryAsConstant(out constant) || constant is not Number number)
             return false;
@@ -25,6 +26,7 @@ internal sealed class Negate(Location location, DMExpression expr) : UnaryOp(loc
 
 // !x
 internal sealed class Not(Location location, DMExpression expr) : UnaryOp(location, expr) {
+    public override DMComplexValueType ValType => DMValueType.Num; // could eventually be updated to be a bool
     public override bool TryAsConstant([NotNullWhen(true)] out Constant? constant) {
         if (!Expr.TryAsConstant(out constant)) return false;
 
@@ -40,6 +42,7 @@ internal sealed class Not(Location location, DMExpression expr) : UnaryOp(locati
 
 // ~x
 internal sealed class BinaryNot(Location location, DMExpression expr) : UnaryOp(location, expr) {
+    public override DMComplexValueType ValType => DMValueType.Num;
     public override bool TryAsConstant([NotNullWhen(true)] out Constant? constant) {
         if (!Expr.TryAsConstant(out constant) || constant is not Number constantNum)
             return false;
@@ -55,6 +58,7 @@ internal sealed class BinaryNot(Location location, DMExpression expr) : UnaryOp(
 }
 
 internal abstract class AssignmentUnaryOp(Location location, DMExpression expr) : UnaryOp(location, expr) {
+    public override DMComplexValueType ValType => Expr.ValType;
     protected abstract void EmitOp(DMObject dmObject, DMProc proc, DMReference reference, string endLabel);
 
     public override void EmitPushValue(DMObject dmObject, DMProc proc) {

--- a/DMCompiler/DMStandard/Types/Atoms/Mob.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/Mob.dm
@@ -1,16 +1,16 @@
 ﻿/mob
 	parent_type = /atom/movable
 
-	var/client/client
+	var/client/client as /client|null
 	var/key as text|null
 	var/tmp/ckey as text|null
 
 	var/tmp/list/group as opendream_unimplemented
 
-	var/see_invisible = 0
-	var/see_infrared = 0 as opendream_unimplemented
-	var/sight = 0
-	var/see_in_dark = 2 as opendream_unimplemented
+	var/see_invisible = 0 as num
+	var/see_infrared = 0 as num|opendream_unimplemented
+	var/sight = 0 as num
+	var/see_in_dark = 2 as num|opendream_unimplemented
 
 	density = TRUE
 	layer = MOB_LAYER

--- a/DMCompiler/DMStandard/Types/Atoms/Movable.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/Movable.dm
@@ -17,7 +17,7 @@
 
 	proc/Bump(atom/Obstacle)
 
-	proc/Move(atom/NewLoc, Dir=0) as num
+	proc/Move(atom/NewLoc, Dir=0 as num)
 		if (isnull(NewLoc) || loc == NewLoc)
 			return FALSE
 
@@ -57,5 +57,4 @@
 				newarea.Entered(src, oldloc)
 
 			return TRUE
-		else
-			return FALSE
+		return FALSE

--- a/DMCompiler/DMStandard/Types/Atoms/Movable.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/Movable.dm
@@ -1,9 +1,9 @@
 ﻿/atom/movable
-	var/screen_loc
+	var/screen_loc as text|null
 
 	var/animate_movement = FORWARD_STEPS as opendream_unimplemented
 	var/list/locs = null as opendream_unimplemented
-	var/glide_size = 0
+	var/glide_size = 0 as num
 	var/step_size as opendream_unimplemented
 	var/tmp/bound_x as opendream_unimplemented
 	var/tmp/bound_y as opendream_unimplemented

--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -29,7 +29,10 @@
 	var/layer = 2.0 as num
 	var/plane = 0 as num
 	var/alpha = 255 as num
-	var/color = "#FFFFFF"
+	// currently we coerce text (hex string) and list(num) (color matrix) to the color type
+	// in the future this should probably be colorstring|colormatrix|null or something
+	// or 'as color' could be a shorthand for that
+	var/color = "#FFFFFF" as color|null
 	var/invisibility = 0 as num
 	var/mouse_opacity = 1 as num
 	var/infra_luminosity = 0 as num|opendream_unimplemented

--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -1,10 +1,10 @@
 ﻿/atom
 	parent_type = /datum
 
-	var/name = null
-	var/text = null
-	var/desc = null
-	var/suffix = null as opendream_unimplemented
+	var/name = null as text|null
+	var/text = null as text|null
+	var/desc = null as text|null
+	var/suffix = null as text|null|opendream_unimplemented
 
 	// The initialization/usage of these lists is handled internally by the runtime
 	var/tmp/list/verbs = null
@@ -14,8 +14,8 @@
 	var/tmp/list/vis_locs = null as opendream_unimplemented
 	var/list/vis_contents = null
 
-	var/tmp/atom/loc
-	var/dir = SOUTH
+	var/tmp/atom/loc as /atom|null
+	var/dir = SOUTH as num
 	var/tmp/x = 0
 	var/tmp/y = 0
 	var/tmp/z = 0
@@ -26,20 +26,20 @@
 
 	var/icon = null
 	var/icon_state = ""
-	var/layer = 2.0
-	var/plane = 0
-	var/alpha = 255
+	var/layer = 2.0 as num
+	var/plane = 0 as num
+	var/alpha = 255 as num
 	var/color = "#FFFFFF"
-	var/invisibility = 0
-	var/mouse_opacity = 1
-	var/infra_luminosity = 0 as opendream_unimplemented
-	var/luminosity = 0 as opendream_unimplemented
-	var/opacity = 0
+	var/invisibility = 0 as num
+	var/mouse_opacity = 1 as num
+	var/infra_luminosity = 0 as num|opendream_unimplemented
+	var/luminosity = 0 as num|opendream_unimplemented
+	var/opacity = 0 as num
 	var/matrix/transform
-	var/blend_mode = 0
+	var/blend_mode = 0 as num
 
 	var/gender = NEUTER
-	var/density = FALSE
+	var/density = FALSE as num
 
 	var/maptext as opendream_unimplemented
 

--- a/DMCompiler/DMStandard/Types/Client.dm
+++ b/DMCompiler/DMStandard/Types/Client.dm
@@ -88,7 +88,7 @@
 	proc/MeasureText(text, style, width=0)
 		set opendream_unimplemented = TRUE
 
-	proc/Move(loc, dir)
+	proc/Move(loc, dir as num)
 		mob.Move(loc, dir)
 
 	proc/North()

--- a/DMCompiler/DMStandard/Types/Client.dm
+++ b/DMCompiler/DMStandard/Types/Client.dm
@@ -11,7 +11,7 @@
 	var/tag
 	var/const/type = /client
 
-	var/mob/mob as /mob|null
+	var/mob/mob as mob|null
 	var/atom/eye
 	var/lazy_eye = 0 as opendream_unimplemented
 	var/perspective = MOB_PERSPECTIVE
@@ -49,8 +49,7 @@
 
 	proc/New(TopicData)
 		// Search every mob for one with our ckey
-		// TODO: This /mob|mob thing is kinda silly huh?
-		for (var/mob/M as /mob|mob in world)
+		for (var/mob/M as mob in world)
 			if (M.key == key)
 				mob = M
 				break

--- a/DMCompiler/DMStandard/Types/Datum.dm
+++ b/DMCompiler/DMStandard/Types/Datum.dm
@@ -1,5 +1,5 @@
 ﻿/datum
-	var/tmp/type as opendream_compiletimereadonly
+	var/tmp/type as path(/datum)|opendream_compiletimereadonly
 	var/tmp/parent_type
 
 	var/tmp/list/vars as opendream_compiletimereadonly

--- a/DMCompiler/DMStandard/Types/Icon.dm
+++ b/DMCompiler/DMStandard/Types/Icon.dm
@@ -44,5 +44,5 @@
 
 	proc/Width()
 
-proc/icon(icon, icon_state, dir, frame, moving)
+proc/icon(icon, icon_state, dir, frame, moving) as icon
 	return new /icon(icon, icon_state, dir, frame, moving)

--- a/DMCompiler/DMStandard/Types/List.dm
+++ b/DMCompiler/DMStandard/Types/List.dm
@@ -4,15 +4,15 @@
 
 	proc/New(Size)
 
-	proc/Add(Item1)
-	proc/Copy(Start = 1, End = 0)
-	proc/Cut(Start = 1, End = 0)
-	proc/Find(Elem, Start = 1, End = 0)
-	proc/Insert(Index, Item1)
+	proc/Add(Item1) as null
+	proc/Copy(Start = 1, End = 0) as /list
+	proc/Cut(Start = 1, End = 0) as num
+	proc/Find(Elem, Start = 1, End = 0) as num
+	proc/Insert(Index, Item1) as num
 	proc/Join(Glue as text|null, Start = 1 as num, End = 0 as num) as text
-	proc/Remove(Item1)
-	proc/RemoveAll(Item1)
-	proc/Swap(Index1, Index2)
+	proc/Remove(Item1) as num
+	proc/RemoveAll(Item1) as num
+	proc/Swap(Index1, Index2) as null
 
-	proc/Splice(Start=1,End=0, ...)
+	proc/Splice(Start=1,End=0, ...) as null
 		set opendream_unimplemented = TRUE

--- a/DMCompiler/DMStandard/Types/World.dm
+++ b/DMCompiler/DMStandard/Types/World.dm
@@ -9,15 +9,15 @@
 	var/mob = /mob as path(/mob)
 
 	var/name = "OpenDream World"
-	var/time
-	var/timezone = 0
-	var/timeofday
-	var/realtime
-	var/tick_lag = 1
-	var/cpu = 0 as opendream_unimplemented
-	var/fps = 10
+	var/time as num
+	var/timezone = 0 as num
+	var/timeofday as num
+	var/realtime as num
+	var/tick_lag = 1 as num
+	var/cpu = 0 as opendream_unimplemented|num
+	var/fps = 10 as num
 	var/tick_usage
-	var/loop_checks = 0 as opendream_unimplemented
+	var/loop_checks = 0 as opendream_unimplemented|num
 
 	var/maxx = null as num|null
 	var/maxy = null as num|null
@@ -32,7 +32,7 @@
 	var/version = 0 as opendream_unimplemented
 
 	var/address
-	var/port = 0 as opendream_compiletimereadonly
+	var/port = 0 as opendream_compiletimereadonly|num
 	var/internet_address = "127.0.0.1" as opendream_unimplemented
 	var/url as opendream_unimplemented
 	var/visibility = 0 as opendream_unimplemented
@@ -40,7 +40,7 @@
 	var/process
 	var/list/params = null
 
-	var/sleep_offline = 0
+	var/sleep_offline = 0 as num
 
 	var/system_type
 

--- a/DMCompiler/DMStandard/Types/World.dm
+++ b/DMCompiler/DMStandard/Types/World.dm
@@ -4,9 +4,9 @@
 
 	var/log = null
 
-	var/area = /area as /area
-	var/turf = /turf as /turf
-	var/mob = /mob as /mob
+	var/area = /area as path(/area)
+	var/turf = /turf as path(/turf)
+	var/mob = /mob as path(/mob)
 
 	var/name = "OpenDream World"
 	var/time

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -75,7 +75,7 @@ proc/range(Dist, Center) as /list|null // NOTE: Not sure if return types have BY
 proc/ref(Object) as text
 proc/replacetext(Haystack as text|null, Needle as text|/regex|null, Replacement, Start = 1, End = 0) as text|null
 proc/replacetextEx(Haystack as text|null, Needle as text|/regex|null, Replacement, Start = 1, End = 0) as text|null
-proc/rgb(R, G, B, A, space) as text|null
+proc/rgb(R, G, B, A, space) as color|null
 proc/rgb2num(color, space = COLORSPACE_RGB) as /list
 proc/roll(ndice = 1 as num|text, sides as num|null) as num
 proc/round(A as num|null, B as num|null) as num
@@ -100,8 +100,8 @@ proc/text2path(T as text|null) as null|path(/datum)|path(/world) // todo: allow 
 proc/time2text(timestamp, format) as text
 proc/trimtext(Text) as text|null
 proc/trunc(n as num|null) as num
-proc/turn(Dir, Angle)
-proc/typesof(Item1) as /list
+proc/turn(Dir as null|num|/matrix|icon, Angle as num) as null|num|/matrix|icon
+proc/typesof(Item1 as text|path(/datum)|path(/proc)|/list(text|path(/datum)|path(/proc))) as /list(path(/datum)|path(/proc))
 proc/uppertext(T as text) as text
 proc/url_decode(UrlText) as text
 proc/url_encode(PlainText, format = 0) as text
@@ -157,7 +157,7 @@ proc/replacetextEx_char(Haystack as text, Needle, Replacement, Start = 1 as num,
 	//TODO: Consider obstacles
 
 	var/dist = get_dist(Ref, Trg)
-	if (dist <= Min) return
+	if (dist <= Min) return 0
 
 	var/step_dir = get_dir(Ref, Trg) as num
 	return step(Ref, step_dir, Speed)
@@ -166,7 +166,7 @@ proc/replacetextEx_char(Haystack as text, Needle, Replacement, Start = 1 as num,
 	set opendream_unimplemented = TRUE
 	CRASH("/get_step_to() is not implemented")
 
-/proc/get_steps_to(Ref, Trg, Min=0 as num) as /list
+/proc/get_steps_to(Ref, Trg, Min=0 as num)
 	set opendream_unimplemented = TRUE
 	CRASH("/get_steps_to() is not implemented")
 
@@ -208,9 +208,7 @@ proc/step_rand(atom/movable/Ref, Speed=0)
 proc/jointext(list/List as /list|text, Glue as text|null, Start = 1 as num, End = 0 as num) as text
 	if(islist(List))
 		return List.Join(Glue, Start, End)
-	if(istext(List))
-		return List
-	CRASH("jointext was passed a non-list, non-text value")
+	return List
 
 proc/lentext(T) as num
 	return length(T)

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -1,17 +1,17 @@
-/var/world/world = /world as /world // Set to /world to suppress issues with Typemaker
+/var/world/world = /world as /world|path(/world)
 
 //These procs should be in alphabetical order, as in DreamProcNativeRoot.cs
 proc/alert(Usr = usr, Message, Title, Button1 = "Ok", Button2, Button3) as text
 proc/animate(Object, time, loop, easing, flags, delay, pixel_x, pixel_y, pixel_z, maptext, maptext_width, maptext_height, maptext_x, maptext_y, dir, alpha, transform, color, luminosity, infra_luminosity, layer, glide_size, icon, icon_state, invisibility, suffix) as null
-proc/ascii2text(N) as text
-proc/block(atom/Start, atom/End, StartZ, EndX=Start, EndY=End, EndZ=StartZ) as /list
-proc/ceil(A) as num
-proc/ckey(Key) as text|null
+proc/ascii2text(N as num|null) as text
+proc/block(atom/Start, atom/End, StartZ, EndX=Start, EndY=End, EndZ=StartZ) as /list(/turf)
+proc/ceil(A as num|null) as num
+proc/ckey(Key as text|null) as text|null
 proc/ckeyEx(Text) as text|null
 proc/clamp(Value, Low, High) as /list|num|null
 proc/cmptext(T1) as num
-proc/copytext(T, Start = 1, End = 0) as text|null
-proc/copytext_char(T,Start=1,End=0) as text|null
+proc/copytext(T as text|null, Start = 1, End = 0) as text|null
+proc/copytext_char(T as text|null,Start=1,End=0) as text|null
 proc/CRASH(msg) as null
 proc/fcopy(Src, Dst) as num
 proc/fcopy_rsc(File) as num|null
@@ -20,10 +20,10 @@ proc/fexists(File) as num
 proc/file(Path)
 proc/file2text(File) as text|null
 proc/filter(type, ...)
-proc/findtext(Haystack, Needle, Start = 1, End = 0) as num
-proc/findtextEx(Haystack, Needle, Start = 1, End = 0) as num
-proc/findlasttext(Haystack, Needle, Start = 1, End = 0) as num
-proc/findlasttextEx(Haystack, Needle, Start = 1, End = 0) as num
+proc/findtext(Haystack as text|null, Needle as text|/regex|null, Start = 1, End = 0) as num
+proc/findtextEx(Haystack as text|null, Needle as text|/regex|null, Start = 1, End = 0) as num
+proc/findlasttext(Haystack as text|null, Needle as text|/regex|null, Start = 1, End = 0) as num
+proc/findlasttextEx(Haystack as text|null, Needle as text|/regex|null, Start = 1, End = 0) as num
 proc/flick(Icon, Object)
 proc/flist(Path) as /list
 proc/floor(A) as num
@@ -63,25 +63,25 @@ proc/noise_hash(...) as num
 	set opendream_unimplemented = 1
 	return 0.5
 proc/nonspantext(Haystack, Needles, Start = 1) as num
-proc/num2text(N, A, B) as text
+proc/num2text(N as num|null, A, B) as text
 proc/orange(Dist = 5, Center = usr) as /list|null // NOTE: Not sure if return types have BYOND parity
 proc/oview(Dist = 5, Center = usr) as /list
 proc/oviewers(Depth = 5, Center = usr) as /list
 proc/ohearers(Depth = world.view, Center = usr) as /list
-proc/params2list(Params) as /list
-proc/rand(L, H) as num
+proc/params2list(Params) as /list(text)
+proc/rand(L as num, H as num) as num
 proc/rand_seed(Seed) as null
 proc/range(Dist, Center) as /list|null // NOTE: Not sure if return types have BYOND parity
 proc/ref(Object) as text
-proc/replacetext(Haystack, Needle, Replacement, Start = 1, End = 0) as text|null
-proc/replacetextEx(Haystack, Needle, Replacement, Start = 1, End = 0) as text|null
+proc/replacetext(Haystack as text|null, Needle as text|/regex|null, Replacement, Start = 1, End = 0) as text|null
+proc/replacetextEx(Haystack as text|null, Needle as text|/regex|null, Replacement, Start = 1, End = 0) as text|null
 proc/rgb(R, G, B, A, space) as text|null
 proc/rgb2num(color, space = COLORSPACE_RGB) as /list
-proc/roll(ndice = 1, sides) as num
-proc/round(A, B) as num
+proc/roll(ndice = 1 as num|text, sides as num|null) as num
+proc/round(A as num|null, B as num|null) as num
 proc/sha1(input) as text|null
 proc/shutdown(Addr,Natural = 0)
-proc/sleep(Delay)
+proc/sleep(Delay as num|null)
 proc/sorttext(T1, T2) as num
 proc/sorttextEx(T1, T2) as num
 proc/sound(file, repeat = 0, wait, channel, volume)
@@ -89,17 +89,17 @@ proc/spantext(Haystack,Needles,Start=1) as num
 proc/spantext_char(Haystack,Needles,Start=1) as num
 proc/splicetext(Text, Start = 1, End = 0, Insert = "") as text|null
 proc/splicetext_char(Text, Start = 1, End = 0, Insert = "") as text|null
-proc/splittext(Text, Delimiter) as /list
+proc/splittext(Text, Delimiter) as /list(text)
 proc/stat(Name, Value)
 proc/statpanel(Panel, Name, Value)
-proc/text2ascii(T, pos = 1) as text
-proc/text2ascii_char(T, pos = 1) as text
+proc/text2ascii(T as text|null, pos = 1) as num
+proc/text2ascii_char(T as text|null, pos = 1) as num
 proc/text2file(Text, File)
 proc/text2num(T, radix = 10) as num|null
-proc/text2path(T)
+proc/text2path(T as text|null) as null|path(/datum)|path(/world) // todo: allow path(/)
 proc/time2text(timestamp, format) as text
 proc/trimtext(Text) as text|null
-proc/trunc(n) as num
+proc/trunc(n as num|null) as num
 proc/turn(Dir, Angle)
 proc/typesof(Item1) as /list
 proc/uppertext(T as text) as text
@@ -142,18 +142,18 @@ proc/winset(player, control_id, params)
 #include "Types\Atoms\Turf.dm"
 #include "UnsortedAdditions.dm"
 
-proc/replacetextEx_char(Haystack as text, Needle, Replacement, Start = 1, End = 0) as text
+proc/replacetextEx_char(Haystack as text, Needle, Replacement, Start = 1 as num, End = 0 as num) as text
 	set opendream_unimplemented = TRUE
 	return Haystack
 
-/proc/step(atom/movable/Ref, var/Dir as num|null, var/Speed=0) as num
+/proc/step(atom/movable/Ref, var/Dir as num|null, var/Speed=0 as num) as num
 	//TODO: Speed = step_size if Speed is 0
 	return Ref.Move(get_step(Ref, Dir), Dir)
 
-/proc/step_away(atom/movable/Ref, /atom/Trg, Max=5, Speed=0) as num
+/proc/step_away(atom/movable/Ref, atom/Trg, Max=5 as num, Speed=0 as num) as num
     return Ref.Move(get_step_away(Ref, Trg, Max), turn(get_dir(Ref, Trg), 180))
 
-/proc/step_to(atom/movable/Ref, atom/Trg, Min = 0, Speed = 0) as num
+/proc/step_to(atom/movable/Ref, atom/Trg, Min = 0 as num, Speed = 0 as num) as num
 	//TODO: Consider obstacles
 
 	var/dist = get_dist(Ref, Trg)
@@ -162,15 +162,15 @@ proc/replacetextEx_char(Haystack as text, Needle, Replacement, Start = 1, End = 
 	var/step_dir = get_dir(Ref, Trg) as num
 	return step(Ref, step_dir, Speed)
 
-/proc/get_step_to(Ref, Trg, Min=0)
+/proc/get_step_to(Ref, Trg, Min=0 as num)
 	set opendream_unimplemented = TRUE
 	CRASH("/get_step_to() is not implemented")
 
-/proc/get_steps_to(Ref, Trg, Min=0) as /list
+/proc/get_steps_to(Ref, Trg, Min=0 as num) as /list
 	set opendream_unimplemented = TRUE
 	CRASH("/get_steps_to() is not implemented")
 
-/proc/walk_away(Ref,Trg,Max=5,Lag=0,Speed=0)
+/proc/walk_away(Ref,Trg,Max=5 as num,Lag=0 as num,Speed=0 as num)
 	set opendream_unimplemented = TRUE
 	CRASH("/walk_away() is not implemented")
 
@@ -182,12 +182,12 @@ proc/get_dist(atom/Loc1, atom/Loc2) as num
 	var/distY = Loc2.y - Loc1.y
 	return round(sqrt(distX ** 2 + distY ** 2))
 
-proc/get_step_towards(atom/movable/Ref, /atom/Trg)
+proc/get_step_towards(atom/movable/Ref, atom/Trg)
 	var/dir = get_dir(Ref, Trg)
 
 	return get_step(Ref, dir)
 
-proc/get_step_away(atom/movable/Ref, /atom/Trg, Max = 5)
+proc/get_step_away(atom/movable/Ref, atom/Trg, Max = 5 as num)
 	var/dir = turn(get_dir(Ref, Trg), 180)
 
 	return get_step(Ref, dir)
@@ -198,7 +198,7 @@ proc/get_step_rand(atom/movable/Ref)
 
 	return get_step(Ref, dir)
 
-proc/step_towards(atom/movable/Ref as obj|mob, /atom/Trg, Speed) as num
+proc/step_towards(atom/movable/Ref, atom/Trg, Speed) as num
 	return Ref.Move(get_step_towards(Ref, Trg), get_dir(Ref, Trg))
 
 proc/step_rand(atom/movable/Ref, Speed=0)

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -35,7 +35,7 @@ proc/hearers(Depth = world.view, Center = usr) as /list
 proc/html_decode(HtmlText) as text
 proc/html_encode(PlainText) as text
 proc/icon_states(Icon, mode = 0) as text|null
-proc/image(icon, loc, icon_state, layer, dir, pixel_x, pixel_y)
+proc/image(icon, loc, icon_state, layer, dir, pixel_x, pixel_y) as /image
 proc/isarea(Loc1) as num
 proc/isfile(File) as num
 proc/isicon(Icon) as num
@@ -55,7 +55,7 @@ proc/json_decode(JSON)
 proc/json_encode(Value, flags)
 proc/length_char(E) as num
 proc/list2params(List) as text
-proc/lowertext(T as text) as text
+proc/lowertext(T as text|null) as text
 proc/max(A) as num|text|null
 proc/md5(T) as text|null
 proc/min(A) as num|text|null
@@ -146,11 +146,11 @@ proc/replacetextEx_char(Haystack as text, Needle, Replacement, Start = 1, End = 
 	set opendream_unimplemented = TRUE
 	return Haystack
 
-/proc/step(atom/movable/Ref as /atom/movable, var/Dir, var/Speed=0) as num
+/proc/step(atom/movable/Ref, var/Dir as num|null, var/Speed=0) as num
 	//TODO: Speed = step_size if Speed is 0
 	return Ref.Move(get_step(Ref, Dir), Dir)
 
-/proc/step_away(atom/movable/Ref as /atom/movable, /atom/Trg, Max=5, Speed=0) as num
+/proc/step_away(atom/movable/Ref, /atom/Trg, Max=5, Speed=0) as num
     return Ref.Move(get_step_away(Ref, Trg, Max), turn(get_dir(Ref, Trg), 180))
 
 /proc/step_to(atom/movable/Ref, atom/Trg, Min = 0, Speed = 0) as num
@@ -159,7 +159,7 @@ proc/replacetextEx_char(Haystack as text, Needle, Replacement, Start = 1, End = 
 	var/dist = get_dist(Ref, Trg)
 	if (dist <= Min) return
 
-	var/step_dir = get_dir(Ref, Trg)
+	var/step_dir = get_dir(Ref, Trg) as num
 	return step(Ref, step_dir, Speed)
 
 /proc/get_step_to(Ref, Trg, Min=0)
@@ -198,7 +198,7 @@ proc/get_step_rand(atom/movable/Ref)
 
 	return get_step(Ref, dir)
 
-proc/step_towards(atom/movable/Ref as /atom/movable, /atom/Trg, Speed) as num
+proc/step_towards(atom/movable/Ref as obj|mob, /atom/Trg, Speed) as num
 	return Ref.Move(get_step_towards(Ref, Trg), get_dir(Ref, Trg))
 
 proc/step_rand(atom/movable/Ref, Speed=0)

--- a/DMCompiler/DreamPath.cs
+++ b/DMCompiler/DreamPath.cs
@@ -107,6 +107,14 @@ public struct DreamPath {
             return DMValueType.Turf;
         if (dmType.IsSubtypeOf(Area))
             return DMValueType.Area;
+        if (dmType.IsSubtypeOf(Movable))
+            return DMValueType.Mob | DMValueType.Obj;
+        if (dmType.IsSubtypeOf(Atom))
+            return DMValueType.Area | DMValueType.Turf | DMValueType.Obj | DMValueType.Mob;
+        if (dmType.IsSubtypeOf(Icon))
+            return DMValueType.Icon;
+        if (dmType.IsSubtypeOf(Sound))
+            return DMValueType.Sound;
 
         return DMValueType.Anything;
     }

--- a/DMCompiler/DreamPath.cs
+++ b/DMCompiler/DreamPath.cs
@@ -265,4 +265,12 @@ public struct DreamPath {
 
         Elements = _elements[..writeIdx];
     }
+
+    public DreamPath GetLastCommonAncestor(DreamPath other) {
+        var thisObject = DMObjectTree.GetDMObject(this, true);
+        var otherObject = DMObjectTree.GetDMObject(other, true);
+        if (thisObject is null || otherObject is null)
+            return Root;
+        return thisObject.GetLastCommonAncestor(otherObject);
+    }
 }

--- a/DMCompiler/Location.cs
+++ b/DMCompiler/Location.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Text;
 
 namespace DMCompiler;
@@ -7,7 +8,7 @@ public readonly struct Location(string filePath, int? line, int? column) {
     /// For when DM location information can't be determined.
     /// </summary>
     public static readonly Location Unknown = new();
-    
+
     /// <summary>
     /// For when internal OpenDream warnings/errors are raised or something internal needs to be passed a location.
     /// </summary>
@@ -18,7 +19,7 @@ public readonly struct Location(string filePath, int? line, int? column) {
     public int? Column { get; } = column;
 
     public override string ToString() {
-        var builder = new StringBuilder(SourceFile ?? "<unknown>");
+        var builder = new StringBuilder((SourceFile is null) ? "<unknown>" : Path.GetRelativePath(".", SourceFile));
 
         if (Line is not null) {
             builder.Append(":" + Line);


### PR DESCRIPTION
A bunch of fixes/improvements to typemaker inference, plus:
- `DMValueType.Instance` is now the default when doing `as /some/typepath`.
- `as path(/some/typepath)` can be used to specifically denote 'a typepath of type `/some/typepath`'.
- Lists can now have types provided: `as /list(some union astypes here)` for normal lists, `as /list(some union astypes here, some others here)` for associative lists. Empty lists currently always match all typed lists because type info is not tracked at runtime. Similarly, a list with only keys and no associated values can match a typed associative list (this was necessary to fix some stuff on TG, and besides, it's hard to differentiate between `list("foo")` and `list("foo" = null)`.
- An experimental `as params[1]` astypes syntax has been added. You can also even do `as params[1] as instance` to denote that, if `params[1]` is a path, this value is an instance with the same type. (This is useful for singleton getters.)

I beg you, please help me find some other way to do the params stuff other than just threading `procParameters` through the entire parser. It's SO BAD. I hate it