### PR TITLE
`RuntimeSearchOperator` pragma lint

### DIFF
--- a/Content.Tests/DMProject/Tests/Dereference/RuntimeSearchOperatorLint.dm
+++ b/Content.Tests/DMProject/Tests/Dereference/RuntimeSearchOperatorLint.dm
@@ -1,0 +1,8 @@
+// COMPILE ERROR OD3300
+#pragma RuntimeSearchOperator error
+/datum/proc/foo()
+	return
+
+/proc/RunTest()
+	var/datum/D = new
+	D:foo()

--- a/DMCompiler/Compiler/CompilerError.cs
+++ b/DMCompiler/Compiler/CompilerError.cs
@@ -72,7 +72,8 @@ public enum WarningCode {
     SuspiciousSwitchCase = 3201, // "else if" cases are actually valid DM, they just spontaneously end the switch context and begin an if-else ladder within the else case of the switch
     AssignmentInConditional = 3202,
     PickWeightedSyntax = 3203,
-    AmbiguousInOrder = 3204
+    AmbiguousInOrder = 3204,
+    RuntimeSearchOperator = 3300,
 
     // 4000 - 4999 are reserved for runtime configuration. (TODO: Runtime doesn't know about configs yet!)
 }

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -2375,10 +2375,15 @@ namespace DMCompiler.Compiler.DM {
                     DMASTDereference.Operation operation;
 
                     switch (token.Type) {
+                        case TokenType.DM_Colon:
+                            DMCompiler.Emit(WarningCode.RuntimeSearchOperator, token.Location, "Runtime search operator ':' should be avoided; prefer typecasting and using '.' instead");
+                            goto case TokenType.DM_QuestionPeriod;
+                        case TokenType.DM_QuestionColon:
+                            DMCompiler.Emit(WarningCode.RuntimeSearchOperator, token.Location, "Runtime search operator '?:' should be avoided; prefer typecasting and using '?.' instead");
+                            goto case TokenType.DM_QuestionPeriod;
                         case TokenType.DM_Period:
                         case TokenType.DM_QuestionPeriod:
-                        case TokenType.DM_Colon:
-                        case TokenType.DM_QuestionColon: {
+                         {
                             var identifier = Identifier();
 
                             if (identifier == null) {

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -51,3 +51,4 @@
 #pragma AssignmentInConditional warning 
 #pragma PickWeightedSyntax disabled
 #pragma AmbiguousInOrder warning
+#pragma RuntimeSearchOperator disabled


### PR DESCRIPTION
Adds a new stylistic pragma that emits for using the [runtime search operator](https://www.byond.com/docs/ref/#/operator/:). Disabled by default.

Requested by beestation.