### PR TITLE
corrects DMStandard default vars for findlasttext(ex)

### DIFF
--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -20,8 +20,8 @@ proc/file2text(File) as text|null
 proc/filter(type, ...)
 proc/findtext(Haystack, Needle, Start = 1, End = 0) as num
 proc/findtextEx(Haystack, Needle, Start = 1, End = 0) as num
-proc/findlasttext(Haystack, Needle, Start = 1, End = 0) as num
-proc/findlasttextEx(Haystack, Needle, Start = 1, End = 0) as num
+proc/findlasttext(Haystack, Needle, Start = 0, End = 1) as num
+proc/findlasttextEx(Haystack, Needle, Start = 0, End = 1) as num
 proc/flick(Icon, Object)
 proc/flist(Path) as /list
 proc/floor(A) as num


### PR DESCRIPTION
we have them right in the procparameter attribute just not here

https://github.com/OpenDreamProject/OpenDream/blob/68765936774ac55512c8812c33fbda2770f06388/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs#L859