### PR TITLE
Fix some sources of runtime errors

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -174,7 +174,8 @@ public class DreamList : DreamObject {
                 _associativeValues.Remove(_values[i - 1]);
         }
 
-        _values.RemoveRange(start - 1, end - start);
+        if (end > start)
+            _values.RemoveRange(start - 1, end - start);
     }
 
     public void Insert(int index, DreamValue value) {

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -416,6 +416,7 @@ internal sealed class DreamListVars(DreamObjectDefinition listDef, DreamObject d
             if (DreamObject.TryGetVariable(varName, out var objectVar)) {
                 return objectVar;
             }
+            
             throw new Exception($"Cannot get value of undefined var \"{key}\" on type {DreamObject.ObjectDefinition.Type}");
         } else {
             throw new Exception($"Invalid var index {key}");

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -409,16 +409,16 @@ internal sealed class DreamListVars(DreamObjectDefinition listDef, DreamObject d
     }
 
     public override DreamValue GetValue(DreamValue key) {
-        if (!key.TryGetValueAsString(out var varName)) {
+        if (key.TryGetValueAsInteger(out int keyInteger)) {
+            return new DreamValue(DreamObject.GetVariableNames().ElementAt(keyInteger - 1)); //1-indexed
+        } else if (key.TryGetValueAsString(out var varName)) {
+            if (DreamObject.TryGetVariable(varName, out var objectVar)) {
+                return objectVar;
+            }
+            throw new Exception($"Cannot get value of undefined var \"{key}\" on type {DreamObject.ObjectDefinition.Type}");
+        } else {
             throw new Exception($"Invalid var index {key}");
         }
-
-        if (!DreamObject.TryGetVariable(varName, out var objectVar)) {
-            throw new Exception(
-                $"Cannot get value of undefined var \"{key}\" on type {DreamObject.ObjectDefinition.Type}");
-        }
-
-        return objectVar;
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -2419,7 +2419,19 @@ namespace OpenDreamRuntime.Procs {
                 foreach (var connection in state.DreamManager.Connections) {
                     connection.OutputControl(message, control);
                 }
+            } else if (receiver is DreamList list) {
+                // Output to every mob in the left-hand list.
+                foreach (var entry in list.GetValues()) {
+                    if (entry.TryGetValueAsDreamObject(out var entryObj)) {
+                        if (entryObj is DreamObjectMob entryMob) {
+                            entryMob.Connection?.OutputControl(message, control);
+                        } else if (entryObj is DreamObjectClient entryClient) {
+                            entryClient.Connection.OutputControl(message, control);
+                        }
+                    }
+                }
             } else {
+                // TODO: BYOND's behavior is to ignore rather than throw here
                 throw new Exception($"Invalid output() recipient: {receiver}");
             }
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2955,7 +2955,7 @@ internal static class DreamProcNativeRoot {
                         addingProcs = type.ObjectDefinition.Procs.Values;
                     } else if (typeString.EndsWith("/verb")) {
                         type = bundle.ObjectTree.GetTreeEntry(typeString.Substring(0, typeString.Length - 5));
-                        addingProcs = type.ObjectDefinition.Verbs;
+                        addingProcs = type.ObjectDefinition.Verbs ?? Enumerable.Empty<int>();
                     } else {
                         type = bundle.ObjectTree.GetTreeEntry(typeString);
                     }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -156,6 +156,7 @@ internal static class DreamProcNativeRoot {
                 return DreamValue.Null;
             chainAnim = true;
         }
+        
         bundle.LastAnimatedObject = new DreamValue(obj);
         if(obj.IsSubtypeOf(bundle.ObjectTree.Filter)) {//TODO animate filters
             return DreamValue.Null;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -156,10 +156,10 @@ internal static class DreamProcNativeRoot {
                 return DreamValue.Null;
             chainAnim = true;
         }
+        bundle.LastAnimatedObject = new DreamValue(obj);
         if(obj.IsSubtypeOf(bundle.ObjectTree.Filter)) {//TODO animate filters
             return DreamValue.Null;
         }
-        bundle.LastAnimatedObject = new DreamValue(obj);
         // TODO: Is this the correct behavior for invalid time?
         if (!bundle.GetArgument(1, "time").TryGetValueAsFloat(out float time))
             return DreamValue.Null;

--- a/OpenDreamShared/Resources/DMIParser.cs
+++ b/OpenDreamShared/Resources/DMIParser.cs
@@ -213,9 +213,9 @@ public static class DMIParser {
         Vector2u? imageSize = null;
 
         while (stream.Position < stream.Length) {
-            long chunkDataPosition = stream.Position;
             uint chunkLength = ReadBigEndianUint32(reader);
-            string chunkType = new string(reader.ReadChars(4));
+            string chunkType = Encoding.UTF8.GetString(reader.ReadBytes(4));
+            long chunkDataPosition = stream.Position;
 
             switch (chunkType) {
                 case "IHDR": //Image header, contains the image size


### PR DESCRIPTION
- Implement `list() << output(...)`
  - Like BYOND, the `list()` form only supports mobs and clients, not world, and is not recursive
- Fix `vars[1]` erroring instead of returning the name of the first var
  - No attempt was made to match BYOND's variable order, just to do something sensible instead of erroring
  - Code example: `for(var/name in (vars & data))`
- Fix `typesof("/foo/verb")` returning non-verb subtypes when there are no verbs
- Fix `Cut(2, 1)` throwing (negative count to RemoveRange) instead of doing nothing
- Fix bad offset math when DMIParser skips a `tEXt` chunk, leading to UTF-8 decode exceptions
- Fix `animate(filter, ...)` not setting LastAnimatedObject
  - Animating filters still isn't implemented, but at least a chained `animate()` call doesn't error