### PR TITLE
Fix a null reference in `mob.ckey` assignment

### DIFF
--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -29,8 +29,9 @@ public sealed class DreamConnection {
 
     [ViewVariables] public ICommonSession? Session { get; private set; }
     [ViewVariables] public DreamObjectClient? Client { get; private set; }
-    [ViewVariables]
-    public DreamObjectMob? Mob {
+    [ViewVariables] public string Key { get; private set; }
+
+    [ViewVariables] public DreamObjectMob? Mob {
         get => _mob;
         set {
             if (_mob != value) {
@@ -61,8 +62,7 @@ public sealed class DreamConnection {
         }
     }
 
-    [ViewVariables]
-    public DreamObjectMovable? Eye {
+    [ViewVariables] public DreamObjectMovable? Eye {
         get => _eye;
         set {
             _eye = value;
@@ -93,8 +93,9 @@ public sealed class DreamConnection {
         }
     }
 
-    public DreamConnection() {
+    public DreamConnection(string key) {
         IoCManager.InjectDependencies(this);
+        Key = key;
 
         _entitySystemManager.TryGetEntitySystem(out _screenOverlaySystem);
         _entitySystemManager.TryGetEntitySystem(out _clientImagesSystem);

--- a/OpenDreamRuntime/DreamManager.Connections.cs
+++ b/OpenDreamRuntime/DreamManager.Connections.cs
@@ -256,7 +256,7 @@ namespace OpenDreamRuntime {
 
                 case SessionStatus.InGame: {
                     if (!_connections.TryGetValue(e.Session.UserId, out var connection)) {
-                        connection = new DreamConnection();
+                        connection = new DreamConnection(e.Session.Name);
 
                         _connections.Add(e.Session.UserId, connection);
                     }

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -344,7 +344,7 @@ namespace OpenDreamRuntime.Objects {
             // /client is a little special and will return its key var
             // TODO: Maybe this should be an override to GetDisplayName()?
             if (this is DreamObjectClient client)
-                return client.Connection.Session!.Name;
+                return client.Connection.Key;
 
             var name = GetRawName();
             bool isProper = StringIsProper(name);

--- a/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
@@ -41,10 +41,10 @@ public sealed class DreamObjectClient : DreamObject {
     protected override bool TryGetVar(string varName, out DreamValue value) {
         switch (varName) {
             case "ckey":
-                value = new(DreamProcNativeHelpers.Ckey(Connection.Session!.Name));
+                value = new(DreamProcNativeHelpers.Ckey(Connection.Key));
                 return true;
             case "key":
-                value = new(Connection.Session!.Name);
+                value = new(Connection.Key);
                 return true;
             case "mob":
                 value = new(Connection.Mob);
@@ -68,7 +68,7 @@ public sealed class DreamObjectClient : DreamObject {
                 MD5 md5 = MD5.Create();
                 // Check on Robust.Shared.Network.NetUserData.HWId" if you want to seed from how RT does user identification.
                 // We don't use it here because it is probably not enough to ensure security, and (as of time of writing) only works on Windows machines.
-                byte[] brown = Encoding.UTF8.GetBytes(Connection.Session!.Name);
+                byte[] brown = Encoding.UTF8.GetBytes(Connection.Key);
                 byte[] hash = md5.ComputeHash(brown);
                 string hashStr = BitConverter.ToString(hash).Replace("-", "").ToLower().Substring(0,15); // Extracting the first 15 digits to ensure it'll fit in a 64-bit number
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectMob.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectMob.cs
@@ -82,12 +82,11 @@ public sealed class DreamObjectMob : DreamObjectMovable {
                 Key = DreamProcNativeHelpers.Ckey(Key);
 
                 foreach (var connection in DreamManager.Connections) {
-                    if (DreamProcNativeHelpers.Ckey(connection.Session!.Name) == Key) {
+                    if (DreamProcNativeHelpers.Ckey(connection.Key) == Key) {
                         connection.Mob = this;
                         break;
                     }
                 }
-
 
                 break;
             case "see_invisible":


### PR DESCRIPTION
`mob.ckey = ...` was looping through every connection, and making the assumption that they were actively connected.