### PR TITLE
Fix stringifying infinity

### DIFF
--- a/Content.Tests/DMProject/Broken Tests/Expression/Constants/numeral_inf.dm
+++ b/Content.Tests/DMProject/Broken Tests/Expression/Constants/numeral_inf.dm
@@ -1,9 +1,0 @@
-
-//# issue 464
-
-/proc/RunTest()
-	var/a = 1#INF
-	var/b = -1#IND
-	// TODO: This actually varies by OS I believe, this is the Windows result. (OpenDream is broken either way)
-	ASSERT(a == "inf")
-	ASSERT(b == 0)

--- a/Content.Tests/DMProject/Tests/Expression/Constants/stringify_inf.dm
+++ b/Content.Tests/DMProject/Tests/Expression/Constants/stringify_inf.dm
@@ -1,0 +1,8 @@
+
+/proc/RunTest()
+	var/a = 1#INF
+	var/b = -1#INF
+	var/c = -1#IND
+	ASSERT("[a]" == "inf")
+	ASSERT("[b]" == "-inf")
+	ASSERT("[c]" == "nan")

--- a/OpenDreamRuntime/DreamValue.cs
+++ b/OpenDreamRuntime/DreamValue.cs
@@ -362,6 +362,11 @@ public struct DreamValue : IEquatable<DreamValue> {
             case DreamValueType.Float:
                 var floatValue = MustGetValueAsFloat();
 
+                if (float.IsInfinity(floatValue)) {
+                    var str = float.IsPositiveInfinity(floatValue) ? "inf" : "-inf";
+                    return str;
+                }
+
                 if (floatValue > 16777216f) {
                     return floatValue.ToString("g6");
                 }
@@ -370,6 +375,8 @@ public struct DreamValue : IEquatable<DreamValue> {
                 if (floatValue >= 1000000 && ((int)floatValue == floatValue)) {
                     return floatValue.ToString("g8");
                 }
+
+                if (float.IsNaN(floatValue)) return "nan";
 
                 return floatValue.ToString("g6");
 


### PR DESCRIPTION
Some notes:
- The original unit test did not work in BYOND like... at all. Infinity is a number and only becomes `"inf"` when you try to stringify it.
- `-1#IND == 0` also doesn't pass in BYOND
- OS variation was fixed in BYOND at some point (can't be bothered to track down the build number). I confirmed I get the same result on both linux and windows.

Original test:
![image](https://github.com/user-attachments/assets/6a0b361f-f86c-4710-9b3f-a9ec8094afc5)

New test:
![image](https://github.com/user-attachments/assets/a8fc907d-b267-4dd2-a1c3-8ec0722d10d9)
