### PR TITLE
Fix recreating deleted savefiles

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
@@ -259,6 +259,7 @@ public sealed class DreamObjectSavefile : DreamObject {
     }
 
     public void Flush() {
+        if (Deleted) return;
         Resource!.Clear();
         Resource!.Output(new DreamValue(JsonSerializer.Serialize(_rootNode)));
     }

--- a/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
@@ -230,7 +230,8 @@ public sealed class DreamObjectSavefile : DreamObject {
         _sawmill ??= Logger.GetSawmill("opendream.res");
         foreach (DreamObjectSavefile savefile in SavefilesToFlush) {
             try {
-                savefile.Flush();
+                // We need to avoid Flush() recreating a nonexistent file
+                if (File.Exists(savefile.Resource!.ResourcePath)) savefile.Flush();
             } catch (Exception e) {
                 _sawmill.Error($"Error flushing savefile {savefile.Resource!.ResourcePath}: {e}");
             }
@@ -239,10 +240,12 @@ public sealed class DreamObjectSavefile : DreamObject {
     }
 
     public void Close() {
-        Flush();
+        // We need to avoid Flush() recreating a nonexistent file
+        if (File.Exists(Resource!.ResourcePath)) Flush();
         if (_isTemporary && Resource?.ResourcePath != null) {
             File.Delete(Resource.ResourcePath);
         }
+
         //check to see if the file is still in use by another savefile datum
         if(Resource?.ResourcePath != null) {
             var fineToDelete = true;
@@ -255,11 +258,12 @@ public sealed class DreamObjectSavefile : DreamObject {
             if (fineToDelete)
                 SavefileDirectories.Remove(Resource.ResourcePath);
         }
+
         Savefiles.Remove(this);
+        SavefilesToFlush.Remove(this);
     }
 
     public void Flush() {
-        if (Deleted) return;
         Resource!.Clear();
         Resource!.Output(new DreamValue(JsonSerializer.Serialize(_rootNode)));
     }


### PR DESCRIPTION
On my machine the `BasicReadAndWrite.dm` test would fail on subsequent runs. This was because after `fdel("savefile.sav")` executed the file would be recreated.

`Flush()` was calling `Resource!.Clear()` which calls `File.WriteAllText(_filePath, string.Empty);` which creates a new file.

Now we simply avoid flushing if the savefile file no longer exists.