### PR TITLE
Cope with extra tokens after proc statements

### DIFF
--- a/Content.Tests/DMProject/Tests/Statements/extra_token_pragma.dm
+++ b/Content.Tests/DMProject/Tests/Statements/extra_token_pragma.dm
@@ -1,0 +1,6 @@
+// COMPILE ERROR OD3205
+#pragma ExtraToken error
+
+/proc/RunTest()
+	if(1).
+		ASSERT(TRUE)

--- a/Content.Tests/DMProject/Tests/Statements/thing_after_statement.dm
+++ b/Content.Tests/DMProject/Tests/Statements/thing_after_statement.dm
@@ -8,3 +8,7 @@
 		ASSERT(TRUE)
 	else
 		ASSERT(FALSE)
+	for(var/i in 1 to 1):
+		ASSERT(TRUE)
+	for(var/i in 1 to 1).
+		ASSERT(TRUE)

--- a/DMCompiler/Compiler/CompilerError.cs
+++ b/DMCompiler/Compiler/CompilerError.cs
@@ -74,6 +74,7 @@ public enum WarningCode {
     AssignmentInConditional = 3202,
     PickWeightedSyntax = 3203,
     AmbiguousInOrder = 3204,
+    ExtraToken = 3205,
     RuntimeSearchOperator = 3300,
 
     // 4000 - 4999 are reserved for runtime configuration. (TODO: Runtime doesn't know about configs yet!)

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -1125,8 +1125,10 @@ namespace DMCompiler.Compiler.DM {
 
             BracketWhitespace();
             ConsumeRightParenthesis();
-            Whitespace();
-            Check(TokenType.DM_Colon);
+            if (Check(TokenType.DM_Colon) || Check(TokenType.DM_Period)) {
+                Emit(WarningCode.ExtraToken, loc, "Extra token at end of proc statement");
+            }
+
             Whitespace();
 
             DMASTProcStatement? procStatement = ProcStatement();
@@ -1165,6 +1167,10 @@ namespace DMCompiler.Compiler.DM {
             Whitespace();
 
             if (Check(TokenType.DM_RightParenthesis)) {
+                if (Check(TokenType.DM_Colon) || Check(TokenType.DM_Period)) {
+                    Emit(WarningCode.ExtraToken, loc, "Extra token at end of proc statement");
+                }
+
                 return new DMASTProcStatementInfLoop(loc, GetForBody(loc));
             }
 
@@ -1185,6 +1191,10 @@ namespace DMCompiler.Compiler.DM {
                 if (expr1 is DMASTAssign assign) {
                     ExpressionTo(out var endRange, out var step);
                     Consume(TokenType.DM_RightParenthesis, "Expected ')' in for after to expression");
+                    if (Check(TokenType.DM_Colon) || Check(TokenType.DM_Period)) {
+                        Emit(WarningCode.ExtraToken, loc, "Extra token at end of proc statement");
+                    }
+
                     return new DMASTProcStatementFor(loc, new DMASTExpressionInRange(loc, assign.LHS, assign.RHS, endRange, step), null, null, dmTypes, GetForBody(loc));
                 } else {
                     Emit(WarningCode.BadExpression, "Expected = before to in for");
@@ -1197,15 +1207,27 @@ namespace DMCompiler.Compiler.DM {
                 DMASTExpression? listExpr = Expression();
                 Whitespace();
                 Consume(TokenType.DM_RightParenthesis, "Expected ')' in for after expression 2");
+                if (Check(TokenType.DM_Colon) || Check(TokenType.DM_Period)) {
+                    Emit(WarningCode.ExtraToken, loc, "Extra token at end of proc statement");
+                }
+
                 return new DMASTProcStatementFor(loc, new DMASTExpressionIn(loc, expr1, listExpr), null, null, dmTypes, GetForBody(loc));
             }
 
             if (!Check(ForSeparatorTypes)) {
                 Consume(TokenType.DM_RightParenthesis, "Expected ')' in for after expression 1");
+                if (Check(TokenType.DM_Colon) || Check(TokenType.DM_Period)) {
+                    Emit(WarningCode.ExtraToken, loc, "Extra token at end of proc statement");
+                }
+
                 return new DMASTProcStatementFor(loc, expr1, null, null, dmTypes, GetForBody(loc));
             }
 
             if (Check(TokenType.DM_RightParenthesis)) {
+                if (Check(TokenType.DM_Colon) || Check(TokenType.DM_Period)) {
+                    Emit(WarningCode.ExtraToken, loc, "Extra token at end of proc statement");
+                }
+
                 return new DMASTProcStatementFor(loc, expr1, null, null, dmTypes, GetForBody(loc));
             }
 
@@ -1221,10 +1243,18 @@ namespace DMCompiler.Compiler.DM {
 
             if (!Check(ForSeparatorTypes)) {
                 Consume(TokenType.DM_RightParenthesis, "Expected ')' in for after expression 2");
+                if (Check(TokenType.DM_Colon) || Check(TokenType.DM_Period)) {
+                    Emit(WarningCode.ExtraToken, loc, "Extra token at end of proc statement");
+                }
+
                 return new DMASTProcStatementFor(loc, expr1, expr2, null, dmTypes, GetForBody(loc));
             }
 
             if (Check(TokenType.DM_RightParenthesis)) {
+                if (Check(TokenType.DM_Colon) || Check(TokenType.DM_Period)) {
+                    Emit(WarningCode.ExtraToken, loc, "Extra token at end of proc statement");
+                }
+
                 return new DMASTProcStatementFor(loc, expr1, expr2, null, dmTypes, GetForBody(loc));
             }
 
@@ -1239,6 +1269,10 @@ namespace DMCompiler.Compiler.DM {
             }
 
             Consume(TokenType.DM_RightParenthesis, "Expected ')' in for after expression 3");
+            if (Check(TokenType.DM_Colon) || Check(TokenType.DM_Period)) {
+                Emit(WarningCode.ExtraToken, loc, "Extra token at end of proc statement");
+            }
+
             return new DMASTProcStatementFor(loc, expr1, expr2, expr3, dmTypes, GetForBody(loc));
 
             DMASTProcBlockInner GetForBody(Location forLocation) {

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -52,4 +52,5 @@
 #pragma AssignmentInConditional warning
 #pragma PickWeightedSyntax disabled
 #pragma AmbiguousInOrder warning
+#pragma ExtraToken warning
 #pragma RuntimeSearchOperator disabled


### PR DESCRIPTION
Trailing `.` and `:` tokens after `if()` and `for()` statements is valid in BYOND:
![image](https://github.com/user-attachments/assets/072aa6aa-76ef-4bb6-872c-b44a8e5bf00b)

We already handled `if():` so I just expanded our copium and fixed & extended a broken unit test in the process. Added the `ExtraToken` stylistic pragma for when this happens. No hits on TG/goon/para.