### PR TITLE
Implement `initial()` for `arglist()`

### DIFF
--- a/Content.Tests/DMProject/Broken Tests/Procs/Arglist/initial.dm
+++ b/Content.Tests/DMProject/Broken Tests/Procs/Arglist/initial.dm
@@ -1,6 +1,0 @@
-
-/proc/_initial(...)
-	return initial(arglist(args))
-
-/proc/RunTest()
-	return

--- a/Content.Tests/DMProject/Tests/Procs/Arglist/initial.dm
+++ b/Content.Tests/DMProject/Tests/Procs/Arglist/initial.dm
@@ -1,0 +1,6 @@
+
+/proc/_initial(...)
+	ASSERT(initial(arglist(args))[1] == "foo")
+
+/proc/RunTest()
+	_initial("foo")

--- a/DMCompiler/DM/Expressions/Builtins.cs
+++ b/DMCompiler/DM/Expressions/Builtins.cs
@@ -505,6 +505,13 @@ internal class Initial(Location location, DMExpression expr) : DMExpression(loca
             return;
         }
 
+        if (Expression is Arglist arglist) {
+            // This happens silently in BYOND
+            ctx.Compiler.Emit(WarningCode.PointlessBuiltinCall, Location, "calling initial() on arglist() returns the current value");
+            arglist.EmitPushArglist(ctx);
+            return;
+        }
+
         ctx.Compiler.Emit(WarningCode.BadArgument, Expression.Location, $"can't get initial value of {Expression}");
         ctx.Proc.Error();
     }


### PR DESCRIPTION
Seems to just return the current value.