### PR TITLE
Compile error when outputting to const vars in `for()` loops

### DIFF
--- a/Content.Tests/DMProject/Tests/Statements/For/reuse_decl_const.dm
+++ b/Content.Tests/DMProject/Tests/Statements/For/reuse_decl_const.dm
@@ -1,4 +1,4 @@
-// COMPILE ERROR
+// COMPILE ERROR OD0501
 
 /datum
 	var/const/idx = 0

--- a/Content.Tests/DMProject/Tests/Statements/For/reuse_decl_const2.dm
+++ b/Content.Tests/DMProject/Tests/Statements/For/reuse_decl_const2.dm
@@ -1,0 +1,18 @@
+// COMPILE ERROR OD0501
+
+/datum
+	var/const/idx = 0
+	var/c = 0
+	proc/do_loop()
+		for (idx in list(1,2,3))
+			c += idx
+
+/proc/RunTest()
+	var/datum/d = new
+	d.do_loop()
+
+	var/const/idx = 0
+	var/c = 0
+	for (idx in list(1,2,3))
+		c += idx
+

--- a/DMCompiler/DM/Builders/DMProcBuilder.cs
+++ b/DMCompiler/DM/Builders/DMProcBuilder.cs
@@ -524,8 +524,8 @@ namespace DMCompiler.DM.Builders {
 
                             if (outputVar is Local outputLocal) {
                                 outputLocal.LocalVar.ExplicitValueType = statementFor.DMTypes;
-                                if(outputLocal.LocalVar is DMProc.LocalConstVariable)
-                                    compiler.Emit(WarningCode.WriteToConstant, outputExpr.Location, "Cannot change constant value");
+                            if(outputLocal.LocalVar is DMProc.LocalConstVariable)
+                                compiler.Emit(WarningCode.WriteToConstant, outputExpr.Location, "Cannot change constant value");
                             } else if (outputVar is Field { IsConst: true })
                                 compiler.Emit(WarningCode.WriteToConstant, outputExpr.Location, "Cannot change constant value");
 

--- a/DMCompiler/DM/Builders/DMProcBuilder.cs
+++ b/DMCompiler/DM/Builders/DMProcBuilder.cs
@@ -525,7 +525,7 @@ namespace DMCompiler.DM.Builders {
                             if (outputVar is Local outputLocal) {
                                 outputLocal.LocalVar.ExplicitValueType = statementFor.DMTypes;
                                 if(outputLocal.LocalVar is DMProc.LocalConstVariable)
-                                    compiler.Emit(WarningCode.WriteToConstant, outputExpr.Location, $"Cannot change constant value");
+                                    compiler.Emit(WarningCode.WriteToConstant, outputExpr.Location, "Cannot change constant value");
                             } else if (outputVar is Field { IsConst: true })
                                 compiler.Emit(WarningCode.WriteToConstant, outputExpr.Location, "Cannot change constant value");
 

--- a/DMCompiler/DM/Builders/DMProcBuilder.cs
+++ b/DMCompiler/DM/Builders/DMProcBuilder.cs
@@ -490,7 +490,7 @@ namespace DMCompiler.DM.Builders {
                             var outputVar = _exprBuilder.Create(outputExpr);
 
                             if (outputVar is Local { LocalVar: DMProc.LocalConstVariable } or Field { IsConst: true }) {
-                                compiler.Emit(WarningCode.WriteToConstant, outputExpr.Location, $"Cannot change constant value");
+                                compiler.Emit(WarningCode.WriteToConstant, outputExpr.Location, "Cannot change constant value");
                             }
 
                             var start = _exprBuilder.Create(exprRange.StartRange);

--- a/DMCompiler/DM/Builders/DMProcBuilder.cs
+++ b/DMCompiler/DM/Builders/DMProcBuilder.cs
@@ -487,6 +487,11 @@ namespace DMCompiler.DM.Builders {
                                 outputExpr = exprRange.Value;
                             }
 
+                            if (outputExpr is DMASTIdentifier identifier &&
+                                dmObject.GetVariable(identifier.Identifier) is { IsConst: true }) {
+                                compiler.Emit(WarningCode.WriteToConstant, outputExpr.Location, "Cannot change constant value");
+                            }
+
                             var outputVar = _exprBuilder.Create(outputExpr);
 
                             var start = _exprBuilder.Create(exprRange.StartRange);

--- a/DMCompiler/DM/Expressions/LValue.cs
+++ b/DMCompiler/DM/Expressions/LValue.cs
@@ -122,6 +122,7 @@ internal sealed class Local(Location location, DMProc.LocalVariable localVar) : 
 
 // Identifier of field
 internal sealed class Field(Location location, DMVariable variable, DMComplexValueType valType) : LValue(location, variable.Type) {
+    public bool IsConst { get; } = variable.IsConst;
     public override DMComplexValueType ValType => valType;
 
     public override void EmitPushInitial(ExpressionContext ctx) {


### PR DESCRIPTION
See included unit test for the issue this PR fixes. Previously, we only runtime errored whereas BYOND compiletime errored.