### PR TITLE
Emit location of original var def for duplicate var errors

### DIFF
--- a/DMCompiler/DM/DMCodeTree.Vars.cs
+++ b/DMCompiler/DM/DMCodeTree.Vars.cs
@@ -175,12 +175,13 @@ internal partial class DMCodeTree {
                 return true;
             } else if (dmObject.HasLocalVariable(VarName)) {
                 if (!varDef.Location.InDMStandard) { // Duplicate instance vars are not an error in DMStandard
-                    compiler.Emit(WarningCode.InvalidVarDefinition, varDef.Location,
-                        $"Duplicate definition of var \"{VarName}\"");
                     var variable = dmObject.GetVariable(VarName);
                     if(variable!.Value is not null)
-                        compiler.Emit(WarningCode.InvalidVarDefinition, variable.Value.Location,
-                            $"Previous definition of var \"{VarName}\"");
+                        compiler.Emit(WarningCode.InvalidVarDefinition, varDef.Location,
+                        $"Duplicate definition of var \"{VarName}\". Previous definition at {variable.Value.Location}");
+                    else
+                        compiler.Emit(WarningCode.InvalidVarDefinition, varDef.Location,
+                        $"Duplicate definition of var \"{VarName}\"");
                 }
 
                 return true;

--- a/DMCompiler/DM/DMCodeTree.Vars.cs
+++ b/DMCompiler/DM/DMCodeTree.Vars.cs
@@ -174,9 +174,15 @@ internal partial class DMCodeTree {
                     $"Duplicate definition of static var \"{VarName}\"");
                 return true;
             } else if (dmObject.HasLocalVariable(VarName)) {
-                if (!varDef.Location.InDMStandard) // Duplicate instance vars are not an error in DMStandard
+                if (!varDef.Location.InDMStandard) { // Duplicate instance vars are not an error in DMStandard
                     compiler.Emit(WarningCode.InvalidVarDefinition, varDef.Location,
                         $"Duplicate definition of var \"{VarName}\"");
+                    var variable = dmObject.GetVariable(VarName);
+                    if(variable!.Value is not null)
+                        compiler.Emit(WarningCode.InvalidVarDefinition, variable.Value.Location,
+                            $"Previous definition of var \"{VarName}\"");
+                }
+
                 return true;
             } else if (IsStatic && VarName == "vars" && dmObject == compiler.DMObjectTree.Root) {
                 compiler.Emit(WarningCode.InvalidVarDefinition, varDef.Location, "Duplicate definition of global.vars");


### PR DESCRIPTION
Example:
```
Error OD0014 at code/modules/banners/__banner.dm:15:2: Duplicate definition of var "name_prefix"
Error OD0014 at code/game/objects/items/__item.dm:10:2: Previous definition of var "name_prefix"
```

Previously we only printed the first line. Printing both gives us parity with BYOND and is useful for fixing the error.