### PR TITLE
Fix off-by-one in peephole optimizer

### DIFF
--- a/DMCompiler/Optimizer/PeepholeOptimizer.cs
+++ b/DMCompiler/Optimizer/PeepholeOptimizer.cs
@@ -141,7 +141,7 @@ internal sealed class PeepholeOptimizer {
             var bytecode = input[i];
             if (bytecode is not AnnotatedBytecodeInstruction instruction) {
                 i -= AttemptCurrentOpt(i);
-                i = Math.Max(i, 0);
+                i = Math.Max(i, -1); // i++ brings -1 back to 0
                 continue;
             }
 
@@ -160,7 +160,7 @@ internal sealed class PeepholeOptimizer {
             }
 
             i -= AttemptCurrentOpt(i);
-            i = Math.Max(i, 0);
+            i = Math.Max(i, -1); // i++ brings -1 back to 0
         }
 
         AttemptCurrentOpt(input.Count);


### PR DESCRIPTION
Fixes #2130 

The `Math.Max()` didn't account for `i++` so `i` could never actually be `0` after the first iteration of the `for()` loop.

tl;dr off-by-one error