### PR TITLE
`IndexRefWithString` peephole opt

### DIFF
--- a/DMCompiler/Bytecode/DreamProcOpcode.cs
+++ b/DMCompiler/Bytecode/DreamProcOpcode.cs
@@ -295,6 +295,8 @@ public enum DreamProcOpcode : byte {
     ReturnReferenceValue = 0x97,
     [OpcodeMetadata(0, OpcodeArgType.Float)]
     ReturnFloat = 0x98,
+    [OpcodeMetadata(1, OpcodeArgType.Reference, OpcodeArgType.String)]
+    IndexRefWithString = 0x99,
 }
 // ReSharper restore MissingBlankLines
 

--- a/DMCompiler/Optimizer/PeepholeOptimizations.cs
+++ b/DMCompiler/Optimizer/PeepholeOptimizations.cs
@@ -117,6 +117,34 @@ internal sealed class PushField : IOptimization {
 }
 
 // PushReferenceValue [ref]
+// PushString [string]
+// DereferenceIndex [value] [string]
+// -> IndexRefWithString [ref, string]
+internal sealed class IndexRefWithString : IOptimization {
+    public OptPass OptimizationPass => OptPass.PeepholeOptimization;
+
+    public ReadOnlySpan<DreamProcOpcode> GetOpcodes() {
+        return [
+            DreamProcOpcode.PushReferenceValue,
+            DreamProcOpcode.PushString,
+            DreamProcOpcode.DereferenceIndex
+        ];
+    }
+
+    public void Apply(DMCompiler compiler, List<IAnnotatedBytecode> input, int index) {
+        AnnotatedBytecodeInstruction firstInstruction = (AnnotatedBytecodeInstruction)(input[index]);
+        AnnotatedBytecodeReference pushVal = firstInstruction.GetArg<AnnotatedBytecodeReference>(0);
+
+        AnnotatedBytecodeInstruction secondInstruction = (AnnotatedBytecodeInstruction)(input[index + 1]);
+        AnnotatedBytecodeString strIndex = secondInstruction.GetArg<AnnotatedBytecodeString>(0);
+
+        input.RemoveRange(index, 3);
+        input.Insert(index, new AnnotatedBytecodeInstruction(DreamProcOpcode.IndexRefWithString, -1,
+            [pushVal, strIndex]));
+    }
+}
+
+// PushReferenceValue [ref]
 // Return
 // -> ReturnReferenceValue [ref]
 internal class ReturnReferenceValue : IOptimization {

--- a/DMCompiler/Optimizer/PeepholeOptimizations.cs
+++ b/DMCompiler/Optimizer/PeepholeOptimizations.cs
@@ -118,7 +118,7 @@ internal sealed class PushField : IOptimization {
 
 // PushReferenceValue [ref]
 // PushString [string]
-// DereferenceIndex [value] [string]
+// DereferenceIndex
 // -> IndexRefWithString [ref, string]
 internal sealed class IndexRefWithString : IOptimization {
     public OptPass OptimizationPass => OptPass.PeepholeOptimization;

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -2556,6 +2556,17 @@ namespace OpenDreamRuntime.Procs {
             return ProcStatus.Continue;
         }
 
+        public static ProcStatus IndexRefWithString(DMProcState state) {
+            DreamReference reference = state.ReadReference();
+            var refValue = state.GetReferenceValue(reference);
+
+            var index = new DreamValue(state.ReadString());
+            var indexResult = state.GetIndex(refValue, index, state);
+
+            state.Push(indexResult);
+            return ProcStatus.Continue;
+        }
+
         public static ProcStatus DereferenceCall(DMProcState state) {
             string name = state.ReadString();
             var argumentInfo = state.ReadProcArguments();

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -279,6 +279,7 @@ namespace OpenDreamRuntime.Procs {
             {DreamProcOpcode.JumpIfFalseReference, DMOpcodeHandlers.JumpIfFalseReference},
             {DreamProcOpcode.DereferenceField, DMOpcodeHandlers.DereferenceField},
             {DreamProcOpcode.DereferenceIndex, DMOpcodeHandlers.DereferenceIndex},
+            {DreamProcOpcode.IndexRefWithString, DMOpcodeHandlers.IndexRefWithString},
             {DreamProcOpcode.DereferenceCall, DMOpcodeHandlers.DereferenceCall},
             {DreamProcOpcode.PopReference, DMOpcodeHandlers.PopReference},
             {DreamProcOpcode.BitShiftLeftReference,DMOpcodeHandlers.BitShiftLeftReference},

--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -119,6 +119,7 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
                 return (opcode, ReadReference(), ReadReference());
 
             case DreamProcOpcode.PushRefAndDereferenceField:
+            case DreamProcOpcode.IndexRefWithString:
                 return (opcode, ReadReference(), ReadString());
 
             case DreamProcOpcode.CallStatement:


### PR DESCRIPTION
`PushReferenceValue -> PushString -> DereferenceIndex` is a pretty common pattern in TG. This combines them into one new `IndexRefWithString` opcode.

The new opcode occurs 6,170 times in TG. This means a pretty decent reduction in pushing/popping the stack.

I joined TG and confirmed it didn't seem to explode, and I could still run around.