### PR TITLE
Remove `Jump` after `Return`

### DIFF
--- a/DMCompiler/Optimizer/PeepholeOptimizations.cs
+++ b/DMCompiler/Optimizer/PeepholeOptimizations.cs
@@ -186,6 +186,24 @@ internal sealed class JumpIfReferenceFalse : IOptimization {
     }
 }
 
+// Return
+// Jump [label]
+// -> Return
+internal sealed class RemoveJumpAfterReturn : IOptimization {
+    public OptPass OptimizationPass => OptPass.PeepholeOptimization;
+
+    public ReadOnlySpan<DreamProcOpcode> GetOpcodes() {
+        return [
+            DreamProcOpcode.Return,
+            DreamProcOpcode.Jump
+        ];
+    }
+
+    public void Apply(DMCompiler compiler, List<IAnnotatedBytecode> input, int index) {
+        input.RemoveRange(index + 1, 1);
+    }
+}
+
 // PushFloat [float]
 // SwitchCase [label]
 // -> SwitchOnFloat [float] [label]


### PR DESCRIPTION
`if()`/`else` blocks with a `return` in the `if()` are left with a dead `Jump` opcode that can never be reached. 

This peephole optimization deals with that and removes over 900 `Jump` opcodes from TG.

I tested that TG doesn't explode with these changes.