### PR TITLE
Optimize the peephole optimizer

### DIFF
--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -170,10 +170,9 @@ namespace DMCompiler.DM {
         }
 
         public ProcDefinitionJson GetJsonRepresentation() {
-            var optimizer = new BytecodeOptimizer();
             var serializer = new AnnotatedBytecodeSerializer(_compiler);
 
-            optimizer.Optimize(_compiler, AnnotatedBytecode.GetAnnotatedBytecode());
+            _compiler.BytecodeOptimizer.Optimize(AnnotatedBytecode.GetAnnotatedBytecode());
 
             List<ProcArgumentJson>? arguments = null;
             if (_parameters.Count > 0) {

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -14,6 +14,7 @@ using DMCompiler.Compiler;
 using DMCompiler.Compiler.DM.AST;
 using DMCompiler.DM.Builders;
 using DMCompiler.Json;
+using DMCompiler.Optimizer;
 
 namespace DMCompiler;
 
@@ -31,11 +32,13 @@ public class DMCompiler {
     internal readonly DMCodeTree DMCodeTree;
     internal readonly DMObjectTree DMObjectTree;
     internal readonly DMProc GlobalInitProc;
+    internal readonly BytecodeOptimizer BytecodeOptimizer;
 
     public DMCompiler() {
         DMCodeTree = new(this);
         DMObjectTree = new(this);
         GlobalInitProc = new(this, -1, DMObjectTree.Root, null);
+        BytecodeOptimizer = new BytecodeOptimizer(this);
     }
 
     public bool Compile(DMCompilerSettings settings) {

--- a/DMCompiler/Optimizer/BytecodeOptimizer.cs
+++ b/DMCompiler/Optimizer/BytecodeOptimizer.cs
@@ -2,8 +2,10 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace DMCompiler.Optimizer;
 
-public class BytecodeOptimizer {
-    internal void Optimize(DMCompiler compiler, List<IAnnotatedBytecode> input) {
+public class BytecodeOptimizer(DMCompiler compiler) {
+    private readonly PeepholeOptimizer _peepholeOptimizer = new(compiler);
+
+    internal void Optimize(List<IAnnotatedBytecode> input) {
         if (input.Count == 0)
             return;
 
@@ -11,10 +13,10 @@ public class BytecodeOptimizer {
         JoinAndForwardLabels(input);
         RemoveUnreferencedLabels(input);
 
-        PeepholeOptimizer.RunPeephole(compiler, input);
+        _peepholeOptimizer.RunPeephole(input);
     }
 
-    private static void RemoveUnreferencedLabels(List<IAnnotatedBytecode> input) {
+    private void RemoveUnreferencedLabels(List<IAnnotatedBytecode> input) {
         Dictionary<string, int> labelReferences = new();
         for (int i = 0; i < input.Count; i++) {
             if (input[i] is AnnotatedBytecodeLabel label) {
@@ -38,7 +40,7 @@ public class BytecodeOptimizer {
         }
     }
 
-    private static void JoinAndForwardLabels(List<IAnnotatedBytecode> input) {
+    private void JoinAndForwardLabels(List<IAnnotatedBytecode> input) {
         Dictionary<string, string> labelAliases = new();
         for (int i = 0; i < input.Count; i++) {
             if (input[i] is AnnotatedBytecodeLabel label) {
@@ -74,7 +76,7 @@ public class BytecodeOptimizer {
         }
     }
 
-    private static bool TryGetLabelName(AnnotatedBytecodeInstruction instruction, [NotNullWhen(true)] out string? labelName) {
+    private bool TryGetLabelName(AnnotatedBytecodeInstruction instruction, [NotNullWhen(true)] out string? labelName) {
         foreach (var arg in instruction.GetArgs()) {
             if (arg is not AnnotatedBytecodeLabel label)
                 continue;

--- a/DMCompiler/Optimizer/PeepholeOptimizer.cs
+++ b/DMCompiler/Optimizer/PeepholeOptimizer.cs
@@ -40,6 +40,7 @@ internal enum OptPass : byte {
 
 // ReSharper disable once ClassNeverInstantiated.Global
 internal sealed class PeepholeOptimizer {
+    private readonly DMCompiler _compiler;
     private class OptimizationTreeEntry {
         public IOptimization? Optimization;
         public Dictionary<DreamProcOpcode, OptimizationTreeEntry>? Children;
@@ -48,14 +49,15 @@ internal sealed class PeepholeOptimizer {
     /// <summary>
     /// The optimization passes in the order that they run
     /// </summary>
-    private static readonly OptPass[] Passes;
+    private readonly OptPass[] Passes;
 
     /// <summary>
     /// Trees matching chains of opcodes to peephole optimizations
     /// </summary>
-    private static readonly Dictionary<DreamProcOpcode, OptimizationTreeEntry>[] OptimizationTrees;
+    private readonly Dictionary<DreamProcOpcode, OptimizationTreeEntry>[] OptimizationTrees;
 
-    static PeepholeOptimizer() {
+    public PeepholeOptimizer(DMCompiler compiler) {
+        _compiler = compiler;
         Passes = (OptPass[])Enum.GetValues(typeof(OptPass));
         OptimizationTrees = new Dictionary<DreamProcOpcode, OptimizationTreeEntry>[Passes.Length];
         for (int i = 0; i < OptimizationTrees.Length; i++) {
@@ -64,7 +66,7 @@ internal sealed class PeepholeOptimizer {
     }
 
     /// Setup <see cref="OptimizationTrees"/> for each <see cref="OptPass"/>
-    private static void GetOptimizations(DMCompiler compiler) {
+    private void GetOptimizations() {
         foreach (var optType in typeof(IOptimization).Assembly.GetTypes()) {
             if (!typeof(IOptimization).IsAssignableFrom(optType) ||
                 optType is not { IsClass: true, IsAbstract: false })
@@ -74,7 +76,7 @@ internal sealed class PeepholeOptimizer {
 
             var opcodes = opt.GetOpcodes();
             if (opcodes.Length < 2) {
-                compiler.ForcedError(Location.Internal,
+                _compiler.ForcedError(Location.Internal,
                     $"Peephole optimization {optType} must have at least 2 opcodes");
                 continue;
             }
@@ -103,14 +105,14 @@ internal sealed class PeepholeOptimizer {
         }
     }
 
-    public static void RunPeephole(DMCompiler compiler, List<IAnnotatedBytecode> input) {
-        GetOptimizations(compiler);
+    public void RunPeephole(List<IAnnotatedBytecode> input) {
+        GetOptimizations();
         foreach (var optPass in Passes) {
-            RunPass(compiler, (byte)optPass, input);
+            RunPass((byte)optPass, input);
         }
     }
 
-    private static void RunPass(DMCompiler compiler, byte pass, List<IAnnotatedBytecode> input) {
+    private void RunPass(byte pass, List<IAnnotatedBytecode> input) {
         OptimizationTreeEntry? currentOpt = null;
         int optSize = 0;
 
@@ -121,7 +123,7 @@ internal sealed class PeepholeOptimizer {
             int offset;
 
             if (currentOpt.Optimization?.CheckPreconditions(input, i - optSize) is true) {
-                currentOpt.Optimization.Apply(compiler, input, i - optSize);
+                currentOpt.Optimization.Apply(_compiler, input, i - optSize);
                 offset = (optSize + 2); // Run over the new opcodes for potential further optimization
             } else {
                 // This chain of opcodes did not lead to a valid optimization.


### PR DESCRIPTION
- Stops instantiating a `BytecodeOptimizer` class for every proc. One is now instantiated on `DMCompiler` and shared.
- `PeepholeOptimizer.GetOptimizations()` avoids allocating a huge list and instead just merges the first loop into the second.
- Removes `static` from the peephole optimizer. A single instance of the class is instantiated on the `BytecodeOptimizer`.