### PR TITLE
Fix off-by-one in regex replace and add test

### DIFF
--- a/Content.Tests/DMProject/Tests/Regex/regex_find_replace.dm
+++ b/Content.Tests/DMProject/Tests/Regex/regex_find_replace.dm
@@ -1,0 +1,18 @@
+var/models = "/obj/cable/brown{\n\ticon_state = \"2-8\"\n\t},\n/obj/cable/brown{\n\ticon_state = \"4-8\"\n\t},\n/turf/simulated/floor/orangeblack,\n/area/station/devzone"
+var/result_match = "/obj/cable/brown{\n\ticon_state = \"1\"\n\t},\n/obj/cable/brown{\n\ticon_state = \"2\"\n\t},\n/turf/simulated/floor/orangeblack,\n/area/station/devzone"
+
+/proc/RunTest()
+	var/list/originalStrings = list()
+	var/regex/noStrings = regex(@{"(["])(?:(?=(\\?))\2(.|\n))*?\1"})
+	var/stringIndex = 1
+	var/found
+	do
+		found = noStrings.Find(models, noStrings.next)
+		if(found)
+			var indexText = {""[stringIndex]""}
+			stringIndex++
+			var match = copytext(noStrings.match, 2, -1) // Strip quotes
+			models = noStrings.Replace(models, indexText, found)
+			originalStrings[indexText] = (match)
+	while(found)
+	ASSERT(models == result_match)

--- a/Content.Tests/DMProject/Tests/Regex/regex_find_replace.dm
+++ b/Content.Tests/DMProject/Tests/Regex/regex_find_replace.dm
@@ -16,3 +16,5 @@ var/result_match = "/obj/cable/brown{\n\ticon_state = \"1\"\n\t},\n/obj/cable/br
 			originalStrings[indexText] = (match)
 	while(found)
 	ASSERT(models == result_match)
+	ASSERT(originalStrings ~= list("\"1\"" = "2-8", "\"2\"" = "4-8"))
+	ASSERT(stringIndex == 3)

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
@@ -117,7 +117,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 if(!regex.IsGlobal) {
                     var match = regex.Regex.Match(haystackString, Math.Clamp(start - 1, 0, haystackSubstring.Length));
                     if (!match.Success) return new DreamValue(haystackString);
-                    regexInstance.SetVariable("next", new DreamValue(match.Index + Math.Max(replacement.Length, 1)));
+                    regexInstance.SetVariable("next", new DreamValue(match.Index + Math.Max(replacement.Length, 1) + 1));
                 }
 
                 string replaced = regex.Regex.Replace(haystackSubstring, replacement, regex.IsGlobal ? -1 : 1,


### PR DESCRIPTION
This was subtly breaking DMM suite when there was a cell with more than one var-edited string var, which caused **one** tile to fail to load properly on goon and made the nuclear reactor control computer not work on devtest.

What a ride that was.