### PR TITLE
Fix atom name/desc not copying on appearance set

### DIFF
--- a/Content.Tests/DMProject/Tests/Image/appearance.dm
+++ b/Content.Tests/DMProject/Tests/Image/appearance.dm
@@ -1,0 +1,10 @@
+/obj/thingtocopy
+    name = "hello"
+    desc = "this is a thing"
+
+/proc/RunTest()
+    var/obj/thingtocopy/T = new()
+    var/obj/otherthing = new()
+    otherthing.appearance = T.appearance
+    ASSERT(otherthing.name == T.name)
+    ASSERT(otherthing.desc == T.desc)

--- a/OpenDreamClient/Interface/DebugWindows/IconDebugWindow.xaml.cs
+++ b/OpenDreamClient/Interface/DebugWindows/IconDebugWindow.xaml.cs
@@ -45,6 +45,7 @@ internal sealed partial class IconDebugWindow : OSWindow {
         // Would be nice if we could use ViewVariables instead, but I couldn't find a nice way to do that
         // Would be especially nice if we could use VV to make these editable
         AddPropertyIfNotDefault("Name", appearance.Name, IconAppearance.Default.Name);
+        AddPropertyIfNotDefault("Desc", appearance.Desc, IconAppearance.Default.Desc);
         AddPropertyIfNotDefault("Icon State", appearance.IconState, IconAppearance.Default.IconState);
         AddPropertyIfNotDefault("Direction", appearance.Direction, IconAppearance.Default.Direction);
         AddPropertyIfNotDefault("Inherits Direction", appearance.InheritsDirection, IconAppearance.Default.InheritsDirection);

--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -209,6 +209,7 @@ public sealed class AtomManager {
     public bool IsValidAppearanceVar(string name) {
         switch (name) {
             case "name":
+            case "desc":
             case "icon":
             case "icon_state":
             case "dir":
@@ -247,6 +248,10 @@ public sealed class AtomManager {
             case "name":
                 value.TryGetValueAsString(out var name);
                 appearance.Name = name ?? string.Empty;
+                break;
+            case "desc":
+                value.TryGetValueAsString(out var desc);
+                appearance.Desc = desc ?? string.Empty;
                 break;
             case "icon":
                 if (_resourceManager.TryLoadIcon(value, out var icon)) {
@@ -387,6 +392,8 @@ public sealed class AtomManager {
         switch (varName) {
             case "name":
                 return new(appearance.Name);
+            case "desc":
+                return new(appearance.Desc);
             case "icon":
                 if (appearance.Icon == null)
                     return DreamValue.Null;
@@ -589,6 +596,7 @@ public sealed class AtomManager {
             return appearance;
 
         def.TryGetVariable("name", out var nameVar);
+        def.TryGetVariable("desc", out var descVar);
         def.TryGetVariable("icon", out var iconVar);
         def.TryGetVariable("icon_state", out var stateVar);
         def.TryGetVariable("color", out var colorVar);
@@ -609,6 +617,7 @@ public sealed class AtomManager {
 
         appearance = new IconAppearance();
         SetAppearanceVar(appearance, "name", nameVar);
+        SetAppearanceVar(appearance, "desc", descVar);
         SetAppearanceVar(appearance, "icon", iconVar);
         SetAppearanceVar(appearance, "icon_state", stateVar);
         SetAppearanceVar(appearance, "color", colorVar);

--- a/OpenDreamRuntime/Objects/DreamObject.cs
+++ b/OpenDreamRuntime/Objects/DreamObject.cs
@@ -13,6 +13,7 @@ using Robust.Server.Player;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Utility;
+using System.ComponentModel;
 
 namespace OpenDreamRuntime.Objects {
     [Virtual]

--- a/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
@@ -5,7 +5,6 @@ namespace OpenDreamRuntime.Objects.Types;
 
 [Virtual]
 public class DreamObjectAtom : DreamObject {
-    public string? Name;
     public string? Desc;
     public readonly DreamOverlaysList Overlays;
     public readonly DreamOverlaysList Underlays;
@@ -22,11 +21,6 @@ public class DreamObjectAtom : DreamObject {
         AtomManager.AddAtom(this);
     }
 
-    public override void Initialize(DreamProcArguments args) {
-        ObjectDefinition.Variables["name"].TryGetValueAsString(out Name);
-        ObjectDefinition.Variables["desc"].TryGetValueAsString(out Desc);
-    }
-
     protected override void HandleDeletion(bool possiblyThreaded) {
         // SAFETY: RemoveAtom is not threadsafe.
         if (possiblyThreaded) {
@@ -37,6 +31,12 @@ public class DreamObjectAtom : DreamObject {
         AtomManager.RemoveAtom(this);
 
         base.HandleDeletion(possiblyThreaded);
+    }
+    public string GetDesc() {
+        if (!TryGetVariable("desc", out DreamValue descVar) || !descVar.TryGetValueAsString(out string? desc))
+            return ObjectDefinition.Type.ToString();
+
+        return desc;
     }
 
     protected override bool TryGetVar(string varName, out DreamValue value) {
@@ -49,13 +49,6 @@ public class DreamObjectAtom : DreamObject {
                 return true;
             case "loc":
                 value = DreamValue.Null;
-                return true;
-
-            case "name":
-                value = (Name != null) ? new(Name) : DreamValue.Null;
-                return true;
-            case "desc":
-                value = (Desc != null) ? new(Desc) : DreamValue.Null;
                 return true;
             case "appearance":
                 var appearanceCopy = new IconAppearance(AtomManager.MustGetAppearance(this)!);
@@ -101,13 +94,6 @@ public class DreamObjectAtom : DreamObject {
             case "y":
             case "z":
             case "loc":
-                break;
-
-            case "name":
-                value.TryGetValueAsString(out Name);
-                break;
-            case "desc":
-                value.TryGetValueAsString(out Desc);
                 break;
             case "appearance":
                 if (!AtomManager.TryCreateAppearanceFrom(value, out var newAppearance))

--- a/OpenDreamRuntime/Objects/Types/DreamObjectMovable.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectMovable.cs
@@ -49,7 +49,7 @@ public class DreamObjectMovable : DreamObjectAtom {
 
         if (EntityManager.TryGetComponent(Entity, out MetaDataComponent? metaData)) {
             MetaDataSystem?.SetEntityName(Entity, GetDisplayName(), metaData);
-            MetaDataSystem?.SetEntityDescription(Entity, Desc ?? string.Empty, metaData);
+            MetaDataSystem?.SetEntityDescription(Entity, GetDesc(), metaData);
         }
 
         args.GetArgument(0).TryGetValueAsDreamObject<DreamObjectAtom>(out var loc);

--- a/OpenDreamShared/Dream/IconAppearance.cs
+++ b/OpenDreamShared/Dream/IconAppearance.cs
@@ -24,6 +24,7 @@ public sealed class IconAppearance : IEquatable<IconAppearance> {
     public static readonly IconAppearance Default = new();
 
     [ViewVariables] public string Name = string.Empty;
+    [ViewVariables] public string Desc = string.Empty;
     [ViewVariables] public int? Icon;
     [ViewVariables] public string? IconState;
     [ViewVariables] public AtomDirection Direction = AtomDirection.South;
@@ -82,6 +83,7 @@ public sealed class IconAppearance : IEquatable<IconAppearance> {
 
     public IconAppearance(IconAppearance appearance) {
         Name = appearance.Name;
+        Desc = appearance.Desc;
         Icon = appearance.Icon;
         IconState = appearance.IconState;
         Direction = appearance.Direction;
@@ -119,6 +121,7 @@ public sealed class IconAppearance : IEquatable<IconAppearance> {
         if (appearance == null) return false;
 
         if (appearance.Name != Name) return false;
+        if (appearance.Desc != Desc) return false;
         if (appearance.Icon != Icon) return false;
         if (appearance.IconState != IconState) return false;
         if (appearance.Direction != Direction) return false;
@@ -207,6 +210,7 @@ public sealed class IconAppearance : IEquatable<IconAppearance> {
         HashCode hashCode = new HashCode();
 
         hashCode.Add(Name);
+        hashCode.Add(Desc);
         hashCode.Add(Icon);
         hashCode.Add(IconState);
         hashCode.Add(Direction);

--- a/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
+++ b/OpenDreamShared/Network/Messages/MsgAllAppearances.cs
@@ -14,6 +14,7 @@ public sealed class MsgAllAppearances(Dictionary<int, IconAppearance> allAppeara
 
     private enum Property : byte {
         Name,
+        Desc,
         Icon,
         IconState,
         Direction,
@@ -65,6 +66,9 @@ public sealed class MsgAllAppearances(Dictionary<int, IconAppearance> allAppeara
                 switch (property) {
                     case Property.Name:
                         appearance.Name = buffer.ReadString();
+                        break;
+                    case Property.Desc:
+                        appearance.Desc = buffer.ReadString();
                         break;
                     case Property.Id:
                         appearanceId = buffer.ReadVariableInt32();
@@ -228,6 +232,11 @@ public sealed class MsgAllAppearances(Dictionary<int, IconAppearance> allAppeara
             if (appearance.Name != IconAppearance.Default.Name) {
                 buffer.Write((byte)Property.Name);
                 buffer.Write(appearance.Name);
+            }
+
+            if (appearance.Desc != IconAppearance.Default.Desc) {
+                buffer.Write((byte)Property.Desc);
+                buffer.Write(appearance.Desc);
             }
 
             if (appearance.Icon != null) {


### PR DESCRIPTION
Fixes #2107 by adding a desc var to appearances and changing atom var access methods to always defer to appearance.
There's a warning on the `IconAppearance` class that begins "Woe, weary traveler" so hopefully I've done all the steps right to avoid doom or whatever.
Includes a DM test to hopefully prove it works.