### PR TITLE
Remove the submodule dependencies thing

### DIFF
--- a/.github/workflows/compiler-test.yml
+++ b/.github/workflows/compiler-test.yml
@@ -18,8 +18,6 @@ jobs:
       run: |
         cd main/
         git submodule update --init --recursive
-    - name: Pull engine updates
-      uses: space-wizards/submodule-dependency@v0.1.5
     - name: Update Engine Submodules
       run: |
         cd main/RobustToolbox/


### PR DESCRIPTION
Apparently writing "requires X" in a PR desc will make it try to pull that PR for the submodule, but it doesn't seem to work.