### PR TITLE
Implement `usr << link()`

### DIFF
--- a/DMCompiler/Bytecode/DreamProcOpcode.cs
+++ b/DMCompiler/Bytecode/DreamProcOpcode.cs
@@ -132,7 +132,8 @@ public enum DreamProcOpcode : byte {
     [OpcodeMetadata(-1)]
     Power = 0x42,
     //0x43,
-    //0x44
+    [OpcodeMetadata(-2)]
+    Link = 0x44,
     [OpcodeMetadata(-3, OpcodeArgType.TypeId)]
     Prompt = 0x45,
     [OpcodeMetadata(-3)]

--- a/DMCompiler/Compiler/DM/AST/DMAST.ProcStatements.cs
+++ b/DMCompiler/Compiler/DM/AST/DMAST.ProcStatements.cs
@@ -191,6 +191,14 @@ public sealed class DMASTProcStatementOutputControl(
     public DMASTExpression Control = control;
 }
 
+public sealed class DMASTProcStatementLink(
+    Location location,
+    DMASTExpression receiver,
+    DMASTExpression url) : DMASTProcStatement(location) {
+    public readonly DMASTExpression Receiver = receiver;
+    public readonly DMASTExpression Url = url;
+}
+
 public sealed class DMASTProcStatementFtp(
     Location location,
     DMASTExpression receiver,

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -725,6 +725,16 @@ namespace DMCompiler.Compiler.DM {
                                     DMASTExpression control = procCall.Parameters[1].Value;
                                     return new DMASTProcStatementOutputControl(loc, leftShift.LHS, msg, control);
                                 }
+                                case "link": {
+                                    if (procCall.Parameters.Length != 1) {
+                                        Emit(WarningCode.InvalidArgumentCount, procCall.Location,
+                                            "link() requires 1 parameter");
+                                        return new DMASTInvalidProcStatement(procCall.Location);
+                                    }
+
+                                    DMASTExpression url = procCall.Parameters[0].Value;
+                                    return new DMASTProcStatementLink(loc, leftShift.LHS, url);
+                                }
                                 case "ftp": {
                                     if (procCall.Parameters.Length is not 1 and not 2) {
                                         Emit(WarningCode.InvalidArgumentCount, procCall.Location,

--- a/DMCompiler/DM/Builders/DMProcBuilder.cs
+++ b/DMCompiler/DM/Builders/DMProcBuilder.cs
@@ -101,6 +101,7 @@ namespace DMCompiler.DM.Builders {
                 case DMASTProcStatementBrowse statementBrowse: ProcessStatementBrowse(statementBrowse); break;
                 case DMASTProcStatementBrowseResource statementBrowseResource: ProcessStatementBrowseResource(statementBrowseResource); break;
                 case DMASTProcStatementOutputControl statementOutputControl: ProcessStatementOutputControl(statementOutputControl); break;
+                case DMASTProcStatementLink statementLink: ProcessStatementLink(statementLink); break;
                 case DMASTProcStatementFtp statementFtp: ProcessStatementFtp(statementFtp); break;
                 case DMASTProcStatementOutput statementOutput: ProcessStatementOutput(statementOutput); break;
                 case DMASTProcStatementInput statementInput: ProcessStatementInput(statementInput); break;
@@ -891,6 +892,12 @@ namespace DMCompiler.DM.Builders {
             _exprBuilder.Emit(statementOutputControl.Message);
             _exprBuilder.Emit(statementOutputControl.Control);
             proc.OutputControl();
+        }
+
+        public void ProcessStatementLink(DMASTProcStatementLink statementLink) {
+            _exprBuilder.Emit(statementLink.Receiver);
+            _exprBuilder.Emit(statementLink.Url);
+            proc.Link();
         }
 
         public void ProcessStatementFtp(DMASTProcStatementFtp statementFtp) {

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -479,6 +479,10 @@ namespace DMCompiler.DM {
             WriteOpcode(DreamProcOpcode.OutputControl);
         }
 
+        public void Link() {
+            WriteOpcode(DreamProcOpcode.Link);
+        }
+
         public void Ftp() {
             WriteOpcode(DreamProcOpcode.Ftp);
         }

--- a/DMCompiler/DMStandard/UnsortedAdditions.dm
+++ b/DMCompiler/DMStandard/UnsortedAdditions.dm
@@ -22,8 +22,6 @@
 	set opendream_unimplemented = TRUE
 /proc/issaved(v)
 	set opendream_unimplemented = TRUE
-/proc/link(url)
-	set opendream_unimplemented = TRUE
 /proc/load_resource(File)
 	set opendream_unimplemented = TRUE
 proc/missile(Type, Start, End)

--- a/OpenDream.sln.DotSettings
+++ b/OpenDream.sln.DotSettings
@@ -4,6 +4,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MissingBlankLines/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantBlankLines/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseCollectionExpression/@EntryIndexedValue">NONE</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PreferConcreteValueOverDefault/@EntryIndexedValue">NONE</s:String>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/BLANK_LINES_AROUND_SINGLE_LINE_TYPE/@EntryValue">0</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_CODE/@EntryValue">1</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_DECLARATIONS/@EntryValue">1</s:Int64>

--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -471,6 +471,19 @@ public sealed class DreamConnection {
     }
 
     /// <summary>
+    /// Sends a URL to the client to open.
+    /// Can be a website, a topic call, or another server to connect to.
+    /// </summary>
+    /// <param name="url">URL to open on the client's side</param>
+    public void SendLink(string url) {
+        var msg = new MsgLink {
+            Url = url
+        };
+
+        Session?.Channel.SendMessage(msg);
+    }
+
+    /// <summary>
     /// Prompts the user to save a file to disk
     /// </summary>
     /// <param name="file">File to save</param>

--- a/OpenDreamRuntime/DreamManager.Connections.cs
+++ b/OpenDreamRuntime/DreamManager.Connections.cs
@@ -65,6 +65,7 @@ namespace OpenDreamRuntime {
             _netManager.RegisterNetMessage<MsgWinClone>();
             _netManager.RegisterNetMessage<MsgWinExists>();
             _netManager.RegisterNetMessage<MsgWinGet>();
+            _netManager.RegisterNetMessage<MsgLink>();
             _netManager.RegisterNetMessage<MsgFtp>();
             _netManager.RegisterNetMessage<MsgLoadInterface>();
             _netManager.RegisterNetMessage<MsgAckLoadInterface>(RxAckLoadInterface);

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -2512,6 +2512,27 @@ namespace OpenDreamRuntime.Procs {
             return ProcStatus.Called;
         }
 
+        public static ProcStatus Link(DMProcState state) {
+            DreamValue url = state.Pop();
+            if (!state.Pop().TryGetValueAsDreamObject(out var receiver) || receiver == null)
+                return ProcStatus.Continue;
+
+            DreamConnection? connection = receiver switch {
+                DreamObjectMob receiverMob => receiverMob.Connection,
+                DreamObjectClient receiverClient => receiverClient.Connection,
+                _ => throw new Exception("Invalid link() recipient")
+            };
+
+            if (!url.TryGetValueAsString(out var urlStr)) {
+                throw new Exception($"Invalid link() url: {url}");
+            } else if (string.IsNullOrWhiteSpace(urlStr)) {
+                return ProcStatus.Continue;
+            }
+
+            connection?.SendLink(urlStr);
+            return ProcStatus.Continue;
+        }
+
         public static ProcStatus Ftp(DMProcState state) {
             DreamValue name = state.Pop();
             DreamValue file = state.Pop();

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -247,6 +247,7 @@ namespace OpenDreamRuntime.Procs {
             {DreamProcOpcode.CreateFilteredListEnumerator, DMOpcodeHandlers.CreateFilteredListEnumerator},
             {DreamProcOpcode.Power, DMOpcodeHandlers.Power},
             {DreamProcOpcode.Prompt, DMOpcodeHandlers.Prompt},
+            {DreamProcOpcode.Link, DMOpcodeHandlers.Link},
             {DreamProcOpcode.Ftp, DMOpcodeHandlers.Ftp},
             {DreamProcOpcode.Initial, DMOpcodeHandlers.Initial},
             {DreamProcOpcode.IsType, DMOpcodeHandlers.IsType},

--- a/OpenDreamShared/Network/Messages/MsgLink.cs
+++ b/OpenDreamShared/Network/Messages/MsgLink.cs
@@ -1,23 +1,20 @@
-﻿using Lidgren.Network;
+using Lidgren.Network;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
 namespace OpenDreamShared.Network.Messages;
 
-public sealed class MsgFtp : NetMessage {
+public sealed class MsgLink : NetMessage {
     public override MsgGroups MsgGroup => MsgGroups.EntityEvent;
     public override NetDeliveryMethod DeliveryMethod => NetDeliveryMethod.ReliableUnordered;
 
-    public int ResourceId;
-    public string SuggestedName = string.Empty;
+    public string Url = string.Empty;
 
     public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer) {
-        ResourceId = buffer.ReadInt32();
-        SuggestedName = buffer.ReadString();
+        Url = buffer.ReadString();
     }
 
     public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer) {
-        buffer.Write(ResourceId);
-        buffer.Write(SuggestedName);
+        buffer.Write(Url);
     }
 }


### PR DESCRIPTION
Implements enough of `link()` to allow opening website links on a client's machine. This allows the github, forum, and other buttons that most SS13 codebases have to work.

Fixes #193