### PR TITLE
Server hop support in `link()`

### DIFF
--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -41,6 +41,7 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly ITimerManager _timerManager = default!;
     [Dependency] private readonly IUriOpener _uriOpener = default!;
+    [Dependency] private readonly IGameController _gameController = default!;
 
     private readonly ISawmill _sawmill = Logger.GetSawmill("opendream.interface");
 
@@ -270,8 +271,10 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
         // TODO: This can be a topic call or a connection to another server
         if (uri.Scheme is "http" or "https") {
             _uriOpener.OpenUri(message.Url);
+        } else if (uri.Scheme is "ss14" or "ss14s") {
+            _gameController.Redial(message.Url, "link() used to connect to another server.");
         } else {
-            _sawmill.Warning($"Received link \"{message.Url}\" which is being ignored because it's not http or https");
+            _sawmill.Warning($"Received link \"{message.Url}\" which is not supported. Ignoring.");
         }
     }
 

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -268,11 +268,15 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
             return;
         }
 
-        // TODO: This can be a topic call or a connection to another server
+        // TODO: This can be a topic call
+
         if (uri.Scheme is "http" or "https") {
             _uriOpener.OpenUri(message.Url);
         } else if (uri.Scheme is "ss14" or "ss14s") {
-            _gameController.Redial(message.Url, "link() used to connect to another server.");
+            if (_gameController.LaunchState.FromLauncher)
+                _gameController.Redial(message.Url, "link() used to connect to another server.");
+            else
+                _sawmill.Warning("link() only supports connecting to other servers when utilizing the launcher. Ignoring.");
         } else {
             _sawmill.Warning($"Received link \"{message.Url}\" which is not supported. Ignoring.");
         }


### PR DESCRIPTION
In BYOND, calling `link()` with a `byond://` server address will cause the client to connect to that server. Similarly, we now support connecting to other RT/SS14 servers via `ss14://` and `ss14s://`

Note that you _must_ join the initial game via the SS14 launcher for server hop (redial) to work; RT doesn't allow it from e.g. your dev TestGame server that you connected to directly from the client.


https://github.com/user-attachments/assets/f1639e50-e7df-4d0b-a3e3-8ae6736a3541

