### PR TITLE
Fix text box on goon by fixing element lookup

### DIFF
--- a/OpenDreamClient/Interface/Descriptors/InterfaceDescriptor.cs
+++ b/OpenDreamClient/Interface/Descriptors/InterfaceDescriptor.cs
@@ -16,9 +16,9 @@ public sealed class InterfaceDescriptor {
         MenuDescriptors = menuDescriptors;
     }
 
-    public ElementDescriptor? GetElementDescriptor(string name) {
+    public ElementDescriptor? GetElementDescriptor(string id) {
         return WindowDescriptors.Concat<ElementDescriptor>(MacroSetDescriptors)
-            .Concat(MenuDescriptors).FirstOrDefault(descriptor => descriptor.Id.Value == name);
+            .Concat(MenuDescriptors).FirstOrDefault(descriptor => descriptor.Id.Value == id);
     }
 }
 

--- a/OpenDreamClient/Interface/Descriptors/InterfaceDescriptor.cs
+++ b/OpenDreamClient/Interface/Descriptors/InterfaceDescriptor.cs
@@ -18,7 +18,7 @@ public sealed class InterfaceDescriptor {
 
     public ElementDescriptor? GetElementDescriptor(string name) {
         return WindowDescriptors.Concat<ElementDescriptor>(MacroSetDescriptors)
-            .Concat(MenuDescriptors).FirstOrDefault(descriptor => descriptor.Name.Value == name);
+            .Concat(MenuDescriptors).FirstOrDefault(descriptor => descriptor.Id.Value == name);
     }
 }
 


### PR DESCRIPTION
`winclone()` was failing because lookup was failing because we were using `Name` instead of `Id` for the search.
![image](https://github.com/user-attachments/assets/551d54a2-a7cc-4e40-b52d-cd2215546ea0)
