### PR TITLE
Fix empty braced object blocks and add null object statements

### DIFF
--- a/DMCompiler/Compiler/DM/AST/DMAST.ObjectStatements.cs
+++ b/DMCompiler/Compiler/DM/AST/DMAST.ObjectStatements.cs
@@ -7,6 +7,9 @@ namespace DMCompiler.Compiler.DM.AST;
 /// </summary>
 public abstract class DMASTStatement(Location location) : DMASTNode(location);
 
+/// Lone semicolon, statement containing nothing
+public sealed class DMASTNullStatement(Location location) : DMASTStatement(location);
+
 public sealed class DMASTObjectDefinition(Location location, DreamPath path, DMASTBlockInner? innerBlock)
     : DMASTStatement(location) {
     /// <summary> Unlike other Path variables stored by AST nodes, this path is guaranteed to be the real, absolute path of this object definition block. <br/>

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -203,6 +203,11 @@ namespace DMCompiler.Compiler.DM {
         protected DMASTStatement? Statement() {
             var loc = CurrentLoc;
 
+            if (Current().Type == TokenType.DM_Semicolon) { // A lone semicolon creates a "null statement" (like C)
+                // Note that we do not consume the semicolon here
+                return new DMASTNullStatement(loc);
+            }
+
             DMASTPath? path = Path();
             if (path is null)
                 return null;
@@ -517,7 +522,7 @@ namespace DMCompiler.Compiler.DM {
                 Newline();
                 Consume(TokenType.DM_RightCurlyBracket, "Expected '}'");
 
-                return new DMASTBlockInner(loc, blockInner.ToArray());
+                return new DMASTBlockInner(loc, blockInner?.ToArray() ?? []);
             }
 
             return null;

--- a/DMCompiler/DM/Builders/DMCodeTreeBuilder.cs
+++ b/DMCompiler/DM/Builders/DMCodeTreeBuilder.cs
@@ -40,6 +40,9 @@ internal class DMCodeTreeBuilder(DMCompiler compiler) {
         }
 
         switch (statement) {
+            case DMASTInvalidStatement: // An error should have been emitted by whatever made this
+            case DMASTNullStatement:
+                break;
             case DMASTObjectDefinition objectDefinition:
                 CodeTree.AddType(objectDefinition.Path);
                 if (objectDefinition.InnerBlock != null)


### PR DESCRIPTION
Fixes these two scenarios:
```dm
/type { }
```
```dm
/type {; a = b}
```