### PR TITLE
Fix `AssignAndPushReferenceValue` ignoring var value coercion

### DIFF
--- a/DMCompiler/Optimizer/PeepholeOptimizations.cs
+++ b/DMCompiler/Optimizer/PeepholeOptimizations.cs
@@ -638,6 +638,11 @@ internal sealed class AssignAndPushReferenceValue : IOptimization {
         AnnotatedBytecodeReference assignTarget = firstInstruction.GetArg<AnnotatedBytecodeReference>(0);
         AnnotatedBytecodeReference pushTarget = secondInstruction.GetArg<AnnotatedBytecodeReference>(0);
 
+        // Assigning certain values to certain vars (e.g. setting a SrcField like "dir" to null)
+        // actually causes the value to be coerced to something different than the value on the stack.
+        // We don't have a good way to identify those vars at this point, so just restrict the opt to locals and args since those shouldn't have side effects
+        if (pushTarget.RefType != DMReference.Type.Local && pushTarget.RefType != DMReference.Type.Argument) return false;
+
         return assignTarget.Equals(pushTarget);
     }
 


### PR DESCRIPTION
This still allows the optimization to apply in most cases and also fixes https://github.com/OpenDreamProject/OpenDream/issues/2188

I disassembled the bytecode of the example and confirmed the optimization is no longer applied in that case.