### PR TITLE
Fix a crash with invalid `FILE_DIR` defines

### DIFF
--- a/DMCompiler/Compiler/CompilerError.cs
+++ b/DMCompiler/Compiler/CompilerError.cs
@@ -33,6 +33,7 @@ public enum WarningCode {
     FileAlreadyIncluded = 1000,
     MissingIncludedFile = 1001,
     InvalidWarningCode = 1002,
+    InvalidFileDirDefine = 1003,
     MisplacedDirective = 1100,
     UndefineMissingDirective = 1101,
     DefinedMissingParen = 1150,

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -304,7 +304,7 @@ internal sealed class DMPreprocessor(DMCompiler compiler, bool enableDirectives)
 
             DMPreprocessorLexer currentLexer = _lexerStack.Peek();
             string dir = Path.Combine(currentLexer.IncludeDirectory, dirTokenValue);
-            compiler.AddResourceDirectory(dir);
+            compiler.AddResourceDirectory(dir, dirToken.Location);
 
             // In BYOND it goes on to set the FILE_DIR macro's value to the added directory
             // I don't see any reason to do that

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -101,10 +101,8 @@ public class DMCompiler {
     public void AddResourceDirectory(string dir, Location loc) {
         dir = dir.Replace('\\', Path.DirectorySeparatorChar);
         if (!Directory.Exists(dir)) {
-            if (!string.IsNullOrWhiteSpace(_codeDirectory))
-                dir = Path.GetRelativePath(_codeDirectory, dir);
-
-            Emit(WarningCode.InvalidFileDirDefine, loc, $"Folder \"{dir}\" does not exist");
+            Emit(WarningCode.InvalidFileDirDefine, loc,
+                $"Folder \"{Path.GetRelativePath(_codeDirectory, dir)}\" does not exist");
             return;
         }
 
@@ -137,7 +135,9 @@ public class DMCompiler {
             }
 
             // Adds the root of the DM project to FILE_DIR
-            _codeDirectory = Path.GetDirectoryName(files[0]) ?? "/";
+            _codeDirectory = Path.GetDirectoryName(files[0]) ?? "";
+            if (string.IsNullOrWhiteSpace(_codeDirectory))
+                _codeDirectory = Path.GetFullPath(".");
             compiler.AddResourceDirectory(_codeDirectory, Location.Internal);
 
             string compilerDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -101,7 +101,10 @@ public class DMCompiler {
     public void AddResourceDirectory(string dir, Location loc) {
         dir = dir.Replace('\\', Path.DirectorySeparatorChar);
         if (!Directory.Exists(dir)) {
-            Emit(WarningCode.InvalidFileDirDefine, loc, $"Folder \"{Path.GetRelativePath(_codeDirectory, dir)}\" does not exist");
+            if (!string.IsNullOrWhiteSpace(_codeDirectory))
+                dir = Path.GetRelativePath(_codeDirectory, dir);
+
+            Emit(WarningCode.InvalidFileDirDefine, loc, $"Folder \"{dir}\" does not exist");
             return;
         }
 

--- a/DMCompiler/DMStandard/DefaultPragmaConfig.dm
+++ b/DMCompiler/DMStandard/DefaultPragmaConfig.dm
@@ -5,6 +5,7 @@
 #pragma FileAlreadyIncluded warning
 #pragma MissingIncludedFile error
 #pragma InvalidWarningCode warning
+#pragma InvalidFileDirDefine warning
 #pragma MisplacedDirective error
 #pragma UndefineMissingDirective warning
 #pragma DefinedMissingParen error


### PR DESCRIPTION
Doing `#define FILE_DIR "nonexistent/folder/"` would cause the compiler to crash when a resource tried to resolve its path. Now it is ignored and emits an `InvalidFileDirDefine` warning.