### PR TITLE
Implement 516 `values_` procs

### DIFF
--- a/Content.Tests/DMProject/Tests/Builtins/values_cut.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/values_cut.dm
@@ -1,25 +1,33 @@
 
 /proc/RunTest()
-	var/list/one = list("a"=1, "b"=2, "c"=-3)
-	ASSERT(values_cut_under(one, 5, 1) == 3)
-	
-	var/list/two = list("a"=1, "b"=2, "c"=0)
-	ASSERT(values_cut_under(two, 1) == 1)
-	
-	var/list/three = list("a"=1, "b"=2, "c"=0)
-	ASSERT(values_cut_under(three, 1, TRUE) == 2)
+    var/list/one = list("a"=1, "b"=2, "c"=-3)
+    ASSERT(values_cut_under(one, 5, 1) == 3)
+    ASSERT(one ~= list())
 
-	var/list/four = list("a"=1, "b"=2, "c"=-3)
-	ASSERT(values_cut_over(four, 5, 1) == 0)
-	
-	var/list/five = list("a"=1, "b"=2, "c"=0)
-	ASSERT(values_cut_over(five, 1) == 1)
-	
-	var/list/six = list("a"=1, "b"=2, "c"=0)
-	ASSERT(values_cut_over(six, 1, TRUE) == 2)
-	
-	var/list/seven = list("a", "b", "c")
-	ASSERT(values_cut_under(seven, -1, 0) == 3)
-	
-	var/list/eight = list("a"=1, "b", "c"=-3)
-	ASSERT(values_cut_under(eight, -1, 0) == 2)
+    var/list/two = list("a"=1, "b"=2, "c"=0)
+    ASSERT(values_cut_under(two, 1) == 1)
+    ASSERT(two ~= list("a"=1, "b"=2))
+
+    var/list/three = list("a"=1, "b"=2, "c"=0)
+    ASSERT(values_cut_under(three, 1, TRUE) == 2)
+    ASSERT(three ~= list("b" = 2))
+
+    var/list/four = list("a"=1, "b"=2, "c"=-3)
+    ASSERT(values_cut_over(four, 5, 1) == 0)
+    ASSERT(four ~= list("a"=1, "b"=2, "c"=-3))
+
+    var/list/five = list("a"=1, "b"=2, "c"=0)
+    ASSERT(values_cut_over(five, 1) == 1)
+    ASSERT(five ~= list("a"=1, "c"=0))
+
+    var/list/six = list("a"=1, "b"=2, "c"=0)
+    ASSERT(values_cut_over(six, 1, TRUE) == 2)
+    ASSERT(six ~= list("c" = 0))
+
+    var/list/seven = list("a", "b", "c")
+    ASSERT(values_cut_under(seven, -1, 0) == 3)
+    ASSERT(seven ~= list())
+
+    var/list/eight = list("a"=1, "b", "c"=-3)
+    ASSERT(values_cut_under(eight, -1, 0) == 2)
+    ASSERT(eight ~= list("a" = 1))

--- a/Content.Tests/DMProject/Tests/Builtins/values_cut.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/values_cut.dm
@@ -1,0 +1,25 @@
+
+/proc/RunTest()
+	var/list/one = list("a"=1, "b"=2, "c"=-3)
+	ASSERT(values_cut_under(one, 5, 1) == 3)
+	
+	var/list/two = list("a"=1, "b"=2, "c"=0)
+	ASSERT(values_cut_under(two, 1) == 1)
+	
+	var/list/three = list("a"=1, "b"=2, "c"=0)
+	ASSERT(values_cut_under(three, 1, TRUE) == 2)
+
+	var/list/four = list("a"=1, "b"=2, "c"=-3)
+	ASSERT(values_cut_over(four, 5, 1) == 0)
+	
+	var/list/five = list("a"=1, "b"=2, "c"=0)
+	ASSERT(values_cut_over(five, 1) == 1)
+	
+	var/list/six = list("a"=1, "b"=2, "c"=0)
+	ASSERT(values_cut_over(six, 1, TRUE) == 2)
+	
+	var/list/seven = list("a", "b", "c")
+	ASSERT(values_cut_under(seven, -1, 0) == 3)
+	
+	var/list/eight = list("a"=1, "b", "c"=-3)
+	ASSERT(values_cut_under(eight, -1, 0) == 2)

--- a/Content.Tests/DMProject/Tests/Builtins/values_dot.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/values_dot.dm
@@ -1,0 +1,5 @@
+
+/proc/RunTest()
+	ASSERT(values_dot(list(a=2.4,b=1,c=7),list(a=2,b=4,c=null)) == 8.8)
+	ASSERT(values_dot(list(),list(a=2,b=4)) == 0)
+	ASSERT(values_dot(list("a"),list(a=2,b=4)) == 0)

--- a/Content.Tests/DMProject/Tests/Builtins/values_product.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/values_product.dm
@@ -1,0 +1,9 @@
+
+/proc/RunTest()
+	ASSERT(values_product(null) == 1)
+	ASSERT(values_product(list(5)) == 1)
+	ASSERT(values_product(list(a=2)) == 2)
+	ASSERT(values_product(list(a=2,b=0)) == 0)
+	ASSERT(values_product(list(a=2,b=null)) == 2)
+	ASSERT(values_product(list(a=2,b=list(c=5))) == 2)
+	ASSERT(values_product(list(a=2,b=4.4)) == 8.8)

--- a/Content.Tests/DMProject/Tests/Builtins/values_sum.dm
+++ b/Content.Tests/DMProject/Tests/Builtins/values_sum.dm
@@ -1,0 +1,9 @@
+
+/proc/RunTest()
+	ASSERT(values_sum(null) == 0)
+	ASSERT(values_sum(list(5)) == 0)
+	ASSERT(values_sum(list(a=2)) == 2)
+	ASSERT(values_sum(list(a=2,b=0)) == 2)
+	ASSERT(values_sum(list(a=2,b=null)) == 2)
+	ASSERT(values_sum(list(a=2,b=list(c=5))) == 2)
+	ASSERT(values_sum(list(a=2,b=4.4)) == 6.4)

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -107,6 +107,7 @@ proc/typesof(Item1) as /list
 proc/uppertext(T as text) as text
 proc/url_decode(UrlText) as text
 proc/url_encode(PlainText, format = 0) as text
+proc/values_dot(A, B) as num
 proc/values_product(Alist) as num
 proc/values_sum(Alist) as num
 proc/view(Dist = 5, Center = usr) as /list

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -107,6 +107,7 @@ proc/typesof(Item1) as /list
 proc/uppertext(T as text) as text
 proc/url_decode(UrlText) as text
 proc/url_encode(PlainText, format = 0) as text
+proc/values_product(Alist) as num
 proc/view(Dist = 5, Center = usr) as /list
 proc/viewers(Depth, Center = usr) as /list
 proc/walk(Ref, Dir, Lag = 0, Speed = 0)

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -107,6 +107,8 @@ proc/typesof(Item1) as /list
 proc/uppertext(T as text) as text
 proc/url_decode(UrlText) as text
 proc/url_encode(PlainText, format = 0) as text
+proc/values_cut_over(Alist, Max, inclusive = 0) as num
+proc/values_cut_under(Alist, Min, inclusive = 0) as num
 proc/values_dot(A, B) as num
 proc/values_product(Alist) as num
 proc/values_sum(Alist) as num

--- a/DMCompiler/DMStandard/_Standard.dm
+++ b/DMCompiler/DMStandard/_Standard.dm
@@ -108,6 +108,7 @@ proc/uppertext(T as text) as text
 proc/url_decode(UrlText) as text
 proc/url_encode(PlainText, format = 0) as text
 proc/values_product(Alist) as num
+proc/values_sum(Alist) as num
 proc/view(Dist = 5, Center = usr) as /list
 proc/viewers(Depth, Center = usr) as /list
 proc/walk(Ref, Dir, Lag = 0, Speed = 0)

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -108,6 +108,7 @@ internal static class DreamProcNative {
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_uppertext);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_url_decode);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_url_encode);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_values_dot);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_values_product);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_values_sum);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_view);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -109,6 +109,7 @@ internal static class DreamProcNative {
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_url_decode);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_url_encode);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_values_product);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_values_sum);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_view);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_viewers);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_walk);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -108,6 +108,7 @@ internal static class DreamProcNative {
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_uppertext);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_url_decode);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_url_encode);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_values_product);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_view);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_viewers);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_walk);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -108,6 +108,8 @@ internal static class DreamProcNative {
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_uppertext);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_url_decode);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_url_encode);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_values_cut_over);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_values_cut_under);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_values_dot);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_values_product);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_values_sum);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -3155,9 +3155,8 @@ internal static class DreamProcNativeRoot {
 
             // Nuke any keys without values
             if (values.Count != assocValues.Count) {
-                // We need to copy the list so we can modify while enumerating
-                var listCopy = new List<DreamValue>(values);
-                foreach (var val in listCopy) {
+                for (var index = 0; index < values.Count; index++) {
+                    var val = values[index];
                     if (!assocValues.ContainsKey(val)) {
                         cutCount += 1;
                         list.RemoveValue(val);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -3108,6 +3108,35 @@ internal static class DreamProcNativeRoot {
         return new DreamValue(HttpUtility.UrlEncode(plainText));
     }
 
+    [DreamProc("values_dot")]
+    [DreamProcParameter("A", Type = DreamValueTypeFlag.DreamObject)]
+    [DreamProcParameter("B", Type = DreamValueTypeFlag.DreamObject)]
+    public static DreamValue NativeProc_values_dot(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
+        if (bundle.Arguments.Length != 2) throw new Exception("expected 2 arguments");
+
+        DreamValue argA = bundle.GetArgument(0, "A");
+        DreamValue argB = bundle.GetArgument(1, "B");
+
+        float sum = 0; // Default return is 0 for invalid args
+
+        if (argA.TryGetValueAsDreamList(out var listA) && listA.IsAssociative && argB.TryGetValueAsDreamList(out var listB) && listB.IsAssociative) {
+            var aValues = listA.GetAssociativeValues();
+            var bValues = listB.GetAssociativeValues();
+
+            // sum += valueA * valueB
+            // for each assoc value whose key exists in both lists
+            // and when both assoc values are floats
+            foreach (var (key,value) in aValues) {
+                if (value.TryGetValueAsFloat(out var aFloat) && bValues.TryGetValue(key, out var bVal) &&
+                    bVal.TryGetValueAsFloat(out var bFloat)) {
+                    sum += (aFloat * bFloat);
+                }
+            }
+        }
+
+        return new DreamValue(sum);
+    }
+
     [DreamProc("values_product")]
     [DreamProcParameter("Alist", Type = DreamValueTypeFlag.DreamObject)]
     public static DreamValue NativeProc_values_product(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -3117,7 +3117,7 @@ internal static class DreamProcNativeRoot {
 
         float product = 1; // Default return is 1 for invalid args
 
-        if (arg.TryGetValueAsDreamList(out var list)) {
+        if (arg.TryGetValueAsDreamList(out var list) && list.IsAssociative) {
             var assocValues = list.GetAssociativeValues();
             foreach (var (_,value) in assocValues) {
                 if(value.TryGetValueAsFloat(out var valFloat)) product *= valFloat;
@@ -3125,6 +3125,25 @@ internal static class DreamProcNativeRoot {
         }
 
         return new DreamValue(product);
+    }
+
+    [DreamProc("values_sum")]
+    [DreamProcParameter("Alist", Type = DreamValueTypeFlag.DreamObject)]
+    public static DreamValue NativeProc_values_sum(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
+        if (bundle.Arguments.Length != 1) throw new Exception("expected 1 argument");
+
+        DreamValue arg = bundle.GetArgument(0, "Alist");
+
+        float sum = 0; // Default return is 0 for invalid args
+
+        if (arg.TryGetValueAsDreamList(out var list) && list.IsAssociative) {
+            var assocValues = list.GetAssociativeValues();
+            foreach (var (_,value) in assocValues) {
+                if(value.TryGetValueAsFloat(out var valFloat)) sum += valFloat;
+            }
+        }
+
+        return new DreamValue(sum);
     }
 
     [DreamProc("view")]

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -3167,8 +3167,7 @@ internal static class DreamProcNativeRoot {
 
             foreach (var (key,value) in assocValues) {
                 if (value.TryGetValueAsFloat(out var valFloat)) {
-                    switch (inclusive)
-                    {
+                    switch (inclusive) {
                         case true when under && valFloat <= min:
                         case true when !under && valFloat >= min:
                         case false when under && valFloat < min:

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -3159,6 +3159,7 @@ internal static class DreamProcNativeRoot {
                     var val = values[index];
                     if (!assocValues.ContainsKey(val)) {
                         cutCount += 1;
+                        index -= 1;
                         list.RemoveValue(val);
                     }
                 }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -3108,6 +3108,25 @@ internal static class DreamProcNativeRoot {
         return new DreamValue(HttpUtility.UrlEncode(plainText));
     }
 
+    [DreamProc("values_product")]
+    [DreamProcParameter("Alist", Type = DreamValueTypeFlag.DreamObject)]
+    public static DreamValue NativeProc_values_product(NativeProc.Bundle bundle, DreamObject? src, DreamObject? usr) {
+        if (bundle.Arguments.Length != 1) throw new Exception("expected 1 argument");
+
+        DreamValue arg = bundle.GetArgument(0, "Alist");
+
+        float product = 1; // Default return is 1 for invalid args
+
+        if (arg.TryGetValueAsDreamList(out var list)) {
+            var assocValues = list.GetAssociativeValues();
+            foreach (var (_,value) in assocValues) {
+                if(value.TryGetValueAsFloat(out var valFloat)) product *= valFloat;
+            }
+        }
+
+        return new DreamValue(product);
+    }
+
     [DreamProc("view")]
     [DreamProcParameter("Dist", Type = DreamValueTypeFlag.Float, DefaultValue = 5)]
     [DreamProcParameter("Center", Type = DreamValueTypeFlag.DreamObject)]

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -3179,6 +3179,7 @@ internal static class DreamProcNativeRoot {
                     }
                 } else {
                     list.RemoveValue(key); // Keys without numeric values seem to always be removed
+                    cutCount += 1;
                 }
             }
         }


### PR DESCRIPTION
https://github.com/OpenDreamProject/OpenDream/issues/2203

Implements:
- `values_dot()` - https://www.byond.com/docs/ref/#/proc/values_dot
- `values_product()` - https://www.byond.com/docs/ref/#/proc/values_product
- `values_sum()` - https://www.byond.com/docs/ref/#/proc/values_sum
- `values_cut_under()` - https://www.byond.com/docs/ref/#/proc/values_cut_under
- `values_cut_over()` - https://www.byond.com/docs/ref/#/proc/values_cut_over

