### PR TITLE
Completely ignore/don't require closing tags of void elements

### DIFF
--- a/OpenDreamClient/Interface/Html/HtmlParser.cs
+++ b/OpenDreamClient/Interface/Html/HtmlParser.cs
@@ -70,8 +70,13 @@ public static class HtmlParser {
                     string tagType = attributes[0].ToLowerInvariant();
 
                     currentText.Clear();
+                    bool isSelfClosing = IsSelfClosing(tagType, attributes);
                     if (closingTag) {
-                        if (tags.Count == 0) {
+                        if (isSelfClosing) {
+                            // ignore closing tags of void elements since they don't
+                            // do anything anyway. Should probably warn.
+                            return;
+                        } else if (tags.Count == 0) {
                             Sawmill.Error("Unexpected closing tag");
                             return;
                         } else if (tags.Peek() != tagType) {
@@ -82,9 +87,9 @@ public static class HtmlParser {
                         appendTo.Pop();
                         tags.Pop();
                     } else {
-                        tags.Push(tagType);
-
-                        bool isSelfClosing = IsSelfClosing(tagType, attributes);
+                        if (!isSelfClosing) {
+                            tags.Push(tagType);
+                        }
                         appendTo.PushTag(new MarkupNode(tagType, null, ParseAttributes(attributes)), selfClosing: isSelfClosing);
                     }
 


### PR DESCRIPTION
HTML parser should not push void elements (or tags marked as self-closing in the style of xhtml) into the tag stack.
HTML parser should just ignore attempted closing tags of void elements instead of peeking into the tag stack. Might be good to throw a warning when it is encountered (although, the DM reference documents a mysterious `<img></img>`, so I don't know)

This is a continuation on !2217 which did not fix the problem adequately (Or, honestly, at all. Whoops!)

#2187.

