### PR TITLE
Various DMF fixes, MouseEntered/MouseExited click params

### DIFF
--- a/OpenDreamClient/Interface/Controls/ControlBrowser.cs
+++ b/OpenDreamClient/Interface/Controls/ControlBrowser.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Net;
+using System.Text;
 using System.Web;
 using OpenDreamClient.Interface.Descriptors;
 using OpenDreamClient.Resources;
@@ -173,7 +174,8 @@ internal sealed class ControlBrowser : InterfaceControl {
     /// <param name="query">The query portion of the embedded winset</param>
     private void HandleEmbeddedWinset(string query) {
         // Strip the question mark out before parsing
-        var queryParams = HttpUtility.ParseQueryString(query.Substring(1));
+        // Also replace ';' with '&' because they're both usable here
+        var queryParams = HttpUtility.ParseQueryString(query.Substring(1).Replace(';', '&'));
 
         // We need to extract the control element (if one was included)
         string? element = queryParams.Get("element");
@@ -205,7 +207,8 @@ internal sealed class ControlBrowser : InterfaceControl {
     // (Not in the XML comment because '&' breaks that apparently)
     private void HandleEmbeddedWinget(string query) {
         // Strip the question mark out before parsing
-        var queryParams = HttpUtility.ParseQueryString(query.Substring(1));
+        // Also replace ';' with '&' because they're both usable here
+        var queryParams = HttpUtility.ParseQueryString(query.Substring(1).Replace(';', '&'));
 
         var elementId = queryParams.Get("id");
         var property = queryParams.Get("property");
@@ -223,13 +226,27 @@ internal sealed class ControlBrowser : InterfaceControl {
             forceJson = false; // property=* does not return "as json" values (why?!)
         }
 
-        var result = _interfaceManager.WinGet(elementId, property, forceJson: forceJson);
+        // Multiple properties can be queried in a single winget with "&property=size,view-size"
+        var properties = property.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        var jsonBuilder = new StringBuilder(); // Build the JSON object that the callback receives
+
+        jsonBuilder.Append("{ ");
+        foreach (var wingetting in properties) {
+            if (jsonBuilder.Length > 2)
+                jsonBuilder.Append(", ");
+
+            jsonBuilder.Append('"');
+            jsonBuilder.Append(HttpUtility.JavaScriptStringEncode(wingetting));
+            jsonBuilder.Append("\": ");
+            var result = _interfaceManager.WinGet(elementId, wingetting, forceJson: forceJson);
+            jsonBuilder.Append(result);
+        }
+
+        jsonBuilder.Append(" }");
 
         // Execute the callback
-        var propertyEncoded = HttpUtility.JavaScriptStringEncode(property);
-        var resultEncoded = HttpUtility.JavaScriptStringEncode(result);
-        var jsonArgument = $"{{ \"{propertyEncoded}\": \"{resultEncoded}\" }}";
-        _webView.ExecuteJavaScript($"{callback}({jsonArgument})");
+        var json = jsonBuilder.ToString();
+        _webView.ExecuteJavaScript($"{callback}({json})");
     }
 
     private void OnShowEvent() {

--- a/OpenDreamClient/Interface/Controls/ControlMap.cs
+++ b/OpenDreamClient/Interface/Controls/ControlMap.cs
@@ -1,6 +1,8 @@
-﻿using OpenDreamClient.Input;
+﻿using System.Diagnostics.CodeAnalysis;
+using OpenDreamClient.Input;
 using OpenDreamClient.Interface.Controls.UI;
 using OpenDreamClient.Interface.Descriptors;
+using OpenDreamClient.Interface.DMF;
 using OpenDreamClient.Rendering;
 using OpenDreamShared.Dream;
 using Robust.Client.Graphics;
@@ -20,24 +22,6 @@ public sealed class ControlMap(ControlDescriptor controlDescriptor, ControlWindo
     private ControlDescriptorMap MapDescriptor => (ControlDescriptorMap)ElementDescriptor;
 
     private ClientObjectReference? _atomUnderMouse;
-
-    private ClientObjectReference? AtomUnderMouse {
-        set {
-            if (!_atomUnderMouse.Equals(value)) {
-                _entitySystemManager.Resolve(ref _appearanceSystem);
-
-                var name = (value != null) ? _appearanceSystem.GetName(value.Value) : string.Empty;
-                Window?.SetStatus(name);
-
-                if (_atomUnderMouse != null)
-                    _mouseInput?.HandleAtomMouseExited(_atomUnderMouse.Value);
-                if (value != null)
-                    _mouseInput?.HandleAtomMouseEntered(value.Value);
-            }
-
-            _atomUnderMouse = value;
-        }
-    }
 
     protected override void UpdateElementDescriptor() {
         base.UpdateElementDescriptor();
@@ -115,11 +99,11 @@ public sealed class ControlMap(ControlDescriptor controlDescriptor, ControlWindo
             return;
 
         var underMouse = _mouseInput.GetAtomUnderMouse(Viewport, e.RelativePixelPosition, e.GlobalPixelPosition);
-        AtomUnderMouse = underMouse?.Atom;
+        UpdateAtomUnderMouse(underMouse?.Atom, e.RelativePixelPosition, underMouse?.IconPosition ?? Vector2i.Zero);
     }
 
-    private void OnViewportMouseExitedEvent(GUIMouseHoverEventArgs obj) {
-        AtomUnderMouse = null;
+    private void OnViewportMouseExitedEvent(GUIMouseHoverEventArgs e) {
+        UpdateAtomUnderMouse(null, Vector2.Zero, Vector2i.Zero);
     }
 
     public void OnShowEvent() {
@@ -134,5 +118,31 @@ public sealed class ControlMap(ControlDescriptor controlDescriptor, ControlWindo
         if (!string.IsNullOrWhiteSpace(controlDescriptor.OnHideCommand.Value)) {
             _interfaceManager.RunCommand(controlDescriptor.OnHideCommand.AsRaw());
         }
+    }
+
+    public override bool TryGetProperty(string property, [NotNullWhen(true)] out IDMFProperty? value) {
+        switch (property) {
+            case "view-size": // Size of the final viewport (resized and all) rather than the whole container
+                value = new DMFPropertyVec2(Viewport.GetDrawBox().Size);
+                return true;
+            default:
+                return base.TryGetProperty(property, out value);
+        }
+    }
+
+    private void UpdateAtomUnderMouse(ClientObjectReference? atom, Vector2 relativePos, Vector2i iconPos) {
+        if (!_atomUnderMouse.Equals(atom)) {
+            _entitySystemManager.Resolve(ref _appearanceSystem);
+
+            var name = (atom != null) ? _appearanceSystem.GetName(atom.Value) : string.Empty;
+            Window?.SetStatus(name);
+
+            if (_atomUnderMouse != null)
+                _mouseInput?.HandleAtomMouseExited(Viewport, _atomUnderMouse.Value);
+            if (atom != null)
+                _mouseInput?.HandleAtomMouseEntered(Viewport, relativePos, atom.Value, iconPos);
+        }
+
+        _atomUnderMouse = atom;
     }
 }

--- a/OpenDreamClient/Interface/Controls/InterfaceControl.cs
+++ b/OpenDreamClient/Interface/Controls/InterfaceControl.cs
@@ -93,6 +93,7 @@ public abstract class InterfaceControl : InterfaceElement {
         switch (property) {
             case "size":
                 var size = new DMFPropertySize(value);
+                ControlDescriptor.Size = size;
 
                 // A size of 0 takes up the remaining space of the window as defined by the DMF
                 if (size.X == 0 && Window != null)
@@ -108,6 +109,7 @@ public abstract class InterfaceControl : InterfaceElement {
                 break;
             case "pos":
                 var pos = new DMFPropertyPos(value);
+                ControlDescriptor.Pos = pos;
 
                 LayoutContainer.SetMarginLeft(UIElement, pos.X);
                 LayoutContainer.SetMarginTop(UIElement, pos.Y);

--- a/OpenDreamClient/Interface/DMF/IDMFProperty.cs
+++ b/OpenDreamClient/Interface/DMF/IDMFProperty.cs
@@ -159,16 +159,16 @@ public struct DMFPropertyVec2 : IDMFProperty, IEquatable<DMFPropertyVec2> {
     }
 
     public DMFPropertyVec2(string value) {
-        if(value.Equals("none",StringComparison.InvariantCultureIgnoreCase)){
+        if (value.Equals("none", StringComparison.InvariantCultureIgnoreCase)) {
             X = 0;
             Y = 0;
             return;
         }
 
-        string[] parts = value.Split([',','x',' ']);
+        string[] parts = value.Split([',', 'x', ' ']);
 
-        X = int.Parse(parts[0]);
-        Y = int.Parse(parts[1]);
+        X = (int)float.Parse(parts[0]);
+        Y = (int)float.Parse(parts[1]);
     }
 
     public DMFPropertyVec2(Vector2 value) {

--- a/OpenDreamClient/Interface/DreamInterfaceManager.cs
+++ b/OpenDreamClient/Interface/DreamInterfaceManager.cs
@@ -609,6 +609,9 @@ internal sealed class DreamInterfaceManager : IDreamInterfaceManager {
             string? elementOverride = winSets.FirstOrDefault(winSet => winSet.Element == null && winSet.Attribute == "id")?.Value;
 
             foreach (DMFWinSet winSet in winSets) {
+                if (winSet.Attribute == "id") // This is used to set the target, not an actual winset
+                    continue;
+
                 string? elementId = winSet.Element ?? elementOverride;
 
                 if (elementId == null) {

--- a/OpenDreamShared/Input/SharedMouseInputSystem.cs
+++ b/OpenDreamShared/Input/SharedMouseInputSystem.cs
@@ -48,18 +48,14 @@ public class SharedMouseInputSystem : EntitySystem {
     }
 
     [Serializable, NetSerializable]
-    public sealed class MouseEnteredEvent(ClientObjectReference atom) : EntityEventArgs, IAtomMouseEvent {
+    public sealed class MouseEnteredEvent(ClientObjectReference atom, ClickParams clickParams) : EntityEventArgs, IAtomMouseEvent {
         public ClientObjectReference Atom = atom;
-
-        // TODO
-        public ClickParams Params { get; } = new(new(0, 0, 32), false, false, false, false, false, 0, 0);
+        public ClickParams Params { get; } = clickParams;
     }
 
     [Serializable, NetSerializable]
-    public sealed class MouseExitedEvent(ClientObjectReference atom) : EntityEventArgs, IAtomMouseEvent {
+    public sealed class MouseExitedEvent(ClientObjectReference atom, ClickParams clickParams) : EntityEventArgs, IAtomMouseEvent {
         public ClientObjectReference Atom = atom;
-
-        // TODO
-        public ClickParams Params { get; } = new(new(0, 0, 32), false, false, false, false, false, 0, 0);
+        public ClickParams Params { get; } = clickParams;
     }
 }


### PR DESCRIPTION
DMF fixes:

- Embedded wingets and winsets can separate parameters with `;` instead of `&`
- Embedded wingets can query multiple properties at once
- Winsetting size or pos wouldn't update the descriptor in time for `UpdateAnchors()`
- Made the map control's `view-size` winget-able
- Cast vectors like `"1.5x2.5"` to integers
- Don't actually winset `id` when it's used to target an element in a winset

I also implemented the click params for `/atom.MouseEntered()` and `/atom.MouseExited()` so location info is sent.

All of this gets SS13 tooltips working.
![image](https://github.com/user-attachments/assets/0eba9986-0419-4a60-beb6-9fb872a12355)
![image](https://github.com/user-attachments/assets/d0b859aa-59bc-49c4-add6-b0b80c2fcb26)