### PR TITLE
Enhancement: `vis_contents_plane_offset`

### DIFF
--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -62,6 +62,8 @@
 	var/render_target
 	var/vis_flags as opendream_unimplemented
 
+	var/vis_contents_plane_offset = 0 //opendream only
+
 	proc/Click(location, control, params)
 	proc/MouseDrop(over_object,src_location,over_location,src_control,over_control,params)
 	proc/MouseEntered(location,control,params)

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -174,7 +174,7 @@ internal sealed partial class DreamViewOverlay : Overlay {
     }
 
     //handles underlays, overlays, appearance flags, images. Adds them to the result list, so they can be sorted and drawn with DrawIcon()
-    private void ProcessIconComponents(DreamIcon icon, Vector2 position, EntityUid uid, bool isScreen, ref int tieBreaker, List<RendererMetaData> result, sbyte seeVis, RendererMetaData? parentIcon = null, bool keepTogether = false, Vector3? turfCoords = null) {
+    private void ProcessIconComponents(DreamIcon icon, Vector2 position, EntityUid uid, bool isScreen, ref int tieBreaker, List<RendererMetaData> result, sbyte seeVis, RendererMetaData? parentIcon = null, bool keepTogether = false, Vector3? turfCoords = null, int planeOffset = 0) {
         if (icon.Appearance is null) //in the event that appearance hasn't loaded yet
             return;
 
@@ -237,6 +237,8 @@ internal sealed partial class DreamViewOverlay : Overlay {
             current.Plane = icon.Appearance.Plane;
             current.Layer = Math.Max(0, icon.Appearance.Layer); //float layers are invalid for icons with no parent
         }
+
+        current.Plane += planeOffset;
 
         //special handling for EFFECTS_LAYER and BACKGROUND_LAYER
         //SO IT TURNS OUT EFFECTS_LAYER IS JUST A LIE *scream
@@ -337,7 +339,7 @@ internal sealed partial class DreamViewOverlay : Overlay {
             if (!sprite.IsVisible(transform, seeVis))
                 continue;
 
-            ProcessIconComponents(sprite.Icon, position, visContentEntity, false, ref tieBreaker, result, seeVis, current, keepTogether);
+            ProcessIconComponents(sprite.Icon, position, visContentEntity, false, ref tieBreaker, result, seeVis, current, keepTogether, planeOffset:icon.Appearance.VisContentsPlaneOffset);
 
             // TODO: click uid should be set to current.uid again
             // TODO: vis_flags

--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -265,6 +265,7 @@ public sealed class AtomManager {
             case "maptext_height":
             case "maptext_x":
             case "maptext_y":
+            case "vis_contents_plane_offset":
                 return true;
 
             // Get/SetAppearanceVar doesn't handle filters right now
@@ -422,6 +423,9 @@ public sealed class AtomManager {
             case "maptext_y":
                 value.TryGetValueAsInteger(out appearance.MaptextOffset.Y);
                 break;
+            case "vis_contents_plane_offset":
+                value.TryGetValueAsInteger(out appearance.VisContentsPlaneOffset);
+                break;
             case "appearance":
                 throw new Exception("Cannot assign the appearance var on an appearance");
 
@@ -530,6 +534,8 @@ public sealed class AtomManager {
                 return new(appearance.MaptextOffset.X);
             case "maptext_y":
                 return new(appearance.MaptextOffset.Y);
+            case "vis_contents_plane_offset":
+                return new(appearance.VisContentsPlaneOffset);
             case "appearance":
                 MutableAppearance appearanceCopy = appearance.ToMutable(); // Return a copy
                 return new(appearanceCopy);

--- a/OpenDreamShared/Dream/ImmutableAppearance.cs
+++ b/OpenDreamShared/Dream/ImmutableAppearance.cs
@@ -51,6 +51,7 @@ public sealed class ImmutableAppearance : IEquatable<ImmutableAppearance> {
     [ViewVariables] public readonly ImmutableAppearance[] Overlays;
     [ViewVariables] public readonly ImmutableAppearance[] Underlays;
     [ViewVariables] public readonly Robust.Shared.GameObjects.NetEntity[] VisContents;
+    [ViewVariables] public int VisContentsPlaneOffset;
     [ViewVariables] public readonly DreamFilter[] Filters;
     [ViewVariables] public readonly int[] Verbs;
     [ViewVariables] public readonly ColorMatrix ColorMatrix = ColorMatrix.Identity;
@@ -103,6 +104,7 @@ public sealed class ImmutableAppearance : IEquatable<ImmutableAppearance> {
         MaptextSize = appearance.MaptextSize;
         MaptextOffset = appearance.MaptextOffset;
         EnabledMouseEvents = appearance.EnabledMouseEvents;
+        VisContentsPlaneOffset = appearance.VisContentsPlaneOffset;
 
         Overlays = appearance.Overlays.ToArray();
         Underlays = appearance.Underlays.ToArray();
@@ -170,6 +172,7 @@ public sealed class ImmutableAppearance : IEquatable<ImmutableAppearance> {
         if (immutableAppearance.Overlays.Length != Overlays.Length) return false;
         if (immutableAppearance.Underlays.Length != Underlays.Length) return false;
         if (immutableAppearance.VisContents.Length != VisContents.Length) return false;
+        if (immutableAppearance.VisContentsPlaneOffset != VisContentsPlaneOffset) return false;
         if (immutableAppearance.Filters.Length != Filters.Length) return false;
         if (immutableAppearance.Verbs.Length != Verbs.Length) return false;
         if (immutableAppearance.Override != Override) return false;
@@ -247,6 +250,7 @@ public sealed class ImmutableAppearance : IEquatable<ImmutableAppearance> {
         hashCode.Add(Maptext);
         hashCode.Add(MaptextOffset);
         hashCode.Add(MaptextSize);
+        hashCode.Add(VisContentsPlaneOffset);
 
         foreach (ImmutableAppearance overlay in Overlays) {
             hashCode.Add(overlay.GetHashCode());
@@ -444,6 +448,10 @@ public sealed class ImmutableAppearance : IEquatable<ImmutableAppearance> {
                     EnabledMouseEvents = (AtomMouseEvents)buffer.ReadByte();
                     break;
                 }
+                case IconAppearanceProperty.VisContentsPlaneOffset: {
+                    VisContentsPlaneOffset = buffer.ReadVariableInt32();
+                    break;
+                }
                 default:
                     throw new Exception($"Invalid property {property}");
             }
@@ -486,6 +494,7 @@ public sealed class ImmutableAppearance : IEquatable<ImmutableAppearance> {
         result.MaptextOffset = MaptextOffset;
         result.MaptextSize = MaptextSize;
         result.EnabledMouseEvents = EnabledMouseEvents;
+        result.VisContentsPlaneOffset = VisContentsPlaneOffset;
 
         result.Overlays.EnsureCapacity(Overlays.Length);
         result.Underlays.EnsureCapacity(Underlays.Length);
@@ -697,6 +706,11 @@ public sealed class ImmutableAppearance : IEquatable<ImmutableAppearance> {
         if (EnabledMouseEvents != MutableAppearance.Default.EnabledMouseEvents) {
             buffer.Write((byte)IconAppearanceProperty.EnabledMouseEvents);
             buffer.Write((byte)EnabledMouseEvents);
+        }
+
+        if(VisContentsPlaneOffset != MutableAppearance.Default.VisContentsPlaneOffset){
+            buffer.Write((byte)IconAppearanceProperty.VisContentsPlaneOffset);
+            buffer.WriteVariableInt32(VisContentsPlaneOffset);
         }
 
         buffer.Write((byte)IconAppearanceProperty.End);

--- a/OpenDreamShared/Dream/MutableAppearance.cs
+++ b/OpenDreamShared/Dream/MutableAppearance.cs
@@ -49,6 +49,8 @@ public sealed class MutableAppearance : IEquatable<MutableAppearance>, IDisposab
     [ViewVariables] public List<ImmutableAppearance> Overlays;
     [ViewVariables] public List<ImmutableAppearance> Underlays;
     [ViewVariables] public List<Robust.Shared.GameObjects.NetEntity> VisContents;
+    [ViewVariables] public int VisContentsPlaneOffset;
+
     [ViewVariables] public List<DreamFilter> Filters;
     [ViewVariables] public List<int> Verbs;
     [ViewVariables] public Vector2i MaptextSize = new(32,32);
@@ -138,6 +140,7 @@ public sealed class MutableAppearance : IEquatable<MutableAppearance>, IDisposab
         MaptextSize = appearance.MaptextSize;
         MaptextOffset = appearance.MaptextOffset;
         EnabledMouseEvents = appearance.EnabledMouseEvents;
+        VisContentsPlaneOffset = appearance.VisContentsPlaneOffset;
 
         Overlays.Clear();
         Underlays.Clear();
@@ -181,6 +184,7 @@ public sealed class MutableAppearance : IEquatable<MutableAppearance>, IDisposab
         if (appearance.Overlays.Count != Overlays.Count) return false;
         if (appearance.Underlays.Count != Underlays.Count) return false;
         if (appearance.VisContents.Count != VisContents.Count) return false;
+        if (appearance.VisContentsPlaneOffset != VisContentsPlaneOffset) return false;
         if (appearance.Filters.Count != Filters.Count) return false;
         if (appearance.Verbs.Count != Verbs.Count) return false;
         if (appearance.Override != Override) return false;
@@ -276,6 +280,7 @@ public sealed class MutableAppearance : IEquatable<MutableAppearance>, IDisposab
         hashCode.Add(Maptext);
         hashCode.Add(MaptextOffset);
         hashCode.Add(MaptextSize);
+        hashCode.Add(VisContentsPlaneOffset);
 
         foreach (var overlay in Overlays) {
             hashCode.Add(overlay.GetHashCode());
@@ -424,6 +429,7 @@ public enum IconAppearanceProperty : byte {
         Overlays,
         Underlays,
         VisContents,
+        VisContentsPlaneOffset,
         Filters,
         Verbs,
         Transform,

--- a/TestGame/code.dm
+++ b/TestGame/code.dm
@@ -339,6 +339,12 @@
 		set category = "Input Test"
 		src << input("Input test: list") as null|anything in list("option 1", "option 2", "option 3", "option 4", "option 5")
 		
+	verb/vis_contents_test()
+		src << "adding a vis_contents thing as the first object in range(2)"
+		for(var/atom/movable/A in orange(2, src))
+			src.vis_contents += A
+			break
+		src.vis_contents_plane_offset = 10
 
 /mob/Stat()
 	if (statpanel("Status"))


### PR DESCRIPTION
Adds a new var to `/atom`: `vis_contents_plane_offset`

Defaults to 0. Applies a simple offset to the plane of items in that atom's `vis_contents`

Requested by TheFinalPotato for cursed multi-z shit