### PR TITLE
Avoid rendering an empty maptext

### DIFF
--- a/OpenDreamClient/Input/MouseInputSystem.cs
+++ b/OpenDreamClient/Input/MouseInputSystem.cs
@@ -111,6 +111,8 @@ internal sealed class MouseInputSystem : SharedMouseInputSystem {
 
         var mapCoords = viewport.ScreenToMap(globalPos.Position);
         var mousePos = (relativePos - viewportBox.TopLeft) / viewportBox.Size * viewport.ViewportSize;
+        if (mousePos.X >= _dreamViewOverlay.MouseMap.Size.X || mousePos.Y >= _dreamViewOverlay.MouseMap.Size.Y)
+            return null;
 
         if(_configurationManager.GetCVar(CVars.DisplayCompat))
             return null; //Compat mode causes crashes with RT's GetPixel because OpenGL ES doesn't support GetTexImage()

--- a/OpenDreamClient/Rendering/ClientScreenOverlaySystem.cs
+++ b/OpenDreamClient/Rendering/ClientScreenOverlaySystem.cs
@@ -3,7 +3,7 @@
 namespace OpenDreamClient.Rendering;
 
 internal sealed class ClientScreenOverlaySystem : SharedScreenOverlaySystem {
-    public HashSet<EntityUid> ScreenObjects = new();
+    public readonly HashSet<EntityUid> ScreenObjects = new();
 
     [Dependency] private readonly IEntityManager _entityManager = default!;
 

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -434,7 +434,7 @@ internal sealed partial class DreamViewOverlay : Overlay {
         }
 
         //Maptext
-        if(iconMetaData.Maptext != null) {
+        if (!string.IsNullOrWhiteSpace(iconMetaData.Maptext)) {
             var maptextSize = iconMetaData.MaptextSize!.Value;
             if (maptextSize.X == 0)
                 maptextSize.X = 32;

--- a/OpenDreamShared/Dream/MouseOpacity.cs
+++ b/OpenDreamShared/Dream/MouseOpacity.cs
@@ -1,7 +1,7 @@
-﻿namespace OpenDreamShared.Dream {
-    public enum MouseOpacity {
-        Transparent = 0,
-        PixelOpaque = 1,
-        Opaque = 2
-    }
+﻿namespace OpenDreamShared.Dream;
+
+public enum MouseOpacity {
+    Transparent = 0,
+    PixelOpaque = 1,
+    Opaque = 2
 }


### PR DESCRIPTION
Don't render maptext if it's empty or whitespace.

Fixes backpack items being unclickable on Paradise, though not by fixing the core issue. A second render, maptext, was resetting LastRenderedTexture.