### PR TITLE
Reset shader before final plane render

### DIFF
--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -580,6 +580,7 @@ internal sealed partial class DreamViewOverlay : Overlay {
                         plane.Master.TextureOverride = plane.RenderTarget.Texture;
                         DrawIcon(handle, _baseRenderTarget!.Size, plane.Master, Vector2.Zero);
                     } else {
+                        handle.UseShader(null);
                         handle.SetTransform(CreateRenderTargetFlipMatrix(_baseRenderTarget!.Size, Vector2.Zero));
                         handle.DrawTextureRect(plane.RenderTarget.Texture, Box2.FromTwoPoints(Vector2.Zero, _baseRenderTarget.Size));
                     }


### PR DESCRIPTION
RobustToolbox now keeps the shader as part of `RenderInRenderTarget()`'s state. This means once `RenderInRenderTarget()` returns, the old shader is put back. This unveiled a bug in our renderer that would reuse the old shader for the final render of a plane.

This fixes the dark HUD on Paradise.