### PR TITLE
Overlays on a different plane are `KEEP_APART`

### DIFF
--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -285,7 +285,11 @@ internal sealed partial class DreamViewOverlay : Overlay {
 
             tieBreaker++;
 
-            if (!keepTogether || (underlay.Appearance.AppearanceFlags & AppearanceFlags.KeepApart) != 0) { //KEEP_TOGETHER wasn't set on our parent, or KEEP_APART
+            // KEEP_APART flag or on a different plane than the parent atom (implicitly treated as KEEP_APART)
+            var keepApart = underlay.Appearance.Plane != icon.Appearance.Plane ||
+                            (underlay.Appearance.AppearanceFlags & AppearanceFlags.KeepApart) != 0;
+
+            if (!keepTogether || keepApart) { //KEEP_TOGETHER wasn't set on our parent, or KEEP_APART
                 ProcessIconComponents(underlay, current.Position, uid, isScreen, ref tieBreaker, result, seeVis, current);
             } else {
                 current.KeepTogetherGroup ??= new();
@@ -303,7 +307,11 @@ internal sealed partial class DreamViewOverlay : Overlay {
 
             tieBreaker++;
 
-            if (!keepTogether || (overlay.Appearance.AppearanceFlags & AppearanceFlags.KeepApart) != 0) { //KEEP_TOGETHER wasn't set on our parent, or KEEP_APART
+            // KEEP_APART flag or on a different plane than the parent atom (implicitly treated as KEEP_APART)
+            var keepApart = overlay.Appearance.Plane != icon.Appearance.Plane ||
+                            (overlay.Appearance.AppearanceFlags & AppearanceFlags.KeepApart) != 0;
+
+            if (!keepTogether || keepApart) { //KEEP_TOGETHER wasn't set on our parent, or KEEP_APART
                 ProcessIconComponents(overlay, current.Position, uid, isScreen, ref tieBreaker, result, seeVis, current);
             } else {
                 current.KeepTogetherGroup ??= new();


### PR DESCRIPTION
Overlays/Underlays on a different plane than their parent atom are treated as having the `KEEP_APART` flag.

Fixes overlay lights on /tg/ from just applying a bright image. They still don't work, the plane they're rendered onto isn't having any effect. /tg/'s documentation implies that the plane should render onto the game plane, though the game plane is much higher than the overlay lighting plane so I have no idea how that's supposed to be the case.

The lighting plane _is_ supposed to be masked by the overlay lighting plane, which would produce an effect. But the plane's filters don't seem to be applying.