### PR TITLE
Group sprite renders by icon

### DIFF
--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -900,6 +900,13 @@ internal sealed class RendererMetaData : IComparable<RendererMetaData> {
             }
         }
 
+        // All else being the same, group them by icon.
+        // This allows Clyde to batch the draw calls more efficiently.
+        val = (MainIcon?.Appearance?.Icon ?? 0) - (other.MainIcon?.Appearance?.Icon ?? 0);
+        if (val != 0) {
+            return val;
+        }
+
         return TieBreaker.CompareTo(other.TieBreaker);
     }
 }


### PR DESCRIPTION
When sorting sprites, try to keep sprites with the same icon resource grouped together. This causes sprites with the same texture to render together which RT batches more efficiently.