### PR TITLE
Rendering optimizations

### DIFF
--- a/OpenDreamClient/Input/ContextMenu/ContextMenuItem.xaml.cs
+++ b/OpenDreamClient/Input/ContextMenu/ContextMenuItem.xaml.cs
@@ -26,6 +26,7 @@ internal sealed partial class ContextMenuItem : PanelContainer {
         NameLabel.Text = name;
 
         Icon.Texture = icon.LastRenderedTexture;
+        Icon.Modulate = icon.Appearance?.Color ?? Color.White;
     }
 
     protected override void MouseEntered() {

--- a/OpenDreamClient/Rendering/DMISpriteComponent.cs
+++ b/OpenDreamClient/Rendering/DMISpriteComponent.cs
@@ -7,24 +7,4 @@ namespace OpenDreamClient.Rendering;
 internal sealed partial class DMISpriteComponent : SharedDMISpriteComponent {
     [ViewVariables] public DreamIcon Icon { get; set; }
     [ViewVariables] public ScreenLocation? ScreenLocation { get; set; }
-
-    /// <summary>
-    /// Checks if this sprite should be visible to the player<br/>
-    /// Checks the appearance's invisibility, and if a transform is given, whether it's parented to another entity
-    /// </summary>
-    /// <param name="transform">The entity's transform, the parent check is skipped if this is null</param>
-    /// <param name="seeInvisibility">The eye's see_invisibility var</param>
-    /// <returns></returns>
-    public bool IsVisible(TransformComponent? transform, int seeInvisibility) {
-        if (Icon.Appearance?.Invisibility > seeInvisibility) return false;
-
-        if (transform != null) {
-            //Only render movables not inside another movable's contents (parented to the grid)
-            //TODO: Use RobustToolbox's container system/components?
-            if (transform.ParentUid != transform.GridUid)
-                return false;
-        }
-
-        return true;
-    }
 }

--- a/OpenDreamClient/Rendering/DreamIcon.cs
+++ b/OpenDreamClient/Rendering/DreamIcon.cs
@@ -1,4 +1,5 @@
-﻿using OpenDreamClient.Resources;
+﻿using System.Diagnostics.CodeAnalysis;
+using OpenDreamClient.Resources;
 using OpenDreamClient.Resources.ResourceTypes;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Resources;
@@ -498,9 +499,17 @@ internal sealed class DreamIcon(RenderTargetPool renderTargetPool, IGameTiming g
     /// </summary>
     /// <remarks>In a separate method to avoid closure allocations when not executed</remarks>
     /// <returns>The final texture</returns>
+    [SuppressMessage("ReSharper", "AccessToModifiedClosure")] // RenderInRenderTarget executes immediately, shouldn't be an issue
     private IRenderTexture FullRenderTexture(DreamViewOverlay viewOverlay, DrawingHandleWorld handle, RendererMetaData iconMetaData, Texture frame) {
-        // TODO: This should determine the size from the filters and their settings, not just double the original
-        var ping = renderTargetPool.Rent(frame.Size * 2);
+        Vector2 requiredRenderSpace = frame.Size;
+        foreach (var filter in iconMetaData.MainIcon!.Appearance!.Filters) {
+            var requiredSpace = filter.CalculateRequiredRenderSpace(frame.Size,
+                renderSource => viewOverlay.RenderSourceLookup.GetValueOrDefault(renderSource)?.Size ?? new(0, 0));
+
+            requiredRenderSpace = Vector2.Max(requiredRenderSpace, requiredSpace);
+        }
+
+        var ping = renderTargetPool.Rent((Vector2i)requiredRenderSpace);
         var pong = renderTargetPool.Rent(ping.Size);
 
         handle.RenderInRenderTarget(pong, () => {
@@ -516,7 +525,7 @@ internal sealed class DreamIcon(RenderTargetPool renderTargetPool, IGameTiming g
             colorShader.SetParameter("isPlaneMaster",iconMetaData.IsPlaneMaster);
             handle.UseShader(colorShader);
 
-            handle.SetTransform(DreamViewOverlay.CreateRenderTargetFlipMatrix(pong.Size, frame.Size / 2));
+            handle.SetTransform(DreamViewOverlay.CreateRenderTargetFlipMatrix(pong.Size, (pong.Size/2 - frame.Size/2)));
             handle.DrawTextureRect(frame, new Box2(Vector2.Zero, frame.Size));
         }, Color.Black.WithAlpha(0));
 

--- a/OpenDreamClient/Rendering/DreamIcon.cs
+++ b/OpenDreamClient/Rendering/DreamIcon.cs
@@ -100,7 +100,6 @@ internal sealed class DreamIcon(RenderTargetPool renderTargetPool, IGameTiming g
         }
 
         var canSkipFullRender = Appearance?.Filters.Length is 0 or null &&
-                                    iconMetaData.ColorToApply == Color.White &&
                                     iconMetaData.ColorMatrixToApply.Equals(ColorMatrix.Identity) &&
                                     iconMetaData.AlphaToApply.Equals(1.0f);
 
@@ -515,9 +514,7 @@ internal sealed class DreamIcon(RenderTargetPool renderTargetPool, IGameTiming g
         handle.RenderInRenderTarget(pong, () => {
             //we can use the color matrix shader here, since we don't need to blend
             //also because blend mode is none, we don't need to clear
-            var colorMatrix = iconMetaData.ColorMatrixToApply.Equals(ColorMatrix.Identity)
-                ? new ColorMatrix(iconMetaData.ColorToApply.WithAlpha(iconMetaData.AlphaToApply))
-                : iconMetaData.ColorMatrixToApply;
+            var colorMatrix = iconMetaData.ColorMatrixToApply;
 
             ShaderInstance colorShader = DreamViewOverlay.ColorInstance.Duplicate();
             colorShader.SetParameter("colorMatrix", colorMatrix.GetMatrix4());

--- a/OpenDreamClient/Rendering/DreamPlane.cs
+++ b/OpenDreamClient/Rendering/DreamPlane.cs
@@ -76,7 +76,7 @@ internal sealed class DreamPlane(IRenderTexture mainRenderTarget) : IDisposable 
 
                 handle.UseShader(overlay.GetBlendAndColorShader(Master, useOverlayMode: true));
                 handle.SetTransform(DreamViewOverlay.CreateRenderTargetFlipMatrix(_temporaryRenderTarget.Size, Master.MainIcon?.TextureRenderOffset ?? Vector2.Zero));
-                handle.DrawTextureRect(texture, new Box2(Vector2.Zero, texture.Size));
+                handle.DrawTextureRect(texture, new Box2(Vector2.Zero, texture.Size), Master.ColorToApply);
             }, new Color());
         }
     }

--- a/OpenDreamClient/Rendering/DreamPlane.cs
+++ b/OpenDreamClient/Rendering/DreamPlane.cs
@@ -51,12 +51,14 @@ internal sealed class DreamPlane(IRenderTexture mainRenderTarget) : IDisposable 
                 return;
 
             foreach (var sprite in Sprites) {
+                var positionOffset = -worldAABB.BottomLeft;
+
                 if (sprite.HasRenderSource && overlay.RenderSourceLookup.TryGetValue(sprite.RenderSource!, out var renderSourceTexture)) {
+                    positionOffset -= renderSourceTexture.Size / 2 / EyeManager.PixelsPerMeter;
                     sprite.TextureOverride = renderSourceTexture.Texture;
-                    overlay.DrawIcon(handle, mainRenderTarget.Size, sprite, (-worldAABB.BottomLeft)-(worldAABB.Size/2)+new Vector2(0.5f,0.5f));
-                } else {
-                    overlay.DrawIcon(handle, mainRenderTarget.Size, sprite, -worldAABB.BottomLeft);
                 }
+
+                overlay.DrawIcon(handle, mainRenderTarget.Size, sprite, positionOffset);
             }
         }, new Color());
 

--- a/OpenDreamClient/Rendering/DreamViewOverlay.TileVisibility.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.TileVisibility.cs
@@ -60,7 +60,7 @@ internal partial class DreamViewOverlay {
                 continue;
 
             var transform = _xformQuery.GetComponent(entity);
-            if (!sprite.IsVisible(transform, seeVis))
+            if (!_spriteSystem.IsVisible(sprite, transform, seeVis, null))
                 continue;
             if (sprite.Icon.Appearance == null) //appearance hasn't loaded yet
                 continue;

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -538,7 +538,7 @@ internal sealed partial class DreamViewOverlay : Overlay {
                     plane.SetTemporaryRenderTarget(tmpRenderTarget);
                 } else { //if not a plane master, draw the sprite to the render target
                     //note we don't draw this to the mouse-map because that's handled when the RenderTarget is used as a source later
-                    DrawOnRenderTarget(handle, tmpRenderTarget, sprite, worldAABB);
+                    DrawOnRenderTarget(handle, tmpRenderTarget, sprite);
                 }
             } else { //We are no longer dealing with RenderTargets, just regular old planes, so we collect the draw actions for batching
                 //if this is a plane master then we don't render it, we just set it as the plane's master
@@ -559,10 +559,10 @@ internal sealed partial class DreamViewOverlay : Overlay {
     /// Used by <see cref="ProcessSprites"/> to render an icon onto its render_target.
     /// In a separate method to prevent unused closure allocations.
     /// </summary>
-    private void DrawOnRenderTarget(DrawingHandleWorld handle, IRenderTarget renderTarget, RendererMetaData sprite, Box2 worldAABB) {
+    private void DrawOnRenderTarget(DrawingHandleWorld handle, IRenderTarget renderTarget, RendererMetaData sprite) {
         handle.RenderInRenderTarget(renderTarget, () => {
             //draw the sprite centered on the RenderTarget
-            DrawIcon(handle, renderTarget.Size, sprite, ((worldAABB.Size/2)-sprite.Position)-new Vector2(0.5f,0.5f));
+            DrawIcon(handle, renderTarget.Size, sprite, -sprite.Position);
         }, new Color());
     }
 

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -408,8 +408,6 @@ internal sealed partial class DreamViewOverlay : Overlay {
         ColorMatrix colorMatrix;
         if (ignoreColor)
             colorMatrix = ColorMatrix.Identity;
-        else if (iconMetaData.ColorMatrixToApply.Equals(ColorMatrix.Identity))
-            colorMatrix = new ColorMatrix(iconMetaData.ColorToApply.WithAlpha(iconMetaData.AlphaToApply));
         else
             colorMatrix = iconMetaData.ColorMatrixToApply;
 
@@ -466,7 +464,7 @@ internal sealed partial class DreamViewOverlay : Overlay {
         handle.UseShader(GetBlendAndColorShader(iconMetaData, ignoreColor: true));
 
         handle.SetTransform(CalculateDrawingMatrix(iconMetaData.TransformToApply, pixelPosition, frame.Size, renderTargetSize));
-        handle.DrawTextureRect(frame, Box2.FromDimensions(Vector2.Zero, frame.Size));
+        handle.DrawTextureRect(frame, Box2.FromDimensions(Vector2.Zero, frame.Size), iconMetaData.ColorToApply);
     }
 
     /// <summary>

--- a/OpenDreamShared/Dream/DreamFilter.cs
+++ b/OpenDreamShared/Dream/DreamFilter.cs
@@ -40,6 +40,46 @@ public partial record DreamFilter {
             _ => null
         };
     }
+
+    /// <summary>
+    /// Calculate the size of the texture necessary to render this filter
+    /// </summary>
+    /// <param name="baseSize">The size of the object the filter is being applied to</param>
+    /// <param name="textureSizeCallback">A callback that returns the size of a given render source</param>
+    public Vector2i CalculateRequiredRenderSpace(Vector2i baseSize, Func<string, Vector2i> textureSizeCallback) {
+        Vector2 requiredSpace = baseSize;
+
+        // All the "* 2" in here is because everything is rendered in the center,
+        // So every increase in size needs applied to both sides
+        switch (this) {
+            case DreamFilterAlpha alpha:
+                requiredSpace += Vector2.Abs(new(alpha.X, alpha.Y)) * 2;
+
+                if (!string.IsNullOrEmpty(alpha.RenderSource)) {
+                    var textureSize = textureSizeCallback(alpha.RenderSource);
+                    requiredSpace = Vector2.Max(requiredSpace, textureSize);
+                } else if (alpha.Icon != 0) {
+                    // TODO
+                }
+
+                break;
+            case DreamFilterBlur blur:
+                requiredSpace += new Vector2(blur.Size) * 2;
+                break;
+            case DreamFilterDropShadow dropShadow:
+                if (dropShadow.Size - dropShadow.X > 0)
+                    requiredSpace.X += (dropShadow.Size + dropShadow.X) * 2;
+
+                if (dropShadow.Size - dropShadow.Y > 0)
+                    requiredSpace.Y += (dropShadow.Size + dropShadow.Y) * 2;
+                break;
+            case DreamFilterOutline outline:
+                requiredSpace += new Vector2(outline.Size) * 2;
+                break;
+        }
+
+        return (Vector2i)requiredSpace;
+    }
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
* ProcessSprites ignores sprites outside the viewport's AABB, greatly reducing the time processing & rendering them
* Ping-Pong rendering now only uses the minimum necessary texture size, reducing the amount of work done
* Objects with render targets now render to a texture the size of their DMI frames, rather than the size of the whole viewport
* Avoid duplicating blend mode shaders when the parameters are the default, reducing allocations and greatly improving RT's batching
* Avoid unnecessarily clearing render targets, reducing RT's render command flushing
* Appearances with simple colors (not a color matrix) no longer do a ping-pong render

On my laptop, goes from ~22FPS observing on /tg/ to ~55FPS.