### PR TITLE
Avoid creating duplicate icon resources

### DIFF
--- a/OpenDreamClient/Audio/DreamSoundEngine.cs
+++ b/OpenDreamClient/Audio/DreamSoundEngine.cs
@@ -68,7 +68,6 @@ public sealed class DreamSoundEngine : IDreamSoundEngine {
         _channels[channel - 1] = new DreamSoundChannel(_audioSystem, source.Value);
     }
 
-
     public void StopChannel(int channel) {
         ref DreamSoundChannel? ch = ref _channels[channel - 1];
 

--- a/OpenDreamClient/Resources/DreamResourceManager.cs
+++ b/OpenDreamClient/Resources/DreamResourceManager.cs
@@ -6,244 +6,241 @@ using Robust.Shared.ContentPack;
 using Robust.Shared.Network;
 using Robust.Shared.Utility;
 
-namespace OpenDreamClient.Resources {
-    public interface IDreamResourceManager {
-        void Initialize();
-        ResPath CreateCacheFile(string filename, string data);
-        ResPath CreateCacheFile(string filename, byte[] data);
+namespace OpenDreamClient.Resources;
 
-        /// <param name="resourceId">Integer ID of the resource, as assigned by the server.</param>
-        /// <param name="onLoadCallback">
-        /// Callback to run when this resource is done loading.
-        /// Note that if the resource is immediately available,
-        /// this callback is immediately invoked before this function returns.
-        /// </param>
-        /// <typeparam name="T">The type of resource to load as.</typeparam>
-        void LoadResourceAsync<T>(int resourceId, Action<T> onLoadCallback) where T : DreamResource;
-        ResPath GetCacheFilePath(string filename);
-        public bool EnsureCacheFile(string filename, int timeoutSeconds = 5);
+public interface IDreamResourceManager {
+    void Initialize();
+    ResPath CreateCacheFile(string filename, string data);
+    ResPath CreateCacheFile(string filename, byte[] data);
+
+    /// <param name="resourceId">Integer ID of the resource, as assigned by the server.</param>
+    /// <param name="onLoadCallback">
+    /// Callback to run when this resource is done loading.
+    /// Note that if the resource is immediately available,
+    /// this callback is immediately invoked before this function returns.
+    /// </param>
+    /// <typeparam name="T">The type of resource to load as.</typeparam>
+    void LoadResourceAsync<T>(int resourceId, Action<T> onLoadCallback) where T : DreamResource;
+
+    ResPath GetCacheFilePath(string filename);
+    public bool EnsureCacheFile(string filename, int timeoutSeconds = 5);
+}
+
+internal sealed class DreamResourceManager : IDreamResourceManager {
+    private readonly Dictionary<int, LoadingResourceEntry> _loadingResources = new();
+    private readonly Dictionary<int, DreamResource> _resourceCache = new();
+
+    [Dependency] private readonly IResourceManager _resourceManager = default!;
+    [Dependency] private readonly IClientNetManager _netManager = default!;
+    [Dependency] private readonly IDynamicTypeFactory _typeFactory = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+
+    private ResPath _cacheDirectory;
+
+    private ISawmill _sawmill = default!;
+
+    private readonly HashSet<string> _activeBrowseRscRequests = new();
+
+    public void Initialize() {
+        _sawmill = Logger.GetSawmill("opendream.res");
+
+        _netManager.RegisterNetMessage<MsgBrowseResource>(RxBrowseResource);
+        _netManager.RegisterNetMessage<MsgBrowseResourceResponse>(RxBrowseResourceResponse);
+        _netManager.RegisterNetMessage<MsgRequestResource>();
+        _netManager.RegisterNetMessage<MsgResource>(RxResource);
+        _netManager.RegisterNetMessage<MsgNotifyResourceUpdate>(RxResourceUpdateNotification);
     }
 
-    internal sealed class DreamResourceManager : IDreamResourceManager {
-        private readonly Dictionary<int, LoadingResourceEntry> _loadingResources = new();
-        private readonly Dictionary<int, DreamResource> _resourceCache = new();
+    private void EnsureCacheDirectory() {
+        if(_cacheDirectory != default)
+            return;
+        if(_netManager.ServerChannel is null)
+            throw new Exception("Server doesn't appear to be connected, can't use cache right now!");
 
-        [Dependency] private readonly IResourceManager _resourceManager = default!;
-        [Dependency] private readonly IClientNetManager _netManager = default!;
-        [Dependency] private readonly IDynamicTypeFactory _typeFactory = default!;
-        [Dependency] private readonly IConfigurationManager _cfg = default!;
+        var address = _netManager.ServerChannel.RemoteEndPoint.ToString();
+        address = address.Replace(':', '.'); // colons aren't legal on Windows
 
-        private ResPath _cacheDirectory = default!;
+        _cacheDirectory = new ResPath($"/OpenDream/Cache/{address}");
+        _resourceManager.UserData.CreateDir(_cacheDirectory);
+        if (!_resourceManager.UserData.Exists(_cacheDirectory))
+            throw new Exception($"Could not create cache directory at {_cacheDirectory}");
 
-        private ISawmill _sawmill = default!;
+        _sawmill.Debug($"Cache directory is {_cacheDirectory}");
+    }
 
-        private readonly HashSet<string> _activeBrowseRscRequests = new();
-
-        public void Initialize() {
-            _sawmill = Logger.GetSawmill("opendream.res");
-
-            _netManager.RegisterNetMessage<MsgBrowseResource>(RxBrowseResource);
-            _netManager.RegisterNetMessage<MsgBrowseResourceResponse>(RxBrowseResourceResponse);
-            _netManager.RegisterNetMessage<MsgRequestResource>();
-            _netManager.RegisterNetMessage<MsgResource>(RxResource);
-            _netManager.RegisterNetMessage<MsgNotifyResourceUpdate>(RxResourceUpdateNotification);
-        }
-
-        private void EnsureCacheDirectory() {
-            if(_cacheDirectory != default)
+    private void RxBrowseResource(MsgBrowseResource message) {
+        _sawmill.Debug($"Received cache check for {message.Filename}");
+        EnsureCacheDirectory();
+        if(_resourceManager.UserData.Exists(GetCacheFilePath(message.Filename))){ //TODO CHECK HASH
+            _sawmill.Debug($"Cache hit for {message.Filename}");
+        } else {
+            if(_activeBrowseRscRequests.Contains(message.Filename)) //we've already requested it, don't need to do it again
                 return;
-            if(_netManager.ServerChannel is null)
-                throw new Exception("Server doesn't appear to be connected, can't use cache right now!");
-
-            var address = _netManager.ServerChannel.RemoteEndPoint.ToString();
-            address = address.Replace(':', '.'); // colons aren't legal on Windows
-
-            _cacheDirectory = new ResPath($"/OpenDream/Cache/{address}");
-            _resourceManager.UserData.CreateDir(_cacheDirectory);
-            if (!_resourceManager.UserData.Exists(_cacheDirectory))
-                throw new Exception($"Could not create cache directory at {_cacheDirectory}");
-
-            _sawmill.Debug($"Cache directory is {_cacheDirectory}");
+            _sawmill.Debug($"Cache miss for {message.Filename}, requesting from server.");
+            _activeBrowseRscRequests.Add(message.Filename);
+            _netManager.ServerChannel?.SendMessage(new MsgBrowseResourceRequest(){ Filename = message.Filename});
         }
+    }
 
-        private void RxBrowseResource(MsgBrowseResource message) {
-            _sawmill.Debug($"Received cache check for {message.Filename}");
+    private void RxBrowseResourceResponse(MsgBrowseResourceResponse message) {
+        if(_activeBrowseRscRequests.Contains(message.Filename)) {
+            _activeBrowseRscRequests.Remove(message.Filename);
             EnsureCacheDirectory();
-            if(_resourceManager.UserData.Exists(GetCacheFilePath(message.Filename))){ //TODO CHECK HASH
-                _sawmill.Debug($"Cache hit for {message.Filename}");
+            CreateCacheFile(message.Filename, message.Data);
+        } else {
+            _sawmill.Error($"Received a browse_rsc response for a file we didn't ask for: {message.Filename}");
+        }
+    }
+
+    private void RxResource(MsgResource message) {
+        if (_loadingResources.ContainsKey(message.ResourceId)) {
+            LoadingResourceEntry entry = _loadingResources[message.ResourceId];
+            DreamResource resource;
+            if(_resourceCache.ContainsKey(message.ResourceId)){
+                _resourceCache[message.ResourceId].UpdateData(message.ResourceData); //we update instead of replacing so we don't have to replace the handle in everything that uses it
+                _resourceCache[message.ResourceId].OnUpdateCallbacks.ForEach(cb => cb.Invoke());
+                resource = _resourceCache[message.ResourceId];
             } else {
-                if(_activeBrowseRscRequests.Contains(message.Filename)) //we've already requested it, don't need to do it again
-                    return;
-                _sawmill.Debug($"Cache miss for {message.Filename}, requesting from server.");
-                _activeBrowseRscRequests.Add(message.Filename);
-                _netManager.ServerChannel?.SendMessage(new MsgBrowseResourceRequest(){ Filename = message.Filename});
+                resource = LoadResourceFromData(
+                    entry.ResourceType,
+                    message.ResourceId,
+                    message.ResourceData);
+                _resourceCache[message.ResourceId] = resource;
             }
-        }
 
-        private void RxBrowseResourceResponse(MsgBrowseResourceResponse message) {
-            if(_activeBrowseRscRequests.Contains(message.Filename)) {
-                _activeBrowseRscRequests.Remove(message.Filename);
-                EnsureCacheDirectory();
-                CreateCacheFile(message.Filename, message.Data);
-            } else {
-                _sawmill.Error($"Recieved a browse_rsc response for a file we didn't ask for: {message.Filename}");
-            }
-        }
-
-        private void RxResource(MsgResource message) {
-            if (_loadingResources.ContainsKey(message.ResourceId)) {
-                LoadingResourceEntry entry = _loadingResources[message.ResourceId];
-                DreamResource resource;
-                if(_resourceCache.ContainsKey(message.ResourceId)){
-                    _resourceCache[message.ResourceId].UpdateData(message.ResourceData); //we update instead of replacing so we don't have to replace the handle in everything that uses it
-                    _resourceCache[message.ResourceId].OnUpdateCallbacks.ForEach(cb => cb.Invoke());
-                    resource = _resourceCache[message.ResourceId];
-                } else {
-                    resource = LoadResourceFromData(
-                        entry.ResourceType,
-                        message.ResourceId,
-                        message.ResourceData);
-                    _resourceCache[message.ResourceId] = resource;
+            foreach (Action<DreamResource> callback in entry.LoadCallbacks) {
+                try {
+                    callback.Invoke(resource);
+                } catch (Exception e) {
+                    _sawmill.Fatal($"Exception while calling resource load callback: {e.Message}");
                 }
-
-                foreach (Action<DreamResource> callback in entry.LoadCallbacks) {
-                    try {
-                        callback.Invoke(resource);
-                    } catch (Exception e) {
-                        _sawmill.Fatal($"Exception while calling resource load callback: {e.Message}");
-                    }
-                }
-
-                _loadingResources.Remove(message.ResourceId);
-            } else {
-                throw new Exception($"Received unexpected resource packet for resource id {message.ResourceId}");
             }
+
+            _loadingResources.Remove(message.ResourceId);
+        } else {
+            throw new Exception($"Received unexpected resource packet for resource id {message.ResourceId}");
+        }
+    }
+
+    private void RxResourceUpdateNotification(MsgNotifyResourceUpdate message) {
+        if (!_loadingResources.ContainsKey(message.ResourceId) && _resourceCache.TryGetValue(message.ResourceId, out var cached)) { //either we're already requesting it, or we don't have it so don't need to update
+            _sawmill.Debug($"Resource id {message.ResourceId} was updated, reloading");
+            _loadingResources[message.ResourceId] = new LoadingResourceEntry(cached.GetType());
+            var msg = new MsgRequestResource() { ResourceId = message.ResourceId };
+            _netManager.ClientSendMessage(msg);
+        }
+    }
+
+    public void LoadResourceAsync<T>(int resourceId, Action<T> onLoadCallback) where T:DreamResource {
+        DreamResource? resource = GetCachedResource(resourceId);
+
+        if (resource != null) {
+            onLoadCallback.Invoke((T)resource);
+            return;
         }
 
-        private void RxResourceUpdateNotification(MsgNotifyResourceUpdate message) {
-            if (!_loadingResources.ContainsKey(message.ResourceId) && _resourceCache.TryGetValue(message.ResourceId, out var cached)) { //either we're already requesting it, or we don't have it so don't need to update
-                _sawmill.Debug($"Resource id {message.ResourceId} was updated, reloading");
-                _loadingResources[message.ResourceId] = new LoadingResourceEntry(cached.GetType());
-                var msg = new MsgRequestResource() { ResourceId = message.ResourceId };
-                _netManager.ClientSendMessage(msg);
+        // Check if file exists in local Robust resources.
+        if (_resourceManager.TryContentFileRead($"/Rsc/{resourceId}", out var stream)) {
+            byte[] data;
+            using (stream) {
+                data = stream.CopyToArray();
             }
+
+            _sawmill.Verbose($"File existed locally, skipping server request: {resourceId}");
+
+            resource = LoadResourceFromData(typeof(T), resourceId, data);
+
+            onLoadCallback((T)resource);
+            return;
         }
 
-        public void LoadResourceAsync<T>(int resourceId, Action<T> onLoadCallback) where T:DreamResource {
-            DreamResource? resource = GetCachedResource(resourceId);
+        // File does not exist locally. Send a request to the server.
+        if (!_loadingResources.ContainsKey(resourceId)) {
+            _loadingResources[resourceId] = new LoadingResourceEntry(typeof(T));
 
-            if (resource != null) {
-                onLoadCallback.Invoke((T)resource);
-                return;
-            }
+            var msg = new MsgRequestResource() { ResourceId = resourceId };
+            _netManager.ClientSendMessage(msg);
 
-            // Check if file exists in local Robust resources.
-            if (_resourceManager.TryContentFileRead($"/Rsc/{resourceId}", out var stream)) {
-                byte[] data;
-                using (stream) {
-                    data = stream.CopyToArray();
+            var timeout = _cfg.GetCVar(OpenDreamCVars.DownloadTimeout);
+            Robust.Shared.Timing.Timer.Spawn(TimeSpan.FromSeconds(timeout), () => {
+                if (_loadingResources.ContainsKey(resourceId)) {
+                    _sawmill.Warning(
+                        $"Resource id {resourceId} was requested, but is still not received {timeout} seconds later.");
                 }
-
-                _sawmill.Verbose($"File existed locally, skipping server request: {resourceId}");
-
-                resource = LoadResourceFromData(typeof(T), resourceId, data);
-
-                onLoadCallback((T)resource);
-                return;
-            }
-
-            // File does not exist locally. Send a request to the server.
-            if (!_loadingResources.ContainsKey(resourceId)) {
-                _loadingResources[resourceId] = new LoadingResourceEntry(typeof(T));
-
-                var msg = new MsgRequestResource() { ResourceId = resourceId };
-                _netManager.ClientSendMessage(msg);
-
-                var timeout = _cfg.GetCVar(OpenDreamCVars.DownloadTimeout);
-                Robust.Shared.Timing.Timer.Spawn(TimeSpan.FromSeconds(timeout), () => {
-                    if (_loadingResources.ContainsKey(resourceId)) {
-                        _sawmill.Warning(
-                            $"Resource id {resourceId} was requested, but is still not received {timeout} seconds later.");
-                    }
-                });
-            }
-
-            _loadingResources[resourceId].LoadCallbacks.Add(loadedResource => {
-                onLoadCallback.Invoke((T)loadedResource);
             });
         }
 
-        private DreamResource LoadResourceFromData(Type resourceType, int resourceId, byte[] data) {
-            var resource = (DreamResource) _typeFactory.CreateInstance(resourceType,
-                new object[] {resourceId, data});
+        _loadingResources[resourceId].LoadCallbacks.Add(loadedResource => {
+            onLoadCallback.Invoke((T)loadedResource);
+        });
+    }
 
-            _resourceCache[resourceId] = resource;
-            return resource;
-        }
+    private DreamResource LoadResourceFromData(Type resourceType, int resourceId, byte[] data) {
+        var resource = (DreamResource) _typeFactory.CreateInstance(resourceType,
+            new object[] {resourceId, data});
 
-        public ResPath GetCacheFilePath(string filename) {
-            EnsureCacheDirectory();
+        _resourceCache[resourceId] = resource;
+        return resource;
+    }
 
-            return _cacheDirectory / new ResPath(filename).ToRelativePath();
-        }
+    public ResPath GetCacheFilePath(string filename) {
+        EnsureCacheDirectory();
 
-        public ResPath CreateCacheFile(string filename, string data) {
-            EnsureCacheDirectory();
+        return _cacheDirectory / new ResPath(filename).ToRelativePath();
+    }
 
-            // in BYOND when filename is a path everything except the filename at the end gets ignored - meaning all resource files end up directly in the cache folder
-            var path = _cacheDirectory / new ResPath(filename).Filename;
-            _resourceManager.UserData.WriteAllText(path, data);
-            return new ResPath(filename);
-        }
+    public ResPath CreateCacheFile(string filename, string data) {
+        EnsureCacheDirectory();
 
-        public ResPath CreateCacheFile(string filename, byte[] data) {
-            EnsureCacheDirectory();
+        // in BYOND when filename is a path everything except the filename at the end gets ignored - meaning all resource files end up directly in the cache folder
+        var path = _cacheDirectory / new ResPath(filename).Filename;
+        _resourceManager.UserData.WriteAllText(path, data);
+        return new ResPath(filename);
+    }
 
-            // in BYOND when filename is a path everything except the filename at the end gets ignored - meaning all resource files end up directly in the cache folder
-            var path = _cacheDirectory / new ResPath(filename).Filename;
-            _resourceManager.UserData.WriteAllBytes(path, data);
-            return new ResPath(filename);
-        }
+    public ResPath CreateCacheFile(string filename, byte[] data) {
+        EnsureCacheDirectory();
 
-        /// <summary>
-        /// Blocking check for the existence of a cached file from `browse_rsc()`. Returns true when the file is ready, or returns false if the file is not ready within timeoutSeconds.
-        /// </summary>
-        /// <param name="filename">filepath of the cached resource (eg `./foo.png`)</param>
-        /// <param name="timeoutSeconds">how long to block for while waiting for the resource. Default 5 seconds.</param>
-        /// <returns></returns>
-        public bool EnsureCacheFile(string filename, int timeoutSeconds = 5) {
-            var actualPath = GetCacheFilePath(filename);
-            if(_resourceManager.UserData.Exists(actualPath)) {
-                return true;
-            } else {
-                if(_activeBrowseRscRequests.Contains(actualPath.Filename)) {
-                    //block until the file arrives for like 5 seconds, then give up
-                    DateTime thresholdTime = DateTime.Now.AddSeconds(timeoutSeconds);
-                    while(!_resourceManager.UserData.Exists(actualPath) && DateTime.Now < thresholdTime) {
-                        _netManager.ProcessPackets(); //todo this should be sleep
-                    }
-                    return _resourceManager.UserData.Exists(actualPath);
-                } else {
-                    _sawmill.Error("Cache was ensured for a file that does not exist in cache and is not requested. Probably someobody called browse() without browse_rsc() first.");
-                    return false;
+        // in BYOND when filename is a path everything except the filename at the end gets ignored - meaning all resource files end up directly in the cache folder
+        var path = _cacheDirectory / new ResPath(filename).Filename;
+        _resourceManager.UserData.WriteAllBytes(path, data);
+        return new ResPath(filename);
+    }
+
+    /// <summary>
+    /// Blocking check for the existence of a cached file from `browse_rsc()`. Returns true when the file is ready, or returns false if the file is not ready within timeoutSeconds.
+    /// </summary>
+    /// <param name="filename">filepath of the cached resource (eg `./foo.png`)</param>
+    /// <param name="timeoutSeconds">how long to block for while waiting for the resource. Default 5 seconds.</param>
+    /// <returns></returns>
+    public bool EnsureCacheFile(string filename, int timeoutSeconds = 5) {
+        var actualPath = GetCacheFilePath(filename);
+        if(_resourceManager.UserData.Exists(actualPath)) {
+            return true;
+        } else {
+            if(_activeBrowseRscRequests.Contains(actualPath.Filename)) {
+                //block until the file arrives for like 5 seconds, then give up
+                DateTime thresholdTime = DateTime.Now.AddSeconds(timeoutSeconds);
+                while(!_resourceManager.UserData.Exists(actualPath) && DateTime.Now < thresholdTime) {
+                    _netManager.ProcessPackets(); //todo this should be sleep
                 }
+
+                return _resourceManager.UserData.Exists(actualPath);
+            } else {
+                _sawmill.Error("Cache was ensured for a file that does not exist in cache and is not requested. Probably somebody called browse() without browse_rsc() first.");
+                return false;
             }
         }
+    }
 
-        private DreamResource? GetCachedResource(int resourceId) {
-            _resourceCache.TryGetValue(resourceId, out var cached);
+    private DreamResource? GetCachedResource(int resourceId) {
+        _resourceCache.TryGetValue(resourceId, out var cached);
 
-            return cached;
-        }
+        return cached;
+    }
 
-        private struct LoadingResourceEntry {
-            public Type ResourceType;
-            public List<Action<DreamResource>> LoadCallbacks;
-
-            public LoadingResourceEntry(Type resourceType) {
-                ResourceType = resourceType;
-                LoadCallbacks = new List<Action<DreamResource>>();
-            }
-        }
+    private struct LoadingResourceEntry(Type resourceType) {
+        public readonly Type ResourceType = resourceType;
+        public readonly List<Action<DreamResource>> LoadCallbacks = new();
     }
 }

--- a/OpenDreamRuntime/Resources/DreamResourceManager.cs
+++ b/OpenDreamRuntime/Resources/DreamResourceManager.cs
@@ -1,5 +1,8 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using OpenDreamRuntime.Objects.Types;
 using OpenDreamShared.Network.Messages;
 using OpenDreamShared.Resources;
@@ -8,237 +11,257 @@ using Robust.Shared.Utility;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
-namespace OpenDreamRuntime.Resources {
-    public sealed class DreamResourceManager {
-        [Dependency] private readonly IServerNetManager _netManager = default!;
+namespace OpenDreamRuntime.Resources;
 
-        public string RootPath { get; private set; }
+public sealed class DreamResourceManager {
+    [Dependency] private readonly IServerNetManager _netManager = default!;
 
-        private readonly List<DreamResource> _resourceCache = new();
-        private readonly Dictionary<string, int> _resourcePathToId = new();
+    public string RootPath { get; private set; } = default!;
 
-        private ISawmill _sawmill;
+    private readonly List<DreamResource> _resourceCache = new();
+    private readonly Dictionary<string, int> _resourcePathToId = new();
+    private readonly Dictionary<string, IconResource> _md5ToGeneratedIcon = new();
 
-        public void PreInitialize() {
-            _sawmill = Logger.GetSawmill("opendream.res");
-            _netManager.RegisterNetMessage<MsgRequestResource>(RxRequestResource);
-            _netManager.RegisterNetMessage<MsgResource>();
-            _netManager.RegisterNetMessage<MsgNotifyResourceUpdate>();
+    private ISawmill _sawmill = default!;
+
+    public void PreInitialize() {
+        _sawmill = Logger.GetSawmill("opendream.res");
+        _netManager.RegisterNetMessage<MsgRequestResource>(RxRequestResource);
+        _netManager.RegisterNetMessage<MsgResource>();
+        _netManager.RegisterNetMessage<MsgNotifyResourceUpdate>();
+    }
+
+    public void Initialize(string rootPath, string[] resources) {
+        _resourceCache.Clear();
+        _resourcePathToId.Clear();
+
+        // An empty resource path is the console
+        _resourceCache.Add(new ConsoleOutputResource());
+        _resourcePathToId.Add(string.Empty, 0);
+
+        RootPath = rootPath;
+
+        // Used to ensure external DLL calls see a consistent current directory.
+        Directory.SetCurrentDirectory(RootPath);
+
+        _sawmill.Debug($"Resource root path set to {RootPath}");
+
+        // Immediately build list of resources from rsc.
+        for (var i = 0; i < resources.Length; i++) {
+            var resource = resources[i];
+            var loaded = LoadResource(resource);
+            // Resource IDs must be consistent with the ordering, or else packaged resources will mismatch.
+            DebugTools.Assert(loaded.Id == i + 1, "Resource IDs not consistent!");
         }
+    }
 
-        public void Initialize(string rootPath, string[] resources) {
-            _resourceCache.Clear();
-            _resourcePathToId.Clear();
+    public bool DoesFileExist(string resourcePath) {
+        return File.Exists(resourcePath);
+    }
 
-            // An empty resource path is the console
-            _resourceCache.Add(new ConsoleOutputResource());
-            _resourcePathToId.Add(string.Empty, 0);
+    public DreamResource LoadResource(string resourcePath, bool forceReload = false) {
+        DreamResource resource;
+        int resourceId;
 
-            RootPath = rootPath;
+        DreamResource GetResource() {
+            // Create a new type of resource based on its extension
+            switch (Path.GetExtension(resourcePath)) {
+                case ".dmi":
+                case ".png":
+                    resource = new IconResource(resourceId, resourcePath, resourcePath);
+                    break;
+                case ".jpg":
+                case ".rsi": // RT-specific, not in BYOND
+                case ".gif":
+                case ".bmp":
+                    // TODO implement other icon file types
+                    goto default;
 
-            // Used to ensure external DLL calls see a consistent current directory.
-            Directory.SetCurrentDirectory(RootPath);
-
-            _sawmill.Debug($"Resource root path set to {RootPath}");
-
-            // Immediately build list of resources from rsc.
-            for (var i = 0; i < resources.Length; i++) {
-                var resource = resources[i];
-                var loaded = LoadResource(resource);
-                // Resource IDs must be consistent with the ordering, or else packaged resources will mismatch.
-                DebugTools.Assert(loaded.Id == i + 1, "Resource IDs not consistent!");
-            }
-        }
-
-        public bool DoesFileExist(string resourcePath) {
-            return File.Exists(resourcePath);
-        }
-
-        public DreamResource LoadResource(string resourcePath, bool forceReload = false) {
-            DreamResource resource;
-            int resourceId;
-
-            DreamResource GetResource() {
-                // Create a new type of resource based on its extension
-                switch (Path.GetExtension(resourcePath)) {
-                    case ".dmi":
-                    case ".png":
-                        resource = new IconResource(resourceId, resourcePath, resourcePath);
-                        break;
-                    case ".jpg":
-                    case ".rsi": // RT-specific, not in BYOND
-                    case ".gif":
-                    case ".bmp":
-                        // TODO implement other icon file types
-                        goto default;
-
-                    default:
-                        resource = new DreamResource(resourceId, resourcePath, resourcePath);
-                        break;
-                }
-                return resource;
-            }
-
-            if (!forceReload && _resourcePathToId.TryGetValue(resourcePath, out resourceId)) {
-                resource = _resourceCache[resourceId];
-            } else if(!forceReload) {
-                resourceId = _resourceCache.Count;
-                resource = GetResource();
-                _resourceCache.Add(resource);
-                _resourcePathToId.Add(resourcePath, resourceId);
-            } else {
-                resourceId = _resourcePathToId[resourcePath];
-                resource = GetResource();
-                _resourceCache[resourceId] = resource;
+                default:
+                    resource = new DreamResource(resourceId, resourcePath, resourcePath);
+                    break;
             }
 
             return resource;
         }
 
-        public bool TryLoadResource(int resourceId, [NotNullWhen(true)] out DreamResource? resource) {
-            if (resourceId >= 0 && resourceId < _resourceCache.Count) {
-                resource = _resourceCache[resourceId];
-                return true;
-            }
+        if (!forceReload && _resourcePathToId.TryGetValue(resourcePath, out resourceId)) {
+            resource = _resourceCache[resourceId];
+        } else if(!forceReload) {
+            resourceId = _resourceCache.Count;
+            resource = GetResource();
+            _resourceCache.Add(resource);
+            _resourcePathToId.Add(resourcePath, resourceId);
+        } else {
+            resourceId = _resourcePathToId[resourcePath];
+            resource = GetResource();
+            _resourceCache[resourceId] = resource;
+        }
 
-            resource = null;
+        return resource;
+    }
+
+    public bool TryLoadResource(int resourceId, [NotNullWhen(true)] out DreamResource? resource) {
+        if (resourceId >= 0 && resourceId < _resourceCache.Count) {
+            resource = _resourceCache[resourceId];
+            return true;
+        }
+
+        resource = null;
+        return false;
+    }
+
+    public bool TryLoadIcon(DreamValue value, [NotNullWhen(true)] out IconResource? icon) {
+        if (value.TryGetValueAsDreamObject<DreamObjectIcon>(out var iconObj)) {
+            icon = iconObj.Icon.GenerateDMI();
+            return true;
+        }
+
+        DreamResource? resource;
+
+        if (value.TryGetValueAsString(out var resourcePath)) {
+            resource = LoadResource(resourcePath);
+        } else {
+            value.TryGetValueAsDreamResource(out resource);
+        }
+
+        if (resource is IconResource iconResource) {
+            icon = iconResource;
+            return true;
+        }
+
+        icon = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Dynamically create a new generic resource that clients can use
+    /// </summary>
+    /// <param name="data">The resource's data</param>
+    public DreamResource CreateResource(byte[] data) {
+        int resourceId = _resourceCache.Count;
+        DreamResource resource = new DreamResource(resourceId, data);
+
+        _resourceCache.Add(resource);
+        return resource;
+    }
+
+    /// <summary>
+    /// Dynamically create a new icon resource that clients can use
+    /// </summary>
+    /// <param name="data">The resource's data</param>
+    /// <param name="texture">The image texture</param>
+    /// <param name="dmi">The image's DMI information, assumed to be equal to what's in the data argument</param>
+    public IconResource CreateIconResource(byte[] data, Image<Rgba32> texture, DMIParser.ParsedDMIDescription dmi) {
+        var resourceId = _resourceCache.Count;
+        var md5 = CalculateMd5(data);
+        if (_md5ToGeneratedIcon.TryGetValue(md5, out var possibleDuplicate) && possibleDuplicate.ResourceData != null) {
+            if (data.SequenceEqual(possibleDuplicate.ResourceData))
+                return possibleDuplicate;
+        }
+
+        IconResource resource = new IconResource(resourceId, data, texture, dmi);
+        _resourceCache.Add(resource);
+        _md5ToGeneratedIcon[md5] = resource; // Would override in the case of collisions, but whatever
+        return resource;
+    }
+
+    /// <summary>
+    /// Dynamically create a new icon resource that clients can use
+    /// </summary>
+    /// <param name="data">The resource's data</param>
+    public IconResource CreateIconResource(byte[] data) {
+        var resourceId = _resourceCache.Count;
+        var md5 = CalculateMd5(data);
+        if (_md5ToGeneratedIcon.TryGetValue(md5, out var possibleDuplicate) && possibleDuplicate.ResourceData != null) {
+            if (data.SequenceEqual(possibleDuplicate.ResourceData))
+                return possibleDuplicate;
+        }
+
+        IconResource resource = new IconResource(resourceId, data);
+        _resourceCache.Add(resource);
+        _md5ToGeneratedIcon[md5] = resource;  // Would override in the case of collisions, but whatever
+        return resource;
+    }
+
+    public void RxRequestResource(MsgRequestResource pRequestResource) {
+        if (TryLoadResource(pRequestResource.ResourceId, out var resource)) {
+            var msg = new MsgResource {
+                ResourceId = resource.Id, ResourceData = resource.ResourceData
+            };
+
+            pRequestResource.MsgChannel.SendMessage(msg);
+        } else {
+            _sawmill.Warning(
+                $"User {pRequestResource.MsgChannel} requested resource with id '{pRequestResource.ResourceId}', which doesn't exist");
+        }
+    }
+
+    public bool DeleteFile(string filePath) {
+        try {
+            File.Delete(filePath);
+        } catch (Exception) {
             return false;
         }
 
-        public bool TryLoadIcon(DreamValue value, [NotNullWhen(true)] out IconResource? icon) {
-            if (value.TryGetValueAsDreamObject<DreamObjectIcon>(out var iconObj)) {
-                icon = iconObj.Icon.GenerateDMI();
-                return true;
-            }
+        return true;
+    }
 
-            DreamResource? resource;
-
-            if (value.TryGetValueAsString(out var resourcePath)) {
-                resource = LoadResource(resourcePath);
-            } else {
-                value.TryGetValueAsDreamResource(out resource);
-            }
-
-            if (resource is IconResource iconResource) {
-                icon = iconResource;
-                return true;
-            }
-
-            icon = null;
+    public bool DeleteDirectory(string directoryPath) {
+        try {
+            Directory.Delete(directoryPath, true);
+        } catch (Exception) {
             return false;
         }
 
-        /// <summary>
-        /// Dynamically create a new icon resource that clients can use
-        /// </summary>
-        /// <param name="data">The resource's data</param>
-        /// <param name="texture">The image texture</param>
-        /// <param name="dmi">The image's DMI information</param>
-        public IconResource CreateIconResource(byte[] data, Image<Rgba32> texture, DMIParser.ParsedDMIDescription dmi) {
-            int resourceId = _resourceCache.Count;
-            IconResource resource = new IconResource(resourceId, data, texture, dmi);
+        return true;
+    }
 
-            _resourceCache.Add(resource);
-            return resource;
+    public bool SaveTextToFile(string filePath, string text) {
+        try {
+            Directory.GetParent(filePath)?.Create();
+            File.WriteAllText(filePath, text);
+        } catch (Exception) {
+            return false;
         }
 
-        /// <summary>
-        /// Dynamically create a new generic resource that clients can use
-        /// </summary>
-        /// <param name="data">The resource's data</param>
-        public DreamResource CreateResource(byte[] data) {
-            int resourceId = _resourceCache.Count;
-            DreamResource resource = new DreamResource(resourceId, data);
+        return true;
+    }
 
-            _resourceCache.Add(resource);
-            return resource;
+    public bool CopyFile(DreamResource sourceFile, string destinationFilePath) {
+        try {
+            var dir = Path.GetDirectoryName(destinationFilePath);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            if (sourceFile.ResourceData == null)
+                File.WriteAllText(string.Empty, destinationFilePath);
+            else
+                File.WriteAllBytes(destinationFilePath, sourceFile.ResourceData);
+        } catch (Exception) {
+            return false;
         }
 
-        /// <summary>
-        /// Dynamically create a new icon resource that clients can use
-        /// </summary>
-        /// <param name="data">The resource's data</param>
-        public IconResource CreateIconResource(byte[] data) {
-            int resourceId = _resourceCache.Count;
-            IconResource resource = new IconResource(resourceId, data);
+        return true;
+    }
 
-            _resourceCache.Add(resource);
-            return resource;
+    public string[] EnumerateListing(string path) {
+        string directory = Path.GetDirectoryName(path);
+        string searchPattern = Path.GetFileName(path);
+
+        var entries = Directory.GetFileSystemEntries(directory, searchPattern);
+        for (var i = 0; i < entries.Length; i++) {
+            var relPath = Path.GetRelativePath(directory, entries[i]);
+            if (Directory.Exists(entries[i])) relPath += "/";
+            entries[i] = relPath;
         }
 
-        public void RxRequestResource(MsgRequestResource pRequestResource) {
-            if (TryLoadResource(pRequestResource.ResourceId, out var resource)) {
-                var msg = new MsgResource() {
-                    ResourceId = resource.Id, ResourceData = resource.ResourceData
-                };
+        return entries;
+    }
 
-                pRequestResource.MsgChannel.SendMessage(msg);
-            } else {
-                _sawmill.Warning(
-                    $"User {pRequestResource.MsgChannel} requested resource with id '{pRequestResource.ResourceId}', which doesn't exist");
-            }
-        }
+    private string CalculateMd5(byte[] date) {
+        using MD5 md5 = MD5.Create();
 
-        public bool DeleteFile(string filePath) {
-            try {
-                File.Delete(filePath);
-            } catch (Exception) {
-                return false;
-            }
-
-            return true;
-        }
-
-        public bool DeleteDirectory(string directoryPath) {
-            try {
-                Directory.Delete(directoryPath, true);
-            } catch (Exception) {
-                return false;
-            }
-
-            return true;
-        }
-
-        public bool SaveTextToFile(string filePath, string text) {
-            try {
-                Directory.GetParent(filePath)?.Create();
-                File.WriteAllText(filePath, text);
-            } catch (Exception) {
-                return false;
-            }
-
-            return true;
-        }
-
-        public bool CopyFile(DreamResource sourceFile, string destinationFilePath) {
-            try {
-                var dir = Path.GetDirectoryName(destinationFilePath);
-                if (!string.IsNullOrEmpty(dir))
-                    Directory.CreateDirectory(dir);
-
-                if (sourceFile.ResourceData == null)
-                    File.WriteAllText(string.Empty, destinationFilePath);
-                else
-                    File.WriteAllBytes(destinationFilePath, sourceFile.ResourceData);
-            } catch (Exception) {
-                return false;
-            }
-
-            return true;
-        }
-
-        public string[] EnumerateListing(string path) {
-            string directory = Path.GetDirectoryName(path);
-            string searchPattern = Path.GetFileName(path);
-
-            var entries = Directory.GetFileSystemEntries(directory, searchPattern);
-            for (var i = 0; i < entries.Length; i++) {
-                var relPath = Path.GetRelativePath(directory, entries[i]);
-                if (Directory.Exists(entries[i])) relPath += "/";
-                entries[i] = relPath;
-            }
-
-            return entries;
-        }
+        return Encoding.ASCII.GetString(md5.ComputeHash(date));
     }
 }


### PR DESCRIPTION
The server now uses MD5 hashes to help prevent creating exact copies of DMIs generated with `/icon`. This saves ~10MB during /tg/ init alone in resources that would have to be sent to the client otherwise.