### PR TITLE
Fix vis_contents not working on screen objects

### DIFF
--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -335,7 +335,7 @@ internal sealed partial class DreamViewOverlay : Overlay {
             if (!_spriteQuery.TryGetComponent(visContentEntity, out var sprite))
                 continue;
             var transform = _xformQuery.GetComponent(visContentEntity);
-            if (!sprite.IsVisible(transform, seeVis))
+            if (!sprite.IsVisible(isScreen ? null : transform, seeVis))
                 continue;
 
             ProcessIconComponents(sprite.Icon, position, visContentEntity, false, ref tieBreaker, result, seeVis, current, keepTogether);

--- a/OpenDreamClient/Rendering/DreamViewOverlay.cs
+++ b/OpenDreamClient/Rendering/DreamViewOverlay.cs
@@ -334,8 +334,7 @@ internal sealed partial class DreamViewOverlay : Overlay {
             EntityUid visContentEntity = _entityManager.GetEntity(visContent);
             if (!_spriteQuery.TryGetComponent(visContentEntity, out var sprite))
                 continue;
-            var transform = _xformQuery.GetComponent(visContentEntity);
-            if (!sprite.IsVisible(isScreen ? null : transform, seeVis))
+            if (!sprite.IsVisible(isScreen ? null : _xformQuery.GetComponent(visContentEntity), seeVis))
                 continue;
 
             ProcessIconComponents(sprite.Icon, position, visContentEntity, false, ref tieBreaker, result, seeVis, current, keepTogether);


### PR DESCRIPTION
These vis contents weren't rendering because they weren't attached to the map.

Was the last issue keeping tg's parallax from working.
![image](https://github.com/user-attachments/assets/1511c7c6-4b1a-412b-8718-8a350861adfc)