### PR TITLE
Make preprocessor dump skip build

### DIFF
--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -180,6 +180,7 @@ public class DMCompiler {
 
             File.WriteAllText(outputPath, result.ToString());
             Console.WriteLine($"Preprocessor output dumped to {outputPath}");
+            return null;
         }
 
         return Build();

--- a/DMCompiler/Program.cs
+++ b/DMCompiler/Program.cs
@@ -71,7 +71,7 @@ internal static class Program {
         Console.WriteLine("--version [VER].[BUILD]   : Used to set the DM_VERSION and DM_BUILD macros");
         Console.WriteLine("--skip-bad-args           : Skip arguments the compiler doesn't recognize");
         Console.WriteLine("--suppress-unimplemented  : Do not warn about unimplemented proc and var uses");
-        Console.WriteLine("--dump-preprocessor       : This saves the result of preprocessing (#include, #if, defines, etc) in a file called preprocessor_dump.dm beside the given DME file.");
+        Console.WriteLine("--dump-preprocessor       : This saves the result of preprocessing (#include, #if, defines, etc) in a file called preprocessor_dump.dm beside the given DME file. Skips compilation.");
         Console.WriteLine("--no-standard             : This disables objects and procs that are usually built-into every DM program by not including DMStandard.dm.");
         Console.WriteLine("--define [KEY=VAL]        : Add extra defines to the compilation");
         Console.WriteLine("--verbose                 : Show verbose output during compile");


### PR DESCRIPTION
Allows to debug preprocessor easier and to use OD as a fast preprocessor potentially