### PR TITLE
Optimize `world.tick_usage`

### DIFF
--- a/Content.Tests/DummyDreamMapManager.cs
+++ b/Content.Tests/DummyDreamMapManager.cs
@@ -22,7 +22,7 @@ public sealed class DummyDreamMapManager : IDreamMapManager {
 
     public void LoadMaps(List<DreamMapJson>? maps) { }
 
-    public void InitializeAtoms(List<DreamMapJson>? maps) { }
+    public void InitializeAtoms() { }
 
     public void SetTurf(DreamObjectTurf turf, DreamObjectDefinition type, DreamProcArguments creationArguments) { }
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectWorld.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectWorld.cs
@@ -29,6 +29,8 @@ public sealed class DreamObjectWorld : DreamObject {
     public float TickUsage =>
         (Environment.TickCount64 - DreamManager.CurrentTickStart) / (float)(_gameTiming.TickPeriod.TotalMilliseconds) * 100;
 
+    public float Cpu { get; set; }
+
     private double TickLag {
         get => _gameTiming.TickPeriod.TotalMilliseconds / 100;
         set => _gameTiming.TickRate = (byte)(1000 / (value * 100));
@@ -162,6 +164,10 @@ public sealed class DreamObjectWorld : DreamObject {
 
             case "tick_usage":
                 value = new DreamValue(TickUsage);
+                return true;
+
+            case "cpu":
+                value = new DreamValue(Cpu);
                 return true;
 
             case "maxx":

--- a/OpenDreamRuntime/Objects/Types/DreamObjectWorld.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectWorld.cs
@@ -25,6 +25,10 @@ public sealed class DreamObjectWorld : DreamObject {
     public readonly ViewRange DefaultView;
     public DreamResource? Log;
 
+    // DM code may request this info a *lot* so we use the more performant Environment.TickCount64 over RT's stopwatches
+    public float TickUsage =>
+        (Environment.TickCount64 - DreamManager.CurrentTickStart) / (float)(_gameTiming.TickPeriod.TotalMilliseconds) * 100;
+
     private double TickLag {
         get => _gameTiming.TickPeriod.TotalMilliseconds / 100;
         set => _gameTiming.TickRate = (byte)(1000 / (value * 100));
@@ -157,9 +161,7 @@ public sealed class DreamObjectWorld : DreamObject {
                 return true;
 
             case "tick_usage":
-                var tickUsage = (_gameTiming.RealTime - _gameTiming.LastTick) / _gameTiming.TickPeriod;
-
-                value = new DreamValue(tickUsage * 100);
+                value = new DreamValue(TickUsage);
                 return true;
 
             case "maxx":

--- a/OpenDreamRuntime/Resources/DreamResource.cs
+++ b/OpenDreamRuntime/Resources/DreamResource.cs
@@ -4,31 +4,32 @@ using System.Text;
 namespace OpenDreamRuntime.Resources;
 
 [Virtual]
-public class DreamResource {
-    public readonly string? ResourcePath;
-    public readonly int Id;
+public class DreamResource(int id, string? filePath, string? resourcePath) {
+    public readonly string? ResourcePath = resourcePath;
+    public readonly int Id = id;
+
     public byte[]? ResourceData {
         get {
-            if (_resourceData == null && File.Exists(_filePath)) {
-                _resourceData = File.ReadAllBytes(_filePath);
+            if (_resourceData == null && File.Exists(filePath)) {
+                _resourceData = File.ReadAllBytes(filePath);
             }
 
             return _resourceData;
         }
     }
 
-    private readonly string? _filePath;
     private byte[]? _resourceData;
 
-    public DreamResource(int id, string? filePath, string? resourcePath) {
-        Id = id;
-        ResourcePath = resourcePath;
-        _filePath = filePath;
+    public DreamResource(int id, byte[] data) : this(id, null, null) {
+        _resourceData = data;
     }
 
-    public DreamResource(int id, byte[] data) {
-        Id = id;
-        _resourceData = data;
+    /// <summary>
+    /// Invalidates any caching this resource may have, causing it to be re-read from disk.
+    /// Calling this alone will not update what clients are holding.
+    /// </summary>
+    public void ReloadFromDisk() {
+        _resourceData = null;
     }
 
     public virtual string? ReadAsString() {
@@ -41,11 +42,11 @@ public class DreamResource {
     }
 
     public void Clear() {
-        if (string.IsNullOrEmpty(_filePath))
+        if (string.IsNullOrEmpty(filePath))
             return;
 
         CreateDirectory();
-        File.WriteAllText(_filePath, string.Empty);
+        File.WriteAllText(filePath, string.Empty);
     }
 
     public virtual void Output(DreamValue value) {
@@ -65,10 +66,10 @@ public class DreamResource {
     }
 
     private void CreateDirectory() {
-        if (_filePath == null)
+        if (filePath == null)
             return;
 
-        string? directory = Path.GetDirectoryName(_filePath);
+        string? directory = Path.GetDirectoryName(filePath);
         if (string.IsNullOrEmpty(directory))
             return;
 


### PR DESCRIPTION
/tg/ must request `world.tick_usage` a bajillion times or something, because it spends 6.5 seconds of init on it:
![image](https://github.com/user-attachments/assets/782c75aa-c243-4440-a290-764844f83dd7)

I swapped it from using RT's `IGameTiming.RealTime` stopwatch to `Environment.TickCount64` which is performing much better:
![image](https://github.com/user-attachments/assets/c64a85bc-0ded-45b4-ba49-6dfa3150e228)
