### PR TITLE
Implement `DblClick()`

### DIFF
--- a/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
+++ b/DMCompiler/DMStandard/Types/Atoms/_Atom.dm
@@ -63,12 +63,10 @@
 	var/vis_flags as opendream_unimplemented
 
 	proc/Click(location, control, params)
+	proc/DblClick(location, control, params)
 	proc/MouseDrop(over_object,src_location,over_location,src_control,over_control,params)
 	proc/MouseEntered(location,control,params)
 	proc/MouseExited(location,control,params)
-
-	proc/DblClick(location, control, params)
-		set opendream_unimplemented = TRUE
 
 	proc/MouseDown(location, control, params)
 		set opendream_unimplemented = TRUE

--- a/DMCompiler/DMStandard/Types/Client.dm
+++ b/DMCompiler/DMStandard/Types/Client.dm
@@ -123,7 +123,6 @@
 		object.Click(location, control, params)
 
 	proc/DblClick(atom/object, location, control, params)
-		set opendream_unimplemented = TRUE
 		object.DblClick(location,control,params)
 
 	proc/MouseDown(atom/object, location, control, params)

--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -26,6 +26,7 @@ public sealed class DreamConnection {
 
     [ViewVariables] private readonly Dictionary<string, List<(string, string, string?)>> _statPanels = new();
     [ViewVariables] private bool _currentlyUpdatingStat;
+    [ViewVariables] public TimeSpan? LastClickTime { get; set; }
 
     [ViewVariables] public ICommonSession? Session { get; private set; }
     [ViewVariables] public DreamObjectClient? Client { get; private set; }

--- a/OpenDreamRuntime/Input/MouseInputSystem.cs
+++ b/OpenDreamRuntime/Input/MouseInputSystem.cs
@@ -121,20 +121,22 @@ internal sealed class MouseInputSystem : SharedMouseInputSystem {
         var connection = _dreamManager.GetConnectionBySession(session);
         var usr = connection.Mob;
 
+        var clickParams = ConstructClickParams(e.Params);
+
         // Double click fires before the second Click() fires
         if (_timing.RealTime - connection.LastClickTime <= _doubleClickDelay) {
             connection.Client?.SpawnProc("DblClick", usr: usr,
                 new DreamValue(atom),
                 DreamValue.Null,
                 DreamValue.Null,
-                new DreamValue(ConstructClickParams(e.Params)));
+                new DreamValue(clickParams));
         }
 
         connection.Client?.SpawnProc("Click", usr: usr,
             new DreamValue(atom),
             DreamValue.Null,
             DreamValue.Null,
-            new DreamValue(ConstructClickParams(e.Params)));
+            new DreamValue(clickParams));
 
         connection.LastClickTime = _timing.RealTime;
     }

--- a/OpenDreamRuntime/Input/MouseInputSystem.cs
+++ b/OpenDreamRuntime/Input/MouseInputSystem.cs
@@ -4,7 +4,6 @@ using OpenDreamRuntime.Objects.Types;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Input;
 using Robust.Shared;
-using Robust.Shared.Configuration;
 using Robust.Shared.Timing;
 
 namespace OpenDreamRuntime.Input;

--- a/OpenDreamRuntime/Input/MouseInputSystem.cs
+++ b/OpenDreamRuntime/Input/MouseInputSystem.cs
@@ -3,7 +3,6 @@ using OpenDreamRuntime.Map;
 using OpenDreamRuntime.Objects.Types;
 using OpenDreamShared.Dream;
 using OpenDreamShared.Input;
-using Robust.Shared;
 using Robust.Shared.Timing;
 
 namespace OpenDreamRuntime.Input;


### PR DESCRIPTION
https://github.com/OpenDreamProject/OpenDream/issues/2194

Implements `DblClick()` for `/client` and `/atom`. This enables ghosts to jump to turf or orbit things on Paradise:

https://github.com/user-attachments/assets/f88812a7-584c-464e-9b4d-7123cfc99f17

