### PR TITLE
public compiler/lexer/preproc

### DIFF
--- a/DMCompiler/Compiler/DM/DMLexer.cs
+++ b/DMCompiler/Compiler/DM/DMLexer.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace DMCompiler.Compiler.DM;
 
-internal sealed class DMLexer : TokenLexer {
+public sealed class DMLexer : TokenLexer {
     public static readonly List<string> ValidEscapeSequences = [
         "icon",
         "Roman", "roman",
@@ -68,7 +68,7 @@ internal sealed class DMLexer : TokenLexer {
     private readonly Stack<int> _indentationStack = new(new[] { 0 });
 
     /// <param name="source">The enumerable list of tokens output by <see cref="DMPreprocessor.DMPreprocessorLexer"/>.</param>
-    internal DMLexer(string sourceName, IEnumerable<Token> source) : base(sourceName, source) { }
+    public DMLexer(string sourceName, IEnumerable<Token> source) : base(sourceName, source) { }
 
     protected override Token ParseNextToken() {
         Token token;

--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -4,7 +4,7 @@ using DMCompiler.Compiler.DM.AST;
 using DMCompiler.DM;
 
 namespace DMCompiler.Compiler.DM {
-    internal partial class DMParser(DMCompiler compiler, DMLexer lexer) : Parser<Token>(compiler, lexer) {
+    public partial class DMParser(DMCompiler compiler, DMLexer lexer) : Parser<Token>(compiler, lexer) {
         protected Location CurrentLoc => Current().Location;
         protected DreamPath CurrentPath = DreamPath.Root;
 

--- a/DMCompiler/Compiler/DM/DMParserHelper.cs
+++ b/DMCompiler/Compiler/DM/DMParserHelper.cs
@@ -6,7 +6,7 @@ using DMCompiler.Compiler.DM.AST;
 
 namespace DMCompiler.Compiler.DM;
 
-internal partial class DMParser {
+public partial class DMParser {
     /// <summary>
     /// If the expression is null, emit an error and set it to a new <see cref="DMASTInvalidExpression" />
     /// </summary>

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -10,7 +10,7 @@ namespace DMCompiler.Compiler.DMPreprocessor;
 /// The master class for handling DM preprocessing.
 /// This is an <see cref="IEnumerable"/>, and is usually accessed via its <see cref="Token"/> output in a for-loop.
 /// </summary>
-internal sealed class DMPreprocessor(DMCompiler compiler, bool enableDirectives) : IEnumerable<Token> {
+public sealed class DMPreprocessor(DMCompiler compiler, bool enableDirectives) : IEnumerable<Token> {
     private readonly DMPreprocessorParser _dmPreprocessorParser = new(compiler);
     public readonly List<string> IncludedMaps = new(8);
     public string? IncludedInterface;

--- a/DMCompiler/Compiler/Lexer.cs
+++ b/DMCompiler/Compiler/Lexer.cs
@@ -2,7 +2,7 @@
 
 namespace DMCompiler.Compiler;
 
-internal class Lexer<TSourceType> {
+public class Lexer<TSourceType> {
     /// <summary>
     /// Location of token that'll be output by <see cref="GetCurrent"/>. If you skip through more
     /// </summary>
@@ -94,7 +94,7 @@ internal class Lexer<TSourceType> {
     }
 }
 
-internal class TokenLexer : Lexer<Token> {
+public class TokenLexer : Lexer<Token> {
     /// <inheritdoc/>
     protected TokenLexer(string sourceName, IEnumerable<Token> source) : base(sourceName, source) {
         Advance();

--- a/DMCompiler/Compiler/Parser.cs
+++ b/DMCompiler/Compiler/Parser.cs
@@ -1,6 +1,6 @@
 namespace DMCompiler.Compiler;
 
-internal class Parser<TSourceType> {
+public class Parser<TSourceType> {
     protected readonly Lexer<TSourceType> Lexer;
     protected readonly DMCompiler Compiler;
 


### PR DESCRIPTION
i think it's fair enough to let consumers use these so i can crawl the ast for https://github.com/OpenDreamProject/od-dm-reference and like language servers in the future. and other things