### PR TITLE
Optimize `RemoveUnreferencedLabels()`

### DIFF
--- a/DMCompiler/Optimizer/BytecodeOptimizer.cs
+++ b/DMCompiler/Optimizer/BytecodeOptimizer.cs
@@ -26,24 +26,39 @@ public class BytecodeOptimizer(DMCompiler compiler) {
     }
 
     private void RemoveUnreferencedLabels(List<IAnnotatedBytecode> input) {
-        Dictionary<string, int> labelReferences = new();
+        Dictionary<string, int>? labelReferences = null;
+        var labelCount = 0;
         for (int i = 0; i < input.Count; i++) {
-            if (input[i] is AnnotatedBytecodeLabel label) {
-                labelReferences.TryAdd(label.LabelName, 0);
-            } else if (input[i] is AnnotatedBytecodeInstruction instruction) {
-                if (TryGetLabelName(instruction, out string? labelName)) {
-                    if (!labelReferences.TryAdd(labelName, 1)) {
-                        labelReferences[labelName]++;
+            switch (input[i])
+            {
+                case AnnotatedBytecodeLabel label:
+                    labelReferences ??= new Dictionary<string, int>();
+                    labelReferences.TryAdd(label.LabelName, 0);
+                    labelCount += 1;
+                    break;
+                case AnnotatedBytecodeInstruction instruction: {
+                    if (TryGetLabelName(instruction, out string? labelName)) {
+                        labelReferences ??= new Dictionary<string, int>();
+                        if (!labelReferences.TryAdd(labelName, 1)) {
+                            labelReferences[labelName] += 1;
+                        }
                     }
+
+                    break;
                 }
             }
         }
+
+        if (labelReferences == null) return;
 
         for (int i = 0; i < input.Count; i++) {
             if (input[i] is AnnotatedBytecodeLabel label) {
                 if (labelReferences[label.LabelName] == 0) {
                     input.RemoveAt(i);
-                    i--;
+                    i -= 1;
+                    labelCount -= 1;
+
+                    if (labelCount <= 0) break;
                 }
             }
         }

--- a/DMCompiler/Optimizer/BytecodeOptimizer.cs
+++ b/DMCompiler/Optimizer/BytecodeOptimizer.cs
@@ -27,14 +27,11 @@ public class BytecodeOptimizer(DMCompiler compiler) {
 
     private void RemoveUnreferencedLabels(List<IAnnotatedBytecode> input) {
         Dictionary<string, int>? labelReferences = null;
-        var labelCount = 0;
         for (int i = 0; i < input.Count; i++) {
-            switch (input[i])
-            {
+            switch (input[i]) {
                 case AnnotatedBytecodeLabel label:
                     labelReferences ??= new Dictionary<string, int>();
                     labelReferences.TryAdd(label.LabelName, 0);
-                    labelCount += 1;
                     break;
                 case AnnotatedBytecodeInstruction instruction: {
                     if (TryGetLabelName(instruction, out string? labelName)) {
@@ -50,6 +47,7 @@ public class BytecodeOptimizer(DMCompiler compiler) {
         }
 
         if (labelReferences == null) return;
+        var labelCount = labelReferences.Count;
 
         for (int i = 0; i < input.Count; i++) {
             if (input[i] is AnnotatedBytecodeLabel label) {
@@ -57,7 +55,7 @@ public class BytecodeOptimizer(DMCompiler compiler) {
                     input.RemoveAt(i);
                     i -= 1;
                 }
-                
+
                 labelCount -= 1;
                 if (labelCount <= 0) break;
             }

--- a/DMCompiler/Optimizer/BytecodeOptimizer.cs
+++ b/DMCompiler/Optimizer/BytecodeOptimizer.cs
@@ -57,6 +57,7 @@ public class BytecodeOptimizer(DMCompiler compiler) {
                     input.RemoveAt(i);
                     i -= 1;
                 }
+                
                 labelCount -= 1;
                 if (labelCount <= 0) break;
             }

--- a/DMCompiler/Optimizer/BytecodeOptimizer.cs
+++ b/DMCompiler/Optimizer/BytecodeOptimizer.cs
@@ -56,10 +56,9 @@ public class BytecodeOptimizer(DMCompiler compiler) {
                 if (labelReferences[label.LabelName] == 0) {
                     input.RemoveAt(i);
                     i -= 1;
-                    labelCount -= 1;
-
-                    if (labelCount <= 0) break;
                 }
+                labelCount -= 1;
+                if (labelCount <= 0) break;
             }
         }
     }


### PR DESCRIPTION
Only create a dictionary when necessary, which reduces the number of dicts allocated by ~150k.

Also avoids/short circuits the last instruction enumeration whenever it won't do anything.