### PR TITLE
Fixes DMF text-color not applying to statpanel / output

### DIFF
--- a/OpenDreamClient/Interface/Controls/ControlInfo.cs
+++ b/OpenDreamClient/Interface/Controls/ControlInfo.cs
@@ -49,6 +49,9 @@ internal sealed class StatPanel : InfoPanel {
             //       I couldn't find a way to do this without recreating the FormattedMessage
             ValueLabel.MouseFilter = MouseFilterMode.Stop;
             ValueLabel.OnKeyBindDown += OnKeyBindDown;
+            if (_owner.InfoDescriptor.TextColor.Value != Color.Black) {
+                _textColor = _owner.InfoDescriptor.TextColor.Value;
+            }
         }
 
         public void Clear() {
@@ -83,7 +86,6 @@ internal sealed class StatPanel : InfoPanel {
             _valueText.Clear();
 
             // Use the default color and font
-            SetTextColor(_owner.InfoDescriptor.TextColor.Value);
             _nameText.PushColor(_textColor);
             _valueText.PushColor(_textColor);
             _nameText.PushTag(new MarkupNode("font", null, null));

--- a/OpenDreamClient/Interface/Controls/ControlInfo.cs
+++ b/OpenDreamClient/Interface/Controls/ControlInfo.cs
@@ -11,13 +11,13 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Input;
 using Robust.Shared.Network;
 using Robust.Shared.Utility;
+using Robust.Shared.Log;
 
 namespace OpenDreamClient.Interface.Controls;
 
 [Virtual]
 internal class InfoPanel : Control {
     public string PanelName { get; }
-
     protected InfoPanel(string name) {
         PanelName = name;
         TabContainer.SetTabTitle(this, name);
@@ -31,7 +31,6 @@ internal sealed class StatPanel : InfoPanel {
     private sealed class StatEntry {
         public readonly RichTextLabel NameLabel = new();
         public readonly RichTextLabel ValueLabel = new();
-
         private readonly ControlInfo _owner;
         private readonly IEntitySystemManager _entitySystemManager;
         private readonly FormattedMessage _nameText = new();
@@ -83,6 +82,7 @@ internal sealed class StatPanel : InfoPanel {
             _valueText.Clear();
 
             // Use the default color and font
+            SetTextColor(_owner.InfoDescriptor.TextColor.Value);
             _nameText.PushColor(_textColor);
             _valueText.PushColor(_textColor);
             _nameText.PushTag(new MarkupNode("font", null, null));
@@ -137,9 +137,7 @@ internal sealed class StatPanel : InfoPanel {
 
     public override void UpdateElementDescriptor(ControlDescriptorInfo descriptor) {
         base.UpdateElementDescriptor(descriptor);
-
         var textColor = (descriptor.TextColor.Value != Color.Transparent) ? descriptor.TextColor.Value : Color.Black;
-
         foreach (var entry in _entries) {
             entry.SetTextColor(textColor);
         }
@@ -148,10 +146,8 @@ internal sealed class StatPanel : InfoPanel {
     public void UpdateLines(List<(string Name, string Value, string? AtomRef)> lines) {
         for (int i = 0; i < Math.Max(_entries.Count, lines.Count); i++) {
             var entry = GetEntry(i);
-
             if (i < lines.Count) {
                 var line = lines[i];
-
                 entry.SetLabels(line.Name, line.Value, line.AtomRef);
             } else {
                 entry.Clear();
@@ -207,7 +203,6 @@ internal sealed class VerbPanel : InfoPanel {
 
         _highlightColor = descriptor.HighlightColor.Value;
         _textColor = (descriptor.TextColor.Value != Color.Transparent) ? descriptor.TextColor.Value : Color.Black;
-
         foreach (var child in _grid.Children) {
             if (child is not Button button)
                 continue;
@@ -287,7 +282,7 @@ public sealed class ControlInfo : InterfaceControl {
             }
         };
 
-        if(ControlDescriptor.IsVisible.Value)
+        if (ControlDescriptor.IsVisible.Value)
             OnShowEvent();
         else
             OnHideEvent();
@@ -388,11 +383,11 @@ public sealed class ControlInfo : InterfaceControl {
 
     private void SortPanels() {
         _tabControl.Children.Clear();
-        foreach(var (_, statPanel) in _statPanels) {
+        foreach (var (_, statPanel) in _statPanels) {
             _tabControl.AddChild(statPanel);
         }
 
-        foreach(var (_, verbPanel) in _verbPanels) {
+        foreach (var (_, verbPanel) in _verbPanels) {
             _tabControl.AddChild(verbPanel);
         }
     }

--- a/OpenDreamClient/Interface/Controls/ControlInfo.cs
+++ b/OpenDreamClient/Interface/Controls/ControlInfo.cs
@@ -11,13 +11,13 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Input;
 using Robust.Shared.Network;
 using Robust.Shared.Utility;
-using Robust.Shared.Log;
 
 namespace OpenDreamClient.Interface.Controls;
 
 [Virtual]
 internal class InfoPanel : Control {
     public string PanelName { get; }
+
     protected InfoPanel(string name) {
         PanelName = name;
         TabContainer.SetTabTitle(this, name);
@@ -31,6 +31,7 @@ internal sealed class StatPanel : InfoPanel {
     private sealed class StatEntry {
         public readonly RichTextLabel NameLabel = new();
         public readonly RichTextLabel ValueLabel = new();
+
         private readonly ControlInfo _owner;
         private readonly IEntitySystemManager _entitySystemManager;
         private readonly FormattedMessage _nameText = new();
@@ -146,8 +147,10 @@ internal sealed class StatPanel : InfoPanel {
     public void UpdateLines(List<(string Name, string Value, string? AtomRef)> lines) {
         for (int i = 0; i < Math.Max(_entries.Count, lines.Count); i++) {
             var entry = GetEntry(i);
+
             if (i < lines.Count) {
                 var line = lines[i];
+
                 entry.SetLabels(line.Name, line.Value, line.AtomRef);
             } else {
                 entry.Clear();
@@ -203,6 +206,7 @@ internal sealed class VerbPanel : InfoPanel {
 
         _highlightColor = descriptor.HighlightColor.Value;
         _textColor = (descriptor.TextColor.Value != Color.Transparent) ? descriptor.TextColor.Value : Color.Black;
+
         foreach (var child in _grid.Children) {
             if (child is not Button button)
                 continue;

--- a/OpenDreamClient/Interface/Controls/ControlOutput.cs
+++ b/OpenDreamClient/Interface/Controls/ControlOutput.cs
@@ -27,7 +27,7 @@ public sealed class ControlOutput(ControlDescriptor controlDescriptor, ControlWi
     public override void Output(string value, string? data) {
         var msg = new FormattedMessage(2);
 
-        msg.PushColor(Color.Black);
+        msg.PushColor(ControlDescriptor.TextColor.Value);
         msg.PushTag(new MarkupNode("font", null, null)); // Use the default font and font size
         // TODO: Look into using RobustToolbox's markup parser once it's customizable enough
         HtmlParser.Parse(value.Replace("\t", "    "), msg);


### PR DESCRIPTION
By default, text-color is being read from the .DMF file, but not being applied in parts of the UI, even though background color is.
This is problematic when the background color is dark, as text-color defaults to black.

This PR makes the UI system correctly apply text-color as well.