### PR TITLE
Allow float DMF values

### DIFF
--- a/OpenDreamClient/Interface/DMF/DMFLexer.cs
+++ b/OpenDreamClient/Interface/DMF/DMFLexer.cs
@@ -126,7 +126,7 @@ public sealed class DMFLexer(string source) {
                 var textBuilder = new StringBuilder();
                 textBuilder.Append(c);
 
-                while (!char.IsWhiteSpace(Advance()) && GetCurrent() is not ';' and not '=' and not '.' and not '?' and not ':' && !AtEndOfSource)
+                while (!char.IsWhiteSpace(Advance()) && GetCurrent() is not ';' and not '=' and not '?' and not ':' && !(_parsingAttributeName && GetCurrent() == '.') && !AtEndOfSource)
                     textBuilder.Append(GetCurrent());
 
                 var text = textBuilder.ToString();


### PR DESCRIPTION
Fixes Daedalus' DMF parsing. It had `splitter = 94.9`.