### PR TITLE
Fix an always-tripped debug assert

### DIFF
--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -300,15 +300,21 @@ public class DMCompiler {
     }
 
     private string SaveJson(List<DreamMapJson> maps, string interfaceFile, string outputFile) {
+        if (!string.IsNullOrWhiteSpace(interfaceFile) &&
+                Path.GetDirectoryName(Path.GetFullPath(outputFile)) is { } interfaceDirectory) {
+            interfaceFile = Path.GetRelativePath(interfaceDirectory, interfaceFile);
+            DMObjectTree.Resources.Add(interfaceFile); // Ensure the DMF is included in the list of resources
+        } else {
+            interfaceFile = string.Empty;
+        }
+
         var jsonRep = DMObjectTree.CreateJsonRepresentation();
         var compiledDream = new DreamCompiledJson {
             Metadata = new DreamCompiledJsonMetadata { Version = OpcodeVerifier.GetOpcodesHash() },
             Strings = DMObjectTree.StringTable,
             Resources = DMObjectTree.Resources.ToArray(),
             Maps = maps,
-            Interface = string.IsNullOrEmpty(interfaceFile)
-                ? ""
-                : Path.GetRelativePath(Path.GetDirectoryName(Path.GetFullPath(outputFile)), interfaceFile),
+            Interface = interfaceFile,
             Types = jsonRep.Item1,
             Procs = jsonRep.Item2
         };

--- a/OpenDreamRuntime/Resources/DreamResourceManager.cs
+++ b/OpenDreamRuntime/Resources/DreamResourceManager.cs
@@ -51,24 +51,25 @@ public sealed class DreamResourceManager {
 
         _sawmill.Debug($"Resource root path set to {RootPath}");
 
-        if (!string.IsNullOrWhiteSpace(interfaceFile)) {
-            if (DoesFileExist(interfaceFile))
-                InterfaceFile = LoadResource(interfaceFile);
-            else
-                throw new FileNotFoundException("Interface DMF not found at " + Path.Join(rootPath, interfaceFile));
-        }
-
         // Immediately build list of resources from rsc.
         for (var i = 0; i < resources.Length; i++) {
             var resource = resources[i];
             var loaded = LoadResource(resource);
             // Resource IDs must be consistent with the ordering, or else packaged resources will mismatch.
+            // First resource is the hardcoded console resource
             DebugTools.Assert(loaded.Id == i + 1, "Resource IDs not consistent!");
         }
 
         _aczProvider = new DreamAczProvider(_dependencyCollection, rootPath, resources);
         _statusHost.SetMagicAczProvider(_aczProvider);
         _statusHost.SetFullHybridAczProvider(_aczProvider);
+
+        if (!string.IsNullOrWhiteSpace(interfaceFile)) {
+            if (DoesFileExist(interfaceFile))
+                InterfaceFile = LoadResource(interfaceFile);
+            else
+                throw new FileNotFoundException("Interface DMF not found at " + Path.Join(rootPath, interfaceFile));
+        }
     }
 
     public bool DoesFileExist(string resourcePath) {


### PR DESCRIPTION
The way the DMF is loaded by the server was changed and caused the hybrid-acz assumptions to break because an extra resource was loaded before the rest. The DMF is now loaded under the same process as the rest of the resources.