### PR TITLE
Fix the location of the byondapi library in linux releases

### DIFF
--- a/OpenDreamPackageTool/ServerPackaging.cs
+++ b/OpenDreamPackageTool/ServerPackaging.cs
@@ -213,14 +213,18 @@ public static class ServerPackaging {
     private static void CopyNatives(PlatformReg platform, string releaseDir) {
         string sourceDir = Path.Combine("bin", "Content.Server");
         string runtimesDir = $"runtimes/{platform.RId}/";
+        string dllSrc, dllDst;
 
-        if (platform.TargetOs == "Windows") { // Windows wants the DLL beside the exe
-            var dllSrc = Path.Combine(sourceDir, runtimesDir, "native/byondcore.dll");
-            var dllDst = Path.Combine(releaseDir, "byondcore.dll");
-
-            File.Copy(dllSrc, dllDst);
-        } else { // Otherwise, copy the respective runtimes/ folder
-            Program.CopyDirectory(Path.Combine(sourceDir, runtimesDir), Path.Combine(releaseDir, runtimesDir));
+        if (platform.TargetOs == "Windows") {
+            dllSrc = Path.Combine(sourceDir, runtimesDir, "native/byondcore.dll");
+            dllDst = Path.Combine(releaseDir, "byondcore.dll");
+        } else if (platform.TargetOs == "Linux") {
+            dllSrc = Path.Combine(sourceDir, runtimesDir, "native/libbyond.so");
+            dllDst = Path.Combine(releaseDir, "libbyond.so");
+        } else {
+            throw new Exception($"Unsupported target OS {platform.TargetOs}");
         }
+
+        File.Copy(dllSrc, dllDst);
     }
 }


### PR DESCRIPTION
Didn't test this after changing the import resolver to use `AppContext.GetData("NATIVE_DLL_SEARCH_DIRECTORIES")`, which apparently does not include the `runtimes/` folder after OD is packaged with `Robust.Server`.