### PR TITLE
Duplicate `#include` fix

### DIFF
--- a/Content.Tests/DMProject/Tests/Preprocessor/Include/duplicate_include.dm
+++ b/Content.Tests/DMProject/Tests/Preprocessor/Include/duplicate_include.dm
@@ -1,0 +1,11 @@
+// COMPILE ERROR OD1000
+
+// issue # 2283
+
+#pragma FileAlreadyIncluded error
+
+#include "test_module/test_file_to_include.dm"
+#include "./test_module/test_file_to_include.dm"
+
+/proc/RunTest()
+	return

--- a/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
+++ b/DMCompiler/Compiler/DMPreprocessor/DMPreprocessor.cs
@@ -197,6 +197,7 @@ public sealed class DMPreprocessor(DMCompiler compiler, bool enableDirectives) :
     public void IncludeFile(string includeDir, string file, bool isDMStandard, Location? includedFrom = null) {
         string filePath = Path.Combine(includeDir, file);
         filePath = filePath.Replace('\\', Path.DirectorySeparatorChar);
+        filePath = Path.GetFullPath(filePath); // Strips out path operators
 
         if (_includedFiles.Contains(filePath)) {
             compiler.Emit(WarningCode.FileAlreadyIncluded, includedFrom ?? Location.Internal, $"File \"{filePath}\" was already included");


### PR DESCRIPTION
Just needed to parse out the path operator.

Fixes #2283 