### PR TITLE
Make macros in showmacros tables scrollable

### DIFF
--- a/OpenDreamClient/Interface/DebugWindows/MacrosWindow.cs
+++ b/OpenDreamClient/Interface/DebugWindows/MacrosWindow.cs
@@ -35,10 +35,10 @@ internal sealed class MacrosWindow : OSWindow {
         AddChild(tabs);
     }
 
-    private GridContainer CreateMacroTable(InterfaceMacroSet macroSet) {
+    private ScrollContainer CreateMacroTable(InterfaceMacroSet macroSet) {
         var macroTable = new GridContainer {
             Columns = 3,
-            Margin = new(5)
+            Margin = new(5, 10, 5, 5),
         };
 
         foreach (var macro in macroSet.Macros.Values) {
@@ -66,12 +66,15 @@ internal sealed class MacrosWindow : OSWindow {
                 }
             };
 
+            macroTable.AddChild(executeButton);
             macroTable.AddChild(idLabel);
             macroTable.AddChild(commandLabel);
-            macroTable.AddChild(executeButton);
         }
 
-        return macroTable;
+        return new ScrollContainer {
+            Children = { macroTable },
+            MinSize = new Vector2(1024, 700)
+        };
     }
 }
 


### PR DESCRIPTION
For when your game has many, many macros

Also shuffles the execute button to the left to prevent the need to horizontally scroll on a large macro

![SS14 Loader_HHMEE2r97W](https://github.com/user-attachments/assets/018fe2e7-428b-493c-9bbf-c5da2cbc7eed)
