### PR TITLE
Add a compiler arg to disable optimizations

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,6 +38,13 @@ jobs:
       run: |
         $env:COMPlus_gcServer=1
         dotnet test --no-build Content.Tests/Content.Tests.csproj -v n
+    - name: Content.Tests (Optimizations Disabled)
+      shell: pwsh
+      env:
+        NO_OPTS: "true"
+      run: |
+        $env:COMPlus_gcServer=1
+        dotnet test --no-build Content.Tests/Content.Tests.csproj -v n
     - name: Content.IntegrationTests
       shell: pwsh
       run: |

--- a/Content.Tests/DMTests.cs
+++ b/Content.Tests/DMTests.cs
@@ -54,8 +54,6 @@ public sealed partial class DMTests : ContentUnitTest {
             NoOpts = Environment.GetEnvironmentVariable("NO_OPTS") != null
         });
 
-        if (compiler.Settings.NoOpts) Environment.Exit(1); // test that it works
-
         return successfulCompile ? Path.ChangeExtension(sourceFile, "json") : null;
     }
 

--- a/Content.Tests/DMTests.cs
+++ b/Content.Tests/DMTests.cs
@@ -54,6 +54,8 @@ public sealed partial class DMTests : ContentUnitTest {
             NoOpts = Environment.GetEnvironmentVariable("NO_OPTS") != null
         });
 
+        if (compiler.Settings.NoOpts) Environment.Exit(1); // test that it works
+
         return successfulCompile ? Path.ChangeExtension(sourceFile, "json") : null;
     }
 

--- a/Content.Tests/DMTests.cs
+++ b/Content.Tests/DMTests.cs
@@ -50,7 +50,8 @@ public sealed partial class DMTests : ContentUnitTest {
 
     private string? Compile(DMCompiler.DMCompiler compiler, string sourceFile) {
         bool successfulCompile = compiler.Compile(new() {
-            Files = [sourceFile]
+            Files = [sourceFile],
+            NoOpts = Environment.GetEnvironmentVariable("NO_OPTS") != null
         });
 
         return successfulCompile ? Path.ChangeExtension(sourceFile, "json") : null;

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -66,10 +66,12 @@ public class DMCompiler {
         DMPreprocessor preprocessor = Preprocess(this, settings.Files, settings.MacroDefines);
         bool successfulCompile = preprocessor is not null && Compile(preprocessor);
 
-        if (settings.SuppressUnimplementedWarnings) {
+        if (settings.SuppressUnimplementedWarnings)
             Emit(WarningCode.UnimplementedAccess, Location.Internal,
                 "Unimplemented proc & var warnings are currently suppressed");
-        }
+
+        if (settings.NoOpts)
+            ForcedWarning("Compiler optimizations (const folding, peephole opts, etc.) are disabled via the \"--no-opts\" arg. This results in slower code execution and is not representative of OpenDream performance.");
 
         if (successfulCompile) {
             //Output file is the first file with the extension changed to .json

--- a/DMCompiler/DMCompiler.cs
+++ b/DMCompiler/DMCompiler.cs
@@ -419,6 +419,8 @@ public struct DMCompilerSettings {
     // These are the default DM_VERSION and DM_BUILD values. They're strings because that's what the preprocessor expects (seriously)
     public string DMVersion = "515";
     public string DMBuild = "1633";
+    /// <summary> Disables compiler optimizations such as const-folding and peephole opts </summary>
+    public bool NoOpts = false;
 
     public DMCompilerSettings() {
     }

--- a/DMCompiler/Optimizer/BytecodeOptimizer.cs
+++ b/DMCompiler/Optimizer/BytecodeOptimizer.cs
@@ -6,6 +6,9 @@ public class BytecodeOptimizer(DMCompiler compiler) {
     private readonly PeepholeOptimizer _peepholeOptimizer = new(compiler);
 
     internal void Optimize(List<IAnnotatedBytecode> input) {
+        if(compiler.Settings.NoOpts) // Optimizations are disabled
+            return;
+
         if (input.Count == 0)
             return;
 

--- a/DMCompiler/Program.cs
+++ b/DMCompiler/Program.cs
@@ -170,9 +170,9 @@ internal static class Program {
 
                     break;
                 }
+                case "no-opt":
                 case "no-opts":
                     settings.NoOpts = true;
-                    compiler.ForcedWarning("Compiler optimizations (const folding, peephole opts, etc.) are disabled via the \"--no-opts\" arg. This results in slower code execution and is not representative of OpenDream performance.");
                     break;
                 default: {
                     if (skipBad) {

--- a/DMCompiler/Program.cs
+++ b/DMCompiler/Program.cs
@@ -77,6 +77,7 @@ internal static class Program {
         Console.WriteLine("--verbose                 : Show verbose output during compile");
         Console.WriteLine("--notices-enabled         : Show notice output during compile");
         Console.WriteLine("--pragma-config [file].dm : Configure the error/warning/notice/ignore level of compiler messages");
+        Console.WriteLine("--no-opts                 : Makes the compiler emit raw unoptimized bytecode. Mainly for debugging/testing purposes. User code will be slower at runtime.");
     }
 
     private static bool TryParseArguments(DMCompiler compiler, string[] args, out DMCompilerSettings settings) {
@@ -169,6 +170,10 @@ internal static class Program {
 
                     break;
                 }
+                case "no-opts":
+                    settings.NoOpts = true;
+                    compiler.ForcedWarning("Compiler optimizations (const folding, peephole opts, etc.) are disabled via the \"--no-opts\" arg. This results in slower code execution and is not representative of OpenDream performance.");
+                    break;
                 default: {
                     if (skipBad) {
                         compiler.ForcedWarning($"Unknown compiler arg '{arg.Name}', skipping");


### PR DESCRIPTION
Resolves #1377 

Adds a `--no-opts` compiler arg which prevents the BytecodeOptimizer from running. The compiler will emit a forced warning when this happens.

CI also now reruns all unit tests with `--no-opts` after the initial test run passes.

The second commit intentionally causes CI to fail if `--no-opts` is used just to ensure the CI actually works.