### PR TITLE
Fix `alist()` in obj definitions

### DIFF
--- a/DMCompiler/DM/DMCodeTree.Vars.cs
+++ b/DMCompiler/DM/DMCodeTree.Vars.cs
@@ -80,6 +80,7 @@ internal partial class DMCodeTree {
                     _ => false
                 },
 
+                AList => true,
                 List => true,
                 DimensionalList => true,
                 NewList => true,


### PR DESCRIPTION
This code currently errors on master:
```
/datum/foo
    var/alist/preference_settings_client = alist()
```
`Error OD0011 at code.dm:354:41: Invalid initial value for "preference_settings_client"`

This PR fixes that.