### PR TITLE
fix `findlasttext()`

### DIFF
--- a/Content.Tests/DMProject/Tests/Text/findlasttext.dm
+++ b/Content.Tests/DMProject/Tests/Text/findlasttext.dm
@@ -1,4 +1,6 @@
 /proc/RunTest()
+	ASSERT(findlasttext("/mob", "/", 0, 1) == 1)
+	ASSERT(findlasttext("/mob", "/") == 1)
 	ASSERT(findlasttext("abcdefg", "f", 0, -1) == 0)
 	ASSERT(findlasttext("abcdefg", "f", 0, -2) == 6)
 	ASSERT(findlasttext("abcdefg", "f", 6) == 6)

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -965,7 +965,7 @@ internal static class DreamProcNativeRoot {
         actualstart = Math.Max(Math.Min(text.Length, actualstart),0);
 
         if(end > 0)
-            actualcount = actualstart - (end-1);
+            actualcount = actualstart - (end-1) + needle.Length;
         else
             actualcount  = actualstart - ((text.Length-1) + (end));
         actualcount += needle.Length-1;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -924,11 +924,10 @@ internal static class DreamProcNativeRoot {
         actualstart += needle.Length-1;
         actualstart = Math.Max(Math.Min(text.Length, actualstart),0);
 
-        if(end > 0)
-            actualcount = actualstart - (end-1);
+        if (end > 0)
+            actualcount = actualstart - (end - 1) + needle.Length;
         else
-            actualcount  = actualstart - ((text.Length-1) + (end));
-        actualcount += needle.Length-1;
+            actualcount = actualstart - ((text.Length - 1) + (end));
         actualcount = Math.Max(Math.Min(actualstart+1, actualcount),0);
         int needleIndex = text.LastIndexOf(needle, actualstart, actualcount, StringComparison.OrdinalIgnoreCase);
         return new DreamValue(needleIndex + 1); //1-indexed, or 0 if not found (LastIndexOf returns -1 if not found)


### PR DESCRIPTION
Fixes #2309 

Applies the same fix to `findlasttextEx()`