### PR TITLE
`PushFloatAssign` Optimization

### DIFF
--- a/DMCompiler/Bytecode/DreamProcOpcode.cs
+++ b/DMCompiler/Bytecode/DreamProcOpcode.cs
@@ -301,6 +301,10 @@ public enum DreamProcOpcode : byte {
     ReturnFloat = 0x98,
     [OpcodeMetadata(1, OpcodeArgType.Reference, OpcodeArgType.String)]
     IndexRefWithString = 0x99,
+    [OpcodeMetadata(2, OpcodeArgType.Float, OpcodeArgType.Reference)]
+    PushFloatAssign = 0x9A,
+    [OpcodeMetadata(true, 0, OpcodeArgType.Int)]
+    NPushFloatAssign = 0x9B,
 }
 // ReSharper restore MissingBlankLines
 

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -3128,6 +3128,25 @@ namespace OpenDreamRuntime.Procs {
             return ProcStatus.Continue;
         }
 
+        public static ProcStatus PushFloatAssign(DMProcState state) {
+            float flt = state.ReadFloat();
+            DreamReference reference = state.ReadReference();
+            state.AssignReference(reference, new DreamValue(flt));
+            return ProcStatus.Continue;
+        }
+
+        public static ProcStatus NPushFloatAssign(DMProcState state) {
+            int count = state.ReadInt();
+
+            for (int i = 0; i < count; i++) {
+                float flt = state.ReadFloat();
+                DreamReference reference = state.ReadReference();
+                state.AssignReference(reference, new DreamValue(flt));
+            }
+
+            return ProcStatus.Continue;
+        }
+
         public static ProcStatus CreateListNFloats(DMProcState state) {
             int size = state.ReadInt();
             var list = state.Proc.ObjectTree.CreateList(size);

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -244,6 +244,8 @@ public sealed class DMProcState : ProcState {
         {DreamProcOpcode.Error, DMOpcodeHandlers.Error},
         {DreamProcOpcode.IsInList, DMOpcodeHandlers.IsInList},
         {DreamProcOpcode.PushFloat, DMOpcodeHandlers.PushFloat},
+        {DreamProcOpcode.PushFloatAssign, DMOpcodeHandlers.PushFloatAssign},
+        {DreamProcOpcode.NPushFloatAssign, DMOpcodeHandlers.NPushFloatAssign},
         {DreamProcOpcode.ModulusReference, DMOpcodeHandlers.ModulusReference},
         {DreamProcOpcode.CreateListEnumerator, DMOpcodeHandlers.CreateListEnumerator},
         {DreamProcOpcode.Enumerate, DMOpcodeHandlers.Enumerate},

--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -71,7 +71,20 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
 
             case DreamProcOpcode.PushStringFloat:
                 return (opcode, ReadString(), ReadFloat());
+            case DreamProcOpcode.PushFloatAssign:
+                return (opcode, ReadFloat(), ReadReference());
+            case DreamProcOpcode.NPushFloatAssign: {
+                var count = ReadInt();
+                var floats = new float[count];
+                var refs = new DMReference[count];
 
+                for (int i = 0; i < count; i++) {
+                    floats[i] = ReadFloat();
+                    refs[i] = ReadReference();
+                }
+
+                return (opcode, floats, refs);
+            }
             case DreamProcOpcode.PushString:
             case DreamProcOpcode.PushResource:
             case DreamProcOpcode.DereferenceField:
@@ -368,6 +381,27 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
                     text.Append(' ');
                     text.Append(floats[index]);
                     if(index + 1 < strings.Length) // Don't leave a trailing space
+                        text.Append(' ');
+                }
+
+                break;
+            }
+
+            case (DreamProcOpcode PushFloatAssign, float value, DMReference reference): {
+                text.Append(value);
+                text.Append(' ');
+                text.Append(reference.ToString());
+                break;
+            }
+
+            case (DreamProcOpcode.NPushFloatAssign, float[] floats, DMReference[] refs): {
+                // The length of both arrays are equal
+                for (var index = 0; index < refs.Length; index++) {
+                    text.Append(floats[index]);
+                    text.Append(' ');
+                    text.Append($"\"{refs[index]}\"");
+
+                    if(index + 1 < refs.Length) // Don't leave a trailing space
                         text.Append(' ');
                 }
 

--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -387,7 +387,7 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
                 break;
             }
 
-            case (DreamProcOpcode PushFloatAssign, float value, DMReference reference): {
+            case (DreamProcOpcode.PushFloatAssign, float value, DMReference reference): {
                 text.Append(value);
                 text.Append(' ');
                 text.Append(reference.ToString());

--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -397,9 +397,9 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
             case (DreamProcOpcode.NPushFloatAssign, float[] floats, DMReference[] refs): {
                 // The length of both arrays are equal
                 for (var index = 0; index < refs.Length; index++) {
+                    text.Append(refs[index]);
+                    text.Append('=');
                     text.Append(floats[index]);
-                    text.Append(' ');
-                    text.Append($"\"{refs[index]}\"");
 
                     if(index + 1 < refs.Length) // Don't leave a trailing space
                         text.Append(' ');


### PR DESCRIPTION
This is the 8th most common opcode pattern in Paradise:
`PushFloat -> AssignNoPush`

It's essentially every time there is a wall of vars assigned float values:
```
  engine = 1
  hull = 1
  electronics = 1
```

This PR adds a new optimization:
```csharp
// PushFloat [float]
// AssignNoPush [ref]
// -> PushFloatAssign [float] [ref]
// or if there's multiple
// -> NPushFloatAssign [count] [float] [ref] ... [float] [ref]
```

The new opt happens ~13.8k times on Paradise, about 600 of which are `NPushFloatAssign`