### PR TITLE
Fix bit-shift operators to match BYOND

### DIFF
--- a/Content.Tests/DMProject/Tests/Operators/bitshift_large.dm
+++ b/Content.Tests/DMProject/Tests/Operators/bitshift_large.dm
@@ -1,3 +1,9 @@
 /proc/RunTest()
+	var/val = 0xBEEF
+	ASSERT(val << 13 == 14540800)
+	val = -1
+	ASSERT(val >> 13 == 2047)
+
+	//check the const folded version
 	ASSERT(0xBEEF << 13 == 14540800)
 	ASSERT(-1 >> 13 == 2047)

--- a/Content.Tests/DMProject/Tests/Operators/bitshift_large.dm
+++ b/Content.Tests/DMProject/Tests/Operators/bitshift_large.dm
@@ -1,0 +1,3 @@
+/proc/RunTest()
+	ASSERT(0xBEEF << 13 == 14540800)
+	ASSERT(-1 >> 13 == 2047)

--- a/Content.Tests/DMProject/Tests/Operators/valid_and_null_assign_const.dm
+++ b/Content.Tests/DMProject/Tests/Operators/valid_and_null_assign_const.dm
@@ -1,0 +1,128 @@
+//simple test of all basic assignment operators with valid and C(null) arguments
+//Const fold everying
+#define C(X) X
+/proc/RunTest()
+	var/a = C(1)
+	a += C(1)
+	ASSERT(a == C(2))
+	a = null
+	a += C(1)
+	ASSERT(a == C(1))
+	a = C(1)
+	a += C(null)
+	ASSERT(a == C(1))
+
+	a = C(1)
+	a -= C(1)
+	ASSERT(a == C(0))
+	a = null
+	a -= C(1)
+	ASSERT(a == C(-1))
+	a = C(1)
+	a -= C(null)
+	ASSERT(a == C(1))
+
+	a = C(2)
+	a *= C(3)
+	ASSERT(a == C(6))
+	a = null
+	a *= C(2)
+	ASSERT(a == C(0))
+	a = C(2)
+	a *= C(null)
+	ASSERT(a == C(0))
+
+	a = C(4)
+	a /= C(2)
+	ASSERT(a == C(2))
+	a = null
+	a /= C(2)
+	ASSERT(a == C(0))
+	//a = C(2) 
+	//a /= C(null)  //Undefined operation error in BYOND
+	//ASSERT(a == C(2))
+
+	a = C(4)
+	a %= C(3)
+	ASSERT(a == C(1))
+	a = null
+	a %= C(3)
+	ASSERT(a == C(0))
+	//a = C(4)
+	//a %= C(null)  //divide by zero error in byond
+	//ASSERT(a == C(4)) 
+
+	a = C(1)
+	a &= C(1)
+	ASSERT(a == C(1))
+	a = null
+	a &= C(1)
+	ASSERT(a == C(0))
+	a = C(1)
+	a &= C(null)
+	ASSERT(a == C(0))
+
+	a = C(1)
+	a |= C(1)
+	ASSERT(a == C(1))
+	a = null
+	a |= C(1)
+	ASSERT(a == C(1))
+	a = C(1)
+	a |= C(null)
+	ASSERT(a == C(1))
+
+	a = C(1)
+	a ^= C(1)
+	ASSERT(a == C(0))
+	a = null
+	a ^= C(1)
+	ASSERT(a == C(1))
+	a = C(1)
+	a ^= C(null)
+	ASSERT(a == C(1))	
+
+	a = C(1)
+	a &&= C(1)
+	ASSERT(a == C(1))
+	a = null
+	a &&= C(1)
+	ASSERT(a == C(null))
+	a = C(1)
+	a &&= C(null)
+	ASSERT(a == C(null))
+
+	a = C(1)
+	a ||= C(1)
+	ASSERT(a == C(1))
+	a = null
+	a ||= C(1)
+	ASSERT(a == C(1))
+	a = C(1)
+	a ||= C(null)
+	ASSERT(a == C(1))
+
+	a = C(1)
+	a <<= C(1)
+	ASSERT(a == C(2))
+	a = null
+	a <<= C(1)
+	ASSERT(a == C(0))
+	a = C(1)
+	a <<= C(null)
+	ASSERT(a == C(1))
+
+	a = C(1)
+	a >>= C(1)
+	ASSERT(a == C(0))
+	a = null
+	a >>= C(1)
+	ASSERT(a == C(0))
+	a = C(1)
+	a >>= C(null)
+	ASSERT(a == C(1))
+
+	a := C(5)
+	ASSERT(a == C(5))
+	a := C(null)
+	ASSERT(a == null)

--- a/Content.Tests/DMProject/Tests/Operators/valid_and_null_const.dm
+++ b/Content.Tests/DMProject/Tests/Operators/valid_and_null_const.dm
@@ -1,0 +1,103 @@
+//simple test of all basic operators with valid and C(null) arguments
+//Const fold everying
+#define C(X) X 
+/proc/RunTest()
+	var/a = C(2)
+	ASSERT(!C(null) == C(1))
+	ASSERT(!!C(null) == C(0))
+
+	ASSERT(~C(1) == 16777214)
+	ASSERT(~C(0) == 16777215)
+	ASSERT(~C(null) == 16777215)
+
+	ASSERT(C(1) + C(1) == C(2))
+	ASSERT(C(null) + C(1) == C(1))
+	ASSERT(C(1) + C(null) == C(1))
+
+	ASSERT(C(1) - C(1) == C(0))
+	ASSERT(C(null) - C(1) == C(-1))
+	ASSERT(C(1) - C(null) == C(1))
+
+	ASSERT(-C(2) == C(-2))
+	ASSERT(-C(null) == C(0))	
+	ASSERT(C(2) ** C(3) == 8)
+	ASSERT(C(2) ** C(null) == C(1))
+	ASSERT(C(null) ** C(2) == C(0))
+
+	ASSERT(C(2) * C(3) == 6)
+	ASSERT(C(2) * C(null) == C(0))
+	ASSERT(C(null) * C(2) == C(0))
+
+	ASSERT(C(4) / C(2) == C(2))
+	ASSERT(C(null) / C(2) == C(0))
+	ASSERT(C(2) / C(null) == C(2))
+	ASSERT(C(null) / C(null) == C(0))
+
+	ASSERT(C(4) % C(3) == C(1))
+	ASSERT(C(null) % C(3) == C(0))
+	//ASSERT(C(4) % C(null) == div by zero)
+
+	ASSERT(C(1) < C(1) == C(0))
+	ASSERT(C(null) < C(1) == C(1))
+	ASSERT(C(1) < C(null) == C(0))
+
+	ASSERT(C(1) <= C(1) == C(1))
+	ASSERT(C(null) <= C(1) == C(1))
+	ASSERT(C(1) <= C(null) == C(0))	
+
+	ASSERT(C(1) > C(1) == C(0))
+	ASSERT(C(null) > C(1) == C(0))
+	ASSERT(C(1) > C(null) == C(1))	
+
+	ASSERT(C(1) >= C(1) == C(1))
+	ASSERT(C(null) >= C(1) == C(0))
+	ASSERT(C(1) >= C(null) == C(1))	
+
+	ASSERT(C(1) << C(1) == C(2))
+	ASSERT(C(null) << C(1) == C(0))
+	ASSERT(C(1) << C(null) == C(1))	
+
+	ASSERT(C(1) >> C(1) == C(0))
+	ASSERT(C(null) >> C(1) == C(0))
+	ASSERT(C(1) >> C(null) == C(1))	
+
+	ASSERT((C(1) == C(1)) == C(1))
+	ASSERT((C(null) == C(null)) == C(1))
+	ASSERT((C(null) == C(0)) == C(0))
+
+	ASSERT((C(1) != C(null)) == C(1))
+	ASSERT((C(null) != C(1)) == C(1))
+	ASSERT((C(null) != C(0)) == C(1))
+
+	ASSERT((C(1) <> C(null)) == C(1))
+	ASSERT((C(null) <> C(1)) == C(1))
+	ASSERT((C(null) <> C(0)) == C(1))	
+
+	ASSERT((C(1) ~= C(1)) == C(1))
+	ASSERT((C(null) ~= C(null)) == C(1))
+	ASSERT((C(null) ~= C(0)) == C(0))
+
+	ASSERT((C(1) ~! C(1)) == C(0))
+	ASSERT((C(null) ~! C(null)) == C(0))
+	ASSERT((C(null) ~! C(0)) == C(1))
+
+	ASSERT((C(1) & C(1)) == C(1))
+	ASSERT((C(null) & C(1)) == C(0))
+	ASSERT((C(1) & C(null)) == C(0))
+
+	ASSERT((C(1) ^ C(1)) == C(0))
+	ASSERT((C(null) ^ C(5)) == C(5))
+	ASSERT((C(5) ^ C(null)) == C(5))	
+
+	ASSERT((C(1) | C(1)) == C(1))
+	ASSERT((C(null) | C(1)) == C(1))
+	ASSERT((C(1) | C(null)) == C(1))	
+
+	ASSERT((C(1) && C(1)) == C(1))
+	ASSERT((C(null) && C(1)) == C(null))
+	ASSERT((C(1) && C(null)) == C(null))	
+
+	ASSERT((C(1) || C(1)) == C(1))
+	ASSERT((C(null) || C(1)) == C(1))
+	ASSERT((C(1) || C(null)) == C(1))	
+

--- a/DMCompiler/DM/Expressions/Binary.cs
+++ b/DMCompiler/DM/Expressions/Binary.cs
@@ -203,7 +203,7 @@ internal sealed class LeftShift(Location location, DMExpression lhs, DMExpressio
         }
 
         if (lhs is Number lhsNum && rhs is Number rhsNum) {
-            constant = new Number(Location, ((int)lhsNum.Value) << ((int)rhsNum.Value));
+            constant = new Number(Location, SharedOperations.BitShiftLeft((int)lhsNum.Value, (int)rhsNum.Value));
         } else {
             constant = null;
             return false;
@@ -228,7 +228,7 @@ internal sealed class RightShift(Location location, DMExpression lhs, DMExpressi
         }
 
         if (lhs is Number lhsNum && rhs is Number rhsNum) {
-            constant = new Number(Location, ((int)lhsNum.Value) >> ((int)rhsNum.Value));
+            constant = new Number(Location, SharedOperations.BitShiftRight((int)lhsNum.Value, (int)rhsNum.Value));
         } else {
             constant = null;
             return false;

--- a/DMCompiler/Optimizer/PeepholeOptimizations.cs
+++ b/DMCompiler/Optimizer/PeepholeOptimizations.cs
@@ -720,7 +720,7 @@ internal sealed class ConstFoldBitshiftLeft : IOptimization {
 
         // At runtime, given "A << B" we pop B then A
         // In the peephole optimizer, index is "A", index+1 is "B"
-        var args = new List<IAnnotatedBytecode>(1) {new AnnotatedBytecodeFloat(((int)pushVal1 << (int)pushVal2), firstInstruction.Location)};
+        var args = new List<IAnnotatedBytecode>(1) {new AnnotatedBytecodeFloat(SharedOperations.BitShiftLeft((int)pushVal1, (int)pushVal2), firstInstruction.Location)};
 
         IOptimization.ReplaceInstructions(input, index, 3,
             new AnnotatedBytecodeInstruction(DreamProcOpcode.PushFloat, 1, args));
@@ -748,7 +748,7 @@ internal sealed class ConstFoldBitshiftRight : IOptimization {
 
         // At runtime, given "A >> B" we pop B then A
         // In the peephole optimizer, index is "A", index+1 is "B"
-        var args = new List<IAnnotatedBytecode>(1) {new AnnotatedBytecodeFloat(((int)pushVal1 >> (int)pushVal2), firstInstruction.Location)};
+        var args = new List<IAnnotatedBytecode>(1) {new AnnotatedBytecodeFloat(SharedOperations.BitShiftRight((int)pushVal1, (int)pushVal2), firstInstruction.Location)};
 
         IOptimization.ReplaceInstructions(input, index, 3,
             new AnnotatedBytecodeInstruction(DreamProcOpcode.PushFloat, 1, args));

--- a/DMCompiler/SharedOperations.cs
+++ b/DMCompiler/SharedOperations.cs
@@ -62,6 +62,8 @@ public static class SharedOperations {
         return MathF.Abs(a);
     }
 
+    //because BYOND has everything as a 32 bit float with 8 bit mantissa, we need to chop off the
+    //top 8 bits when bit shifting for parity
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int BitShiftLeft(int left, int right) {
         return (left << right) & 0x00FFFFFF;

--- a/DMCompiler/SharedOperations.cs
+++ b/DMCompiler/SharedOperations.cs
@@ -67,7 +67,6 @@ public static class SharedOperations {
         return (left << right) & 0x00FFFFFF;
     }
 
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int BitShiftRight(int left, int right) {
         return (left & 0x00FFFFFF) >> (right) ;

--- a/DMCompiler/SharedOperations.cs
+++ b/DMCompiler/SharedOperations.cs
@@ -61,4 +61,15 @@ public static class SharedOperations {
     public static float Abs(float a) {
         return MathF.Abs(a);
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int BitShiftLeft(int left, int right) {
+        return (left << right) & 0x00FFFFFF;
+    }
+
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int BitShiftRight(int left, int right) {
+        return (left & 0x00FFFFFF) >> (right) ;
+    }
 }

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -950,7 +950,7 @@ namespace OpenDreamRuntime.Procs {
                     state.Push(new DreamValue(0));
                     break;
                 case DreamValue.DreamValueType.Float when second.Type == DreamValue.DreamValueType.Float:
-                    state.Push(new DreamValue(first.MustGetValueAsInteger() << second.MustGetValueAsInteger()));
+                    state.Push(new DreamValue((first.MustGetValueAsInteger() << second.MustGetValueAsInteger()) & 0x00FFFFFF)); //to match byond's 24bit shifts - top 8 bits are 0'd
                     break;
                 case DreamValue.DreamValueType.Float when second.IsNull:
                     state.Push(new DreamValue(first.MustGetValueAsInteger()));
@@ -972,7 +972,7 @@ namespace OpenDreamRuntime.Procs {
                     result = new DreamValue(0);
                     break;
                 case DreamValue.DreamValueType.Float when second.Type == DreamValue.DreamValueType.Float:
-                    result = new DreamValue(first.MustGetValueAsInteger() << second.MustGetValueAsInteger());
+                    result = new DreamValue(first.MustGetValueAsInteger() << second.MustGetValueAsInteger() & 0x00FFFFFF); //to match byond's 24bit shifts - top 8 bits are 0'd
                     break;
                 case DreamValue.DreamValueType.Float when second.IsNull:
                     result = new DreamValue(first.MustGetValueAsInteger());

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -950,7 +950,7 @@ namespace OpenDreamRuntime.Procs {
                     state.Push(new DreamValue(0));
                     break;
                 case DreamValue.DreamValueType.Float when second.Type == DreamValue.DreamValueType.Float:
-                    state.Push(new DreamValue((first.MustGetValueAsInteger() << second.MustGetValueAsInteger()) & 0x00FFFFFF)); //to match byond's 24bit shifts - top 8 bits are 0'd
+                    state.Push(new DreamValue(SharedOperations.BitShiftLeft(first.MustGetValueAsInteger(), second.MustGetValueAsInteger())));
                     break;
                 case DreamValue.DreamValueType.Float when second.IsNull:
                     state.Push(new DreamValue(first.MustGetValueAsInteger()));
@@ -972,7 +972,7 @@ namespace OpenDreamRuntime.Procs {
                     result = new DreamValue(0);
                     break;
                 case DreamValue.DreamValueType.Float when second.Type == DreamValue.DreamValueType.Float:
-                    result = new DreamValue(first.MustGetValueAsInteger() << second.MustGetValueAsInteger() & 0x00FFFFFF); //to match byond's 24bit shifts - top 8 bits are 0'd
+                    result = new DreamValue(SharedOperations.BitShiftLeft(first.MustGetValueAsInteger(), second.MustGetValueAsInteger()));
                     break;
                 case DreamValue.DreamValueType.Float when second.IsNull:
                     result = new DreamValue(first.MustGetValueAsInteger());
@@ -995,7 +995,7 @@ namespace OpenDreamRuntime.Procs {
                     state.Push(new DreamValue(0));
                     break;
                 case DreamValue.DreamValueType.Float when second.Type == DreamValue.DreamValueType.Float:
-                    state.Push(new DreamValue(first.MustGetValueAsInteger() >> second.MustGetValueAsInteger()));
+                    state.Push(new DreamValue(SharedOperations.BitShiftRight(first.MustGetValueAsInteger(), second.MustGetValueAsInteger())));
                     break;
                 case DreamValue.DreamValueType.Float when second.IsNull:
                     state.Push(new DreamValue(first.MustGetValueAsInteger()));
@@ -1017,7 +1017,7 @@ namespace OpenDreamRuntime.Procs {
                     result = new DreamValue(0);
                     break;
                 case DreamValue.DreamValueType.Float when second.Type == DreamValue.DreamValueType.Float:
-                    result = new DreamValue(first.MustGetValueAsInteger() >> second.MustGetValueAsInteger());
+                    result = new DreamValue(SharedOperations.BitShiftRight(first.MustGetValueAsInteger(), second.MustGetValueAsInteger()));
                     break;
                 case DreamValue.DreamValueType.Float when second.IsNull:
                     result = new DreamValue(first.MustGetValueAsInteger());


### PR DESCRIPTION
BYOND zeros out the top 8 bits after a bit shift because everything is a 32 bit float

This modifies our `<<`, `>>`, and `<<=`, `>>=` operators to do that too