### PR TITLE
Allow semicolons in object var blocks

### DIFF
--- a/DMCompiler/Compiler/DM/DMParser.cs
+++ b/DMCompiler/Compiler/DM/DMParser.cs
@@ -328,7 +328,7 @@ namespace DMCompiler.Compiler.DM {
                     var varDef = new DMASTObjectVarDefinition(loc, varPath, value, valType);
 
                     varDefinitions.Add(varDef);
-                    if (Check(TokenType.DM_Comma) || (isIndented && Newline())) {
+                    if (Check(TokenType.DM_Comma) || (isIndented && Delimiter())) {
                         Whitespace();
                         DMASTPath? newVarPath = Path();
 

--- a/DMCompiler/DMStandard/Types/Client.dm
+++ b/DMCompiler/DMStandard/Types/Client.dm
@@ -15,6 +15,7 @@
 	var/atom/eye
 	var/lazy_eye = 0 as opendream_unimplemented
 	var/perspective = MOB_PERSPECTIVE
+	var/edge_limit = null as opendream_unimplemented
 	var/view
 	var/pixel_x = 0 as opendream_unimplemented
 	var/pixel_y = 0 as opendream_unimplemented


### PR DESCRIPTION
Fix parsing of code like this:
```dm
/obj
    var
        var1;var2
```

I also added a client var we were missing, `edge_limit`