### PR TITLE
Reuse large lists

### DIFF
--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -41,7 +41,7 @@ public sealed partial class DreamManager {
     public Random Random { get; set; } = new();
     public Dictionary<string, List<DreamObject>> Tags { get; } = new();
     public DreamProc ImageConstructor, ImageFactoryProc;
-    public ushort ListPoolThreshold, ListPoolSize;
+    public int ListPoolThreshold, ListPoolSize;
 
     public bool Initialized { get; private set; }
     public GameTick InitializedTick { get; private set; }

--- a/OpenDreamRuntime/DreamManager.cs
+++ b/OpenDreamRuntime/DreamManager.cs
@@ -41,6 +41,7 @@ public sealed partial class DreamManager {
     public Random Random { get; set; } = new();
     public Dictionary<string, List<DreamObject>> Tags { get; } = new();
     public DreamProc ImageConstructor, ImageFactoryProc;
+    public ushort ListPoolThreshold, ListPoolSize;
 
     public bool Initialized { get; private set; }
     public GameTick InitializedTick { get; private set; }
@@ -71,6 +72,8 @@ public sealed partial class DreamManager {
     //TODO This arg is awful and temporary until RT supports cvar overrides in unit tests
     public void PreInitialize(string? jsonPath) {
         _sawmill = Logger.GetSawmill("opendream");
+        ListPoolThreshold = _config.GetCVar(OpenDreamCVars.ListPoolThreshold);
+        ListPoolSize = _config.GetCVar(OpenDreamCVars.ListPoolSize);
         ByondApi.ByondApi.Initialize(this, _atomManager, _dreamMapManager, _objectTree);
 
         InitializeConnectionManager();

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -86,7 +86,7 @@ public class DreamList : DreamObject, IDreamList {
 
     // Hold on to large lists for reuse later
     protected override void HandleDeletion(bool possiblyThreaded) {
-        if (_values.Capacity < 2048) {
+        if (_values.Capacity < DreamManager.ListPoolThreshold) {
             base.HandleDeletion(possiblyThreaded);
             return;
         }
@@ -96,11 +96,12 @@ public class DreamList : DreamObject, IDreamList {
             return;
         }
 
-        base.HandleDeletion(possiblyThreaded);
-        if (ListPool.Count < 5000) {
+        if (ListPool.Count < DreamManager.ListPoolSize) {
             _values.Clear();
             ListPool.Push(_values);
         }
+
+        base.HandleDeletion(possiblyThreaded);
     }
 
     public DreamList CreateCopy(int start = 1, int end = 0) {
@@ -247,7 +248,7 @@ public class DreamList : DreamObject, IDreamList {
                 //TODO emit configurable warning here
                 throw new InvalidOperationException("Setting a list size to a negative value is invalid");
             }
-            
+
             Cut(size + 1);
         }
 
@@ -305,6 +306,7 @@ public class DreamList : DreamObject, IDreamList {
     }
 
     #region Operators
+
     public override DreamValue OperatorIndex(DreamValue index, DMProcState state) {
         return GetValue(index);
     }
@@ -456,6 +458,7 @@ public class DreamList : DreamObject, IDreamList {
 
         return DreamValue.True;
     }
+
     #endregion Operators
 }
 

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -27,7 +27,7 @@ public class DreamList : DreamObject, IDreamList {
     #endif
 
     public DreamList(DreamObjectDefinition listDef, int size) : base(listDef) {
-        if (size >= 2048 && ListPool.TryPop(out var poppedValues)) {
+        if (size >= DreamManager.ListPoolThreshold && ListPool.TryPop(out var poppedValues)) {
             _values = poppedValues;
             _values.EnsureCapacity(size);
         } else {

--- a/OpenDreamShared/OpenDreamCVars.cs
+++ b/OpenDreamShared/OpenDreamCVars.cs
@@ -30,13 +30,13 @@ public abstract class OpenDreamCVars {
     /// How large a /list's capacity has to be before it will be held in the list pool
     /// </summary>
     public static readonly CVarDef<ushort> ListPoolThreshold =
-        CVarDef.Create<ushort>("opendream.list_pool_threshold", 2048, CVar.SERVERONLY);
+        CVarDef.Create<int>("opendream.list_pool_threshold", 2048, CVar.SERVERONLY);
 
     /// <summary>
     /// The maximum amount of lists kept in the list pool
     /// </summary>
     public static readonly CVarDef<ushort> ListPoolSize =
-        CVarDef.Create<ushort>("opendream.list_pool_size", 256, CVar.SERVERONLY);
+        CVarDef.Create<int>("opendream.list_pool_size", 256, CVar.SERVERONLY);
 
     /// <summary>
     /// If Tracy should be enabled. ONLY FUNCTIONS IN TOOLS BUILD.

--- a/OpenDreamShared/OpenDreamCVars.cs
+++ b/OpenDreamShared/OpenDreamCVars.cs
@@ -26,6 +26,24 @@ public abstract class OpenDreamCVars {
     public static readonly CVarDef<ushort> TopicPort =
         CVarDef.Create<ushort>("opendream.topic_port", 25567, CVar.SERVERONLY);
 
+    /// <summary>
+    /// How large a /list's capacity has to be before it will be held in the list pool
+    /// </summary>
+    public static readonly CVarDef<ushort> ListPoolThreshold =
+        CVarDef.Create<ushort>("opendream.list_pool_threshold", 2048, CVar.SERVERONLY);
+
+    /// <summary>
+    /// The maximum amount of lists kept in the list pool
+    /// </summary>
+    public static readonly CVarDef<ushort> ListPoolSize =
+        CVarDef.Create<ushort>("opendream.list_pool_size", 256, CVar.SERVERONLY);
+
+    /// <summary>
+    /// If Tracy should be enabled. ONLY FUNCTIONS IN TOOLS BUILD.
+    /// </summary>
+    public static readonly CVarDef<bool> TracyEnable =
+        CVarDef.Create("opendream.enable_tracy", false, CVar.SERVERONLY);
+
     /*
         * INFOLINKS
         */
@@ -59,11 +77,4 @@ public abstract class OpenDreamCVars {
     /// </summary>
     public static readonly CVarDef<string> InfoLinksWiki =
         CVarDef.Create("infolinks.wiki", "", CVar.SERVER | CVar.REPLICATED);
-
-    /// <summary>
-    /// If Tracy should be enabled. ONLY FUNCTIONS IN TOOLS BUILD.
-    /// </summary>
-    public static readonly CVarDef<bool> TracyEnable =
-        CVarDef.Create("opendream.enable_tracy", false, CVar.SERVERONLY);
-
 }

--- a/OpenDreamShared/OpenDreamCVars.cs
+++ b/OpenDreamShared/OpenDreamCVars.cs
@@ -29,13 +29,13 @@ public abstract class OpenDreamCVars {
     /// <summary>
     /// How large a /list's capacity has to be before it will be held in the list pool
     /// </summary>
-    public static readonly CVarDef<ushort> ListPoolThreshold =
+    public static readonly CVarDef<int> ListPoolThreshold =
         CVarDef.Create<int>("opendream.list_pool_threshold", 2048, CVar.SERVERONLY);
 
     /// <summary>
     /// The maximum amount of lists kept in the list pool
     /// </summary>
-    public static readonly CVarDef<ushort> ListPoolSize =
+    public static readonly CVarDef<int> ListPoolSize =
         CVarDef.Create<int>("opendream.list_pool_size", 256, CVar.SERVERONLY);
 
     /// <summary>

--- a/OpenDreamShared/OpenDreamCVars.cs
+++ b/OpenDreamShared/OpenDreamCVars.cs
@@ -30,13 +30,13 @@ public abstract class OpenDreamCVars {
     /// How large a /list's capacity has to be before it will be held in the list pool
     /// </summary>
     public static readonly CVarDef<int> ListPoolThreshold =
-        CVarDef.Create<int>("opendream.list_pool_threshold", 2048, CVar.SERVERONLY);
+        CVarDef.Create("opendream.list_pool_threshold", 2048, CVar.SERVERONLY);
 
     /// <summary>
     /// The maximum amount of lists kept in the list pool
     /// </summary>
     public static readonly CVarDef<int> ListPoolSize =
-        CVarDef.Create<int>("opendream.list_pool_size", 256, CVar.SERVERONLY);
+        CVarDef.Create("opendream.list_pool_size", 256, CVar.SERVERONLY);
 
     /// <summary>
     /// If Tracy should be enabled. ONLY FUNCTIONS IN TOOLS BUILD.


### PR DESCRIPTION
Keep a list to reuse later if it can hold at least ~~2048~~ a configurable amount of elements. Paradise was using `block()` to grab a large list of turfs thousands of times during init, allocating gigabytes. This optimizes that.