### PR TITLE
Cleans up the error message on setting a list to a negative size

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -217,6 +217,10 @@ public class DreamList : DreamObject, IDreamList {
                 AddValue(DreamValue.Null);
             }
         } else {
+            if (size < 0) {
+                //TODO emit configurable warning here
+                throw new InvalidOperationException("Setting a list size to a negative value is invalid");
+            }
             Cut(size + 1);
         }
 


### PR DESCRIPTION
Makes the error tons easier to understand, but could probably still benefit from a configurable warning system

Related #2332
