### PR TITLE
Implement `"\icon[atom]"`

### DIFF
--- a/DMCompiler/Bytecode/StringFormatEncoder.cs
+++ b/DMCompiler/Bytecode/StringFormatEncoder.cs
@@ -30,7 +30,8 @@ public static class StringFormatEncoder {
         //States that Interpolated values can have (the [] thingies)
         StringifyWithArticle = 0x0,    //[] and we include an appropriate article for the resulting value, if necessary
         StringifyNoArticle = 0x1,      //[] and we never include an article (because it's elsewhere)
-        ReferenceOfValue = 0x2,        //\ref[]
+        NoStringify = 0x2,             //Appends no text at all
+        ReferenceOfValue = 0x3,        //\ref[]
 
         //States that macros can have
         //(these can have any arbitrary value as long as compiler/server/client all agree)

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -1175,12 +1175,12 @@ internal sealed class DMProc {
 
     public void FormatString(string value) {
         int formatCount = 0;
-        for (int i = 0; i < value.Length; i++) {
-            if (StringFormatEncoder.Decode(value[i], out var formatType))
-            {
-                if(StringFormatEncoder.IsInterpolation(formatType.Value))
-                    formatCount++;
-            }
+        foreach (var c in value) {
+            if (!StringFormatEncoder.Decode(c, out var formatType))
+                continue;
+
+            if(StringFormatEncoder.IsInterpolation(formatType.Value))
+                formatCount++;
         }
 
         ResizeStack(-(formatCount - 1)); //Shrinks by the amount of formats in the string, grows 1

--- a/OpenDreamClient/Interface/Controls/ControlOutput.cs
+++ b/OpenDreamClient/Interface/Controls/ControlOutput.cs
@@ -1,17 +1,17 @@
-﻿using OpenDreamClient.Interface.Descriptors;
+﻿using OpenDreamClient.Interface.Controls.UI;
+using OpenDreamClient.Interface.Descriptors;
 using OpenDreamClient.Interface.Html;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
-using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Utility;
 
 namespace OpenDreamClient.Interface.Controls;
 
 public sealed class ControlOutput(ControlDescriptor controlDescriptor, ControlWindow window) : InterfaceControl(controlDescriptor, window) {
-    private OutputPanel _textBox;
+    private OutputControl _textBox = default!;
 
     protected override Control CreateUIElement() {
-        _textBox = new OutputPanel();
+        _textBox = new OutputControl();
 
         return _textBox;
     }
@@ -29,7 +29,6 @@ public sealed class ControlOutput(ControlDescriptor controlDescriptor, ControlWi
 
         msg.PushColor(ControlDescriptor.TextColor.Value);
         msg.PushTag(new MarkupNode("font", null, null)); // Use the default font and font size
-        // TODO: Look into using RobustToolbox's markup parser once it's customizable enough
         HtmlParser.Parse(value.Replace("\t", "    "), msg);
         msg.Pop();
         msg.Pop();

--- a/OpenDreamClient/Interface/Controls/UI/AppearanceControl.cs
+++ b/OpenDreamClient/Interface/Controls/UI/AppearanceControl.cs
@@ -1,0 +1,49 @@
+using OpenDreamClient.Rendering;
+using Robust.Client.Graphics;
+using Robust.Client.UserInterface;
+using Robust.Shared.Timing;
+
+namespace OpenDreamClient.Interface.Controls.UI;
+
+/// <summary>
+/// Draws an icon with an appearance ID
+/// </summary>
+public sealed class AppearanceControl : Control {
+    [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly IClyde _clyde = default!;
+    [Dependency] private readonly IOverlayManager _overlayManager = default!;
+    [Dependency] private readonly IDreamInterfaceManager _interfaceManager = default!;
+
+    private readonly DreamViewOverlay _overlay;
+    private readonly DreamIcon _icon;
+
+    public AppearanceControl(uint appearanceId) {
+        IoCManager.InjectDependencies(this);
+
+        var dmiSpriteSystem = _entitySystemManager.GetEntitySystem<DMISpriteSystem>();
+        var appearanceSystem = _entitySystemManager.GetEntitySystem<ClientAppearanceSystem>();
+        _overlay = _overlayManager.GetOverlay<DreamViewOverlay>();
+        _icon = new DreamIcon(dmiSpriteSystem.RenderTargetPool, _interfaceManager,
+            _gameTiming, _clyde, appearanceSystem, appearanceId);
+
+        _icon.SizeChanged += InvalidateMeasure;
+    }
+
+    protected override void Draw(DrawingHandleScreen handle) {
+        var texture = _icon.GetTexture(_overlay, handle, new RendererMetaData {MainIcon = _icon}, null, null);
+        if (texture is null)
+            return;
+
+        var position = new Vector2(0, PixelPosition.Y); // For, uh, some reason
+        handle.DrawTextureRect(texture, new UIBox2(position, position + PixelSize));
+    }
+
+    protected override Vector2 MeasureOverride(Vector2 availableSize) {
+        // TODO: Would be ideal if we could always render at the texture's size
+        //       RichTextLabel doesn't make that possible right now though (enforces the font's line height)
+        var size = Math.Min(_icon.DMI?.IconSize.Y ?? 0, availableSize.Y);
+
+        return new(size);
+    }
+}

--- a/OpenDreamClient/Interface/Controls/UI/OutputControl.cs
+++ b/OpenDreamClient/Interface/Controls/UI/OutputControl.cs
@@ -1,0 +1,48 @@
+using Robust.Client.Graphics;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Utility;
+
+namespace OpenDreamClient.Interface.Controls.UI;
+
+/// <summary>
+/// Similar functionality to RobustToolbox's OutputPanel
+/// Works with inline controls in the rich texts
+/// </summary>
+public sealed class OutputControl : Control {
+    public StyleBox? StyleBoxOverride {
+        get => _panelContainer.PanelOverride;
+        set => _panelContainer.PanelOverride = value;
+    }
+
+    private readonly PanelContainer _panelContainer;
+    private readonly BoxContainer _messageContainer;
+
+    public OutputControl() {
+        _panelContainer = new PanelContainer {
+            HorizontalExpand = true,
+            VerticalExpand = true,
+            Children = {
+                new ScrollContainer {
+                    HorizontalExpand = true,
+                    VerticalExpand = true,
+                    HScrollEnabled = false,
+                    Children = {
+                        (_messageContainer = new BoxContainer {
+                            Orientation = BoxContainer.LayoutOrientation.Vertical
+                        })
+                    }
+                }
+            }
+        };
+
+        AddChild(_panelContainer);
+    }
+
+    public void AddMessage(FormattedMessage message) {
+        var label = new RichTextLabel();
+
+        label.SetMessage(message);
+        _messageContainer.AddChild(label);
+    }
+}

--- a/OpenDreamClient/Interface/Html/HtmlParser.cs
+++ b/OpenDreamClient/Interface/Html/HtmlParser.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using OpenDreamShared.Dream;
 using Robust.Shared.Utility;
 
 namespace OpenDreamClient.Interface.Html;
@@ -90,6 +91,7 @@ public static class HtmlParser {
                         if (!isSelfClosing) {
                             tags.Push(tagType);
                         }
+
                         appendTo.PushTag(new MarkupNode(tagType, null, ParseAttributes(attributes)), selfClosing: isSelfClosing);
                     }
 
@@ -135,6 +137,18 @@ public static class HtmlParser {
                     appendTo.PushNewline();
                     break;
                 default:
+                    // Not really HTML, but this is a very convenient place to put this
+                    if (c == StringFormatting.Icon) {
+                        // The appearance ID is encoded in the next 2 chars (4 bytes)
+                        var upper = (ushort)text[++i];
+                        var lower = (ushort)text[++i];
+                        var appearanceId = (uint)((upper << 16) | lower);
+
+                        PushCurrentText();
+                        appendTo.PushTag(new MarkupNode("icon", new(appearanceId), null), true);
+                        break;
+                    }
+
                     currentText.Append(c);
                     break;
             }

--- a/OpenDreamClient/Interface/Html/Tags/TagIcon.cs
+++ b/OpenDreamClient/Interface/Html/Tags/TagIcon.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics.CodeAnalysis;
+using OpenDreamClient.Interface.Controls.UI;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.RichText;
+using Robust.Shared.Utility;
+
+namespace OpenDreamClient.Interface.Html.Tags;
+
+/// <summary>
+/// Display an appearance
+/// </summary>
+public sealed class TagIcon : IMarkupTagHandler {
+    public const string AppearanceIdAttribute = "AppearanceId";
+
+    public string Name => "icon";
+
+    public bool TryCreateControl(MarkupNode node, [NotNullWhen(true)] out Control? control) {
+        if (node.Value.LongValue is not { } appearanceId) {
+            control = null;
+            return false;
+        }
+
+        control = new AppearanceControl((uint)appearanceId) {
+            HorizontalAlignment = Control.HAlignment.Left
+        };
+
+        return true;
+    }
+}

--- a/OpenDreamClient/Rendering/DreamIcon.cs
+++ b/OpenDreamClient/Rendering/DreamIcon.cs
@@ -85,7 +85,7 @@ internal sealed class DreamIcon(RenderTargetPool renderTargetPool, IDreamInterfa
         DMI = null; //triggers the removal of the onUpdateCallback
     }
 
-    public Texture? GetTexture(DreamViewOverlay viewOverlay, DrawingHandleWorld handle, RendererMetaData iconMetaData, Texture? textureOverride, ClientAppearanceSystem.Flick? flick) {
+    public Texture? GetTexture(DreamViewOverlay viewOverlay, DrawingHandleBase handle, RendererMetaData iconMetaData, Texture? textureOverride, ClientAppearanceSystem.Flick? flick) {
         Texture? frame;
 
         if (textureOverride == null) {
@@ -508,7 +508,7 @@ internal sealed class DreamIcon(RenderTargetPool renderTargetPool, IDreamInterfa
     /// <remarks>In a separate method to avoid closure allocations when not executed</remarks>
     /// <returns>The final texture</returns>
     [SuppressMessage("ReSharper", "AccessToModifiedClosure")] // RenderInRenderTarget executes immediately, shouldn't be an issue
-    private IRenderTexture FullRenderTexture(DreamViewOverlay viewOverlay, DrawingHandleWorld handle, RendererMetaData iconMetaData, Texture frame) {
+    private IRenderTexture FullRenderTexture(DreamViewOverlay viewOverlay, DrawingHandleBase handle, RendererMetaData iconMetaData, Texture frame) {
         Vector2 requiredRenderSpace = frame.Size;
         foreach (var filter in iconMetaData.MainIcon!.Appearance!.Filters) {
             var requiredSpace = filter.CalculateRequiredRenderSpace(frame.Size,
@@ -532,7 +532,7 @@ internal sealed class DreamIcon(RenderTargetPool renderTargetPool, IDreamInterfa
             handle.UseShader(colorShader);
 
             handle.SetTransform(DreamViewOverlay.CreateRenderTargetFlipMatrix(pong.Size, (pong.Size/2 - frame.Size/2)));
-            handle.DrawTextureRect(frame, new Box2(Vector2.Zero, frame.Size));
+            handle.DrawTexture(frame, Vector2.Zero);
         }, Color.Black.WithAlpha(0));
 
         foreach (DreamFilter filterId in iconMetaData.MainIcon!.Appearance!.Filters) {
@@ -543,7 +543,7 @@ internal sealed class DreamIcon(RenderTargetPool renderTargetPool, IDreamInterfa
 
                 // Technically this should be ping.Size, but they are the same size so avoid the extra closure alloc
                 handle.SetTransform(DreamViewOverlay.CreateRenderTargetFlipMatrix(pong.Size, Vector2.Zero));
-                handle.DrawTextureRect(pong.Texture, new Box2(Vector2.Zero, pong.Size));
+                handle.DrawTexture(pong.Texture, Vector2.Zero);
             }, Color.Black.WithAlpha(0));
 
             // The blur filter runs a more performant two passes
@@ -556,7 +556,7 @@ internal sealed class DreamIcon(RenderTargetPool renderTargetPool, IDreamInterfa
 
                     // Technically this should be ping.Size, but they are the same size so avoid the extra closure alloc
                     handle.SetTransform(DreamViewOverlay.CreateRenderTargetFlipMatrix(pong.Size, Vector2.Zero));
-                    handle.DrawTextureRect(pong.Texture, new Box2(Vector2.Zero, pong.Size));
+                    handle.DrawTexture(pong.Texture, Vector2.Zero);
                 }, Color.Black.WithAlpha(0));
             }
 

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -9,9 +9,11 @@ using DMCompiler.Bytecode;
 using OpenDreamRuntime.Objects;
 using OpenDreamRuntime.Objects.Types;
 using OpenDreamRuntime.Procs.Native;
+using OpenDreamRuntime.Rendering;
 using OpenDreamRuntime.Resources;
 using OpenDreamShared.Dream;
 using Robust.Shared.Random;
+using FormatSuffix = DMCompiler.Bytecode.StringFormatEncoder.FormatSuffix;
 using Vector4 = Robust.Shared.Maths.Vector4;
 
 namespace OpenDreamRuntime.Procs {
@@ -400,7 +402,7 @@ namespace OpenDreamRuntime.Procs {
 
             int interpCount = state.ReadInt();
 
-            StringFormatEncoder.FormatSuffix? postPrefix = null; // Prefix that needs the effects of a suffix
+            FormatSuffix? postPrefix = null; // Prefix that needs the effects of a suffix
 
             ReadOnlySpan<DreamValue> interps = state.PopCount(interpCount);
             int nextInterpIndex = 0; // If we find a prefix macro, this is what it points to
@@ -414,20 +416,20 @@ namespace OpenDreamRuntime.Procs {
 
                 switch (formatType) {
                     //Interp values
-                    case StringFormatEncoder.FormatSuffix.StringifyWithArticle:{
+                    case FormatSuffix.StringifyWithArticle:{
                         // TODO: use postPrefix for \th interpolation
                         formattedString.Append(interps[nextInterpIndex].Stringify());
                         prevInterpIndex = nextInterpIndex;
                         nextInterpIndex++;
                         continue;
                     }
-                    case StringFormatEncoder.FormatSuffix.ReferenceOfValue: {
+                    case FormatSuffix.ReferenceOfValue: {
                         formattedString.Append(state.DreamManager.CreateRef(interps[nextInterpIndex]));
                         //suffix macro marker is not updated because suffixes do not point to \ref[] interpolations
                         nextInterpIndex++;
                         continue;
                     }
-                    case StringFormatEncoder.FormatSuffix.StringifyNoArticle: {
+                    case FormatSuffix.StringifyNoArticle: {
                         if (interps[nextInterpIndex].TryGetValueAsDreamObject<DreamObject>(out var dreamObject)) {
                             formattedString.Append(dreamObject.GetNameUnformatted());
                         } else if (interps[nextInterpIndex].TryGetValueAsString(out var interpStr)) {
@@ -437,10 +439,10 @@ namespace OpenDreamRuntime.Procs {
                         // NOTE probably should put this above the TryGetAsDreamObject function and continue if formatting has occured
                         if(postPrefix != null) { // Cursed Hack
                             switch (postPrefix) {
-                                case StringFormatEncoder.FormatSuffix.LowerRoman:
+                                case FormatSuffix.LowerRoman:
                                     ToRoman(ref formattedString, interps, nextInterpIndex, false);
                                     break;
-                                case StringFormatEncoder.FormatSuffix.UpperRoman:
+                                case FormatSuffix.UpperRoman:
                                     ToRoman(ref formattedString, interps, nextInterpIndex, true);
                                     break;
                             }
@@ -453,23 +455,28 @@ namespace OpenDreamRuntime.Procs {
                         nextInterpIndex++;
                         continue;
                     }
+                    case FormatSuffix.NoStringify:
+                        prevInterpIndex = nextInterpIndex;
+                        nextInterpIndex++;
+                        break;
+
                     //Macro values//
                     //Prefix macros
-                    case StringFormatEncoder.FormatSuffix.UpperDefiniteArticle:
-                    case StringFormatEncoder.FormatSuffix.LowerDefiniteArticle: {
+                    case FormatSuffix.UpperDefiniteArticle:
+                    case FormatSuffix.LowerDefiniteArticle: {
                         if (interps[nextInterpIndex].TryGetValueAsDreamObject<DreamObject>(out var dreamObject)) {
                             bool hasName = dreamObject.TryGetVariable("name", out var objectName);
                             if (!hasName) continue;
                             string nameStr = objectName.Stringify();
                             if (!DreamObject.StringIsProper(nameStr)) {
-                                formattedString.Append(formatType == StringFormatEncoder.FormatSuffix.UpperDefiniteArticle ? "The " : "the ");
+                                formattedString.Append(formatType == FormatSuffix.UpperDefiniteArticle ? "The " : "the ");
                             }
                         }
 
                         continue;
                     }
-                    case StringFormatEncoder.FormatSuffix.UpperIndefiniteArticle:
-                    case StringFormatEncoder.FormatSuffix.LowerIndefiniteArticle: {
+                    case FormatSuffix.UpperIndefiniteArticle:
+                    case FormatSuffix.LowerIndefiniteArticle: {
                         var interpValue = interps[nextInterpIndex];
                         string displayName;
                         bool isPlural = false;
@@ -493,7 +500,7 @@ namespace OpenDreamRuntime.Procs {
                             break; // Proper nouns don't need articles, I guess.
 
                         // saves some wordiness with the ternaries below
-                        bool wasCapital = formatType == StringFormatEncoder.FormatSuffix.UpperIndefiniteArticle;
+                        bool wasCapital = formatType == FormatSuffix.UpperIndefiniteArticle;
 
                         if (isPlural)
                             formattedString.Append(wasCapital ? "Some " : "some ");
@@ -505,37 +512,37 @@ namespace OpenDreamRuntime.Procs {
                         break;
                     }
                     //Suffix macros
-                    case StringFormatEncoder.FormatSuffix.UpperSubjectPronoun:
+                    case FormatSuffix.UpperSubjectPronoun:
                         HandleSuffixPronoun(ref formattedString, interps, prevInterpIndex, new[] { "He", "She", "They", "Tt" });
                         break;
-                    case StringFormatEncoder.FormatSuffix.LowerSubjectPronoun:
+                    case FormatSuffix.LowerSubjectPronoun:
                         HandleSuffixPronoun(ref formattedString, interps, prevInterpIndex, new[] { "he", "she", "they", "it" });
                         break;
-                    case StringFormatEncoder.FormatSuffix.UpperPossessiveAdjective:
+                    case FormatSuffix.UpperPossessiveAdjective:
                         HandleSuffixPronoun(ref formattedString, interps, prevInterpIndex, new[] { "His", "Her", "Their", "Its" });
                         break;
-                    case StringFormatEncoder.FormatSuffix.LowerPossessiveAdjective:
+                    case FormatSuffix.LowerPossessiveAdjective:
                         HandleSuffixPronoun(ref formattedString, interps, prevInterpIndex, new[] { "his", "her", "their", "its" });
                         break;
-                    case StringFormatEncoder.FormatSuffix.ObjectPronoun:
+                    case FormatSuffix.ObjectPronoun:
                         HandleSuffixPronoun(ref formattedString, interps, prevInterpIndex, new[] { "him", "her", "them", "it" });
                         break;
-                    case StringFormatEncoder.FormatSuffix.ReflexivePronoun:
+                    case FormatSuffix.ReflexivePronoun:
                         HandleSuffixPronoun(ref formattedString, interps, prevInterpIndex, new[] { "himself", "herself", "themself", "itself" });
                         break;
-                    case StringFormatEncoder.FormatSuffix.UpperPossessivePronoun:
+                    case FormatSuffix.UpperPossessivePronoun:
                         HandleSuffixPronoun(ref formattedString, interps, prevInterpIndex, new[] { "His", "Hers", "Theirs", "Its" });
                         break;
-                    case StringFormatEncoder.FormatSuffix.LowerPossessivePronoun:
+                    case FormatSuffix.LowerPossessivePronoun:
                         HandleSuffixPronoun(ref formattedString, interps, prevInterpIndex, new[] { "his", "hers", "theirs", "its" });
                         break;
-                    case StringFormatEncoder.FormatSuffix.PluralSuffix:
+                    case FormatSuffix.PluralSuffix:
                         if (interps[prevInterpIndex].TryGetValueAsFloat(out var pluralNumber) && pluralNumber.Equals(1f))
                             continue;
 
                         formattedString.Append("s");
                         continue;
-                    case StringFormatEncoder.FormatSuffix.OrdinalIndicator:
+                    case FormatSuffix.OrdinalIndicator:
                         var interp = interps[prevInterpIndex];
                         if (interp.TryGetValueAsInteger(out var ordinalNumber)) {
                             // For some mystical reason byond converts \th to integers
@@ -579,14 +586,34 @@ namespace OpenDreamRuntime.Procs {
                         }
 
                         continue;
-                    case StringFormatEncoder.FormatSuffix.LowerRoman:
+                    case FormatSuffix.LowerRoman:
                         postPrefix = formatType;
                         continue;
-                    case StringFormatEncoder.FormatSuffix.UpperRoman:
+                    case FormatSuffix.UpperRoman:
                         postPrefix = formatType;
+                        continue;
+                    case FormatSuffix.Icon:
+                        var iconValue = interps[nextInterpIndex];
+                        if (!iconValue.TryGetValueAsDreamObject<DreamObjectAtom>(out var atom))
+                            continue;
+                        if (!state.Proc.AtomManager.TryGetAppearance(atom, out var appearance))
+                            continue;
+
+                        var entitySystemManager = IoCManager.Resolve<IEntitySystemManager>();
+                        if (!entitySystemManager.TryGetEntitySystem(out ServerAppearanceSystem? appearanceSystem))
+                            continue;
+                        if (!appearanceSystem.AddAppearance(appearance).TryGetId(out var appearanceId))
+                            continue;
+
+                        // Encode the 4-byte appearance ID as characters in the string
+                        var upper = (char)(((ushort)(appearanceId & 0xFFFF0000)) >> 16);
+                        var lower = (char)((ushort)(appearanceId & 0xFFFF));
+                        formattedString.Append(StringFormatting.Icon);
+                        formattedString.Append(upper);
+                        formattedString.Append(lower);
                         continue;
                     default:
-                        if (Enum.IsDefined(typeof(StringFormatEncoder.FormatSuffix), formatType)) {
+                        if (Enum.IsDefined(typeof(FormatSuffix), formatType)) {
                             //Likely an unimplemented text macro, ignore it
                             break;
                         }

--- a/OpenDreamShared/Dream/StringFormatting.cs
+++ b/OpenDreamShared/Dream/StringFormatting.cs
@@ -1,0 +1,5 @@
+namespace OpenDreamShared.Dream;
+
+public static class StringFormatting {
+    public static char Icon = (char)(0xFF00);
+}


### PR DESCRIPTION
Allows inlining an atom's icon anywhere you can use HTML in the DMF

Examples from Exadv1's Console:
![image](https://github.com/user-attachments/assets/1cd24ee4-8539-4084-b8e2-efa34c5bc4ca)
![image](https://github.com/user-attachments/assets/6238f515-298f-4214-aee6-9c79605fa4bf)
