### PR TITLE
Fix various `/regex` vars not being updated when used in `findtext()`

### DIFF
--- a/OpenDreamRuntime/Objects/Types/DreamObjectRegex.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectRegex.cs
@@ -79,4 +79,33 @@ public sealed class DreamObjectRegex(DreamObjectDefinition objectDefinition) : D
             throw new Exception("Invalid regex pattern " + pattern);
         }
     }
+
+    public DreamValue FindHelper(string haystackString, int start, int end) {
+        Match match = Regex.Match(haystackString, Math.Clamp(start - 1, 0, haystackString.Length), end - start + 1);
+        if (match.Success) {
+            SetVariable("index", new DreamValue(match.Index + 1));
+            SetVariable("match", new DreamValue(match.Value));
+            if (match.Groups.Count > 0) {
+                DreamList groupList = ObjectTree.CreateList(match.Groups.Count);
+
+                for (int i = 1; i < match.Groups.Count; i++) {
+                    groupList.AddValue(new DreamValue(match.Groups[i].Value));
+                }
+
+                SetVariable("group", new DreamValue(groupList));
+            }
+
+            if (IsGlobal) {
+                SetVariable("next", new DreamValue(match.Index + match.Length + 1));
+            }
+
+            return new DreamValue(match.Index + 1);
+        }
+
+        if (IsGlobal) {
+            SetVariable("next", DreamValue.Null);
+        }
+
+        return new DreamValue(0);
+    }
 }

--- a/OpenDreamRuntime/Objects/Types/DreamObjectRegex.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectRegex.cs
@@ -81,7 +81,7 @@ public sealed class DreamObjectRegex(DreamObjectDefinition objectDefinition) : D
     }
 
     public DreamValue FindHelper(string haystackString, int start, int end) {
-        Match match = Regex.Match(haystackString, Math.Clamp(start - 1, 0, haystackString.Length), end - start + 1);
+        Match match = Regex.Match(haystackString, start, end);
         if (match.Success) {
             SetVariable("index", new DreamValue(match.Index + 1));
             SetVariable("match", new DreamValue(match.Value));

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
@@ -27,35 +27,11 @@ namespace OpenDreamRuntime.Procs.Native {
                 if (dreamRegex.IsGlobal) {
                     dreamRegex.SetVariable("next", DreamValue.Null);
                 }
-                return new DreamValue(0);
-            }
-
-            Match match = dreamRegex.Regex.Match(haystackString, Math.Clamp(next - 1, 0, haystackString.Length), end - next + 1);
-            if (match.Success) {
-                dreamRegex.SetVariable("index", new DreamValue(match.Index + 1));
-                dreamRegex.SetVariable("match", new DreamValue(match.Value));
-                if (match.Groups.Count > 0) {
-                    DreamList groupList = bundle.ObjectTree.CreateList(match.Groups.Count);
-
-                    for (int i = 1; i < match.Groups.Count; i++) {
-                        groupList.AddValue(new DreamValue(match.Groups[i].Value));
-                    }
-
-                    dreamRegex.SetVariable("group", new DreamValue(groupList));
-                }
-
-                if (dreamRegex.IsGlobal) {
-                    dreamRegex.SetVariable("next", new DreamValue(match.Index + match.Length + 1));
-                }
-
-                return new DreamValue(match.Index + 1);
-            } else {
-                if (dreamRegex.IsGlobal) {
-                    dreamRegex.SetVariable("next", DreamValue.Null);
-                }
 
                 return new DreamValue(0);
             }
+
+            return dreamRegex.FindHelper(haystackString, next, end);
         }
 
         public static DreamValue RegexReplace(DreamObject regexInstance, DreamValue haystack, DreamValue replace, int start, int end) {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRegex.cs
@@ -31,7 +31,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 return new DreamValue(0);
             }
 
-            return dreamRegex.FindHelper(haystackString, next, end);
+            return dreamRegex.FindHelper(haystackString, Math.Clamp(next - 1, 0, haystackString.Length), end - next + 1);
         }
 
         public static DreamValue RegexReplace(DreamObject regexInstance, DreamValue haystack, DreamValue replace, int start, int end) {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -876,7 +876,7 @@ internal static class DreamProcNativeRoot {
         }
 
         if (regex is not null) {
-            return regex.FindHelper(text, start, end);
+            return regex.FindHelper(text, start - 1, end - start);
         }
 
         int needleIndex = text.IndexOf(needle, start - 1, end - start, StringComparison.OrdinalIgnoreCase);
@@ -917,7 +917,7 @@ internal static class DreamProcNativeRoot {
         }
 
         if (regex is not null) {
-            return regex.FindHelper(text, start, end);
+            return regex.FindHelper(text, start - 1, end - start);
         }
 
         int needleIndex = text.IndexOf(needle, start - 1, end - start, StringComparison.InvariantCulture);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -878,7 +878,26 @@ internal static class DreamProcNativeRoot {
         if (regex is not null) {
             Match match = regex.Regex.Match(text, start - 1, end - start);
 
-            return match.Success ? new DreamValue(match.Index + 1) : new DreamValue(0);
+            if (match.Success) {
+                regex.SetVariable("index", new DreamValue(match.Index + 1));
+                regex.SetVariable("match", new DreamValue(match.Value));
+                if (match.Groups.Count > 0) {
+                    DreamList groupList = bundle.ObjectTree.CreateList(match.Groups.Count);
+
+                    for (int i = 1; i < match.Groups.Count; i++) {
+                        groupList.AddValue(new DreamValue(match.Groups[i].Value));
+                    }
+
+                    regex.SetVariable("group", new DreamValue(groupList));
+                }
+
+                if(regex.IsGlobal)
+                    regex.SetVariable("next", new DreamValue(match.Index + match.Length + 1));
+
+                return new DreamValue(match.Index + 1);
+            }
+
+            return new DreamValue(0);
         }
 
         int needleIndex = text.IndexOf(needle, start - 1, end - start, StringComparison.OrdinalIgnoreCase);
@@ -920,8 +939,26 @@ internal static class DreamProcNativeRoot {
 
         if (regex is not null) {
             Match match = regex.Regex.Match(text, start - 1, end - start);
+            if (match.Success) {
+                regex.SetVariable("index", new DreamValue(match.Index + 1));
+                regex.SetVariable("match", new DreamValue(match.Value));
+                if (match.Groups.Count > 0) {
+                    DreamList groupList = bundle.ObjectTree.CreateList(match.Groups.Count);
 
-            return match.Success ? new DreamValue(match.Index + 1) : new DreamValue(0);
+                    for (int i = 1; i < match.Groups.Count; i++) {
+                        groupList.AddValue(new DreamValue(match.Groups[i].Value));
+                    }
+
+                    regex.SetVariable("group", new DreamValue(groupList));
+                }
+
+                if(regex.IsGlobal)
+                    regex.SetVariable("next", new DreamValue(match.Index + match.Length + 1));
+
+                return new DreamValue(match.Index + 1);
+            }
+
+            return new DreamValue(0);
         }
 
         int needleIndex = text.IndexOf(needle, start - 1, end - start, StringComparison.InvariantCulture);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -876,28 +876,7 @@ internal static class DreamProcNativeRoot {
         }
 
         if (regex is not null) {
-            Match match = regex.Regex.Match(text, start - 1, end - start);
-
-            if (match.Success) {
-                regex.SetVariable("index", new DreamValue(match.Index + 1));
-                regex.SetVariable("match", new DreamValue(match.Value));
-                if (match.Groups.Count > 0) {
-                    DreamList groupList = bundle.ObjectTree.CreateList(match.Groups.Count);
-
-                    for (int i = 1; i < match.Groups.Count; i++) {
-                        groupList.AddValue(new DreamValue(match.Groups[i].Value));
-                    }
-
-                    regex.SetVariable("group", new DreamValue(groupList));
-                }
-
-                if(regex.IsGlobal)
-                    regex.SetVariable("next", new DreamValue(match.Index + match.Length + 1));
-
-                return new DreamValue(match.Index + 1);
-            }
-
-            return new DreamValue(0);
+            return regex.FindHelper(text, start, end);
         }
 
         int needleIndex = text.IndexOf(needle, start - 1, end - start, StringComparison.OrdinalIgnoreCase);
@@ -938,27 +917,7 @@ internal static class DreamProcNativeRoot {
         }
 
         if (regex is not null) {
-            Match match = regex.Regex.Match(text, start - 1, end - start);
-            if (match.Success) {
-                regex.SetVariable("index", new DreamValue(match.Index + 1));
-                regex.SetVariable("match", new DreamValue(match.Value));
-                if (match.Groups.Count > 0) {
-                    DreamList groupList = bundle.ObjectTree.CreateList(match.Groups.Count);
-
-                    for (int i = 1; i < match.Groups.Count; i++) {
-                        groupList.AddValue(new DreamValue(match.Groups[i].Value));
-                    }
-
-                    regex.SetVariable("group", new DreamValue(groupList));
-                }
-
-                if(regex.IsGlobal)
-                    regex.SetVariable("next", new DreamValue(match.Index + match.Length + 1));
-
-                return new DreamValue(match.Index + 1);
-            }
-
-            return new DreamValue(0);
+            return regex.FindHelper(text, start, end);
         }
 
         int needleIndex = text.IndexOf(needle, start - 1, end - start, StringComparison.InvariantCulture);


### PR DESCRIPTION
Fixes https://github.com/OpenDreamProject/OpenDream/issues/1785

Using a `/regex` in `findtext()` would not update the regex object's vars. Now it does.

The original issue was slightly misleading, this was the real root cause. I tested that there is no more maploader runtime spam in daedalus.