### PR TITLE
Better initial() parity

### DIFF
--- a/Content.Tests/DMProject/Tests/SpecialProcs/initial/InitialVarOnPrimativePragma.dm
+++ b/Content.Tests/DMProject/Tests/SpecialProcs/initial/InitialVarOnPrimativePragma.dm
@@ -1,0 +1,8 @@
+// RUNTIME ERROR
+#pragma InitialVarOnPrimativeException error
+
+/proc/initial_test(obj/A)
+	return initial(A.name)
+
+/proc/RunTest()
+	initial_test("foo")

--- a/Content.Tests/DMProject/Tests/SpecialProcs/initial/initial_var_non_object.dm
+++ b/Content.Tests/DMProject/Tests/SpecialProcs/initial/initial_var_non_object.dm
@@ -1,0 +1,3 @@
+/proc/RunTest()
+	var/obj/A = "foo" // Lie about the type
+	ASSERT(initial(A.name) == null)

--- a/DMCompiler/Compiler/CompilerError.cs
+++ b/DMCompiler/Compiler/CompilerError.cs
@@ -83,6 +83,7 @@ public enum WarningCode {
 
     // 4000 - 4999 are reserved for runtime configuration. (TODO: Runtime doesn't know about configs yet!)
     ListNegativeSizeException = 4000, // When a list's length is decremented below zero, raise an exception.
+    InitialVarOnPrimativeException = 4001, // initial(foo.var) where foo is a variable containing a non-datum value.
 }
 
 public enum ErrorLevel {

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -613,7 +613,6 @@ namespace OpenDreamRuntime.Procs {
             if (!key.TryGetValueAsString(out string? property)) {
                 throw new Exception("Invalid var for initial() call: " + key);
             }
-
             DreamObjectDefinition objectDefinition;
             if (owner.TryGetValueAsDreamObject(out var dreamObject)) {
                 switch (dreamObject) {
@@ -632,7 +631,9 @@ namespace OpenDreamRuntime.Procs {
             } else if (owner.TryGetValueAsType(out var ownerType)) {
                 objectDefinition = ownerType.ObjectDefinition;
             } else {
-                throw new Exception($"Invalid owner for initial() call {owner}");
+                state.DreamManager.OptionalException<ArgumentException>(DMCompiler.Compiler.WarningCode.InitialVarOnPrimativeException, "Initial() attempted to get the initial value of a variable on a primative.");
+                state.Push(DreamValue.Null);
+                return ProcStatus.Continue;
             }
 
             var result = property switch {


### PR DESCRIPTION
Fixes initial(A.var) throwing an exception instead of returning null if A is a primitive. Retains exception behavior via optional runtime pragma. 