### PR TITLE
Fixes inconsistencies with text handling, adds splittext_char()

### DIFF
--- a/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNative.cs
@@ -96,6 +96,7 @@ internal static class DreamProcNative {
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_splicetext);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_splicetext_char);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_splittext);
+        objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_splittext_char);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_stat);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_statpanel);
         objectTree.SetGlobalNativeProc(DreamProcNativeRoot.NativeProc_text2ascii);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2934,17 +2934,17 @@ internal static class DreamProcNativeRoot {
             return new DreamValue(0);
         }
 
-        StringInfo textElements = new StringInfo(text);
+        Rune[] runes = text.EnumerateRunes().ToArray();
 
         bundle.GetArgument(1, "pos").TryGetValueAsInteger(out var pos); //1-indexed
         if (pos == 0) pos = 1; //0 is same as 1
-        else if (pos < 0) pos += textElements.LengthInTextElements + 1; //Wraps around
+        else if (pos < 0) pos += runes.Length + 1; //Wraps around
 
-        if (pos > textElements.LengthInTextElements || pos < 1) {
+        if (pos > runes.Length || pos < 1) {
             return new DreamValue(0);
         } else {
             //practically identical to (our) text2ascii but more explicit about subchar indexing
-            return new DreamValue((int)textElements.SubstringByTextElements(pos - 1, 1)[0]);
+            return new DreamValue((int)runes[pos].ToString()[0]);
         }
     }
 

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2755,22 +2755,23 @@ internal static class DreamProcNativeRoot {
         else if(text == "")
             return new DreamValue(insertText);
 
+        Rune[] runes = text.EnumerateRunes().ToArray();
+
         //runtime if start = 0 runtime error: bad text or out of bounds
-        StringInfo textElements = new StringInfo(text);
-        if(end == 0 || end > textElements.LengthInTextElements + 1)
-            end = textElements.LengthInTextElements+1;
+        if (end == 0 || end > runes.Length + 1)
+            end = runes.Length + 1;
         if(start < 0)
-            start = Math.Max(start + textElements.LengthInTextElements + 1, 1);
+            start = Math.Max(start + runes.Length + 1, 1);
         if(end < 0)
-            end = Math.Min(end + textElements.LengthInTextElements + 1, textElements.LengthInTextElements);
+            end = Math.Min(end + runes.Length + 1, runes.Length);
 
-        if(start == 0 || start > textElements.LengthInTextElements || start > end)
-            throw new Exception("bad text or out of bounds");
+        if(start == 0 || start > runes.Length || start > end)
+            throw new ArgumentException("bad text or out of bounds");
 
-        string result = textElements.SubstringByTextElements(0, start - 1);
+        string result = TextHelpers.RuneSubstring(runes, 0, start - 1);
         result += insertText;
-        if(end <= textElements.LengthInTextElements)
-            result += textElements.SubstringByTextElements(end - 1);
+        if(end <= runes.Length)
+            result += TextHelpers.RuneSubstring(runes, end - 1, 0);
 
         return new DreamValue(result);
     }

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2656,24 +2656,24 @@ internal static class DreamProcNativeRoot {
             return new DreamValue(0);
         }
 
-        StringInfo textStringInfo = new StringInfo(text);
+        Rune[] runes = text.EnumerateRunes().ToArray();
 
         if(start < 0) {
-            start = Math.Max(start + textStringInfo.LengthInTextElements + 1, 1);
+            start = Math.Max(start + runes.Length + 1, 1);
         }
 
         int result = 0;
 
-        TextElementEnumerator needlesElementEnumerator = StringInfo.GetTextElementEnumerator(needles);
-        TextElementEnumerator textElementEnumerator = StringInfo.GetTextElementEnumerator(text, start - 1);
+        IEnumerator<Rune> needlesRuneEnumerator = needles.EnumerateRunes();
+        IEnumerator<Rune> textElementEnumerator = TextHelpers.RuneSubstring(runes, start - 1, 0).EnumerateRunes();
 
         while(textElementEnumerator.MoveNext()) {
             bool found = false;
-            needlesElementEnumerator.Reset();
+            needlesRuneEnumerator.Reset();
 
             //lol O(N*M)
-            while (needlesElementEnumerator.MoveNext()) {
-                if (textElementEnumerator.Current.Equals(needlesElementEnumerator.Current)) {
+            while (needlesRuneEnumerator.MoveNext()) {
+                if (textElementEnumerator.Current.Equals(textElementEnumerator.Current)) {
                     result++;
                     found = true;
                     break;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -2665,15 +2665,15 @@ internal static class DreamProcNativeRoot {
         int result = 0;
 
         IEnumerator<Rune> needlesRuneEnumerator = needles.EnumerateRunes();
-        IEnumerator<Rune> textElementEnumerator = TextHelpers.RuneSubstring(runes, start - 1, 0).EnumerateRunes();
+        IEnumerator<Rune> textRuneEnumerator = TextHelpers.RuneSubstring(runes, start - 1, 0).EnumerateRunes();
 
-        while(textElementEnumerator.MoveNext()) {
+        while(textRuneEnumerator.MoveNext()) {
             bool found = false;
             needlesRuneEnumerator.Reset();
 
             //lol O(N*M)
             while (needlesRuneEnumerator.MoveNext()) {
-                if (textElementEnumerator.Current.Equals(textElementEnumerator.Current)) {
+                if (textRuneEnumerator.Current.Equals(needlesRuneEnumerator.Current)) {
                     result++;
                     found = true;
                     break;

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -630,13 +630,13 @@ internal static class DreamProcNativeRoot {
         if (!bundle.GetArgument(1, "Start").TryGetValueAsInteger(out int start)) //1-indexed
             return new DreamValue("");
 
-        if (end <= 0) end += text.Length + 1;
-        else if (end > text.Length + 1) end = text.Length + 1;
+        var textAsBytes = Encoding.UTF8.GetBytes(text);
+        if (end <= 0) end += textAsBytes.Length + 1;
+        else if (end > textAsBytes.Length + 1) end = textAsBytes.Length + 1;
 
         if (start == 0) return new DreamValue("");
-        else if (start < 0) start += text.Length + 1;
-
-        return new DreamValue(text.Substring(start - 1, end - start));
+        else if (start < 0) start += textAsBytes.Length + 1;
+        return new DreamValue(Encoding.UTF8.GetString(new ArraySegment<byte>(textAsBytes, start - 1, end - start)));
     }
 
     [DreamProc("copytext_char")]
@@ -651,18 +651,24 @@ internal static class DreamProcNativeRoot {
         if (!bundle.GetArgument(1, "Start").TryGetValueAsInteger(out int start)) //1-indexed
             return new DreamValue("");
 
-        StringInfo textElements = new StringInfo(text);
+        ;
 
-        if (end <= 0) end += textElements.LengthInTextElements + 1;
-        else if (end > textElements.LengthInTextElements + 1) end = textElements.LengthInTextElements + 1;
+        Rune[] runes = text.EnumerateRunes().ToArray();
+
+        if (end <= 0) end += runes.Length + 1;
+        else if (end > runes.Length + 1) end = runes.Length + 1;
 
         if (start == 0) return new DreamValue("");
-        else if (start < 0) start += textElements.LengthInTextElements + 1;
+        else if (start < 0) start += runes.Length  + 1;
 
-        if (start > textElements.LengthInTextElements)
-            return new(string.Empty);
+        if (start > runes.Length)
+            return new DreamValue(string.Empty);
 
-        return new DreamValue(textElements.SubstringByTextElements(start - 1, end - start));
+        var stringBuilder = new StringBuilder();
+        for (int i = start - 1; i < end - 1; i++) {
+            stringBuilder.Append(runes[i].ToString());
+        }
+        return new DreamValue(stringBuilder.ToString());
     }
 
     [DreamProc("CRASH")]

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1594,7 +1594,7 @@ internal static class DreamProcNativeRoot {
 
     public static DreamValue _length(DreamValue value, bool countBytes) {
         if (value.TryGetValueAsString(out var str)) {
-            return new DreamValue(countBytes ? str.Length : str.EnumerateRunes().Count());
+            return new DreamValue(countBytes ? Encoding.UTF8.GetByteCount(str) : str.EnumerateRunes().Count());
         } else if (value.TryGetValueAsDreamList(out var list)) {
             return new DreamValue(list.GetLength());
         } else if (value.Type is DreamValueType.Float or DreamValueType.DreamObject or DreamValueType.DreamType) {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -1597,7 +1597,7 @@ internal static class DreamProcNativeRoot {
 
     public static DreamValue _length(DreamValue value, bool countBytes) {
         if (value.TryGetValueAsString(out var str)) {
-            return new DreamValue(countBytes ? Encoding.UTF8.GetByteCount(str) : str.EnumerateRunes().Count());
+            return new DreamValue(countBytes ? str.Length : str.EnumerateRunes().Count());
         } else if (value.TryGetValueAsDreamList(out var list)) {
             return new DreamValue(list.GetLength());
         } else if (value.Type is DreamValueType.Float or DreamValueType.DreamObject or DreamValueType.DreamType) {
@@ -2800,7 +2800,7 @@ internal static class DreamProcNativeRoot {
             return new DreamValue(bundle.ObjectTree.CreateList());
         }
 
-        int consideredLength = useByteLength ? Encoding.UTF8.GetByteCount(text) : text.EnumerateRunes().Count();
+        int consideredLength = useByteLength ? text.Length : text.EnumerateRunes().Count();
         int start = 0;
         int end = 0;
         if (bundle.GetArgument(2, "Start").TryGetValueAsInteger(out start))

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -25,6 +25,7 @@ using DreamValueTypeFlag = OpenDreamRuntime.DreamValue.DreamValueTypeFlag;
 using Robust.Server;
 using Robust.Shared.Asynchronous;
 using Vector4 = Robust.Shared.Maths.Vector4;
+using OpenDreamRuntime.Util;
 
 namespace OpenDreamRuntime.Procs.Native;
 
@@ -664,11 +665,7 @@ internal static class DreamProcNativeRoot {
         if (start > runes.Length)
             return new DreamValue(string.Empty);
 
-        var stringBuilder = new StringBuilder();
-        for (int i = start - 1; i < end - 1; i++) {
-            stringBuilder.Append(runes[i].ToString());
-        }
-        return new DreamValue(stringBuilder.ToString());
+        return new DreamValue(TextHelpers.RuneSubstring(runes, start - 1, end - 1));
     }
 
     [DreamProc("CRASH")]

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -631,13 +631,13 @@ internal static class DreamProcNativeRoot {
         if (!bundle.GetArgument(1, "Start").TryGetValueAsInteger(out int start)) //1-indexed
             return new DreamValue("");
 
-        var textAsBytes = Encoding.UTF8.GetBytes(text);
-        if (end <= 0) end += textAsBytes.Length + 1;
-        else if (end > textAsBytes.Length + 1) end = textAsBytes.Length + 1;
+        if (end <= 0) end += text.Length + 1;
+        else if (end > text.Length + 1) end = text.Length + 1;
 
         if (start == 0) return new DreamValue("");
-        else if (start < 0) start += textAsBytes.Length + 1;
-        return new DreamValue(Encoding.UTF8.GetString(new ArraySegment<byte>(textAsBytes, start - 1, end - start)));
+        else if (start < 0) start += text.Length + 1;
+
+        return new DreamValue(text.Substring(start - 1, end - start));
     }
 
     [DreamProc("copytext_char")]

--- a/OpenDreamRuntime/Util/TextHelpers.cs
+++ b/OpenDreamRuntime/Util/TextHelpers.cs
@@ -3,10 +3,14 @@ using System.Text;
 namespace OpenDreamRuntime.Util;
 
 public static class TextHelpers {
-    // Like string.Substring(), but takes an array of runes instead.
+    // Returns a slice of a rune array as a string.
     public static string RuneSubstring(Rune[] runes, int start, int end) {
         if (start < 0) throw new ArgumentOutOfRangeException("Start position is less than zero");
         if (end < 0 || end > runes.Length) throw new ArgumentOutOfRangeException("End position is not within array size");
+
+        if (end == 0) {
+            end = runes.Length;
+        }
 
         var stringBuilder = new StringBuilder();
         for (int i = start; i < end; i++) {

--- a/OpenDreamRuntime/Util/TextHelpers.cs
+++ b/OpenDreamRuntime/Util/TextHelpers.cs
@@ -1,0 +1,17 @@
+using System.Text;
+
+namespace OpenDreamRuntime.Util;
+
+public static class TextHelpers {
+    // Like string.Substring(), but takes an array of runes instead.
+    public static string RuneSubstring(Rune[] runes, int start, int end) {
+        if (start < 0) throw new ArgumentOutOfRangeException("Start position is less than zero");
+        if (end < 0 || end > runes.Length) throw new ArgumentOutOfRangeException("End position is not within array size");
+
+        var stringBuilder = new StringBuilder();
+        for (int i = start; i < end; i++) {
+            stringBuilder.Append(runes[i].ToString());
+        }
+        return stringBuilder.ToString();
+    }
+}


### PR DESCRIPTION
fixes:
* copytext_char() using text elements instead of runes.
* splicetext_char() using text elements instead of runes.
* text2ascii_char() using text elements instead of runes.
* spantext_char() using text elements instead of runes.

adds: splittext_char()