### PR TITLE
Fix disassembling `CreateStrictAssociativeList`

### DIFF
--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -148,6 +148,7 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
 
             case DreamProcOpcode.CreateList:
             case DreamProcOpcode.CreateAssociativeList:
+            case DreamProcOpcode.CreateStrictAssociativeList:
             case DreamProcOpcode.PickWeighted:
             case DreamProcOpcode.PickUnweighted:
             case DreamProcOpcode.Spawn:


### PR DESCRIPTION
Fixes disassembling procs with `alist(...)`