### PR TITLE
Fix some issues with key-value loops

### DIFF
--- a/DMCompiler/Bytecode/DMReference.cs
+++ b/DMCompiler/Bytecode/DMReference.cs
@@ -15,6 +15,9 @@ public struct DMReference {
     public static readonly DMReference Invalid = new() { RefType = Type.Invalid };
 
     public enum Type : byte {
+        /// References nothing, reads return null and writes are no-op
+        NoRef,
+
         Src,
         Self,
         Usr,

--- a/DMCompiler/Bytecode/DreamProcOpcode.cs
+++ b/DMCompiler/Bytecode/DreamProcOpcode.cs
@@ -132,7 +132,7 @@ public enum DreamProcOpcode : byte {
     CreateFilteredListEnumerator = 0x41,
     [OpcodeMetadata(-1)]
     Power = 0x42,
-    [OpcodeMetadata(0, OpcodeArgType.EnumeratorId, OpcodeArgType.Reference, OpcodeArgType.Reference, OpcodeArgType.Reference, OpcodeArgType.Label)]
+    [OpcodeMetadata(0, OpcodeArgType.EnumeratorId, OpcodeArgType.Reference, OpcodeArgType.Reference, OpcodeArgType.Label)]
     EnumerateAssoc = 0x43,
     [OpcodeMetadata(-2)]
     Link = 0x44,

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -596,12 +596,11 @@ internal sealed class DMProc {
         }
     }
 
-    public void EnumerateAssoc(DMReference assocRef, DMReference listRef, DMReference outputRef) {
+    public void EnumerateAssoc(DMReference assocRef, DMReference outputRef) {
         if (_loopStack?.TryPeek(out var peek) ?? false) {
             WriteOpcode(DreamProcOpcode.EnumerateAssoc);
             WriteEnumeratorId(_enumeratorIdCounter - 1);
             WriteReference(assocRef);
-            WriteReference(listRef);
             WriteReference(outputRef);
             WriteLabel($"{peek}_end");
         } else {

--- a/OpenDreamRuntime/DreamReference.cs
+++ b/OpenDreamRuntime/DreamReference.cs
@@ -2,7 +2,8 @@
 
 namespace OpenDreamRuntime;
 
-public struct DreamReference {
+public readonly struct DreamReference(DMRefType type, int value) : IEquatable<DreamReference> {
+    public static readonly DreamReference NoRef = new(DMRefType.NoRef, 0);
     public static readonly DreamReference Src = new(DMRefType.Src, 0);
     public static readonly DreamReference Self = new(DMRefType.Self, 0);
     public static readonly DreamReference Usr = new(DMRefType.Usr, 0);
@@ -10,13 +11,10 @@ public struct DreamReference {
     public static readonly DreamReference SuperProc = new(DMRefType.SuperProc, 0);
     public static readonly DreamReference ListIndex = new(DMRefType.ListIndex, 0);
 
-    private long _innerValue;
     public DMRefType Type => (DMRefType)(_innerValue >> 32);
     public int Value => (int)_innerValue;
 
-    public DreamReference(DMRefType type, int value) {
-        _innerValue = ((long)type << 32) | (uint)value;
-    }
+    private readonly long _innerValue = ((long)type << 32) | (uint)value;
 
     public static DreamReference CreateArgument(int index) {
         return new DreamReference(DMRefType.Argument, index);
@@ -45,4 +43,19 @@ public struct DreamReference {
     public static DreamReference CreateSrcProc(int nameId) {
         return new DreamReference(DMRefType.SrcProc, nameId);
     }
+
+    public bool Equals(DreamReference other) {
+        return _innerValue == other._innerValue;
+    }
+
+    public override bool Equals(object? obj) {
+        return obj is DreamReference other && Equals(other);
+    }
+
+    public override int GetHashCode() {
+        return _innerValue.GetHashCode();
+    }
+
+    public static bool operator ==(DreamReference a, DreamReference b) => a._innerValue == b._innerValue;
+    public static bool operator !=(DreamReference a, DreamReference b) => a._innerValue != b._innerValue;
 }

--- a/OpenDreamRuntime/Objects/Types/DreamAssocList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamAssocList.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-
 namespace OpenDreamRuntime.Objects.Types;
 
 // TODO: An arglist given to New() can be used to initialize an alist with values

--- a/OpenDreamRuntime/Objects/Types/DreamAssocList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamAssocList.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace OpenDreamRuntime.Objects.Types;
 
 // TODO: An arglist given to New() can be used to initialize an alist with values
@@ -23,5 +25,20 @@ public sealed class DreamAssocList(DreamObjectDefinition aListDef, int size) : D
 
     public IEnumerable<DreamValue> EnumerateValues() {
         return _values.Keys; // The keys, counter-intuitively
+    }
+
+    public IEnumerable<KeyValuePair<DreamValue, DreamValue>> EnumerateAssocValues() {
+        return _values;
+    }
+
+    public DreamValue[] CopyToArray() {
+        var array = new DreamValue[_values.Count];
+
+        _values.Keys.CopyTo(array, 0);
+        return array;
+    }
+
+    public Dictionary<DreamValue, DreamValue> CopyAssocValues() {
+        return new(_values);
     }
 }

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -138,6 +138,21 @@ public class DreamList : DreamObject, IDreamList {
         return _values;
     }
 
+    public IEnumerable<KeyValuePair<DreamValue, DreamValue>> EnumerateAssocValues() {
+        return _associativeValues ?? [];
+    }
+
+    public DreamValue[] CopyToArray() {
+        return _values.ToArray();
+    }
+
+    public Dictionary<DreamValue, DreamValue> CopyAssocValues() {
+        if (_associativeValues is null)
+            return new();
+
+        return new(_associativeValues);
+    }
+
     public Dictionary<DreamValue, DreamValue> GetAssociativeValues() {
         return _associativeValues ??= new Dictionary<DreamValue, DreamValue>();
     }

--- a/OpenDreamRuntime/Objects/Types/IDreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/IDreamList.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace OpenDreamRuntime.Objects.Types;
 
 public interface IDreamList {
@@ -7,4 +9,13 @@ public interface IDreamList {
     public DreamValue GetValue(DreamValue key);
     public bool ContainsKey(DreamValue key);
     public IEnumerable<DreamValue> EnumerateValues();
+    public IEnumerable<KeyValuePair<DreamValue, DreamValue>> EnumerateAssocValues();
+
+    public DreamValue[] CopyToArray() {
+        return EnumerateValues().ToArray();
+    }
+
+    public Dictionary<DreamValue, DreamValue> CopyAssocValues() {
+        return new(EnumerateAssocValues());
+    }
 }

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -190,6 +190,7 @@ public sealed class DMProcState : ProcState {
     private const int NoTryCatchVar = -1;
 
     #region Opcode Handlers
+
     //Human-readable friendly version, which will be converted to a more efficient lookup at runtime.
     private static readonly Dictionary<DreamProcOpcode, OpcodeHandler> OpcodeHandlers = new() {
         {DreamProcOpcode.BitShiftLeft, DMOpcodeHandlers.BitShiftLeft},
@@ -343,6 +344,7 @@ public sealed class DMProcState : ProcState {
     };
 
     public static readonly unsafe delegate*<DMProcState, ProcStatus>[] OpcodeHandlersTable;
+
     #endregion
 
     public DreamManager DreamManager => _proc.DreamManager;
@@ -590,6 +592,7 @@ public sealed class DMProcState : ProcState {
     }
 
     #region Stack
+
     private DreamValue[] _stack = default!;
     private int _stackIndex;
     public ReadOnlyMemory<DreamValue> DebugStack() => _stack.AsMemory(0, _stackIndex);
@@ -638,9 +641,11 @@ public sealed class DMProcState : ProcState {
 
         return CreateProcArguments(values, proc, argumentsType, argumentStackSize);
     }
+
     #endregion
 
     #region Operands
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int ReadByte() {
         var r = _proc.Bytecode[_pc];
@@ -714,9 +719,11 @@ public sealed class DMProcState : ProcState {
     public (DMCallArgumentsType Type, int StackSize) ReadProcArguments() {
         return ((DMCallArgumentsType) ReadByte(), ReadInt());
     }
+
     #endregion
 
     #region References
+
     /// <summary>
     /// Takes a DMReference with a <see cref="DMReference.Type.ListIndex"/> type and returns the value being indexed
     /// as well as what it's being indexed with.
@@ -742,6 +749,7 @@ public sealed class DMProcState : ProcState {
 
     public void AssignReference(DreamReference reference, DreamValue value, bool peek = false) {
         switch (reference.Type) {
+            case DMReference.Type.NoRef: break;
             case DMReference.Type.Self: Result = value; break;
             case DMReference.Type.Argument: SetArgument(reference.Value, value); break;
             case DMReference.Type.Local: _localVariables[ArgumentCount + reference.Value] = value; break;
@@ -815,6 +823,7 @@ public sealed class DMProcState : ProcState {
 
     public DreamValue GetReferenceValue(DreamReference reference, bool peek = false) {
         switch (reference.Type) {
+            case DMReference.Type.NoRef: return DreamValue.Null;
             case DMReference.Type.Src: return new(Instance);
             case DMReference.Type.Usr: return new(Usr);
             case DMReference.Type.Self: return Result;
@@ -976,6 +985,7 @@ public sealed class DMProcState : ProcState {
     private static void ThrowAttemptedToIndexString(DreamValue index) {
         throw new Exception($"Attempted to index string with {index}");
     }
+
     #endregion References
 
     public IEnumerable<(string, DreamValue)> DebugArguments() {


### PR DESCRIPTION
Fix #2360
Fix #2361

Creating a list enumerator now copies that list's associated values, if it has any. The EnumerateNoAssign opcode also no longer uses a DreamReference to grab the list, removing the need for an LValue.

Potentially room for optimization here, as always copying the associated values regardless of loop type is a bit much. Trying to get goonstation compiling again though.