### PR TITLE
Fix `for(var/V in list)` for special lists

### DIFF
--- a/OpenDreamRuntime/AtomManager.cs
+++ b/OpenDreamRuntime/AtomManager.cs
@@ -385,7 +385,7 @@ public sealed class AtomManager {
                 appearance.Verbs.Clear();
 
                 if (value.TryGetValueAsDreamList(out var valueList)) {
-                    foreach (DreamValue verbValue in valueList.GetValues()) {
+                    foreach (DreamValue verbValue in valueList.EnumerateValues()) {
                         if (!verbValue.TryGetValueAsProc(out var verb))
                             continue;
 

--- a/OpenDreamRuntime/ByondApi/ByondApi.Functions.cs
+++ b/OpenDreamRuntime/ByondApi/ByondApi.Functions.cs
@@ -303,16 +303,19 @@ public static unsafe partial class ByondApi {
                 return 0;
             }
 
-            var srcDreamVals = srcList.GetValues();
-            int length = srcDreamVals.Count;
+            int length = srcList.GetLength();
             *len = (uint)length;
             if (list == null || providedBufLen < length) {
                 return 0;
             }
 
             try {
-                for (int i = 0; i < length; i++) {
-                    list[i] = ValueToByondApi(srcDreamVals[i]);
+                int i = 0;
+                foreach (var value in srcList.EnumerateValues()) {
+                    if (i >= length)
+                        throw new Exception($"List {srcList} had more elements than the expected {length}");
+
+                    list[i++] = ValueToByondApi(value);
                 }
             } catch (Exception) {
                 return 0;
@@ -706,7 +709,7 @@ public static unsafe partial class ByondApi {
                     corner1->x, corner1->y, corner1->z,
                     corner2->x, corner2->y, corner2->z);
 
-                foreach (var turf in turfs.GetValues()) {
+                foreach (var turf in turfs.EnumerateValues()) {
                     list.Add(ValueToByondApi(turf));
                 }
             } catch (Exception) {
@@ -879,15 +882,10 @@ public static unsafe partial class ByondApi {
                 var objectDef = treeEntry.ObjectDefinition;
 
                 var arglistVal = ValueFromDreamApi(*cArglist);
-                if (!arglistVal.TryGetValueAsDreamList(out DreamList? arglist)) return 0;
+                if (!arglistVal.TryGetValueAsIDreamList(out var arglist)) return 0;
 
                 // Copy the arglist's values to a new array to ensure no shenanigans
-                var argListValues = arglist.GetValues();
-                var argValues = new DreamValue[argListValues.Count];
-                for (int i = 0; i < argListValues.Count; i++) {
-                    argValues[i] = argListValues[i];
-                }
-
+                var argValues = arglist.CopyToArray();
                 var args = new DreamProcArguments(argValues);
 
                 // TODO: This is code duplicated with DMOpcodeHandlers.CreateObject()

--- a/OpenDreamRuntime/DreamConnection.cs
+++ b/OpenDreamRuntime/DreamConnection.cs
@@ -273,10 +273,10 @@ public sealed class DreamConnection {
         return task;
     }
 
-    public async Task<DreamValue> PromptList(DreamValueType types, DreamList list, string title, string message, DreamValue defaultValue) {
-        List<DreamValue> listValues = list.GetValues();
+    public async Task<DreamValue> PromptList(DreamValueType types, IDreamList list, string title, string message, DreamValue defaultValue) {
+        DreamValue[] listValues = list.CopyToArray();
 
-        List<string> promptValues = new(listValues.Count);
+        List<string> promptValues = new(listValues.Length);
         foreach (var value in listValues) {
             if (types.HasFlag(DreamValueType.Obj) && !value.TryGetValueAsDreamObject<DreamObjectMovable>(out _))
                 continue;
@@ -307,7 +307,7 @@ public sealed class DreamConnection {
 
         // The client returns the index of the selected item, this needs turned back into the DreamValue.
         var selectedIndex = await task;
-        if (selectedIndex.TryGetValueAsInteger(out int index) && index < listValues.Count) {
+        if (selectedIndex.TryGetValueAsInteger(out int index) && index < listValues.Length) {
             return listValues[index];
         }
 

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -130,20 +130,23 @@ public class DreamList : DreamObject, IDreamList {
     /// <summary>
     /// Returns the list of array values. Doesn't include the associative values indexable by some of these.
     /// </summary>
+    [Obsolete("Deprecated. Use EnumerateValues() instead.")]
     public virtual List<DreamValue> GetValues() {
         return _values;
     }
 
-    public IEnumerable<DreamValue> EnumerateValues() {
+    public virtual IEnumerable<DreamValue> EnumerateValues() {
         return _values;
     }
 
     public IEnumerable<KeyValuePair<DreamValue, DreamValue>> EnumerateAssocValues() {
-        return _associativeValues ?? [];
-    }
-
-    public DreamValue[] CopyToArray() {
-        return _values.ToArray();
+        foreach (var value in _values) {
+            if (_associativeValues?.TryGetValue(value, out var associativeValue) is true) {
+                yield return new(value, associativeValue);
+            } else {
+                yield return new(value, DreamValue.Null);
+            }
+        }
     }
 
     public Dictionary<DreamValue, DreamValue> CopyAssocValues() {
@@ -333,7 +336,7 @@ public class DreamList : DreamObject, IDreamList {
         DreamList listCopy = CreateCopy();
 
         if (b.TryGetValueAsDreamList(out var bList)) {
-            foreach (DreamValue value in bList.GetValues()) {
+            foreach (DreamValue value in bList.EnumerateValues()) {
                 if (bList._associativeValues?.TryGetValue(value, out var assocValue) is true) {
                     listCopy.SetValue(value, assocValue);
                 } else {
@@ -351,7 +354,7 @@ public class DreamList : DreamObject, IDreamList {
         DreamList listCopy = CreateCopy();
 
         if (b.TryGetValueAsDreamList(out var bList)) {
-            foreach (DreamValue value in bList.GetValues()) {
+            foreach (DreamValue value in bList.EnumerateValues()) {
                 listCopy.RemoveValue(value);
             }
         } else {
@@ -409,7 +412,7 @@ public class DreamList : DreamObject, IDreamList {
 
     public override DreamValue OperatorCombine(DreamValue b) {
         if (b.TryGetValueAsDreamList(out var bList)) {
-            foreach (DreamValue value in bList.GetValues()) {
+            foreach (DreamValue value in bList.EnumerateValues()) {
                 if (ContainsValue(value))
                     continue;
 
@@ -488,7 +491,11 @@ internal sealed class DreamListVars(DreamObjectDefinition listDef, DreamObject d
     }
 
     public override List<DreamValue> GetValues() {
-        return DreamObject.GetVariableNames().Concat(DreamObject.ObjectDefinition.GlobalVariables.Keys).Select(name => new DreamValue(name)).ToList();
+        return EnumerateValues().ToList();
+    }
+
+    public override IEnumerable<DreamValue> EnumerateValues() {
+        return DreamObject.GetVariableNames().Concat(DreamObject.ObjectDefinition.GlobalVariables.Keys).Select(name => new DreamValue(name));
     }
 
     public override bool ContainsKey(DreamValue value) {
@@ -552,14 +559,15 @@ internal sealed class DreamGlobalVars : DreamList {
     }
 
     public override List<DreamValue> GetValues() {
-        var root = _objectTree.Root.ObjectDefinition;
-        List<DreamValue> values = new List<DreamValue>(root.GlobalVariables.Keys.Count - 1);
-        // Skip world
-        foreach (var key in root.GlobalVariables.Keys.Skip(1)) {
-            values.Add(new DreamValue(key));
-        }
+        return EnumerateValues().ToList();
+    }
 
-        return values;
+    public override IEnumerable<DreamValue> EnumerateValues() {
+        var root = _objectTree.Root.ObjectDefinition;
+
+        foreach (var key in root.GlobalVariables.Keys) {
+            yield return new DreamValue(key);
+        }
     }
 
     public override bool ContainsKey(DreamValue value) {
@@ -637,12 +645,12 @@ public sealed class ClientVerbsList : DreamList {
     }
 
     public override List<DreamValue> GetValues() {
-        List<DreamValue> values = new(Verbs.Count);
+        return EnumerateValues().ToList();
+    }
 
+    public override IEnumerable<DreamValue> EnumerateValues() {
         foreach (DreamProc verb in Verbs)
-            values.Add(new(verb));
-
-        return values;
+            yield return new(verb);
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
@@ -694,19 +702,19 @@ public sealed class VerbsList(DreamObjectTree objectTree, AtomManager atomManage
     }
 
     public override List<DreamValue> GetValues() {
-        var appearance = atomManager.MustGetAppearance(atom);
-        if (appearance == null || verbSystem == null)
-            return new List<DreamValue>();
+        return EnumerateValues().ToList();
+    }
 
-        var values = new List<DreamValue>(appearance.Verbs.Length);
+    public override IEnumerable<DreamValue> EnumerateValues() {
+        var appearance = atomManager.MustGetAppearance(atom);
+        if (verbSystem == null)
+            yield break;
 
         foreach (var verbId in appearance.Verbs) {
             var verb = verbSystem.GetVerb(verbId);
 
-            values.Add(new(verb));
+            yield return new(verb);
         }
-
-        return values;
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
@@ -770,18 +778,17 @@ public sealed class DreamOverlaysList : DreamList {
     }
 
     public override List<DreamValue> GetValues() {
+        return EnumerateValues().ToList();
+    }
+
+    public override IEnumerable<DreamValue> EnumerateValues() {
         var appearance = _atomManager.MustGetAppearance(_owner);
-        if (appearance == null || _appearanceSystem == null)
-            return new List<DreamValue>();
+        if (_appearanceSystem == null)
+            yield break;
 
-        var overlays = GetOverlaysArray(appearance);
-        var values = new List<DreamValue>(overlays.Length);
-
-        foreach (var overlay in overlays) {
-            values.Add(new(overlay.ToMutable()));
+        foreach (var overlay in GetOverlaysArray(appearance)) {
+            yield return new(overlay.ToMutable());
         }
-
-        return values;
     }
 
     public override void Cut(int start = 1, int end = 0) {
@@ -893,13 +900,12 @@ public sealed class DreamVisContentsList : DreamList {
     }
 
     public override List<DreamValue> GetValues() {
-        var values = new List<DreamValue>(_visContents.Count);
+        return EnumerateValues().ToList();
+    }
 
-        foreach (var visContent in _visContents) {
-            values.Add(new(visContent));
-        }
-
-        return values;
+    public override IEnumerable<DreamValue> EnumerateValues() {
+        foreach (var visContent in _visContents)
+            yield return new(visContent);
     }
 
     public override void Cut(int start = 1, int end = 0) {
@@ -1039,16 +1045,18 @@ public sealed class DreamFilterList : DreamList {
     }
 
     public override List<DreamValue> GetValues() {
+        return EnumerateValues().ToList();
+    }
+
+    public override IEnumerable<DreamValue> EnumerateValues() {
         ImmutableAppearance appearance = GetAppearance();
-        List<DreamValue> filterList = new List<DreamValue>(appearance.Filters.Length);
 
         foreach (var filter in appearance.Filters) {
             DreamObjectFilter filterObject = ObjectTree.CreateObject<DreamObjectFilter>(ObjectTree.Filter);
             filterObject.Filter = filter;
-            filterList.Add(new DreamValue(filterObject));
-        }
 
-        return filterList;
+            yield return new DreamValue(filterObject);
+        }
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
@@ -1126,6 +1134,10 @@ public sealed class ClientScreenList(DreamObjectTree objectTree, ServerScreenOve
         return _screenObjects;
     }
 
+    public override IEnumerable<DreamValue> EnumerateValues() {
+        return _screenObjects;
+    }
+
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
         throw new Exception("Cannot write to an index of a screen list");
     }
@@ -1186,6 +1198,10 @@ public sealed class ClientImagesList(
         return _imageObjects;
     }
 
+    public override IEnumerable<DreamValue> EnumerateValues() {
+        return _imageObjects;
+    }
+
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
         throw new Exception("Cannot write to an index of a client images list");
     }
@@ -1242,7 +1258,11 @@ public sealed class WorldContentsList(DreamObjectDefinition listDef, AtomManager
     }
 
     public override List<DreamValue> GetValues() {
-        return AtomManager.EnumerateAtoms().Select(atom => new DreamValue(atom)).ToList();
+        return EnumerateValues().ToList();
+    }
+
+    public override IEnumerable<DreamValue> EnumerateValues() {
+        return AtomManager.EnumerateAtoms().Select(atom => new DreamValue(atom));
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
@@ -1279,15 +1299,13 @@ public sealed class TurfContentsList(DreamObjectDefinition listDef, DreamObjectT
         return new DreamValue(Cell.Movables[index - 1]);
     }
 
-    // TODO: This would preferably be an IEnumerable<> method. Probably as part of #985.
     public override List<DreamValue> GetValues() {
-        List<DreamValue> values = new(Cell.Movables.Count);
+        return EnumerateValues().ToList();
+    }
 
-        foreach (var movable in Cell.Movables) {
-            values.Add(new(movable));
-        }
-
-        return values;
+    public override IEnumerable<DreamValue> EnumerateValues() {
+        foreach (var movable in Cell.Movables)
+            yield return new(movable);
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
@@ -1346,14 +1364,16 @@ public sealed class AreaContentsList(DreamObjectDefinition listDef, DreamObjectA
     }
 
     public override List<DreamValue> GetValues() {
-        List<DreamValue> values = new(area.Turfs.Count);
+        return EnumerateValues().ToList();
+    }
 
+    public override IEnumerable<DreamValue> EnumerateValues() {
         foreach (var turf in area.Turfs) {
-            values.Add(new(turf));
-            values.AddRange(turf.Contents.GetValues());
-        }
+            yield return new(turf);
 
-        return values;
+            foreach (var content in turf.Contents.EnumerateValues())
+                yield return content;
+        }
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
@@ -1418,17 +1438,18 @@ public sealed class MovableContentsList(DreamObjectDefinition listDef, DreamObje
     }
 
     public override List<DreamValue> GetValues() {
-        List<DreamValue> values = new List<DreamValue>(transform.ChildCount);
+        return EnumerateValues().ToList();
+    }
+
+    public override IEnumerable<DreamValue> EnumerateValues() {
         using var childEnumerator = transform.ChildEnumerator;
 
         while (childEnumerator.MoveNext(out EntityUid child)) {
             if (!AtomManager.TryGetMovableFromEntity(child, out var childObject))
                 continue;
 
-            values.Add(new DreamValue(childObject));
+            yield return new DreamValue(childObject);
         }
-
-        return values;
     }
 
     public override int FindValue(DreamValue value, int start = 1, int end = 0) {
@@ -1497,15 +1518,13 @@ internal sealed class ProcArgsList(DreamObjectDefinition listDef, DMProcState st
         return state.GetArguments()[index - 1];
     }
 
-    // TODO: This would preferably be an IEnumerable<> method. Probably as part of #985.
     public override List<DreamValue> GetValues() {
-        List<DreamValue> values = new(state.ArgumentCount);
+        return EnumerateValues().ToList();
+    }
 
-        foreach (DreamValue value in state.GetArguments()) {
-            values.Add(value);
-        }
-
-        return values;
+    public override IEnumerable<DreamValue> EnumerateValues() {
+        for (int i = 0; i < state.ArgumentCount; i++)
+            yield return state.GetArguments()[i];
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
@@ -1549,11 +1568,12 @@ internal sealed class SavefileDirList(DreamObjectDefinition listDef, DreamObject
     }
 
     public override List<DreamValue> GetValues() {
-        List<DreamValue> values = new(backedSaveFile.CurrentDir.Count);
+        return EnumerateValues().ToList();
+    }
 
+    public override IEnumerable<DreamValue> EnumerateValues() {
         foreach (string value in backedSaveFile.CurrentDir.Keys.OrderBy(x => x))
-            values.Add(new DreamValue(value));
-        return values;
+            yield return new DreamValue(value);
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {

--- a/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectAtom.cs
@@ -109,7 +109,7 @@ public class DreamObjectAtom : DreamObject {
 
                 if (value.TryGetValueAsDreamList(out var valueList)) {
                     // TODO: This should postpone UpdateAppearance until after everything is added
-                    foreach (DreamValue overlayValue in valueList.GetValues()) {
+                    foreach (DreamValue overlayValue in valueList.EnumerateValues()) {
                         Overlays.AddValue(overlayValue);
                     }
                 } else if (!value.IsNull) {
@@ -123,7 +123,7 @@ public class DreamObjectAtom : DreamObject {
 
                 if (value.TryGetValueAsDreamList(out var valueList)) {
                     // TODO: This should postpone UpdateAppearance until after everything is added
-                    foreach (DreamValue underlayValue in valueList.GetValues()) {
+                    foreach (DreamValue underlayValue in valueList.EnumerateValues()) {
                         Underlays.AddValue(underlayValue);
                     }
                 } else if (!value.IsNull) {
@@ -137,7 +137,7 @@ public class DreamObjectAtom : DreamObject {
 
                 if (value.TryGetValueAsDreamList(out var valueList)) {
                     // TODO: This should postpone UpdateAppearance until after everything is added
-                    foreach (DreamValue visContentsValue in valueList.GetValues()) {
+                    foreach (DreamValue visContentsValue in valueList.EnumerateValues()) {
                         VisContents.AddValue(visContentsValue);
                     }
                 } else if (!value.IsNull) {

--- a/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectClient.cs
@@ -153,7 +153,7 @@ public sealed class DreamObjectClient : DreamObject {
                 Screen.Cut();
 
                 if (value.TryGetValueAsDreamList(out var valueList)) {
-                    foreach (DreamValue screenValue in valueList.GetValues()) {
+                    foreach (DreamValue screenValue in valueList.EnumerateValues()) {
                         Screen.AddValue(screenValue);
                     }
                 } else if (!value.IsNull) {
@@ -166,7 +166,7 @@ public sealed class DreamObjectClient : DreamObject {
                 Images.Cut();
 
                 if (value.TryGetValueAsDreamList(out var valueList)) {
-                    foreach (DreamValue screenValue in valueList.GetValues()) {
+                    foreach (DreamValue screenValue in valueList.EnumerateValues()) {
                         Images.AddValue(screenValue);
                     }
                 } else if (!value.IsNull) {
@@ -179,7 +179,7 @@ public sealed class DreamObjectClient : DreamObject {
                 ClientVerbs.Cut();
 
                 if (value.TryGetValueAsDreamList(out var valueList)) {
-                    foreach (DreamValue verbValue in valueList.GetValues()) {
+                    foreach (DreamValue verbValue in valueList.EnumerateValues()) {
                         ClientVerbs.AddValue(verbValue);
                     }
                 } else {

--- a/OpenDreamRuntime/Objects/Types/DreamObjectFilter.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectFilter.cs
@@ -75,7 +75,7 @@ public sealed class DreamObjectFilter(DreamObjectDefinition objectDefinition) : 
 
     public static DreamObjectFilter? TryCreateFilter(DreamObjectTree objectTree, DreamList list) {
         static IEnumerable<(string, DreamValue)> EnumerateProperties(DreamList list) {
-            foreach (var key in list.GetValues()) {
+            foreach (var key in list.EnumerateValues()) {
                 if (!key.TryGetValueAsString(out var keyStr))
                     continue;
 

--- a/OpenDreamRuntime/Objects/Types/DreamObjectImage.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectImage.cs
@@ -150,7 +150,7 @@ public sealed class DreamObjectImage : DreamObject {
 
                 if (valueList != null) {
                     // TODO: This should postpone UpdateAppearance until after everything is added
-                    foreach (DreamValue overlayValue in valueList.GetValues()) {
+                    foreach (DreamValue overlayValue in valueList.EnumerateValues()) {
                         _overlays.AddValue(overlayValue);
                     }
                 } else if (!value.IsNull) {
@@ -183,7 +183,7 @@ public sealed class DreamObjectImage : DreamObject {
 
                 if (valueList != null) {
                     // TODO: This should postpone UpdateAppearance until after everything is added
-                    foreach (DreamValue underlayValue in valueList.GetValues()) {
+                    foreach (DreamValue underlayValue in valueList.EnumerateValues()) {
                         _underlays.AddValue(underlayValue);
                     }
                 } else if (!value.IsNull) {

--- a/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectSavefile.cs
@@ -436,13 +436,14 @@ public sealed class DreamObjectSavefile : DreamObject {
                     if(dreamList.IsAssociative)
                         jsonEncodedList.AssocData = new List<SFDreamJsonValue?>(dreamList.GetLength()); //only init the list if it's needed
 
-                    foreach (var keyValue in dreamList.GetValues()) { //get all normal values and keys
+                    foreach (var keyValue in dreamList.EnumerateValues()) { //get all normal values and keys
                         if(keyValue.TryGetValueAsDreamObject(out var _) && !keyValue.IsNull) {
                             SFDreamJsonValue jsonEncodedObject = SerializeDreamValue(keyValue, thisObjectCount);
                             //merge the object subdirectories into the list parent directory
                             foreach(var key in jsonEncodedObject.Keys) {
                                 jsonEncodedList[key] = jsonEncodedObject[key];
                             }
+
                             //we already merged the nodes into the parent, so clear them from the child
                             jsonEncodedObject.Clear();
                             //add the object path to the list
@@ -451,6 +452,7 @@ public sealed class DreamObjectSavefile : DreamObject {
                         } else {
                             jsonEncodedList.AssocKeys.Add(SerializeDreamValue(keyValue));
                         }
+
                         if(dreamList.IsAssociative) { //if it's an assoc list, check if this value is a key
                             if(!dreamList.ContainsKey(keyValue)) {
                                 jsonEncodedList.AssocData!.Add(null); //store an actual null if this key does not have an associated value - this is distinct from storing DreamValue.Null
@@ -462,6 +464,7 @@ public sealed class DreamObjectSavefile : DreamObject {
                                     foreach(var key in jsonEncodedObject.Keys) {
                                         jsonEncodedList[key] = jsonEncodedObject[key];
                                     }
+
                                     //we already merged the nodes into the parent, so clear them from the child
                                     jsonEncodedObject.Clear();
                                     //add the object path to the list
@@ -509,11 +512,13 @@ public sealed class DreamObjectSavefile : DreamObject {
                             Crc32 = CalculateCrc32(iconResource.ResourceData),
                             Data = Convert.ToBase64String(iconResource.ResourceData)};
                     }
+
                     //Call the Write proc on the object - note that this is a weird one, it does not need to call parent to the native function to save the object
                     dreamObject.SpawnProc("Write", null, [new DreamValue(this)]);
                     jsonEncodedObject[jsonEncodedObject.Path] = objectVars;
                     return jsonEncodedObject;
                 }
+
                 break;
             // noop
             case DreamValue.DreamValueType.DreamProc:

--- a/OpenDreamRuntime/Objects/Types/DreamObjectTurf.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectTurf.cs
@@ -69,7 +69,7 @@ public sealed class DreamObjectTurf : DreamObjectAtom {
                 Contents.Cut();
 
                 if (value.TryGetValueAsDreamList(out var valueList)) {
-                    foreach (DreamValue contentValue in valueList.GetValues()) {
+                    foreach (DreamValue contentValue in valueList.EnumerateValues()) {
                         Contents.AddValue(contentValue);
                     }
                 }

--- a/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
+++ b/OpenDreamRuntime/Procs/DebugAdapter/DreamDebugManager.cs
@@ -746,13 +746,13 @@ internal sealed class DreamDebugManager : IDreamDebugManager {
     private IEnumerable<Variable> ExpandList(RequestVariables req, DreamList list) {
         if (list.IsAssociative) {
             var assoc = list.GetAssociativeValues();
-            foreach (var (i, key) in list.GetValues().Select((v, i) => (i + 1, v)).Skip(req.Arguments.Start ?? 0).Take((req.Arguments.Count ?? int.MaxValue) / 2)) {
+            foreach (var (i, key) in list.EnumerateValues().Select((v, i) => (i + 1, v)).Skip(req.Arguments.Start ?? 0).Take((req.Arguments.Count ?? int.MaxValue) / 2)) {
                 assoc.TryGetValue(key, out var value);
                 yield return DescribeValue($"keys[{i}]", key);
                 yield return DescribeValue($"vals[{i}]", value);
             }
         } else {
-            foreach (var (i, value) in list.GetValues().Select((v, i) => (i + 1, v)).Skip(req.Arguments.Start ?? 0).Take(req.Arguments.Count ?? int.MaxValue)) {
+            foreach (var (i, value) in list.EnumerateValues().Select((v, i) => (i + 1, v)).Skip(req.Arguments.Start ?? 0).Take(req.Arguments.Count ?? int.MaxValue)) {
                 yield return DescribeValue($"[{i}]", value);
             }
         }
@@ -848,7 +848,7 @@ internal sealed class DreamDebugManager : IDreamDebugManager {
             requestHotReloadResource.RespondError(client, "No file provided for a hot reload");
             return;
         }
-        
+
         _sawmill.Debug("Debug adapter triggered resource hot reload for "+requestHotReloadResource.Arguments.FilePath);
         try {
             _dreamManager.HotReloadResource(requestHotReloadResource.Arguments.FilePath);

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeList.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeList.cs
@@ -12,7 +12,7 @@ namespace OpenDreamRuntime.Procs.Native {
 
             foreach (var argument in bundle.Arguments) {
                 if (argument.TryGetValueAsDreamList(out var argumentList)) {
-                    foreach (DreamValue value in argumentList.GetValues()) {
+                    foreach (DreamValue value in argumentList.EnumerateValues()) {
                         list.AddValue(value);
                     }
                 } else {
@@ -75,7 +75,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 var item = bundle.Arguments[i];
 
                 if (item.TryGetValueAsDreamList(out var valueList)) {
-                    foreach (DreamValue value in valueList.GetValues()) {
+                    foreach (DreamValue value in valueList.EnumerateValues()) {
                         list.Insert(index++, value);
                     }
                 } else {
@@ -144,7 +144,7 @@ namespace OpenDreamRuntime.Procs.Native {
             var itemRemoved = 0;
             foreach (var argument in args) {
                 if (argument.TryGetValueAsDreamList(out var argumentList)) {
-                    foreach (DreamValue value in argumentList.GetValues()) {
+                    foreach (DreamValue value in argumentList.EnumerateValues()) {
                         if (list.ContainsValue(value)) {
                             list.RemoveValue(value);
 
@@ -182,7 +182,7 @@ namespace OpenDreamRuntime.Procs.Native {
                 var item = bundle.Arguments[i];
 
                 if (item.TryGetValueAsDreamList(out var valueList)) {
-                    foreach (DreamValue value in valueList.GetValues()) {
+                    foreach (DreamValue value in valueList.EnumerateValues()) {
                         list.Insert(startIndex++, value);
                     }
                 } else {

--- a/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
+++ b/OpenDreamRuntime/Procs/Native/DreamProcNativeRoot.cs
@@ -548,7 +548,7 @@ internal static class DreamProcNativeRoot {
 
         if (value.TryGetValueAsDreamList(out var list)) {
             DreamList tmp = bundle.ObjectTree.CreateList();
-            foreach (DreamValue val in list.GetValues()) {
+            foreach (DreamValue val in list.EnumerateValues()) {
                 if (!val.TryGetValueAsFloat(out float floatVal))
                     continue;
 
@@ -2040,7 +2040,7 @@ internal static class DreamProcNativeRoot {
         DreamList rangeList = bundle.ObjectTree.CreateList(range.Height * range.Width);
         foreach (var turf in DreamProcNativeHelpers.MakeViewSpiral(center, range)) {
             rangeList.AddValue(new DreamValue(turf));
-            foreach (DreamValue content in turf.Contents.GetValues()) {
+            foreach (DreamValue content in turf.Contents.EnumerateValues()) {
                 rangeList.AddValue(content);
             }
         }
@@ -2194,7 +2194,7 @@ internal static class DreamProcNativeRoot {
         //Have to include centre
         rangeList.AddValue(new DreamValue(center));
         if(center.TryGetVariable("contents", out var centerContents) && centerContents.TryGetValueAsDreamList(out var centerContentsList)) {
-            foreach(DreamValue content in centerContentsList.GetValues()) {
+            foreach(DreamValue content in centerContentsList.EnumerateValues()) {
                 rangeList.AddValue(content);
             }
         }
@@ -2203,7 +2203,7 @@ internal static class DreamProcNativeRoot {
             if(center.TryGetVariable("loc",out DreamValue centerLoc) && centerLoc.TryGetValueAsDreamObject<DreamObjectAtom>(out var centerLocObject)) {
                 rangeList.AddValue(centerLoc);
                 if(centerLocObject.GetVariable("contents").TryGetValueAsDreamList(out var locContentsList)) {
-                    foreach (DreamValue content in locContentsList.GetValues()) {
+                    foreach (DreamValue content in locContentsList.EnumerateValues()) {
                         rangeList.AddValue(content);
                     }
                 }
@@ -2213,7 +2213,7 @@ internal static class DreamProcNativeRoot {
         //And then everything else
         foreach (var turf in DreamProcNativeHelpers.MakeViewSpiral(center, range)) {
             rangeList.AddValue(new DreamValue(turf));
-            foreach (DreamValue content in turf.Contents.GetValues()) {
+            foreach (DreamValue content in turf.Contents.EnumerateValues()) {
                 rangeList.AddValue(content);
             }
         }
@@ -2840,7 +2840,7 @@ internal static class DreamProcNativeRoot {
 
     private static void OutputToStatPanel(DreamManager dreamManager, DreamConnection connection, DreamValue name, DreamValue value) {
         if (name.IsNull && value.TryGetValueAsDreamList(out var list)) {
-            foreach (var item in list.GetValues())
+            foreach (var item in list.EnumerateValues())
                 OutputToStatPanel(dreamManager, connection, name, item);
         } else {
             string nameStr = name.Stringify();
@@ -3401,7 +3401,7 @@ internal static class DreamProcNativeRoot {
             return new(view);
 
         if (center.TryGetVariable("contents", out var centerContents) && centerContents.TryGetValueAsDreamList(out var centerContentsList)) {
-            foreach (var item in centerContentsList.GetValues()) {
+            foreach (var item in centerContentsList.EnumerateValues()) {
                 view.AddValue(item);
             }
         }


### PR DESCRIPTION
#2363 broke list enumeration on special lists because it started enumerating on `DreamList`'s internal `_values` array which special lists don't use.

I moved every `GetValues()` implementation to `EnumerateValues()` instead, as a step towards making every list implement IDreamList instead of inheriting DreamList.