### PR TITLE
Misc DMParser Tests & Fixes

### DIFF
--- a/Content.Tests/DMProject/Tests/Call/call_no_params.dm
+++ b/Content.Tests/DMProject/Tests/Call/call_no_params.dm
@@ -1,0 +1,3 @@
+// COMPILE ERROR OD0013
+/proc/RunTest()
+	var/foo = call()()

--- a/Content.Tests/DMProject/Tests/Dereference/deref_no_ident.dm
+++ b/Content.Tests/DMProject/Tests/Dereference/deref_no_ident.dm
@@ -1,0 +1,4 @@
+// COMPILE ERROR OD0001
+/proc/RunTest()
+	var/datum/D = new
+	var/foo = D?.

--- a/Content.Tests/DMProject/Tests/Procs/pick_no_arg.dm
+++ b/Content.Tests/DMProject/Tests/Procs/pick_no_arg.dm
@@ -1,0 +1,4 @@
+// COMPILE ERROR OD0012
+
+/proc/RunTest()
+	var/foo = pick()

--- a/Content.Tests/DMProject/Tests/SetStatements/no_identifier.dm
+++ b/Content.Tests/DMProject/Tests/SetStatements/no_identifier.dm
@@ -1,0 +1,4 @@
+// COMPILE ERROR OD0001
+/proc/RunTest()
+	set
+	return

--- a/Content.Tests/DMProject/Tests/Statements/ControlFlow/goto_no_label.dm
+++ b/Content.Tests/DMProject/Tests/Statements/ControlFlow/goto_no_label.dm
@@ -1,0 +1,3 @@
+// COMPILE ERROR OD0001
+/proc/RunTest()
+	goto

--- a/Content.Tests/DMProject/Tests/Statements/ControlFlow/trycatch_no_body.dm
+++ b/Content.Tests/DMProject/Tests/Statements/ControlFlow/trycatch_no_body.dm
@@ -1,0 +1,5 @@
+// COMPILE ERROR OD0015
+
+/proc/RunTest()
+	try
+	catch(var/exception/e)

--- a/Content.Tests/DMProject/Tests/Statements/Switch/no_cases.dm
+++ b/Content.Tests/DMProject/Tests/Statements/Switch/no_cases.dm
@@ -1,0 +1,3 @@
+// COMPILE ERROR OD0015
+/proc/RunTest()
+	switch(1)

--- a/Content.Tests/DMProject/Tests/Statements/Switch/no_expression.dm
+++ b/Content.Tests/DMProject/Tests/Statements/Switch/no_expression.dm
@@ -1,0 +1,7 @@
+// COMPILE ERROR OD3201
+#pragma SuspiciousSwitchCase error
+
+/proc/RunTest()
+	switch(1)
+		if()
+			return

--- a/Content.Tests/DMProject/Tests/Statements/Switch/no_upper_limit.dm
+++ b/Content.Tests/DMProject/Tests/Statements/Switch/no_upper_limit.dm
@@ -1,0 +1,5 @@
+// COMPILE ERROR OD0011
+/proc/RunTest()
+	switch(1)
+		if(1 to)
+			return

--- a/Content.Tests/DMProject/Tests/Statements/While/do_while_no_body1.dm
+++ b/Content.Tests/DMProject/Tests/Statements/While/do_while_no_body1.dm
@@ -1,0 +1,4 @@
+// COMPILE ERROR OD0015
+/proc/RunTest()
+	do while(0)
+	return

--- a/Content.Tests/DMProject/Tests/Statements/While/do_while_no_body2.dm
+++ b/Content.Tests/DMProject/Tests/Statements/While/do_while_no_body2.dm
@@ -1,0 +1,5 @@
+// COMPILE ERROR OD0015
+/proc/RunTest()
+	do 
+	while(0)
+	return

--- a/Content.Tests/DMProject/Tests/Statements/While/while_no_body.dm
+++ b/Content.Tests/DMProject/Tests/Statements/While/while_no_body.dm
@@ -1,0 +1,4 @@
+// RETURN TRUE
+/proc/RunTest()
+	while(0)
+	return TRUE

--- a/Content.Tests/DMProject/Tests/Tree/upward_search_no_path.dm
+++ b/Content.Tests/DMProject/Tests/Tree/upward_search_no_path.dm
@@ -1,0 +1,5 @@
+/datum/foo
+
+/proc/RunTest()
+	var/bar = /datum/foo.
+	ASSERT(bar == /datum/foo)

--- a/DMCompiler/DM/Builders/DMProcBuilder.cs
+++ b/DMCompiler/DM/Builders/DMProcBuilder.cs
@@ -709,10 +709,10 @@ internal sealed class DMProcBuilder(DMCompiler compiler, DMObject dmObject, DMPr
                         Constant lower = GetCaseValue(range.RangeStart);
                         Constant upper = GetCaseValue(range.RangeEnd);
 
-                        Constant CoerceBound(Constant bound) {
+                        Constant CoerceBound(Constant bound, bool upperRange) {
                             if (bound is Null) { // We do a little null coercion, as a treat
                                 compiler.Emit(WarningCode.MalformedRange, range.RangeStart.Location,
-                                    "Malformed range, lower bound is coerced from null to 0");
+                                    $"Malformed range, {(upperRange ? "upper" : "lower")} bound is coerced from null to 0");
                                 return new Number(lower.Location, 0.0f);
                             }
 
@@ -720,15 +720,15 @@ internal sealed class DMProcBuilder(DMCompiler compiler, DMObject dmObject, DMPr
                             //We are (hopefully) deviating from parity here and just calling that a Compiler error.
                             if (bound is not Number) {
                                 compiler.Emit(WarningCode.InvalidRange, range.RangeStart.Location,
-                                    "Invalid range, lower bound is not a number");
+                                    $"Invalid range, {(upperRange ? "upper" : "lower")} bound is not a number");
                                 bound = new Number(bound.Location, 0.0f);
                             }
 
                             return bound;
                         }
 
-                        lower = CoerceBound(lower);
-                        upper = CoerceBound(upper);
+                        lower = CoerceBound(lower, false);
+                        upper = CoerceBound(upper, true);
 
                         lower.EmitPushValue(ExprContext);
                         upper.EmitPushValue(ExprContext);


### PR DESCRIPTION
- Add a bunch of random tests to improve codecov
- Fix a few cases where error handling would actually result in additional parser errors
- Improve the wording of some errors to be more accurate
- Fix a parity break in switch cases. `switch(foo) if()` is effectively a no-op AFAICT; it is not equivalent to `if(null)` nor `if("")`. We were treating it as an error; I converted it to a pragma.
- Fix a parity break in path search:
<img width="605" height="892" alt="image" src="https://github.com/user-attachments/assets/67fdf701-d03a-40e0-afa3-fcc54320d569" />
