### PR TITLE
Fix decoding the `EnumerateAssoc` opcode

### DIFF
--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -183,7 +183,7 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
             case DreamProcOpcode.Enumerate:
                 return (opcode, ReadInt(), ReadReference(), ReadInt());
             case DreamProcOpcode.EnumerateAssoc:
-                return (opcode, ReadInt(), ReadReference(), ReadReference(), ReadReference(), ReadInt());
+                return (opcode, ReadInt(), ReadReference(), ReadReference(), ReadInt());
 
             case DreamProcOpcode.CreateFilteredListEnumerator:
             case DreamProcOpcode.EnumerateNoAssign:
@@ -307,21 +307,6 @@ public struct ProcDecoder(IReadOnlyList<string> strings, byte[] bytecode) {
                     or DreamProcOpcode.JumpIfReferenceFalse, DMReference reference, int jumpPosition):
                 text.Append(reference.ToString());
                 text.AppendFormat(" 0x{0:x}", jumpPosition);
-                break;
-
-            case (DreamProcOpcode.Enumerate, DMReference reference, int jumpPosition):
-                text.Append(reference);
-                text.Append(' ');
-                text.Append(jumpPosition);
-                break;
-            case (DreamProcOpcode.EnumerateAssoc, DMReference reference, DMReference assocReference, DMReference listReference, int jumpPosition):
-                text.Append(reference);
-                text.Append(' ');
-                text.Append(assocReference);
-                text.Append(' ');
-                text.Append(listReference);
-                text.Append(' ');
-                text.Append(jumpPosition);
                 break;
 
             case (DreamProcOpcode.PushType


### PR DESCRIPTION
Fixes disassembling opcodes produced by `for (var/key,value in list)`. Changes to the opcode weren't reflected in the decoder.

Recent changes to /tg/ were triggering an error because of this.