### PR TITLE
mark `/world/Error()` as implemented

### DIFF
--- a/DMCompiler/DMStandard/Types/World.dm
+++ b/DMCompiler/DMStandard/Types/World.dm
@@ -74,7 +74,6 @@
 		return FALSE;
 
 	proc/Error(exception)
-		set opendream_unimplemented = TRUE
 
 	proc/Reboot()
 		set opendream_unimplemented = TRUE


### PR DESCRIPTION
think this was just an oversight since it is very implemented