### PR TITLE
Mark a bunch of `/world` vars as unsupported

### DIFF
--- a/DMCompiler/DMStandard/Types/World.dm
+++ b/DMCompiler/DMStandard/Types/World.dm
@@ -29,14 +29,14 @@
 	var/byond_version = DM_VERSION
 	var/byond_build = DM_BUILD
 
-	var/version = 0 as opendream_unimplemented
+	var/version = 0 as opendream_unsupported //only used to notify users on the hub - unsupported due to no hub
 
 	var/address
 	var/port = 0 as opendream_compiletimereadonly
 	var/internet_address = "127.0.0.1" as opendream_unimplemented
 	var/url as opendream_unimplemented
-	var/visibility = 0 as opendream_unimplemented
-	var/status as opendream_unimplemented
+	var/visibility = 0 as opendream_unsupported //used to control server appearing on the hub - unsupported due to no hub
+	var/status as opendream_unsupported //used to display a message appearing under the server on the hub - unsupported due to no hub
 	var/process
 	var/list/params = null
 
@@ -45,13 +45,13 @@
 	var/const/system_type as opendream_noconstfold
 
 	var/map_cpu = 0 as opendream_unimplemented
-	var/hub as opendream_unimplemented
-	var/hub_password as opendream_unimplemented
+	var/hub as opendream_unsupported //used to mark a game as unique on the hub - unsupported due to no hub
+	var/hub_password as opendream_unsupported //authentication for above - unsupported due to no hub
 	var/reachable as opendream_unimplemented
-	var/game_state as opendream_unimplemented
-	var/host as opendream_unimplemented
+	var/game_state as opendream_unsupported //used to display server joinability on the hub - does not actually affect joining - unsupported due to no hub
+	var/host opendream_unsupported //contains the key of the world's host - unsupported as OD server does not run as a user
 	var/map_format = TOPDOWN_MAP as opendream_unimplemented
-	var/cache_lifespan = 30 as opendream_unimplemented
+	var/cache_lifespan = 30 as opendream_unsupported //used to control cache expiry in RSC - unsupported due to no RSC
 	var/executor as opendream_unimplemented
 	
 	// An OpenDream read-only var that tells you what port Topic() is listening on


### PR DESCRIPTION
most are hub things