### PR TITLE
Fix `list() | list()` not including the first list's associated values

### DIFF
--- a/Content.Tests/DMProject/Tests/List/ListOr.dm
+++ b/Content.Tests/DMProject/Tests/List/ListOr.dm
@@ -1,0 +1,6 @@
+﻿/proc/RunTest()
+	var/list/L1 = list("a" = 1, "b" = 2)
+	var/list/L2 = list("c" = 3, "d" = 4)
+	var/list/result = L1 | L2
+	
+	ASSERT(result ~= list("a" = 1, "b" = 2, "c" = 3, "d" = 4))

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -323,7 +323,7 @@ public class DreamList : DreamObject, IDreamList {
     }
 
     public DreamList Union(DreamList other) {
-        DreamList newList = new DreamList(ObjectDefinition, _values.Union(other.GetValues()).ToList(), null);
+        DreamList newList = new DreamList(ObjectDefinition, _values.Union(other.EnumerateValues()).ToList(), IsAssociative ? new(_associativeValues!) : null);
         foreach ((DreamValue key, DreamValue value) in other.GetAssociativeValues()) {
             newList.SetValue(key, value);
         }


### PR DESCRIPTION
`json_encode(list("a"=1, "b"=2) | list("c"=3, "d"=4))`
was giving
`{"a":null,"b":null,"c":3,"d":4}`