### PR TITLE
Support UTF8 file text

### DIFF
--- a/OpenDreamRuntime/Resources/DreamResource.cs
+++ b/OpenDreamRuntime/Resources/DreamResource.cs
@@ -54,7 +54,7 @@ public class DreamResource(int id, string? filePath, string? resourcePath) {
     public virtual string? ReadAsString() {
         if (ResourceData == null) return null;
 
-        string resourceString = Encoding.ASCII.GetString(ResourceData);
+        string resourceString = Encoding.UTF8.GetString(ResourceData);
 
         resourceString = resourceString.Replace("\r\n", "\n");
         return resourceString;

--- a/OpenDreamShared/Network/Messages/MsgLoadInterface.cs
+++ b/OpenDreamShared/Network/Messages/MsgLoadInterface.cs
@@ -2,30 +2,30 @@
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
-namespace OpenDreamShared.Network.Messages {
+namespace OpenDreamShared.Network.Messages;
+
+/// <summary>
+/// Sent server -> client to tell the client to load the interface after connecting, before going in-game.
+/// </summary>
+public sealed class MsgLoadInterface : NetMessage {
+    public override MsgGroups MsgGroup => MsgGroups.Core;
+
     /// <summary>
-    /// Sent server -> client to tell the client to load the interface after connecting, before going in-game.
+    /// The DMF source for the interface. Null if none exists.
     /// </summary>
-    public sealed class MsgLoadInterface : NetMessage {
-        public override MsgGroups MsgGroup => MsgGroups.Core;
+    public string? InterfaceText;
 
-        /// <summary>
-        /// The DMF source for the interface. Null if none exists.
-        /// </summary>
-        public string? InterfaceText;
+    public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer) {
+        bool hasInterface = buffer.ReadBoolean();
 
-        public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer) {
-            bool hasInterface = buffer.ReadBoolean();
+        if (hasInterface)
+            InterfaceText = buffer.ReadString();
+    }
 
-            if (hasInterface)
-                InterfaceText = buffer.ReadString();
-        }
+    public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer) {
+        buffer.Write(InterfaceText != null);
 
-        public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer) {
-            buffer.Write(InterfaceText != null);
-
-            if (InterfaceText != null)
-                buffer.Write(InterfaceText);
-        }
+        if (InterfaceText != null)
+            buffer.Write(InterfaceText);
     }
 }


### PR DESCRIPTION
Non-ASCII text in files was being converted to question marks. This fixes non-latin scripts, such as Russian's.

Before:
<img width="350" height="507" alt="image" src="https://github.com/user-attachments/assets/52f298b4-805b-4b95-808f-38a3027b8ad3" />
After:
<img width="350" height="507" alt="image" src="https://github.com/user-attachments/assets/aad5b9d4-3eed-4432-979a-3642e4563f01" />