### PR TITLE
Fixes mobs with keys GCing

### DIFF
--- a/Content.IntegrationTests/DMProject/Tests/area_not_garbage_collected.dm
+++ b/Content.IntegrationTests/DMProject/Tests/area_not_garbage_collected.dm
@@ -13,12 +13,12 @@ var/global/gc_datum_deleted = 0
 	..()
 
 // Both objects are unreferenced once this returns
-/proc/gc_test_make_and_drop()
+/proc/gc_test_area_make_and_drop()
 	var/area/gc_test/A = new()
 	var/datum/gc_test/D = new()
 
 /datum/unit_test/test_area_not_garbage_collected/RunTest()
-	gc_test_make_and_drop()
+	gc_test_area_make_and_drop()
 
 	// A plain datum dies as soon as nothing references it anymore...
 	ASSERT(global.gc_datum_deleted == 1)

--- a/Content.IntegrationTests/DMProject/Tests/mob_with_key_not_garbage_collected.dm
+++ b/Content.IntegrationTests/DMProject/Tests/mob_with_key_not_garbage_collected.dm
@@ -1,0 +1,34 @@
+//# issue 2704
+// Mobs with keys are never garbage collected by BYOND
+
+var/global/gc_no_key_deleted = 0
+var/global/gc_with_key_deleted = 0
+
+/mob/gc_test/key/New()
+	key = "test"
+	. = ..()
+
+/mob/gc_test/key/Del()
+	global.gc_with_key_deleted = 1
+	. = ..()
+
+/mob/gc_test/keyless/Del()
+	global.gc_no_key_deleted = 1
+	. = ..()
+
+/proc/gc_test_mobkey_make_and_drop()
+	var/mob/gc_test/key/K = new()
+	var/mob/gc_test/keyless/KL = new()
+
+/datum/unit_test/test_mob_with_key_not_garbage_collected/RunTest()
+	gc_test_mobkey_make_and_drop()
+
+	// If the mob doesn't have a key, it cleanly deletes with no refs.
+	ASSERT(global.gc_no_key_deleted == 1)
+	// a mob with a key doesn't get deleted
+	ASSERT(global.gc_with_key_deleted == 0)
+
+	// But an explicit del() still deletes it
+	var/mob/gc_test/key/M = new()
+	del(M)
+	ASSERT(global.gc_with_key_deleted == 1)

--- a/OpenDreamRuntime/Objects/Types/DreamObjectMob.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamObjectMob.cs
@@ -7,6 +7,9 @@ public sealed class DreamObjectMob : DreamObjectMovable {
     public DreamConnection? Connection;
     public string? Key;
 
+    // DM specific behavior, do not garbage collect mobs that have a key.
+    public override bool ShouldGarbageCollect => string.IsNullOrEmpty(Key);
+
     public int SeeInvisible {
         get => _sightComponent.SeeInvisibility;
         private set {


### PR DESCRIPTION
closes #2704

Here is the exact same test added by this running on Wrench, with all ASSERT replaced with world.log <<:

<img width="1096" height="886" alt="image" src="https://github.com/user-attachments/assets/32f4d01f-4229-4288-9dc5-d2d72c82f1b7" />
