### PR TITLE
`.Find()` for special lists

### DIFF
--- a/Content.IntegrationTests/DMProject/Tests/special_list_find.dm
+++ b/Content.IntegrationTests/DMProject/Tests/special_list_find.dm
@@ -6,7 +6,7 @@
 	return args.Find(b)
 
 /datum/unit_test/special_list_find/RunTest()
-	var/turf/T = locate(1, 1, 1)
+	var/turf/T = locate(2, 2, 1)
 	var/obj/first = new(T)
 	var/obj/second = new(T)
 

--- a/Content.IntegrationTests/DMProject/Tests/special_list_find.dm
+++ b/Content.IntegrationTests/DMProject/Tests/special_list_find.dm
@@ -1,0 +1,107 @@
+/mob/find_test/verb/hello()
+	set src = usr
+	usr << "hi"
+
+/datum/unit_test/special_list_find/proc/find_in_args(a, b, c)
+	return args.Find(b)
+
+/datum/unit_test/special_list_find/RunTest()
+	var/turf/T = locate(1, 1, 1)
+	var/obj/first = new(T)
+	var/obj/second = new(T)
+
+	// turf.contents
+	ASSERT(T.contents.Find(first) == 1)
+	ASSERT(T.contents.Find(second) == 2)
+	ASSERT(T.contents.Find(second, 1, 2) == 0)
+	ASSERT(T.contents.Find(second, 3) == 0)
+	ASSERT(T.contents.Find(new /obj) == 0)
+	// contents lists ignore an out-of-range End by default
+	ASSERT(T.contents.Find(second, 1, 99) == 2)
+	ASSERT(T.contents.Find(second, 0) == 2)
+	ASSERT(T.contents.Find(second, -1) == 0)
+
+	// obj.contents
+	var/obj/holder = new(T)
+	var/obj/held = new(holder)
+	ASSERT(holder.contents.Find(held) == 1)
+	ASSERT(holder.contents.Find(held, 1, 99) == 1)
+	ASSERT(holder.contents.Find(second) == 0)
+
+	// area.contents, its turfs and their contents
+	var/area/A = T.loc
+	ASSERT(A.contents.Find(T) > 0)
+	ASSERT(A.contents.Find(second) > A.contents.Find(T))
+	ASSERT(A.contents.Find(second, 1, 9999) == A.contents.Find(second))
+
+	// world.contents
+	ASSERT(world.contents.Find(second) > 0)
+	ASSERT(world.contents.Find(T) > 0)
+
+	// overlays only match appearances read back out of the list
+	first.overlays += "somestate"
+	var/image/overlayImage = new()
+	overlayImage.icon_state = "other"
+	first.overlays += overlayImage
+	ASSERT(length(first.overlays) == 2)
+	ASSERT(first.overlays.Find(first.overlays[1]) == 1)
+	ASSERT(first.overlays.Find(first.overlays[2]) == 2)
+	ASSERT(first.overlays.Find(first.overlays[2], 2) == 2)
+	ASSERT(first.overlays.Find(first.overlays[2], 1, 2) == 0)
+	ASSERT(first.overlays.Find("somestate") == 0)
+	ASSERT(first.overlays.Find(overlayImage) == 0)
+	ASSERT(first.overlays.Find(null) == 0)
+	// equal appearances match across atoms
+	second.overlays += "somestate"
+	ASSERT(first.overlays.Find(second.overlays[1]) == 1)
+	// `in` matches the same things Find() does
+	ASSERT(first.overlays[1] in first.overlays)
+	ASSERT(!("somestate" in first.overlays))
+	ASSERT(!(overlayImage in first.overlays))
+
+	// BYOND's filters list matches nothing at all, unfortunately
+	first.filters += filter(type = "blur", size = 2)
+	ASSERT(length(first.filters) == 1)
+	ASSERT(!(first.filters[1] in first.filters))
+
+	first.underlays += "understate"
+	ASSERT(first.underlays.Find(first.underlays[1]) == 1)
+	ASSERT(first.underlays[1] in first.underlays)
+	ASSERT(first.underlays.Find("understate") == 0)
+
+	// vis_contents
+	first.vis_contents += second
+	ASSERT(first.vis_contents.Find(second) == 1)
+	ASSERT(first.vis_contents.Find(holder) == 0)
+
+	// verbs
+	var/mob/find_test/M = new(T)
+	ASSERT(M.verbs.Find(/mob/find_test/verb/hello) == 1)
+	ASSERT(M.verbs.Find(M.verbs[1]) == 1)
+
+	// savefile.dir also ignores an out-of-range End
+	var/savefile/S = new("special_list_find.sav")
+	S.dir.Add("alpha")
+	S.dir.Add("beta")
+	ASSERT(S.dir.Find("alpha") == 1)
+	ASSERT(S.dir.Find("beta") == 2)
+	ASSERT(S.dir.Find("gamma") == 0)
+	ASSERT(S.dir.Find("alpha", 1, 99) == 1)
+	ASSERT(S.dir.Find("alpha", -1) == 0)
+
+	// vars, global.vars and args
+	var/list/varsList = first.vars
+	var/nameIndex = varsList.Find("name")
+	ASSERT(nameIndex > 0)
+	ASSERT(varsList.Find("name", nameIndex + 1) == 0)
+	ASSERT(varsList.Find("name", 1, nameIndex) == 0)
+	ASSERT(varsList.Find("not_a_var") == 0)
+	ASSERT(global.vars.Find("areas_by_type") > 0)
+	ASSERT(global.vars.Find("definitely_not_a_global") == 0)
+	ASSERT(find_in_args("a", "b", "c") == 2)
+
+	// Start rules, same on every list
+	var/list/L = list("a", "b", "c")
+	ASSERT(L.Find("a", 0) == 1) // Start 0 counts as 1
+	ASSERT(L.Find("a", -1) == 0) // negative Start finds nothing
+	ASSERT(L.Find("c", 1, 4) == 3) // End of len+1 is the last valid position

--- a/Content.Tests/DMProject/Tests/List/ListFindOOBPragma.dm
+++ b/Content.Tests/DMProject/Tests/List/ListFindOOBPragma.dm
@@ -1,0 +1,8 @@
+// RUNTIME ERROR
+// NOBYOND
+#pragma ListFindOutOfBoundsException error
+
+/proc/RunTest()
+	var/obj/holder = new
+	var/obj/held = new(holder)
+	holder.contents.Find(held, 1, 99) // BYOND ignores this OOB End param, the pragma makes it a runtime

--- a/DMCompiler/Compiler/CompilerError.cs
+++ b/DMCompiler/Compiler/CompilerError.cs
@@ -87,6 +87,7 @@ public enum WarningCode {
     // 4000 - 4999 are reserved for runtime configuration. (TODO: Runtime doesn't know about configs yet!)
     ListNegativeSizeException = 4000, // When a list's length is decremented below zero, raise an exception.
     InitialVarOnPrimitiveException = 4001, // initial(foo.var) where foo is a variable containing a non-datum value.
+    ListFindOutOfBoundsException = 4002, // list.Find() with an End past the end of the list, otherwise ignored on some special lists.
 }
 
 public enum ErrorLevel {
@@ -194,6 +195,7 @@ public struct CompilerEmission {
         //4000-4999
         {WarningCode.ListNegativeSizeException, ErrorLevel.Disabled},
         {WarningCode.InitialVarOnPrimitiveException, ErrorLevel.Disabled},
+        {WarningCode.ListFindOutOfBoundsException, ErrorLevel.Disabled},
     };
 
     public CompilerEmission(ErrorLevel level, Location? location, string message) {

--- a/OpenDreamRuntime/Objects/Types/DreamList.cs
+++ b/OpenDreamRuntime/Objects/Types/DreamList.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using JetBrains.Annotations;
 using OpenDreamRuntime.Map;
 using OpenDreamRuntime.Procs;
@@ -250,10 +251,60 @@ public class DreamList : DreamObject, IDreamList {
     }
 
     public virtual int FindValue(DreamValue value, int start = 1, int end = 0) {
-        if (end == 0 || end > _values.Count) end = _values.Count + 1;
+        if (!NormalizeFindRange(_values.Count, ref start, ref end))
+            return 0;
 
         for (int i = start; i < end; i++) {
             if (_values[i - 1].Equals(value)) return i;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Turns Find()'s Start/End into a [start, end) range of 1-indexed positions.
+    /// End 0 is just past the last element, Start 0 is 1, a negative Start finds nothing.
+    /// </summary>
+    /// <param name="lenientEnd">Whether an out-of-range End searches to the end instead of erroring</param>
+    /// <returns>false if the range is empty</returns>
+    protected bool NormalizeFindRange(int length, ref int start, ref int end, bool lenientEnd = false) {
+        if (end <= 0 || end > length + 1) {
+            if (end != 0) {
+                if (!lenientEnd)
+                    throw new DMException("list index out of bounds");
+
+                // BYOND ignores this, but it's still a bug worth catching
+                DreamManager.OptionalException<DMException>(DMCompiler.Compiler.WarningCode.ListFindOutOfBoundsException, "list index out of bounds");
+            }
+
+            end = length + 1;
+        }
+
+        if (start < 0) // A negative Start doesn't search at all, unlike one past the end
+            return false;
+        if (start == 0)
+            start = 1;
+
+        return start < end;
+    }
+
+    /// <returns>The 1-indexed position of the value, or 0 if it isn't in the [start, end) range</returns>
+    protected static int FindValueInSpan<T>(ReadOnlySpan<T> values, T value, int start, int end) where T : IEquatable<T> {
+        var index = values.Slice(start - 1, end - start).IndexOf(value);
+
+        return index < 0 ? 0 : index + start;
+    }
+
+    protected int FindValueByEnumeration(DreamValue value, int start, int end, bool lenientEnd = false) {
+        if (!NormalizeFindRange(GetLength(), ref start, ref end, lenientEnd))
+            return 0;
+
+        var index = 0;
+        foreach (var listValue in EnumerateValues()) {
+            index++;
+            if (index < start) continue;
+            if (index >= end) break;
+            if (listValue.Equals(value)) return index;
         }
 
         return 0;
@@ -632,7 +683,7 @@ internal sealed class DreamListVars(DreamObjectDefinition listDef, DreamObject d
     }
 
     public override int FindValue(DreamValue value, int start = 1, int end = 0) {
-        return GetValues().IndexOf(value)+1; // IndexOf is 0 indexed, returns -1 on fail, DM is 1 indexed and returns 0 on fail, so +1
+        return FindValueByEnumeration(value, start, end);
     }
 }
 
@@ -665,6 +716,10 @@ internal sealed class DreamGlobalVars(DreamObjectDefinition listDef) : DreamList
         return ContainsKey(value);
     }
 
+    public override int GetLength() {
+        return ObjectTree.Root.ObjectDefinition.GlobalVariables.Count;
+    }
+
     public override DreamValue GetValue(DreamValue key) {
         if (!key.TryGetValueAsString(out var varName)) {
             throw new DMException($"Invalid var index {key}");
@@ -694,7 +749,7 @@ internal sealed class DreamGlobalVars(DreamObjectDefinition listDef) : DreamList
     }
 
     public override int FindValue(DreamValue value, int start = 1, int end = 0) {
-        throw new NotImplementedException($".Find() is not yet implemented on {GetType()}");
+        return FindValueByEnumeration(value, start, end);
     }
 }
 
@@ -783,7 +838,12 @@ public sealed class ClientVerbsList : DreamList {
     }
 
     public override int FindValue(DreamValue value, int start = 1, int end = 0) {
-        throw new NotImplementedException($".Find() is not yet implemented on {GetType()}");
+        if (!NormalizeFindRange(Verbs.Count, ref start, ref end))
+            return 0;
+        if (!value.TryGetValueAsProc(out var verb))
+            return 0;
+
+        return Verbs.IndexOf(verb, start - 1, end - start) + 1; // IndexOf() is 0-indexed, -1 on failure
     }
 }
 
@@ -883,7 +943,13 @@ public sealed class VerbsList(DreamObjectTree objectTree, AtomManager atomManage
     }
 
     public override int FindValue(DreamValue value, int start = 1, int end = 0) {
-        throw new NotImplementedException($".Find() is not yet implemented on {GetType()}");
+        var verbs = GetVerbs();
+        if (!NormalizeFindRange(verbs.Length, ref start, ref end))
+            return 0;
+        if (!value.TryGetValueAsProc(out var verb) || verb.VerbId == null)
+            return 0;
+
+        return FindValueInSpan(verbs.AsSpan(), verb.VerbId.Value, start, end);
     }
 }
 
@@ -967,7 +1033,25 @@ public sealed class DreamOverlaysList(DreamObjectDefinition listDef, DreamObject
     }
 
     public override int FindValue(DreamValue value, int start = 1, int end = 0) {
-        throw new NotImplementedException($".Find() is not yet implemented on {GetType()}");
+        var overlays = GetOverlaysArray(AtomManager.MustGetAppearance(owner));
+        if (!NormalizeFindRange(overlays.Length, ref start, ref end))
+            return 0;
+
+        // Only appearances match, not the /image or icon_state an overlay was made from
+        if (!value.TryGetValueAsAppearance(out var searchAppearance))
+            return 0;
+
+        var immutableSearchAppearance = new ImmutableAppearance(searchAppearance, appearanceSystem);
+        for (int i = start; i < end; i++) {
+            if (overlays[i - 1].Equals(immutableSearchAppearance))
+                return i;
+        }
+
+        return 0;
+    }
+
+    public override bool ContainsValue(DreamValue value) {
+        return FindValue(value) != 0;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1087,7 +1171,12 @@ public sealed class DreamVisContentsList : DreamList {
     }
 
     public override int FindValue(DreamValue value, int start = 1, int end = 0) {
-        throw new NotImplementedException($".Find() is not yet implemented on {GetType()}");
+        if (!NormalizeFindRange(_visContents.Count, ref start, ref end))
+            return 0;
+        if (!value.TryGetValueAsDreamObject<DreamObjectAtom>(out var atom))
+            return 0;
+
+        return _visContents.IndexOf(atom, start - 1, end - start) + 1;
     }
 
     public override bool ContainsValue(DreamValue value) {
@@ -1230,8 +1319,15 @@ public sealed class DreamFilterList(DreamObjectDefinition listDef, DreamObject o
         return GetAppearance().Filters.Length;
     }
 
+    // TODO: Consider searching filters anyway, despite BYOND not supporting it
     public override int FindValue(DreamValue value, int start = 1, int end = 0) {
-        throw new NotImplementedException($".Find() is not yet implemented on {GetType()}");
+        throw new DMException("operation not supported by this list");
+    }
+
+    public override bool ContainsValue(DreamValue value) {
+        // BYOND's filters list matches nothing
+        // TODO: Consider implementing this
+        return false;
     }
 
     private ImmutableAppearance GetAppearance() {
@@ -1315,7 +1411,10 @@ public sealed class ClientScreenList(DreamObjectTree objectTree, ServerScreenOve
     }
 
     public override int FindValue(DreamValue value, int start = 1, int end = 0) {
-        throw new NotImplementedException($".Find() is not yet implemented on {GetType()}");
+        if (!NormalizeFindRange(_screenObjects.Count, ref start, ref end))
+            return 0;
+
+        return FindValueInSpan(CollectionsMarshal.AsSpan(_screenObjects), value, start, end);
     }
 }
 
@@ -1378,7 +1477,10 @@ public sealed class ClientImagesList(DreamObjectTree objectTree, ServerClientIma
     }
 
     public override int FindValue(DreamValue value, int start = 1, int end = 0) {
-        throw new NotImplementedException($".Find() is not yet implemented on {GetType()}");
+        if (!NormalizeFindRange(_imageObjects.Count, ref start, ref end))
+            return 0;
+
+        return FindValueInSpan(CollectionsMarshal.AsSpan(_imageObjects), value, start, end);
     }
 
     public override bool ContainsValue(DreamValue value) => _imageObjects.Contains(value);
@@ -1423,7 +1525,7 @@ public sealed class WorldContentsList(DreamObjectDefinition listDef, AtomManager
     }
 
     public override int FindValue(DreamValue value, int start = 1, int end = 0) {
-        throw new NotImplementedException($".Find() is not yet implemented on {GetType()}");
+        return FindValueByEnumeration(value, start, end);
     }
 
     public override bool ContainsValue(DreamValue value) {
@@ -1482,7 +1584,12 @@ public sealed class TurfContentsList(DreamObjectDefinition listDef, DreamObjectT
     }
 
     public override int FindValue(DreamValue value, int start = 1, int end = 0) {
-        throw new NotImplementedException($".Find() is not yet implemented on {GetType()}");
+        if (!NormalizeFindRange(Cell.Movables.Count, ref start, ref end, lenientEnd: true))
+            return 0;
+        if (!value.TryGetValueAsDreamObject<DreamObjectMovable>(out var movable))
+            return 0;
+
+        return Cell.Movables.IndexOf(movable, start - 1, end - start) + 1;
     }
 
     public override bool ContainsValue(DreamValue value) {
@@ -1567,7 +1674,7 @@ public sealed class AreaContentsList(DreamObjectDefinition listDef, DreamObjectA
     }
 
     public override int FindValue(DreamValue value, int start = 1, int end = 0) {
-        throw new NotImplementedException($".Find() is not yet implemented on {GetType()}");
+        return FindValueByEnumeration(value, start, end, lenientEnd: true);
     }
 
     public override bool ContainsValue(DreamValue value) {
@@ -1627,22 +1734,7 @@ public sealed class MovableContentsList(DreamObjectDefinition listDef, DreamObje
     }
 
     public override int FindValue(DreamValue value, int start = 1, int end = 0) {
-        if (end == 0 || end > transform.ChildCount) end = transform.ChildCount;
-
-        using var childEnumerator = transform.ChildEnumerator;
-
-        int i = 0;
-        while (childEnumerator.MoveNext(out EntityUid child)) {
-            if (!AtomManager.TryGetMovableFromEntity(child, out var childObject))
-                continue;
-            i++;
-            if (i >= start && new DreamValue(childObject).Equals(value))
-                return i;
-            if (i > end)
-                return 0;
-        }
-
-        return 0;
+        return FindValueByEnumeration(value, start, end, lenientEnd: true);
     }
 
     public override void SetValue(DreamValue key, DreamValue value, bool allowGrowth = false) {
@@ -1729,7 +1821,15 @@ internal sealed class ProcArgsList(DreamObjectDefinition listDef, ProcState stat
     }
 
     public override int FindValue(DreamValue value, int start = 1, int end = 0) {
-        throw new NotImplementedException($".Find() is not yet implemented on {GetType()}");
+        if (!NormalizeFindRange(state.ArgumentCount, ref start, ref end))
+            return 0;
+
+        var args = state.GetArguments();
+        for (int i = start; i < end; i++) {
+            if (args[i - 1].Equals(value)) return i;
+        }
+
+        return 0;
     }
 }
 
@@ -1788,6 +1888,6 @@ public sealed class SavefileDirList(DreamObjectDefinition listDef, DreamObjectSa
     }
 
     public override int FindValue(DreamValue value, int start = 1, int end = 0) {
-        throw new NotImplementedException($".Find() is not yet implemented on {GetType()}");
+        return FindValueByEnumeration(value, start, end, lenientEnd: true);
     }
 }


### PR DESCRIPTION
also implemented `DreamGlobalVars.GetLength()` since my enumeration stuff needs it and it was missing

tested pretty thoroughly in the DM tests, only ones not covered are the 3 client ones (verbs, screen, images)

fixes #2302